### PR TITLE
chore: run `yesqa`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,17 +7,11 @@ exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generate
 per-file-ignores =
     tests/*: T, AK1
     dev/*: T, T201, AK1
-    setup.py: T, T201, AK1
-    localbuild.py: T, T201, AK1
     src/awkward/__init__.py: E402, F401, F403, AK1
-    awkward/__init__.py: E402, F401, F403, AK1
     src/awkward/__init__.py: F401, F403
-    awkward/__init__.py: F401, F403
     src/awkward/operations/__init__.py: F401
-    awkward/operations/__init__.py: F401
     src/awkward/_connect/numba/*: AK1
-    src/awkward/[!_]*: AK1
-    src/awkward/_[!v]*: AK1
+    src/awkward/_errors.py: AK1
 
 [flake8:local-plugins]
 extension =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,3 +72,8 @@ repos:
   rev: "v0.8.0.4"
   hooks:
   - id: shellcheck
+
+- repo: https://github.com/asottile/yesqa
+  rev: v1.4.0
+  hooks:
+  - id: yesqa

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,8 +72,3 @@ repos:
   rev: "v0.8.0.4"
   hooks:
   - id: shellcheck
-
-- repo: https://github.com/asottile/yesqa
-  rev: v1.4.0
-  hooks:
-  - id: yesqa

--- a/dev/flake8_awkward.py
+++ b/dev/flake8_awkward.py
@@ -11,7 +11,7 @@ class Flake8ASTErrorInfo(NamedTuple):
 
 
 class Visitor(ast.NodeVisitor):
-    msg = "AK101 exception must be wrapped in ak._util.*error"
+    msg = "AK101 exception must be wrapped in ak._errors.*_error"
 
     def __init__(self):
         self.errors: list[Flake8ASTErrorInfo] = []

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -42,8 +42,8 @@ import awkward.builder
 import awkward.forth
 
 behavior: dict = {}
-awkward.behaviors.string.register(behavior)  # noqa: F405
-awkward.behaviors.categorical.register(behavior)  # noqa: F405
+awkward.behaviors.string.register(behavior)
+awkward.behaviors.categorical.register(behavior)
 
 # operations
 from awkward.operations import *

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -10,25 +10,25 @@ from collections.abc import Sequence
 from typing import Any, Callable, Dict, List, Union
 
 import awkward as ak
-from awkward.contents.bitmaskedarray import BitMaskedArray  # noqa: F401
-from awkward.contents.bytemaskedarray import ByteMaskedArray  # noqa: F401
-from awkward.contents.content import Content  # noqa: F401
-from awkward.contents.emptyarray import EmptyArray  # noqa: F401
-from awkward.contents.indexedarray import IndexedArray  # noqa: F401
-from awkward.contents.indexedoptionarray import IndexedOptionArray  # noqa: F401
-from awkward.contents.listarray import ListArray  # noqa: F401
-from awkward.contents.listoffsetarray import ListOffsetArray  # noqa: F401
-from awkward.contents.numpyarray import NumpyArray  # noqa: F401
-from awkward.contents.recordarray import RecordArray  # noqa: F401
-from awkward.contents.regulararray import RegularArray  # noqa: F401
-from awkward.contents.unionarray import UnionArray  # noqa: F401
-from awkward.contents.unmaskedarray import UnmaskedArray  # noqa: F401
-from awkward.index import Index  # noqa: F401
-from awkward.index import Index8  # noqa: F401
-from awkward.index import (  # IndexU8,  # noqa: F401; Index32,  # noqa: F401; IndexU32,  # noqa: F401; noqa: F401
+from awkward.contents.bitmaskedarray import BitMaskedArray
+from awkward.contents.bytemaskedarray import ByteMaskedArray
+from awkward.contents.content import Content
+from awkward.contents.emptyarray import EmptyArray
+from awkward.contents.indexedarray import IndexedArray
+from awkward.contents.indexedoptionarray import IndexedOptionArray
+from awkward.contents.listarray import ListArray
+from awkward.contents.listoffsetarray import ListOffsetArray
+from awkward.contents.numpyarray import NumpyArray
+from awkward.contents.recordarray import RecordArray
+from awkward.contents.regulararray import RegularArray
+from awkward.contents.unionarray import UnionArray
+from awkward.contents.unmaskedarray import UnmaskedArray
+from awkward.index import (  # IndexU8,  ; Index32,  ; IndexU32,  ; noqa: F401
+    Index,
+    Index8,
     Index64,
 )
-from awkward.record import Record  # noqa: F401
+from awkward.record import Record
 
 np = ak.nplikes.NumpyMetadata.instance()
 numpy = ak.nplikes.Numpy.instance()

--- a/src/awkward/_connect/avro.py
+++ b/src/awkward/_connect/avro.py
@@ -39,7 +39,7 @@ class ReadAvroFT:
                 pos = self.cont_spec(pos)
                 break
 
-            except _ReachedEndofArrayError:  # noqa: AK101
+            except _ReachedEndofArrayError:
                 numbytes *= 2
 
         ind = 2
@@ -85,7 +85,7 @@ class ReadAvroFT:
                 if len(temp_data) < len_block:
                     raise _ReachedEndofArrayError  # noqa: AK101
                 self.update_pos(len_block)
-            except _ReachedEndofArrayError:  # noqa: AK101
+            except _ReachedEndofArrayError:
                 break
 
             if limit_entries is not None and self.blocks > limit_entries:

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -7,8 +7,8 @@ import cppyy
 import ROOT
 
 import awkward as ak
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward._connect.cling
+import awkward._lookup
 from awkward.types.numpytype import primitive_to_dtype
 
 cpp_type_of = {

--- a/src/awkward/_connect/rdataframe/to_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/to_rdataframe.py
@@ -5,8 +5,8 @@ import threading
 import ROOT
 
 import awkward as ak
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward._connect.cling
+import awkward._lookup
 
 compiler_lock = threading.Lock()
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -38,7 +38,7 @@ def regularize_backend(backend):
     if backend in _backends:
         return _backends[backend].instance()
     else:
-        raise ak._errors.wrap_error(  # noqa: AK101
+        raise ak._errors.wrap_error(
             ValueError("The available backends for now are `cpu` and `cuda`.")
         )
 

--- a/src/awkward/contents/__init__.py
+++ b/src/awkward/contents/__init__.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward.index  # noqa: F401
+import awkward.index
 import awkward.record  # noqa: F401
 from awkward.contents.bitmaskedarray import BitMaskedArray  # noqa: F401
 from awkward.contents.bytemaskedarray import ByteMaskedArray  # noqa: F401

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -130,19 +130,19 @@ class Content:
         self,
         getkey: Callable[[Content], form.Form],
     ) -> form.Form:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def Form(self) -> type[form.Form]:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def typetracer(self) -> Self:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def length(self) -> int:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def forget_length(self) -> Self:
         if not isinstance(self._nplike, ak._typetracer.TypeTracer):
@@ -151,7 +151,7 @@ class Content:
             return self._forget_length()
 
     def _forget_length(self) -> Self:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def to_buffers(
         self,
@@ -214,7 +214,7 @@ class Content:
         container: MutableMapping[str, Any] | None,
         nplike: NumpyLike | None,
     ) -> tuple[form.Form, int, Mapping[str, Any]]:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def __len__(self) -> int:
         return self.length
@@ -652,22 +652,22 @@ class Content:
             )
 
     def _getitem_at(self, where: Integral):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_range(self, where: slice):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_field(self, where: str):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_fields(self, where: list[str], only_fields: tuple[str, ...] = ()):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _getitem_next(self, head, tail, advanced: ak.index.Index | None):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _carry(self, carry: ak.index.Index, allow_lazy: bool):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _carry_asrange(self, carry: ak.index.Index):
         assert isinstance(carry, ak.index.Index)
@@ -848,7 +848,7 @@ class Content:
         return self._local_index(axis, 0)
 
     def _local_index(self, axis: Integral, depth: Integral):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _reduce(
         self,
@@ -921,7 +921,7 @@ class Content:
         keepdims: bool,
         behavior: dict | None,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def argmin(
         self,
@@ -1086,7 +1086,7 @@ class Content:
         kind: Any,
         order: Any,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def sort(
         self,
@@ -1151,7 +1151,7 @@ class Content:
         kind: Any,
         order: Any,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _combinations_axis0(
         self,
@@ -1246,7 +1246,7 @@ class Content:
         axis: Integral,
         depth: Integral,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def validity_error_parameters(self, path: str) -> str:
         if self.parameter("__array__") == "string":
@@ -1355,7 +1355,7 @@ class Content:
         return self._validity_error(path)
 
     def _validity_error(self, path: str) -> str:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def nbytes(self) -> int:
@@ -1377,7 +1377,7 @@ class Content:
         parents: ak.index.Index,
         outlength: Integral,
     ) -> bool:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def unique(self, axis=None):
         if axis == -1 or axis is None:
@@ -1434,7 +1434,7 @@ class Content:
         parents: ak.index.Index,
         outlength: Integral,
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     @property
     def is_identity_like(self) -> bool:
@@ -1500,7 +1500,7 @@ class Content:
     def _pad_none(
         self, target: Integral, axis: Integral, depth: Integral, clip: bool
     ) -> Content:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def to_arrow(
         self,
@@ -1541,13 +1541,13 @@ class Content:
         length: Integral,
         options: dict[str, Any],
     ):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def to_numpy(self, allow_missing: bool):
         return self._to_numpy(allow_missing)
 
     def _to_numpy(self, allow_missing: bool):
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def completely_flatten(
         self,
@@ -1571,7 +1571,7 @@ class Content:
     def _completely_flatten(
         self, nplike: NumpyLike | None, options: dict[str, Any]
     ) -> list:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def recursively_apply(
         self,
@@ -1609,7 +1609,7 @@ class Content:
         lateral_context: dict | None,
         options: dict[str, Any],
     ) -> Content | None:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def to_json(
         self,
@@ -1647,7 +1647,7 @@ class Content:
         )
 
     def packed(self) -> Content:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def tolist(self, behavior: dict | None = None) -> list:
         return self.to_list(behavior)
@@ -1658,7 +1658,7 @@ class Content:
     def _to_list(
         self, behavior: dict | None, json_conversions: dict[str, Any] | None
     ) -> list:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _to_list_custom(
         self, behavior: dict | None, json_conversions: dict[str, Any] | None
@@ -1767,7 +1767,7 @@ class Content:
     def _offsets_and_flattened(
         self, axis: Integral, depth: Integral
     ) -> tuple[ak.index.Index, Content]:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def to_backend(self, backend: str) -> Self:
         if self.nplike is ak._util.regularize_backend(backend):
@@ -1776,7 +1776,7 @@ class Content:
             return self._to_nplike(ak._util.regularize_backend(backend))
 
     def _to_nplike(self, nplike: NumpyLike) -> Self:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def with_parameter(self, key: str, value: Any) -> Self:
         out = copy.copy(self)
@@ -1811,7 +1811,7 @@ class Content:
     def _layout_equal(
         self, other: Self, index_dtype: bool = True, numpyarray: bool = True
     ) -> bool:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def _repr(self, indent: str, pre: str, post: str) -> str:
-        raise ak._util.error(NotImplementedError)
+        raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -512,7 +512,7 @@ class NumpyArray(Content):
 
         tmp = self._nplike.index_nplike.empty(length, self.dtype)
         self._handle_error(
-            self._nplike[  # noqa: E231
+            self._nplike[
                 "awkward_NumpyArray_fill",
                 self.dtype.type,
                 self._data.dtype.type,
@@ -681,7 +681,7 @@ class NumpyArray(Content):
             out = self._nplike.empty(offsets[1], dtype)
             assert offsets.nplike is self._nplike
             self._handle_error(
-                self._nplike[  # noqa: E231
+                self._nplike[
                     "awkward_sort",
                     dtype.type,
                     dtype.type,
@@ -701,11 +701,11 @@ class NumpyArray(Content):
             nextlength = ak.index.Index64.empty(1, self._nplike)
             assert nextlength.nplike is self._nplike
             self._handle_error(
-                self._nplike[  # noqa: E231
+                self._nplike[
                     "awkward_unique",
                     out.dtype.type,
                     nextlength.dtype.type,
-                ](
+                ](  # noqa: E231
                     out,
                     out.shape[0],
                     nextlength.data,
@@ -749,7 +749,7 @@ class NumpyArray(Content):
             offsets = ak.index.Index64.empty(offsets_length[0], self._nplike)
             assert offsets.nplike is self._nplike and parents.nplike is self._nplike
             self._handle_error(
-                self._nplike[  # noqa: E231
+                self._nplike[
                     "awkward_sorting_ranges",
                     offsets.dtype.type,
                     parents.dtype.type,
@@ -1009,7 +1009,7 @@ class NumpyArray(Content):
             out = self._nplike.empty(self.length, dtype)
             assert offsets.nplike is self._nplike
             self._handle_error(
-                self._nplike[  # noqa: E231
+                self._nplike[
                     "awkward_sort",
                     dtype.type,
                     dtype.type,
@@ -1084,7 +1084,7 @@ class NumpyArray(Content):
         assert self._data.ndim == 1
 
         if isinstance(self.nplike, ak.nplikes.Jax):
-            from awkward._connect.jax.reducers import get_jax_reducer  # noqa: F401
+            from awkward._connect.jax.reducers import get_jax_reducer
 
             reducer = get_jax_reducer(reducer)
         out = reducer.apply(self, parents, outlength)

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -406,7 +406,7 @@ class Form:
         raise _errors.wrap_error(NotImplementedError)
 
     def _to_dict_part(self, verbose, toplevel):
-        raise _errors._errors(NotImplementedError)
+        raise _errors.wrap_error(NotImplementedError)
 
     def _type(self, typestrs):
         raise _errors.wrap_error(NotImplementedError)

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -12,7 +12,7 @@ numpy = nplikes.Numpy()
 
 
 def assert_never(arg) -> None:
-    raise AssertionError(f"this should never be run: {arg}")
+    raise ak._errors.wrap_error(AssertionError(f"this should never be run: {arg}"))
 
 
 class _RegistrationState(enum.Enum):

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -109,7 +109,7 @@ def _register():
                 jax_connect.register_pytree_class(cls)
         except Exception:
             _registration_state = _RegistrationState.FAILED
-            raise
+            raise  # noqa: AK101
         else:
             _registration_state = _RegistrationState.SUCCESS
 

--- a/tests-cuda/test_1276-cuda-num.py
+++ b/tests-cuda/test_1276-cuda-num.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import cupy as cp  # noqa: F401
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_num_1():

--- a/tests-cuda/test_1276-cuda-transfers.py
+++ b/tests-cuda/test_1276-cuda-transfers.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import cupy as cp  # noqa: F401
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_tocuda():

--- a/tests-cuda/test_1276-cupy-interop.py
+++ b/tests-cuda/test_1276-cupy-interop.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import cupy as cp  # noqa: F401
-import numpy as np  # noqa: F401
+import cupy as cp
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_cupy_interop():

--- a/tests-cuda/test_1276-from-cupy.py
+++ b/tests-cuda/test_1276-from-cupy.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import cupy as cp  # noqa: F401
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import cupy as cp
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_from_cupy():

--- a/tests-cuda/test_1381-check-errors.py
+++ b/tests-cuda/test_1381-check-errors.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import cupy as cp  # noqa: F401
+import cupy as cp
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 import awkward._connect.cuda
 
 

--- a/tests/test_0002-minimal-listarray.py
+++ b/tests/test_0002-minimal-listarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0006-deep-iteration.py
+++ b/tests/test_0006-deep-iteration.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_iterator():

--- a/tests/test_0008-slices-and-getitem.py
+++ b/tests/test_0008-slices-and-getitem.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0011-listarray.py
+++ b/tests/test_0011-listarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0013-error-handling-struct.py
+++ b/tests/test_0013-error-handling-struct.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_numpyarray():

--- a/tests/test_0014-finish-up-getitem.py
+++ b/tests/test_0014-finish-up-getitem.py
@@ -2,10 +2,10 @@
 
 import itertools
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0019-use-json-library.py
+++ b/tests/test_0019-use-json-library.py
@@ -7,10 +7,10 @@ import pathlib
 # FIXME: for float32
 import re
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 simpledec = re.compile(r"\d*\.\d+")
 

--- a/tests/test_0020-support-unsigned-indexes.py
+++ b/tests/test_0020-support-unsigned-indexes.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0021-emptyarray.py
+++ b/tests/test_0021-emptyarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0023-regular-array.py
+++ b/tests/test_0023-regular-array.py
@@ -2,10 +2,10 @@
 
 import itertools
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0024-use-regular-array.py
+++ b/tests/test_0024-use-regular-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0025-record-array.py
+++ b/tests/test_0025-record-array.py
@@ -2,10 +2,10 @@
 
 import json
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0028-add-dressed-types.py
+++ b/tests/test_0028-add-dressed-types.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0032-replace-dressedtype.py
+++ b/tests/test_0032-replace-dressedtype.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0046-start-indexedarray.py
+++ b/tests/test_0046-start-indexedarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
+++ b/tests/test_0049-distinguish-record-and-recordarray-behaviors.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 class Pointy(ak.highlevel.Record):

--- a/tests/test_0057-introducing-forms.py
+++ b/tests/test_0057-introducing-forms.py
@@ -6,7 +6,7 @@ import pickle
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_forms():

--- a/tests/test_0070-argmin-and-argmax.py
+++ b/tests/test_0070-argmin-and-argmax.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0072-fillna-operation.py
+++ b/tests/test_0072-fillna-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0074-argsort-and-sort.py
+++ b/tests/test_0074-argsort-and-sort.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0077-zip-operation.py
+++ b/tests/test_0077-zip-operation.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0078-argcross-and-cross.py
+++ b/tests/test_0078-argcross-and-cross.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0079-argchoose-and-choose.py
+++ b/tests/test_0079-argchoose-and-choose.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
+++ b/tests/test_0080-flatpandas-multiindex-rows-and-columns.py
@@ -3,10 +3,10 @@
 import json
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 import setuptools
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pandas = pytest.importorskip("pandas")
 

--- a/tests/test_0084-start-unionarray.py
+++ b/tests/test_0084-start-unionarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0086-nep13-ufunc.py
+++ b/tests/test_0086-nep13-ufunc.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0089-numpy-functions.py
+++ b/tests/test_0089-numpy-functions.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0093-simplify-uniontypes-and-optiontypes.py
+++ b/tests/test_0093-simplify-uniontypes-and-optiontypes.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0107-assign-fields-to-records.py
+++ b/tests/test_0107-assign-fields-to-records.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0111-jagged-and-masked-getitem.py
+++ b/tests/test_0111-jagged-and-masked-getitem.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0115-generic-reducer-operation.py
+++ b/tests/test_0115-generic-reducer-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0118-numba-cpointers.py
+++ b/tests/test_0118-numba-cpointers.py
@@ -3,10 +3,10 @@
 import operator
 import sys
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0119-numexpr-and-broadcast-arrays.py
+++ b/tests/test_0119-numexpr-and-broadcast-arrays.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 
@@ -24,7 +24,7 @@ def test_numexpr():
     # NumExpr's interface pulls variables from the surrounding scope,
     # so these F841 "unused variables" actually are used.
 
-    a = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], check_valid=True)  # noqa: F841
+    a = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], check_valid=True)
     b = ak.Array([100, 200, 300], check_valid=True)  # noqa: F841
     assert to_list(ak._connect.numexpr.evaluate("a + b")) == [
         [101.1, 102.2, 103.3],

--- a/tests/test_0124-strings-in-numba.py
+++ b/tests/test_0124-strings-in-numba.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0127-tomask-operation.py
+++ b/tests/test_0127-tomask-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0127b-tomask-operation-numba.py
+++ b/tests/test_0127b-tomask-operation-numba.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0138-emptyarray-type.py
+++ b/tests/test_0138-emptyarray-type.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0150-flatten.py
+++ b/tests/test_0150-flatten.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0163-negative-axis-wrap.py
+++ b/tests/test_0163-negative-axis-wrap.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0166-0167-0170-random-issues.py
+++ b/tests/test_0166-0167-0170-random-issues.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0173-astype-operation.py
+++ b/tests/test_0173-astype-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0184-concatenate-operation.py
+++ b/tests/test_0184-concatenate-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0193-is_none-axis-parameter.py
+++ b/tests/test_0193-is_none-axis-parameter.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0198-tutorial-documentation-1.py
+++ b/tests/test_0198-tutorial-documentation-1.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0222-count-with-axis0.py
+++ b/tests/test_0222-count-with-axis0.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0224-arrow-to-awkward.py
+++ b/tests/test_0224-arrow-to-awkward.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 pytest.importorskip("awkward._connect.pyarrow")

--- a/tests/test_0264-reduce-last-empty.py
+++ b/tests/test_0264-reduce-last-empty.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0273-path-for-with-field.py
+++ b/tests/test_0273-path-for-with-field.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0286-broadcast-single-value-with-field.py
+++ b/tests/test_0286-broadcast-single-value-with-field.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0290-bug-fixes-for-hats.py
+++ b/tests/test_0290-bug-fixes-for-hats.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0315-integerindex.py
+++ b/tests/test_0315-integerindex.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0331-pandas-indexedarray.py
+++ b/tests/test_0331-pandas-indexedarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0334-fully-broadcastable-where.py
+++ b/tests/test_0334-fully-broadcastable-where.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0339-highlevel-sorting-function.py
+++ b/tests/test_0339-highlevel-sorting-function.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0348-form-keys.py
+++ b/tests/test_0348-form-keys.py
@@ -2,10 +2,10 @@
 
 import pickle
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ak_Array = ak.highlevel.Array
 ak_Record = ak.highlevel.Record

--- a/tests/test_0355-mixins.py
+++ b/tests/test_0355-mixins.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -2,10 +2,10 @@
 
 import numbers  # noqa: F401
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0395-fix-numba-indexedarray.py
+++ b/tests/test_0395-fix-numba-indexedarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0397-arrays-as-constants-in-numba.py
+++ b/tests/test_0397-arrays-as-constants-in-numba.py
@@ -3,9 +3,9 @@
 import sys
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
+++ b/tests/test_0401-add-categorical-type-for-arrow-dictionary.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0404-array-validity-check.py
+++ b/tests/test_0404-array-validity-check.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/master/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0410-fix-argminmax-positions-for-missing-values.py
+++ b/tests/test_0410-fix-argminmax-positions-for-missing-values.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0437-stream-of-many-json-files.py
+++ b/tests/test_0437-stream-of-many-json-files.py
@@ -2,10 +2,10 @@
 
 from pathlib import Path
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 samples_path = Path(__file__).parent / "samples"
 

--- a/tests/test_0447-preserve-regularness-in-reduce.py
+++ b/tests/test_0447-preserve-regularness-in-reduce.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0449-merge-many-arrays-in-one-pass.py
+++ b/tests/test_0449-merge-many-arrays-in-one-pass.py
@@ -2,10 +2,10 @@
 
 import itertools
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0493-zeros-ones-full-like.py
+++ b/tests/test_0493-zeros-ones-full-like.py
@@ -2,10 +2,10 @@
 
 import datetime
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0496-provide-local-index.py
+++ b/tests/test_0496-provide-local-index.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0499-getitem-indexedarray-bug.py
+++ b/tests/test_0499-getitem-indexedarray-bug.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0504-block-ufuncs-for-strings.py
+++ b/tests/test_0504-block-ufuncs-for-strings.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0511-copy-and-deepcopy.py
+++ b/tests/test_0511-copy-and-deepcopy.py
@@ -2,10 +2,10 @@
 
 import copy
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
+++ b/tests/test_0527-fix-unionarray-ufuncs-and-parameters-in-merging.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 # https://github.com/scikit-hep/awkward-1.0/issues/459#issuecomment-694941328
 #

--- a/tests/test_0546-fill_none-replacement-value-type.py
+++ b/tests/test_0546-fill_none-replacement-value-type.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0549-numba-array-asarray.py
+++ b/tests/test_0549-numba-array-asarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0557-min-max-initial-argument.py
+++ b/tests/test_0557-min-max-initial-argument.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0559-fix-booleans-in-numba.py
+++ b/tests/test_0559-fix-booleans-in-numba.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0572-numba-array-ndim.py
+++ b/tests/test_0572-numba-array-ndim.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0582-propagate-context-in-broadcast_and_apply.py
+++ b/tests/test_0582-propagate-context-in-broadcast_and_apply.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0583-implement-unflatten-function.py
+++ b/tests/test_0583-implement-unflatten-function.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0590-allow-regulararray-size-zero.py
+++ b/tests/test_0590-allow-regulararray-size-zero.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0593-preserve-nullability-in-arrow-and-parquet.py
+++ b/tests/test_0593-preserve-nullability-in-arrow-and-parquet.py
@@ -2,10 +2,10 @@
 
 # import os
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0627-behavior-from-dict-of-arrays.py
+++ b/tests/test_0627-behavior-from-dict-of-arrays.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0652-tests-of-complex-numbers.py
+++ b/tests/test_0652-tests-of-complex-numbers.py
@@ -2,10 +2,10 @@
 
 import json
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_from_iter():

--- a/tests/test_0674-categorical-validation.py
+++ b/tests/test_0674-categorical-validation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0713-getitem_field-should-simplify_optiontype.py
+++ b/tests/test_0713-getitem_field-should-simplify_optiontype.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0723-ensure-that-jagged-slice-fits-array-length.py
+++ b/tests/test_0723-ensure-that-jagged-slice-fits-array-length.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_first_issue():

--- a/tests/test_0730-unflatten-axis-parameter.py
+++ b/tests/test_0730-unflatten-axis-parameter.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0733-run_lengths.py
+++ b/tests/test_0733-run_lengths.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0736-implement-argsort-for-strings.py
+++ b/tests/test_0736-implement-argsort-for-strings.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_but_first_fix_sort():

--- a/tests/test_0758-ak-zip-scallars.py
+++ b/tests/test_0758-ak-zip-scallars.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0766-prevent-combinations-of-characters.py
+++ b/tests/test_0766-prevent-combinations-of-characters.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0773-typeparser.py
+++ b/tests/test_0773-typeparser.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 from awkward.types.listtype import ListType
 from awkward.types.numpytype import NumpyType
 from awkward.types.optiontype import OptionType

--- a/tests/test_0788-indexedarray-carrying-recordarray-parameters.py
+++ b/tests/test_0788-indexedarray-carrying-recordarray-parameters.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0794-ak-cartesian-on-empty-array.py
+++ b/tests/test_0794-ak-cartesian-on-empty-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0803-argsort-fix-type.py
+++ b/tests/test_0803-argsort-fix-type.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_argsort():

--- a/tests/test_0806-empty-lists-cartesian-fix.py
+++ b/tests/test_0806-empty-lists-cartesian-fix.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0813-full-like-dtype-arg.py
+++ b/tests/test_0813-full-like-dtype-arg.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0815-broadcast-union-types-to-all-possibilities.py
+++ b/tests/test_0815-broadcast-union-types-to-all-possibilities.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0819-issue.py
+++ b/tests/test_0819-issue.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0828-arrow-datatype-null.py
+++ b/tests/test_0828-arrow-datatype-null.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0835-datetime-type-pandas.py
+++ b/tests/test_0835-datetime-type-pandas.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pandas = pytest.importorskip("pandas")
 

--- a/tests/test_0835-datetime-type-pyarrow.py
+++ b/tests/test_0835-datetime-type-pyarrow.py
@@ -2,10 +2,10 @@
 
 import datetime
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0835-datetime-type.py
+++ b/tests/test_0835-datetime-type.py
@@ -2,10 +2,10 @@
 
 import datetime
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0850-argsort-mask-array.py
+++ b/tests/test_0850-argsort-mask-array.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0863-is-none-numpy-array.py
+++ b/tests/test_0863-is-none-numpy-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_numpy_array():

--- a/tests/test_0866-getitem_field-and-flatten-unions.py
+++ b/tests/test_0866-getitem_field-and-flatten-unions.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0875-arrow-null-type.py
+++ b/tests/test_0875-arrow-null-type.py
@@ -3,9 +3,9 @@
 import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0879-non-primitive-with-field.py
+++ b/tests/test_0879-non-primitive-with-field.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_unknown_type():

--- a/tests/test_0884-index-and-identifier-refactoring.py
+++ b/tests/test_0884-index-and-identifier-refactoring.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_index32():

--- a/tests/test_0889-ptp.py
+++ b/tests/test_0889-ptp.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_regular():

--- a/tests/test_0896-content-classes-refactoring.py
+++ b/tests/test_0896-content-classes-refactoring.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_EmptyArray():

--- a/tests/test_0898-unzip-heterogeneous-records.py
+++ b/tests/test_0898-unzip-heterogeneous-records.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0903-ArrayView-expects-contiguous-NumpyArrays.py
+++ b/tests/test_0903-ArrayView-expects-contiguous-NumpyArrays.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_0905-leading-zeros-in-unflatten.py
+++ b/tests/test_0905-leading-zeros-in-unflatten.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0906-arrow-fixed-size-list-type.py
+++ b/tests/test_0906-arrow-fixed-size-list-type.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 

--- a/tests/test_0910-unflatten-counts-relation.py
+++ b/tests/test_0910-unflatten-counts-relation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0912-packed.py
+++ b/tests/test_0912-packed.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0914-types-and-forms.py
+++ b/tests/test_0914-types-and-forms.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_UnknownType():

--- a/tests/test_0916-datetime-values-astype.py
+++ b/tests/test_0916-datetime-values-astype.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0927-numpy-array-nbytes.py
+++ b/tests/test_0927-numpy-array-nbytes.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():
@@ -91,7 +91,7 @@ def test_EmptyArray_nbytes():
 def test_IndexedArray_nbytes():
     np_index = np.array([2, 2, 0, 1, 4, 5, 4])
     np_content = np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-    array = ak.contents.indexedarray.IndexedArray(  # noqa: F841
+    array = ak.contents.indexedarray.IndexedArray(
         ak.index.Index(np_index),
         ak.contents.numpyarray.NumpyArray(np_content),
     )
@@ -101,7 +101,7 @@ def test_IndexedArray_nbytes():
 def test_IndexedOptionArray_nbytes():
     np_index = np.array([2, 2, -1, 1, -1, 5, 4])
     np_content = np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
-    array = ak.contents.indexedoptionarray.IndexedOptionArray(  # noqa: F841
+    array = ak.contents.indexedoptionarray.IndexedOptionArray(
         ak.index.Index(np_index),
         ak.contents.numpyarray.NumpyArray(np_content),
     )
@@ -112,7 +112,7 @@ def test_ListArray_nbytes():
     np_starts = np.array([4, 100, 1])
     np_stops = np.array([7, 100, 3, 200])
     np_content = np.array([6.6, 4.4, 5.5, 7.7, 3.3, 2.2, 1.1, 8.8])
-    array = ak.contents.listarray.ListArray(  # noqa: F841
+    array = ak.contents.listarray.ListArray(
         ak.index.Index(np_starts),
         ak.index.Index(np_stops),
         ak.contents.numpyarray.NumpyArray(np_content),
@@ -141,7 +141,7 @@ def test_RecordArray_nbytes():
 
 def test_RegularArray_nbytes():
     np_content = np.array([0.0, 1.1, 2.2, 33.33, 4.4, 5.5, -6.6])
-    array = ak.contents.regulararray.RegularArray(  # noqa: F841
+    array = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
             [ak.contents.numpyarray.NumpyArray(np_content)],
             ["nest"],

--- a/tests/test_0930-bug-in-unionarray-purelist_parameter.py
+++ b/tests/test_0930-bug-in-unionarray-purelist_parameter.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0945-argsort-sort-nan-array.py
+++ b/tests/test_0945-argsort-sort-nan-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0958-new-forms-must-accept-old-form-json.py
+++ b/tests/test_0958-new-forms-must-accept-old-form-json.py
@@ -5,7 +5,7 @@ import json
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_EmptyArray():

--- a/tests/test_0959-_getitem_array-implementation.py
+++ b/tests/test_0959-_getitem_array-implementation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0975-mask-multidimensional-numpy-array.py
+++ b/tests/test_0975-mask-multidimensional-numpy-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0979-where-multidimentional-numpy-array.py
+++ b/tests/test_0979-where-multidimentional-numpy-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0982-missing-case-in-nonlocal-reducers.py
+++ b/tests/test_0982-missing-case-in-nonlocal-reducers.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_0984-ravel.py
+++ b/tests/test_0984-ravel.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_0992-correct-ptp-unmasking.py
+++ b/tests/test_0992-correct-ptp-unmasking.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
+++ b/tests/test_1000-fixes-argmax-for-ListOffsetArray-with-nonzero-start.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1006-packed-regular-array-zero-size.py
+++ b/tests/test_1006-packed-regular-array-zero-size.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1007-from_buffers-empty-ndarray.py
+++ b/tests/test_1007-from_buffers-empty-ndarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1017-numpyarray-broadcast.py
+++ b/tests/test_1017-numpyarray-broadcast.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1030-mixin-class-name.py
+++ b/tests/test_1030-mixin-class-name.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 behavior = {}
 

--- a/tests/test_1031b-start-getitem_next-specialized.py
+++ b/tests/test_1031b-start-getitem_next-specialized.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1049-concatenate-single-array.py
+++ b/tests/test_1049-concatenate-single-array.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_single_numpy_array():

--- a/tests/test_1055-fill_none-numpy-dimension.py
+++ b/tests/test_1055-fill_none-numpy-dimension.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1059-localindex.py
+++ b/tests/test_1059-localindex.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 
@@ -610,7 +610,7 @@ def test_unionarray_localindex():
 
 
 def test_recordarray_localindex():
-    v2_array = ak.contents.regulararray.RegularArray(  # noqa: F841
+    v2_array = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
             [
                 ak.contents.numpyarray.NumpyArray(
@@ -635,7 +635,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(2)
 
-    v2_array = ak.contents.regulararray.RegularArray(  # noqa: F841
+    v2_array = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
             [ak.contents.emptyarray.EmptyArray()], ["nest"]
         ),
@@ -699,7 +699,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(-3)
 
-    v2_array = ak.contents.listarray.ListArray(  # noqa: F841
+    v2_array = ak.contents.listarray.ListArray(
         ak.index.Index(np.array([4, 100, 1])),
         ak.index.Index(np.array([7, 100, 3, 200])),
         ak.contents.recordarray.RecordArray(
@@ -726,7 +726,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(2)
 
-    v2_array = ak.contents.listoffsetarray.ListOffsetArray(  # noqa: F841
+    v2_array = ak.contents.listoffsetarray.ListOffsetArray(
         ak.index.Index(np.array([1, 4, 4, 6])),
         ak.contents.recordarray.RecordArray(
             [ak.contents.numpyarray.NumpyArray([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])],
@@ -747,7 +747,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(2)
 
-    v2_array = ak.contents.indexedarray.IndexedArray(  # noqa: F841
+    v2_array = ak.contents.indexedarray.IndexedArray(
         ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
         ak.contents.recordarray.RecordArray(
             [
@@ -768,7 +768,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.indexedoptionarray.IndexedOptionArray(  # noqa: F841
+    v2_array = ak.contents.indexedoptionarray.IndexedOptionArray(
         ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
         ak.contents.recordarray.RecordArray(
             [
@@ -789,7 +789,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(  # noqa: F841
+    v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(
         ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
         ak.contents.recordarray.RecordArray(
             [
@@ -812,7 +812,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(  # noqa: F841
+    v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(
         ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
         ak.contents.recordarray.RecordArray(
             [
@@ -924,7 +924,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
+    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
             np.packbits(
                 np.array(
@@ -1015,7 +1015,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
+    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
             np.packbits(
                 np.array(
@@ -1109,7 +1109,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(  # noqa: F841
+    v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
             np.packbits(
                 np.array(
@@ -1203,7 +1203,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.unmaskedarray.UnmaskedArray(  # noqa: F841
+    v2_array = ak.contents.unmaskedarray.UnmaskedArray(
         ak.contents.recordarray.RecordArray(
             [
                 ak.contents.numpyarray.NumpyArray(
@@ -1224,7 +1224,7 @@ def test_recordarray_localindex():
     with pytest.raises(IndexError):
         v2_array.local_index(1)
 
-    v2_array = ak.contents.unionarray.UnionArray(  # noqa: F841
+    v2_array = ak.contents.unionarray.UnionArray(
         ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
         ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
         [

--- a/tests/test_1066-to_numpy-masked-structured-array.py
+++ b/tests/test_1066-to_numpy-masked-structured-array.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1071-mask-identity-false-should-not-return-option-type.py
+++ b/tests/test_1071-mask-identity-false-should-not-return-option-type.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1072-sort.py
+++ b/tests/test_1072-sort.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 
@@ -301,7 +301,7 @@ def test_emptyarray_sort():
 
 
 def test_listarray_sort():
-    v2_array = ak.contents.listarray.ListArray(  # noqa: F841
+    v2_array = ak.contents.listarray.ListArray(
         ak.index.Index(np.array([4, 100, 1])),
         ak.index.Index(np.array([7, 100, 3, 200])),
         ak.contents.numpyarray.NumpyArray(
@@ -647,7 +647,7 @@ def test_unionarray_sort():
 
 
 def test_unionarray_sort_2():
-    v2_array = ak.contents.unionarray.UnionArray(  # noqa: F841
+    v2_array = ak.contents.unionarray.UnionArray(
         ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
         ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
         [
@@ -661,7 +661,7 @@ def test_unionarray_sort_2():
 
 
 def test_indexedarray_sort():
-    v2_array = ak.contents.indexedarray.IndexedArray(  # noqa: F841
+    v2_array = ak.contents.indexedarray.IndexedArray(
         ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
         ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
     )
@@ -671,7 +671,7 @@ def test_indexedarray_sort():
 
 
 def test_indexedoptionarray_sort():
-    v2_array = ak.contents.indexedoptionarray.IndexedOptionArray(  # noqa: F841
+    v2_array = ak.contents.indexedoptionarray.IndexedOptionArray(
         ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
         ak.contents.recordarray.RecordArray(
             [
@@ -828,7 +828,7 @@ def test_sort_zero_length_arrays():
 
 
 def test_recordarray_sort():
-    v2_array = ak.contents.regulararray.RegularArray(  # noqa: F841
+    v2_array = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
             [
                 ak.contents.numpyarray.NumpyArray(

--- a/tests/test_1074-combinations.py
+++ b/tests/test_1074-combinations.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 
@@ -1172,7 +1172,7 @@ def test_EmptyArray():
 
 
 def test_RecordArray():
-    v2_array = ak.contents.listarray.ListArray(  # noqa: F841
+    v2_array = ak.contents.listarray.ListArray(
         ak.index.Index(np.array([4, 100, 1])),
         ak.index.Index(np.array([7, 100, 3, 200])),
         ak.contents.recordarray.RecordArray(
@@ -1227,7 +1227,7 @@ def test_RecordArray():
 
 
 def test_UnionArray():
-    v2_array = ak.contents.unionarray.UnionArray(  # noqa: F841
+    v2_array = ak.contents.unionarray.UnionArray(
         ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
         ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
         [

--- a/tests/test_1075-validityerror.py
+++ b/tests/test_1075-validityerror.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_ListOffsetArray():
@@ -129,7 +129,7 @@ def test_EmptyArray():
 
 
 def test_RecordArray():
-    v2_array = ak.contents.listarray.ListArray(  # noqa: F841
+    v2_array = ak.contents.listarray.ListArray(
         ak.index.Index(np.array([4, 100, 1])),
         ak.index.Index(np.array([7, 100, 3, 200])),
         ak.contents.recordarray.RecordArray(
@@ -147,7 +147,7 @@ def test_RecordArray():
 
 
 def test_UnionArray():
-    v2_array = ak.contents.unionarray.UnionArray(  # noqa: F841
+    v2_array = ak.contents.unionarray.UnionArray(
         ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
         ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
         [

--- a/tests/test_1106-argminmax-axis-None-missing-values.py
+++ b/tests/test_1106-argminmax-axis-None-missing-values.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1110-type-tracer-1.py
+++ b/tests/test_1110-type-tracer-1.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 from awkward._typetracer import UnknownLength
 
 typetracer = ak._typetracer.TypeTracer.instance()

--- a/tests/test_1116-project-maskedarrays.py
+++ b/tests/test_1116-project-maskedarrays.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1125-to-arrow-from-arrow.py
+++ b/tests/test_1125-to-arrow-from-arrow.py
@@ -2,10 +2,10 @@
 
 import os
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 pyarrow_parquet = pytest.importorskip("pyarrow.parquet")

--- a/tests/test_1132-utility-methods-for-highlevel-functions.py
+++ b/tests/test_1132-utility-methods-for-highlevel-functions.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1134-from-buffers-to-buffers.py
+++ b/tests/test_1134-from-buffers-to-buffers.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ak_to_buffers = ak.operations.to_buffers
 ak_from_buffers = ak.operations.from_buffers

--- a/tests/test_1135-rpad-operation.py
+++ b/tests/test_1135-rpad-operation.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1136-regulararray-zeros-in-shape.py
+++ b/tests/test_1136-regulararray-zeros-in-shape.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_toRegularArray():

--- a/tests/test_1137-num.py
+++ b/tests/test_1137-num.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1142-numbers-to-type.py
+++ b/tests/test_1142-numbers-to-type.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_numbers_to_type():

--- a/tests/test_1149-datetime-sort.py
+++ b/tests/test_1149-datetime-sort.py
@@ -2,10 +2,10 @@
 
 import datetime
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1154-arrow-tables-should-preserve-parameters.py
+++ b/tests/test_1154-arrow-tables-should-preserve-parameters.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pytest.importorskip("pyarrow")
 

--- a/tests/test_1162-ak-from_json_schema.py
+++ b/tests/test_1162-ak-from_json_schema.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_boolean():

--- a/tests/test_1183-bugs-found-by-dask-project-2.py
+++ b/tests/test_1183-bugs-found-by-dask-project-2.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_example():

--- a/tests/test_1189-fix-singletons-for-non-optional-data.py
+++ b/tests/test_1189-fix-singletons-for-non-optional-data.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1192-iterables-in-__array_function__.py
+++ b/tests/test_1192-iterables-in-__array_function__.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1193-is-none-nested-option.py
+++ b/tests/test_1193-is-none-nested-option.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1233-ak-with_name.py
+++ b/tests/test_1233-ak-with_name.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1240-v2-implementation-of-numba-1.py
+++ b/tests/test_1240-v2-implementation-of-numba-1.py
@@ -2,10 +2,10 @@
 
 import sys
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1259-simplify_optiontype.py
+++ b/tests/test_1259-simplify_optiontype.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_byte_masked_array():

--- a/tests/test_1260-simplify-masked-option-types.py
+++ b/tests/test_1260-simplify-masked-option-types.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_byte_masked_array():

--- a/tests/test_1271-fix-4D-reducers.py
+++ b/tests/test_1271-fix-4D-reducers.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1294-to-and-from_parquet.py
+++ b/tests/test_1294-to-and-from_parquet.py
@@ -2,10 +2,10 @@
 
 import os.path
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow_parquet = pytest.importorskip("pyarrow.parquet")
 

--- a/tests/test_1298-allow-nan_to_num-arguments-to-be-arrays.py
+++ b/tests/test_1298-allow-nan_to_num-arguments-to-be-arrays.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1300-awkward-to-cpp-converter-with-cling.py
+++ b/tests/test_1300-awkward-to-cpp-converter-with-cling.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1300b-same-for-numba.py
+++ b/tests/test_1300b-same-for-numba.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numba = pytest.importorskip("numba")
 

--- a/tests/test_1305-mixed-awkward-numpy-slicing.py
+++ b/tests/test_1305-mixed-awkward-numpy-slicing.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1308-zip-after-option.py
+++ b/tests/test_1308-zip-after-option.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_all_options():

--- a/tests/test_1320-mask_identity-defaults.py
+++ b/tests/test_1320-mask_identity-defaults.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1344-broadcast-arrays-depth-limit.py
+++ b/tests/test_1344-broadcast-arrays-depth-limit.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1345-avro-reader.py
+++ b/tests/test_1345-avro-reader.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import os  # noqa: F401
+import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 DIR = os.path.dirname(__file__)
 SAMPLES_DIR = os.path.join(os.path.abspath(DIR), "samples")

--- a/tests/test_1351-is-tuple.py
+++ b/tests/test_1351-is-tuple.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 tuple = ak.contents.RecordArray([ak.contents.NumpyArray(np.arange(10))], None)
 record = ak.contents.RecordArray([ak.contents.NumpyArray(np.arange(10))], ["x"])

--- a/tests/test_1374-to-rdataframe.py
+++ b/tests/test_1374-to-rdataframe.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1379-reducers-with-axis-None-and-typetracers.py
+++ b/tests/test_1379-reducers-with-axis-None-and-typetracers.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1399-from-jax.py
+++ b/tests/test_1399-from-jax.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_enable_x64", True)

--- a/tests/test_1399-to-jax.py
+++ b/tests/test_1399-to-jax.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_enable_x64", True)

--- a/tests/test_1400-with_name-record.py
+++ b/tests/test_1400-with_name-record.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1403-from_numpy-strings.py
+++ b/tests/test_1403-from_numpy-strings.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_unicode():

--- a/tests/test_1405-slicing-untested-cases.py
+++ b/tests/test_1405-slicing-untested-cases.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_index_packed():

--- a/tests/test_1415-behaviour-forwarding.py
+++ b/tests/test_1415-behaviour-forwarding.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 @pytest.mark.parametrize("operation_behavior", [None, {"other-type": ak.Record}])

--- a/tests/test_1440-start-v2-to_parquet.py
+++ b/tests/test_1440-start-v2-to_parquet.py
@@ -3,10 +3,10 @@
 import io
 import os
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pyarrow = pytest.importorskip("pyarrow")
 pyarrow_parquet = pytest.importorskip("pyarrow.parquet")

--- a/tests/test_1449-v2-to_json-from_json-functions.py
+++ b/tests/test_1449-v2-to_json-from_json-functions.py
@@ -4,9 +4,9 @@ import base64
 import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_without_control():

--- a/tests/test_1453-write-single-records-to-parquet.py
+++ b/tests/test_1453-write-single-records-to-parquet.py
@@ -3,9 +3,9 @@
 import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pytest.importorskip("pyarrow")
 pytest.importorskip("pyarrow.parquet")

--- a/tests/test_1473-from-rdataframe.py
+++ b/tests/test_1473-from-rdataframe.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1477-generator-entry-type-as-rvec.py
+++ b/tests/test_1477-generator-entry-type-as-rvec.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1502-getitem-jagged-issue1406.py
+++ b/tests/test_1502-getitem-jagged-issue1406.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1508-awkward-from-rdataframe.py
+++ b/tests/test_1508-awkward-from-rdataframe.py
@@ -2,12 +2,12 @@
 
 import sys
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1511-set-attribute.py
+++ b/tests/test_1511-set-attribute.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_array():

--- a/tests/test_1539-isnone-axis-check-issue1417.py
+++ b/tests/test_1539-isnone-axis-check-issue1417.py
@@ -1,8 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1559_fix_ufuncs_records_1439.py
+++ b/tests/test_1559_fix_ufuncs_records_1439.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1565-axis_wrap_if_negative_record.py
+++ b/tests/test_1565-axis_wrap_if_negative_record.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1567-fix-longlong-in-Index.py
+++ b/tests/test_1567-fix-longlong-in-Index.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_fix_longlong_type_passed_to_index_1530():

--- a/tests/test_1568-fix-lengths-empty-regular-slices.py
+++ b/tests/test_1568-fix-lengths-empty-regular-slices.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 

--- a/tests/test_1578-to_arrow-empty-recordarray.py
+++ b/tests/test_1578-to_arrow-empty-recordarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pytest.importorskip("pyarrow")
 

--- a/tests/test_1586-concatenate-should-preserve-regulararray.py
+++ b/tests/test_1586-concatenate-should-preserve-regulararray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 from awkward.types import ArrayType, ListType, NumpyType, OptionType, RegularType
 
 

--- a/tests/test_1604-preserve-form-in-concatenate.py
+++ b/tests/test_1604-preserve-form-in-concatenate.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 from awkward.forms import (
     BitMaskedForm,
     ByteMaskedForm,

--- a/tests/test_1607_no_reducers_on_records.py
+++ b/tests/test_1607_no_reducers_on_records.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_reducers():

--- a/tests/test_1613-generator-tolayout-records.py
+++ b/tests/test_1613-generator-tolayout-records.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1619-from-parquet-empty-field.py
+++ b/tests/test_1619-from-parquet-empty-field.py
@@ -3,9 +3,9 @@
 import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 pytest.importorskip("pyarrow.parquet")
 

--- a/tests/test_1620-layout-builders.py
+++ b/tests/test_1620-layout-builders.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 
@@ -170,7 +170,7 @@ def test_data_frame_vec_of_vec():
     """,
     )
     assert rdf3.GetColumnType("output2") == "vector<vector<vector<double> > >"
-    out = ak.from_rdataframe(  # noqa: F841
+    out = ak.from_rdataframe(
         rdf3,
         columns=("output2",),
     )

--- a/tests/test_1625-multiple-columns-from-rdataframe.py
+++ b/tests/test_1625-multiple-columns-from-rdataframe.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 
@@ -170,7 +170,7 @@ def test_data_frame_vec_of_vec():
     )
     assert rdf4.GetColumnType("output2") == "vector<vector<vector<double> > >"
 
-    out = ak.from_rdataframe(  # noqa: F841
+    out = ak.from_rdataframe(
         rdf4,
         columns=(
             "output",

--- a/tests/test_1642-from_iter-of-tuples.py
+++ b/tests/test_1642-from_iter-of-tuples.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1644-concatenate-zeros-length.py
+++ b/tests/test_1644-concatenate-zeros-length.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1650-Record-to_list-should-listify-itself.py
+++ b/tests/test_1650-Record-to_list-should-listify-itself.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_record_nochange():

--- a/tests/test_1671-categorical-type.py
+++ b/tests/test_1671-categorical-type.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1672-broadcast-parameters.py
+++ b/tests/test_1672-broadcast-parameters.py
@@ -1,8 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numpy = ak.nplikes.Numpy.instance()
 

--- a/tests/test_1677-array-builder-in-numba.py
+++ b/tests/test_1677-array-builder-in-numba.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 nb = pytest.importorskip("numba")
 

--- a/tests/test_1688-pack-categorical.py
+++ b/tests/test_1688-pack-categorical.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numpy = ak.nplikes.Numpy.instance()
 

--- a/tests/test_1703-fill-none-typetracer.py
+++ b/tests/test_1703-fill-none-typetracer.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1707-broadcast-parameters-ufunc.py
+++ b/tests/test_1707-broadcast-parameters-ufunc.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numpy = ak.nplikes.Numpy.instance()
 

--- a/tests/test_1709-ak-array-constructor-behavior.py
+++ b/tests/test_1709-ak-array-constructor-behavior.py
@@ -2,7 +2,7 @@
 
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 numpy = ak.nplikes.Numpy.instance()
 

--- a/tests/test_1735-from-numpy-mask.py
+++ b/tests/test_1735-from-numpy-mask.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1747-bytemaskedarray-mergemany.py
+++ b/tests/test_1747-bytemaskedarray-mergemany.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1753-indexedarray-merge-kernel.py
+++ b/tests/test_1753-indexedarray-merge-kernel.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1765-add-ioanas-test-of-to_arraylib.py
+++ b/tests/test_1765-add-ioanas-test-of-to_arraylib.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1766-record-form-fields.py
+++ b/tests/test_1766-record-form-fields.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import numpy as np
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_new_style_record():

--- a/tests/test_1781-rdataframe-snapshot.py
+++ b/tests/test_1781-rdataframe-snapshot.py
@@ -3,9 +3,9 @@
 import os
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1784-reduce-leading-sublist.py
+++ b/tests/test_1784-reduce-leading-sublist.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1790-reduce-regulararray.py
+++ b/tests/test_1790-reduce-regulararray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1791-reduce-trailing-sublist.py
+++ b/tests/test_1791-reduce-trailing-sublist.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1794-run-lengths-empty-sublist.py
+++ b/tests/test_1794-run-lengths-empty-sublist.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_trailing_sublist():

--- a/tests/test_1823-fill-none-axis-none.py
+++ b/tests/test_1823-fill-none-axis-none.py
@@ -3,7 +3,7 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1826-ravel-preserve-none.py
+++ b/tests/test_1826-ravel-preserve-none.py
@@ -3,9 +3,9 @@
 import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 
 def test():

--- a/tests/test_1829-to-from-rdataframe-bool.py
+++ b/tests/test_1829-to-from-rdataframe-bool.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
-import pytest  # noqa: F401
+import pytest
 
-import awkward as ak  # noqa: F401
-import awkward._connect.cling  # noqa: E402
-import awkward._lookup  # noqa: E402
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 

--- a/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
+++ b/tests/test_1840-ak_type-to-handle-ndarray-dtype-and-nptypes.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_array():

--- a/tests/test_1847-numpy-array-contiguous.py
+++ b/tests/test_1847-numpy-array-contiguous.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test_reduce_1d_strided():

--- a/tests/test_1850-bytemasked-array-to-bytemaskedarray.py
+++ b/tests/test_1850-bytemasked-array-to-bytemaskedarray.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 
 def test():

--- a/tests/test_1867-pass-behavior-through-combinations.py
+++ b/tests/test_1867-pass-behavior-through-combinations.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numpy as np  # noqa: F401
+import numpy as np
 import pytest  # noqa: F401
 
-import awkward as ak  # noqa: F401
+import awkward as ak
 
 to_list = ak.operations.to_list
 


### PR DESCRIPTION
This PR:
- runs the `yesqa` tool to remove unnecessary `#noqa` comments. It doesn't seem to be perfect, so I've not added it to pre-commit in the end.
- fixes the flake8 configuration that was erroneously ignoring some `src` files (my bad!)
- catches some instances of exceptions not being raised

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-chore-yesqa/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->