### PR TITLE
feat: split nplike into two nplikes

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -118,9 +118,7 @@ def all_same_offsets(nplike, inputs):
                 return False
 
             elif offsets is None:
-                offsets = index_nplike.empty(
-                    starts.shape[0] + 1, dtype=starts.dtype
-                )
+                offsets = index_nplike.empty(starts.shape[0] + 1, dtype=starts.dtype)
                 if offsets.shape[0] == 1:
                     offsets[0] = 0
                 else:
@@ -600,9 +598,7 @@ def apply_step(
                 )
                 index = Index64(index)
                 if any(not isinstance(x, optiontypes) for x in inputs):
-                    nextindex = index_nplike.arange(
-                        mask.shape[0], dtype=np.int64
-                    )
+                    nextindex = index_nplike.arange(mask.shape[0], dtype=np.int64)
                     nextindex[mask] = -1
                     nextindex = Index64(nextindex)
 
@@ -622,9 +618,7 @@ def apply_step(
                 nextinputs = []
                 for x in inputs:
                     if isinstance(x, optiontypes):
-                        index = Index64(
-                            index_nplike.empty((x.length,), np.int64)
-                        )
+                        index = Index64(index_nplike.empty((x.length,), np.int64))
                         nextinputs.append(x.content)
                     else:
                         nextinputs.append(x)
@@ -662,9 +656,7 @@ def apply_step(
                             if maxsize > 1 and x.size == 1:
                                 tmpindex = Index64(
                                     index_nplike.repeat(
-                                        index_nplike.arange(
-                                            x.length, dtype=np.int64
-                                        ),
+                                        index_nplike.arange(x.length, dtype=np.int64),
                                         maxsize,
                                     ),
                                     nplike=nplike,
@@ -733,17 +725,13 @@ def apply_step(
                 for x in inputs:
                     if isinstance(x, ListOffsetArray):
                         offsets = Index64(
-                            index_nplike.empty(
-                                (x.offsets.data.shape[0],), np.int64
-                            ),
+                            index_nplike.empty((x.offsets.data.shape[0],), np.int64),
                             nplike=nplike,
                         )
                         nextinputs.append(x.content)
                     elif isinstance(x, ListArray):
                         offsets = Index64(
-                            index_nplike.empty(
-                                (x.starts.data.shape[0] + 1,), np.int64
-                            ),
+                            index_nplike.empty((x.starts.data.shape[0] + 1,), np.int64),
                             nplike=nplike,
                         )
                         nextinputs.append(x.content)

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -53,9 +53,7 @@ def broadcast_pack(inputs, isscalar):
             isscalar.append(True)
         elif isinstance(x, Content):
             nextinputs.append(
-                RegularArray(
-                    x, x.length if x.nplike.known_shape else 1, 1, None, x.nplike
-                )
+                RegularArray(x, x.length if x.nplike.known_shape else 1, 1, None)
             )
             isscalar.append(False)
         else:

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -82,11 +82,21 @@ class Sum(Reducer):
         result = jax.ops.segment_sum(array.data, parents.data)
 
         if array.dtype.kind == "m":
-            return ak.contents.NumpyArray(array.nplike.asarray(result, array.dtype))
+            return ak.contents.NumpyArray(
+                array.nplike.asarray(result, array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         elif array.dtype.type in (np.complex128, np.complex64):
-            return ak.contents.NumpyArray(result.view(array.dtype))
+            return ak.contents.NumpyArray(
+                result.view(array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         else:
-            return ak.contents.NumpyArray(result, nplike=array.nplike)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 class Prod(Reducer):
@@ -102,9 +112,15 @@ class Prod(Reducer):
         )
 
         if array.dtype.type in (np.complex128, np.complex64):
-            return ak.contents.NumpyArray(result.view(array.dtype), nplike=array.nplike)
+            return ak.contents.NumpyArray(
+                result.view(array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         else:
-            return ak.contents.NumpyArray(result, nplike=array.nplike)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 class Any(Reducer):
@@ -121,7 +137,9 @@ class Any(Reducer):
         result = jax.ops.segment_max(array.data, parents.data)
         result = jax.numpy.asarray(result, dtype=bool)
 
-        return ak.contents.NumpyArray(result, nplike=array.nplike)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class All(Reducer):
@@ -138,7 +156,9 @@ class All(Reducer):
         result = jax.ops.segment_min(array.data, parents.data)
         result = jax.numpy.asarray(result, dtype=bool)
 
-        return ak.contents.NumpyArray(result, nplike=array.nplike)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class Min(Reducer):
@@ -182,9 +202,12 @@ class Min(Reducer):
             return ak.contents.NumpyArray(
                 array.nplike.array(result.view(array.dtype), array.dtype),
                 nplike=array.nplike,
+                index_nplike=array.index_nplike,
             )
         else:
-            return ak.contents.NumpyArray(result, nplike=array.nplike)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 class Max(Reducer):
@@ -228,9 +251,12 @@ class Max(Reducer):
             return ak.contents.NumpyArray(
                 array.nplike.array(result.view(array.dtype), array.dtype),
                 nplike=array.nplike,
+                index_nplike=array.index_nplike,
             )
         else:
-            return ak.contents.NumpyArray(result, nplike=array.nplike)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 def get_jax_reducer(reducer: Reducer) -> Reducer:

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -42,7 +42,12 @@ def replace_all_buffers(
             if not (numpy.is_own_array(buffer) or jax.is_own_array(buffer)):
                 return
             else:
-                return ak.contents.NumpyArray(buffer, node.parameters, nplike=nplike)
+                return ak.contents.NumpyArray(
+                    buffer,
+                    node.parameters,
+                    nplike=nplike,
+                    index_nplike=ak.nplikes.index_nplike_for(nplike),
+                )
 
     return layout.recursively_apply(action=action, numpy_to_regular=False)
 

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -152,6 +152,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             for x in inputs
         ):
             nplike = ak.nplikes.nplike_of(*inputs)
+            index_nplike = ak.nplikes.index_nplike_for(nplike)
 
             # Broadcast parameters against one another
             parameters_factory = ak._broadcasting.intersection_parameters_factory(
@@ -186,7 +187,14 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                 assert shape is not None
                 tmp = getattr(ufunc, method)(*args, **kwargs)
                 result = nplike.empty((shape[0],) + tmp.shape[1:], tmp.dtype)
-            return (NumpyArray(result, nplike=nplike, parameters=parameters),)
+            return (
+                NumpyArray(
+                    result,
+                    nplike=nplike,
+                    index_nplike=index_nplike,
+                    parameters=parameters,
+                ),
+            )
 
         for x in inputs:
             if isinstance(x, ak.contents.Content):

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -492,6 +492,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
                 numpy.frombuffer(pacontent, dtype=np.uint8),
                 parameters=sub_parameters,
                 nplike=ak.nplikes.Numpy.instance(),
+                index_nplike=ak.nplikes.Numpy.instance(),
             ),
             storage_type.byte_width,
             parameters=parameters,
@@ -528,6 +529,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
                 numpy.frombuffer(pacontent, dtype=np.uint8),
                 parameters=sub_parameters,
                 nplike=ak.nplikes.Numpy.instance(),
+                index_nplike=ak.nplikes.Numpy.instance(),
             ),
             parameters=parameters,
         )
@@ -628,6 +630,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
             bytedata.view(np.bool_),
             parameters=node_parameters(awkwardarrow_type),
             nplike=ak.nplikes.Numpy.instance(),
+            index_nplike=ak.nplikes.Numpy.instance(),
         )
         return popbuffers_finalize(
             out, paarray, validbits, awkwardarrow_type, generate_bitmasks
@@ -648,6 +651,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
             numpy.frombuffer(data, dtype=dt),
             parameters=node_parameters(awkwardarrow_type),
             nplike=ak.nplikes.Numpy.instance(),
+            index_nplike=ak.nplikes.Numpy.instance(),
         )
         return popbuffers_finalize(
             out, paarray, validbits, awkwardarrow_type, generate_bitmasks

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -82,7 +82,9 @@ class ArgMin(Reducer):
                     outlength,
                 )
             )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class ArgMax(Reducer):
@@ -131,7 +133,9 @@ class ArgMax(Reducer):
                     outlength,
                 )
             )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class Count(Reducer):
@@ -157,7 +161,9 @@ class Count(Reducer):
                 outlength,
             )
         )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class CountNonzero(Reducer):
@@ -205,7 +211,9 @@ class CountNonzero(Reducer):
                     outlength,
                 )
             )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class Sum(Reducer):
@@ -295,11 +303,21 @@ class Sum(Reducer):
             )
 
         if array.dtype.kind == "m":
-            return ak.contents.NumpyArray(array.nplike.asarray(result, array.dtype))
+            return ak.contents.NumpyArray(
+                array.nplike.asarray(result, array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         elif array.dtype.type in (np.complex128, np.complex64):
-            return ak.contents.NumpyArray(result.view(array.dtype))
+            return ak.contents.NumpyArray(
+                result.view(array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         else:
-            return ak.contents.NumpyArray(result)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 class Prod(Reducer):
@@ -375,9 +393,15 @@ class Prod(Reducer):
                 )
             )
         if array.dtype.type in (np.complex128, np.complex64):
-            return ak.contents.NumpyArray(result.view(array.dtype))
+            return ak.contents.NumpyArray(
+                result.view(array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
         else:
-            return ak.contents.NumpyArray(result)
+            return ak.contents.NumpyArray(
+                result, nplike=array.nplike, index_nplike=array.index_nplike
+            )
 
 
 class Any(Reducer):
@@ -425,7 +449,9 @@ class Any(Reducer):
                     outlength,
                 )
             )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class All(Reducer):
@@ -473,7 +499,9 @@ class All(Reducer):
                     outlength,
                 )
             )
-        return ak.contents.NumpyArray(result)
+        return ak.contents.NumpyArray(
+            result, nplike=array.nplike, index_nplike=array.index_nplike
+        )
 
 
 class Min(Reducer):
@@ -565,10 +593,16 @@ class Min(Reducer):
             )
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.nplike.array(result.view(array.dtype), array.dtype)
+                array.nplike.array(result.view(array.dtype), array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
             )
         else:
-            return ak.contents.NumpyArray(array.nplike.array(result, array.dtype))
+            return ak.contents.NumpyArray(
+                array.nplike.array(result, array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )
 
 
 class Max(Reducer):
@@ -660,7 +694,13 @@ class Max(Reducer):
             )
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.nplike.array(result.view(array.dtype), array.dtype)
+                array.nplike.array(result.view(array.dtype), array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
             )
         else:
-            return ak.contents.NumpyArray(array.nplike.array(result, array.dtype))
+            return ak.contents.NumpyArray(
+                array.nplike.array(result, array.dtype),
+                nplike=array.nplike,
+                index_nplike=array.index_nplike,
+            )

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -303,14 +303,14 @@ def normalise_item_nested(item):
         ),
     ):
         is_valid = item.mask_as_bool(valid_when=True)
-        positions_where_valid = item.nplike.index_nplike.nonzero(is_valid)[0]
+        positions_where_valid = item.index_nplike.nonzero(is_valid)[0]
 
         nextcontent = normalise_item_nested(
             item.content._carry(ak.index.Index64(positions_where_valid), False)
         )
 
-        nextindex = item.nplike.index_nplike.full(is_valid.shape[0], -1, np.int64)
-        nextindex[positions_where_valid] = item.nplike.index_nplike.arange(
+        nextindex = item.index_nplike.full(is_valid.shape[0], -1, np.int64)
+        nextindex[positions_where_valid] = item.index_nplike.arange(
             positions_where_valid.shape[0], dtype=np.int64
         )
 
@@ -357,11 +357,11 @@ def normalise_item_bool_to_int(item):
             localindex = item.local_index(axis=1)
             nextcontent = localindex.content.data[item.content.data]
 
-            cumsum = item.nplike.index_nplike.empty(
+            cumsum = item.index_nplike.empty(
                 item.content.data.shape[0] + 1, np.int64
             )
             cumsum[0] = 0
-            cumsum[1:] = item.nplike.index_nplike.asarray(
+            cumsum[1:] = item.index_nplike.asarray(
                 item.nplike.cumsum(item.content.data)
             )
             nextoffsets = cumsum[item.offsets]
@@ -392,7 +392,7 @@ def normalise_item_bool_to_int(item):
                 )
             # missing values as any integer other than -1 are extremely rare
             isnegative = item.content.index.data < 0
-            if item.nplike.index_nplike.any(item.content.index.data < -1):
+            if item.index_nplike.any(item.content.index.data < -1):
                 safeindex = item.content.index.data.copy()
                 safeindex[isnegative] = -1
             else:
@@ -420,8 +420,8 @@ def normalise_item_bool_to_int(item):
             nextoffsets = cumsum[item.offsets]
 
             # outindex fits into the lists; non-missing are sequential
-            outindex = item.nplike.index_nplike.full(nextoffsets[-1], -1, np.int64)
-            outindex[~isnegative[expanded]] = item.nplike.index_nplike.arange(
+            outindex = item.index_nplike.full(nextoffsets[-1], -1, np.int64)
+            outindex[~isnegative[expanded]] = item.index_nplike.arange(
                 nextcontent.shape[0], dtype=np.int64
             )
 
@@ -463,7 +463,7 @@ def normalise_item_bool_to_int(item):
                     )
                 # missing values as any integer other than -1 are extremely rare
                 isnegative = item.index.data < 0
-                if item.nplike.index_nplike.any(item.index.data < -1):
+                if item.index_nplike.any(item.index.data < -1):
                     safeindex = item.index.data.copy()
                     safeindex[isnegative] = -1
                 else:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -220,6 +220,7 @@ def normalise_item_nested(item):
                 item.data.astype(np.int64),
                 parameters=item.parameters,
                 nplike=item.nplike,
+                index_nplike=item.index_nplike,
             )
         next = next.to_RegularArray()
         next = normalise_item_RegularArray_to_ListOffsetArray64(next)
@@ -373,7 +374,9 @@ def normalise_item_bool_to_int(item):
 
         return ak.contents.ListOffsetArray(
             ak.index.Index64(nextoffsets),
-            ak.contents.NumpyArray(nextcontent, nplike=item.nplike),
+            ak.contents.NumpyArray(
+                nextcontent, nplike=item.nplike, index_nplike=item.index_nplike
+            ),
         )
 
     elif (
@@ -433,7 +436,9 @@ def normalise_item_bool_to_int(item):
             ak.index.Index64(nextoffsets, nplike=item.nplike),
             ak.contents.IndexedOptionArray(
                 ak.index.Index(outindex, nplike=item.nplike),
-                ak.contents.NumpyArray(nextcontent, nplike=item.nplike),
+                ak.contents.NumpyArray(
+                    nextcontent, nplike=item.nplike, index_nplike=item.index_nplike
+                ),
             ),
         )
 
@@ -492,7 +497,9 @@ def normalise_item_bool_to_int(item):
 
             return ak.contents.IndexedOptionArray(
                 ak.index.Index(outindex, nplike=item.nplike),
-                ak.contents.NumpyArray(nextcontent, nplike=item.nplike),
+                ak.contents.NumpyArray(
+                    nextcontent, nplike=item.nplike, index_nplike=item.index_nplike
+                ),
             )
 
         else:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -357,9 +357,7 @@ def normalise_item_bool_to_int(item):
             localindex = item.local_index(axis=1)
             nextcontent = localindex.content.data[item.content.data]
 
-            cumsum = item.index_nplike.empty(
-                item.content.data.shape[0] + 1, np.int64
-            )
+            cumsum = item.index_nplike.empty(item.content.data.shape[0] + 1, np.int64)
             cumsum[0] = 0
             cumsum[1:] = item.index_nplike.asarray(
                 item.nplike.cumsum(item.content.data)

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -593,7 +593,8 @@ class TypeTracer(ak.nplikes.NumpyLike):
             and ak._util.is_integer(step)
         ):
             length = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
-
+        else:
+            length = UnknownLength
         return TypeTracerArray(kwargs["dtype"], (length,))
 
     def meshgrid(self, *args, **kwargs):

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -43,6 +43,15 @@ def regularize_backend(backend):
         )
 
 
+def is_buffer(obj) -> bool:
+    try:
+        memoryview(obj)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
 def parse_version(version):
     return packaging.version.parse(version)
 
@@ -625,7 +634,10 @@ def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
                 ak.index.Index64(starts),
                 ak.index.Index64(stops),
                 ak.contents.NumpyArray(
-                    asbytes.view("u1"), parameters={"__array__": "byte"}, nplike=numpy
+                    asbytes.view("u1"),
+                    parameters={"__array__": "byte"},
+                    nplike=numpy,
+                    index_nplike=ak.nplikes.index_nplike_for(numpy),
                 ),
                 parameters={"__array__": "bytestring"},
             )
@@ -643,7 +655,10 @@ def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
                 ak.index.Index64(starts),
                 ak.index.Index64(stops),
                 ak.contents.NumpyArray(
-                    asbytes.view("u1"), parameters={"__array__": "char"}, nplike=numpy
+                    asbytes.view("u1"),
+                    parameters={"__array__": "char"},
+                    nplike=numpy,
+                    index_nplike=ak.nplikes.index_nplike_for(numpy),
                 ),
                 parameters={"__array__": "string"},
             )

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -203,7 +203,7 @@ class BitMaskedArray(Content):
 
     def to_IndexedOptionArray64(self):
         index = ak.index.Index64.empty(self._mask.length * 8, self._nplike)
-        assert index.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_BitMaskedArray_to_IndexedOptionArray",
@@ -225,7 +225,7 @@ class BitMaskedArray(Content):
 
     def to_ByteMaskedArray(self):
         bytemask = ak.index.Index8.empty(self._mask.length * 8, self._nplike)
-        assert bytemask.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert bytemask.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_BitMaskedArray_to_ByteMaskedArray",
@@ -287,7 +287,7 @@ class BitMaskedArray(Content):
             nplike = self._nplike
 
         bytemask = ak.index.Index8.empty(self._mask.length * 8, nplike)
-        assert bytemask.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert bytemask.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             nplike[
                 "awkward_BitMaskedArray_to_ByteMaskedArray",

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -25,7 +25,6 @@ class BitMaskedArray(Content):
         length=unset,
         lsb_order=unset,
         parameters=unset,
-        nplike=unset,
     ):
         return BitMaskedArray(
             self._mask if mask is unset else mask,
@@ -34,7 +33,6 @@ class BitMaskedArray(Content):
             self._length if length is unset else length,
             self._lsb_order if lsb_order is unset else lsb_order,
             self._parameters if parameters is unset else parameters,
-            self._nplike if nplike is unset else nplike,
         )
 
     def __copy__(self):
@@ -47,16 +45,7 @@ class BitMaskedArray(Content):
             parameters=copy.deepcopy(self._parameters, memo),
         )
 
-    def __init__(
-        self,
-        mask,
-        content,
-        valid_when,
-        length,
-        lsb_order,
-        parameters=None,
-        nplike=None,
-    ):
+    def __init__(self, mask, content, valid_when, length, lsb_order, parameters=None):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.uint8)):
             raise ak._errors.wrap_error(
                 TypeError(
@@ -114,17 +103,13 @@ class BitMaskedArray(Content):
                     )
                 )
             )
-        if nplike is None:
-            nplike = content.nplike
-        if nplike is None:
-            nplike = mask.nplike
 
         self._mask = mask
         self._content = content
         self._valid_when = valid_when
         self._length = length
         self._lsb_order = lsb_order
-        self._init(parameters, nplike)
+        self._init(parameters, nplike=content.nplike, index_nplike=content.index_nplike)
 
     @property
     def mask(self):
@@ -171,7 +156,6 @@ class BitMaskedArray(Content):
             self._length,
             self._lsb_order,
             self._parameters,
-            tt,
         )
 
     @property
@@ -186,7 +170,6 @@ class BitMaskedArray(Content):
             ak._typetracer.UnknownLength,
             self._lsb_order,
             self._parameters,
-            self._nplike,
         )
 
     def __repr__(self):
@@ -216,7 +199,6 @@ class BitMaskedArray(Content):
             self._length,
             self._lsb_order,
             ak._util.merge_parameters(self._parameters, parameters),
-            self._nplike,
         )
 
     def to_IndexedOptionArray64(self):
@@ -239,7 +221,6 @@ class BitMaskedArray(Content):
             index[0 : self._length],
             self._content,
             self._parameters,
-            self._nplike,
         )
 
     def to_ByteMaskedArray(self):
@@ -263,7 +244,6 @@ class BitMaskedArray(Content):
             self._content,
             self._valid_when,
             self._parameters,
-            self._nplike,
         )
 
     def to_BitMaskedArray(self, valid_when, lsb_order):
@@ -278,7 +258,6 @@ class BitMaskedArray(Content):
                     self._length,
                     lsb_order,
                     self._parameters,
-                    self._nplike,
                 )
 
         else:
@@ -299,7 +278,6 @@ class BitMaskedArray(Content):
                 self._length,
                 lsb_order,
                 self._parameters,
-                self._nplike,
             )
 
     def mask_as_bool(self, valid_when=None, nplike=None):
@@ -356,7 +334,6 @@ class BitMaskedArray(Content):
             self._length,
             self._lsb_order,
             None,
-            self._nplike,
         ).simplify_optiontype()
 
     def _getitem_fields(self, where, only_fields=()):
@@ -367,7 +344,6 @@ class BitMaskedArray(Content):
             self._length,
             self._lsb_order,
             None,
-            self._nplike,
         ).simplify_optiontype()
 
     def _carry(self, carry, allow_lazy):
@@ -624,7 +600,6 @@ class BitMaskedArray(Content):
                     self._length,
                     self._lsb_order,
                     self._parameters if options["keep_parameters"] else None,
-                    self._nplike,
                 )
 
         else:
@@ -669,7 +644,6 @@ class BitMaskedArray(Content):
                 next._index,
                 content,
                 next._parameters,
-                self._nplike,
             )
 
         else:
@@ -690,7 +664,6 @@ class BitMaskedArray(Content):
                 self._length,
                 self._lsb_order,
                 self._parameters,
-                self._nplike,
             )
 
     def _to_list(self, behavior, json_conversions):
@@ -719,7 +692,6 @@ class BitMaskedArray(Content):
             length=len(self),
             lsb_order=self._lsb_order,
             parameters=self._parameters,
-            nplike=nplike,
         )
 
     def _layout_equal(self, other, index_dtype=True, numpyarray=True):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -202,8 +202,11 @@ class BitMaskedArray(Content):
         )
 
     def to_IndexedOptionArray64(self):
-        index = ak.index.Index64.empty(self._mask.length * 8, self._nplike)
-        assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        index = ak.index.Index64.empty(self._mask.length * 8, self._index_nplike)
+        assert (
+            index.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_BitMaskedArray_to_IndexedOptionArray",
@@ -224,8 +227,11 @@ class BitMaskedArray(Content):
         )
 
     def to_ByteMaskedArray(self):
-        bytemask = ak.index.Index8.empty(self._mask.length * 8, self._nplike)
-        assert bytemask.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        bytemask = ak.index.Index8.empty(self._mask.length * 8, self._index_nplike)
+        assert (
+            bytemask.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_BitMaskedArray_to_ByteMaskedArray",
@@ -285,9 +291,13 @@ class BitMaskedArray(Content):
             valid_when = self._valid_when
         if nplike is None:
             nplike = self._nplike
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
 
-        bytemask = ak.index.Index8.empty(self._mask.length * 8, nplike)
-        assert bytemask.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        bytemask = ak.index.Index8.empty(self._mask.length * 8, nplike=index_nplike)
+        assert (
+            bytemask.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             nplike[
                 "awkward_BitMaskedArray_to_ByteMaskedArray",

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -161,8 +161,11 @@ class ByteMaskedArray(Content):
         )
 
     def to_IndexedOptionArray64(self):
-        index = ak.index.Index64.empty(self._mask.length, self._nplike)
-        assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        index = ak.index.Index64.empty(self._mask.length, self._index_nplike)
+        assert (
+            index.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_toIndexedOptionArray",
@@ -295,9 +298,13 @@ class ByteMaskedArray(Content):
         )
 
     def _nextcarry_outindex(self, nplike):
-        numnull = ak.index.Index64.empty(1, nplike)
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
+        numnull = ak.index.Index64.empty(1, index_nplike)
 
-        assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        assert (
+            numnull.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_numnull",
@@ -310,12 +317,12 @@ class ByteMaskedArray(Content):
                 self._valid_when,
             )
         )
-        nextcarry = ak.index.Index64.empty(self.length - numnull[0], self._nplike)
-        outindex = ak.index.Index64.empty(self.length, self._nplike)
+        nextcarry = ak.index.Index64.empty(self.length - numnull[0], self._index_nplike)
+        outindex = ak.index.Index64.empty(self.length, self._index_nplike)
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and outindex.index_nplike is self._index_nplike
-            and self._mask.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and outindex.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -351,15 +358,17 @@ class ByteMaskedArray(Content):
 
         numnull, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
 
-        reducedstarts = ak.index.Index64.empty(self.length - numnull, self._nplike)
-        reducedstops = ak.index.Index64.empty(self.length - numnull, self._nplike)
+        reducedstarts = ak.index.Index64.empty(
+            self.length - numnull, self._index_nplike
+        )
+        reducedstops = ak.index.Index64.empty(self.length - numnull, self._index_nplike)
 
         assert (
-            outindex.index_nplike is self._index_nplike
-            and slicestarts.index_nplike is self._index_nplike
-            and slicestops.index_nplike is self._index_nplike
-            and reducedstarts.index_nplike is self._index_nplike
-            and reducedstops.index_nplike is self._index_nplike
+            outindex.nplike is self._index_nplike
+            and slicestarts.nplike is self._index_nplike
+            and slicestops.nplike is self._index_nplike
+            and reducedstarts.nplike is self._index_nplike
+            and reducedstops.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -430,7 +439,7 @@ class ByteMaskedArray(Content):
 
     def project(self, mask=None):
         mask_length = self._mask.length
-        numnull = ak.index.Index64.zeros(1, self._nplike)
+        numnull = ak.index.Index64.zeros(1, self._index_nplike)
 
         if mask is not None:
             if self._nplike.known_shape and mask_length != mask.length:
@@ -442,11 +451,11 @@ class ByteMaskedArray(Content):
                     )
                 )
 
-            nextmask = ak.index.Index8.empty(mask_length, self._nplike)
+            nextmask = ak.index.Index8.empty(mask_length, self._index_nplike)
             assert (
-                nextmask.index_nplike is self._index_nplike
-                and mask.index_nplike is self._index_nplike
-                and self._mask.index_nplike is self._index_nplike
+                nextmask.nplike is self._index_nplike
+                and mask.nplike is self._index_nplike
+                and self._mask.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -472,7 +481,10 @@ class ByteMaskedArray(Content):
             return next.project()
 
         else:
-            assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+            assert (
+                numnull.nplike is self._index_nplike
+                and self._mask.nplike is self._index_nplike
+            )
             self._handle_error(
                 self.nplike[
                     "awkward_ByteMaskedArray_numnull",
@@ -485,9 +497,12 @@ class ByteMaskedArray(Content):
                     self._valid_when,
                 )
             )
-            nextcarry = ak.index.Index64.empty(mask_length - numnull[0], self._nplike)
+            nextcarry = ak.index.Index64.empty(
+                mask_length - numnull[0], self._index_nplike
+            )
             assert (
-                nextcarry.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and self._mask.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -561,9 +576,9 @@ class ByteMaskedArray(Content):
                 )
 
                 assert (
-                    outoffsets.index_nplike is self._index_nplike
-                    and outindex.index_nplike is self._index_nplike
-                    and offsets.index_nplike is self._index_nplike
+                    outoffsets.nplike is self._index_nplike
+                    and outindex.nplike is self._index_nplike
+                    and offsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -739,8 +754,11 @@ class ByteMaskedArray(Content):
     ):
         mask_length = self._mask.length
 
-        numnull = ak.index.Index64.empty(1, self._nplike)
-        assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+        numnull = ak.index.Index64.empty(1, self._index_nplike)
+        assert (
+            numnull.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_numnull",
@@ -755,15 +773,15 @@ class ByteMaskedArray(Content):
         )
 
         next_length = mask_length - numnull[0]
-        nextcarry = ak.index.Index64.empty(next_length, self._nplike)
-        nextparents = ak.index.Index64.empty(next_length, self._nplike)
-        outindex = ak.index.Index64.empty(mask_length, self._nplike)
+        nextcarry = ak.index.Index64.empty(next_length, self._index_nplike)
+        nextparents = ak.index.Index64.empty(next_length, self._index_nplike)
+        outindex = ak.index.Index64.empty(mask_length, self._index_nplike)
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and nextparents.index_nplike is self._index_nplike
-            and outindex.index_nplike is self._index_nplike
-            and self._mask.index_nplike is self._index_nplike
-            and parents.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and nextparents.nplike is self._index_nplike
+            and outindex.nplike is self._index_nplike
+            and self._mask.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -787,11 +805,11 @@ class ByteMaskedArray(Content):
         branch, depth = self.branch_depth
 
         if reducer.needs_position and (not branch and negaxis == depth):
-            nextshifts = ak.index.Index64.empty(next_length, self._nplike)
+            nextshifts = ak.index.Index64.empty(next_length, self._index_nplike)
             if shifts is None:
                 assert (
-                    nextshifts.index_nplike is self._index_nplike
-                    and self._mask.index_nplike is self._index_nplike
+                    nextshifts.nplike is self._index_nplike
+                    and self._mask.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -807,8 +825,8 @@ class ByteMaskedArray(Content):
                 )
             else:
                 assert (
-                    nextshifts.index_nplike is self._index_nplike
-                    and self._mask.index_nplike is self._index_nplike
+                    nextshifts.nplike is self._index_nplike
+                    and self._mask.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -857,8 +875,8 @@ class ByteMaskedArray(Content):
                     )
                 )
 
-            outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
-            assert outoffsets.index_nplike is self._index_nplike
+            outoffsets = ak.index.Index64.empty(starts.length + 1, self._index_nplike)
+            assert outoffsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_reduce_next_fix_offsets_64",
@@ -910,8 +928,11 @@ class ByteMaskedArray(Content):
             return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
-            index = ak.index.Index64.empty(mask.length, self._nplike)
-            assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
+            index = ak.index.Index64.empty(mask.length, self._index_nplike)
+            assert (
+                index.nplike is self._index_nplike
+                and self._mask.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedOptionArray_rpad_and_clip_mask_axis1",

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -162,7 +162,7 @@ class ByteMaskedArray(Content):
 
     def to_IndexedOptionArray64(self):
         index = ak.index.Index64.empty(self._mask.length, self._nplike)
-        assert index.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_toIndexedOptionArray",
@@ -297,7 +297,7 @@ class ByteMaskedArray(Content):
     def _nextcarry_outindex(self, nplike):
         numnull = ak.index.Index64.empty(1, nplike)
 
-        assert numnull.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_numnull",
@@ -313,9 +313,9 @@ class ByteMaskedArray(Content):
         nextcarry = ak.index.Index64.empty(self.length - numnull[0], self._nplike)
         outindex = ak.index.Index64.empty(self.length, self._nplike)
         assert (
-            nextcarry.nplike is self._nplike
-            and outindex.nplike is self._nplike
-            and self._mask.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and outindex.index_nplike is self._index_nplike
+            and self._mask.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -355,11 +355,11 @@ class ByteMaskedArray(Content):
         reducedstops = ak.index.Index64.empty(self.length - numnull, self._nplike)
 
         assert (
-            outindex.nplike is self._nplike
-            and slicestarts.nplike is self._nplike
-            and slicestops.nplike is self._nplike
-            and reducedstarts.nplike is self._nplike
-            and reducedstops.nplike is self._nplike
+            outindex.index_nplike is self._index_nplike
+            and slicestarts.index_nplike is self._index_nplike
+            and slicestops.index_nplike is self._index_nplike
+            and reducedstarts.index_nplike is self._index_nplike
+            and reducedstops.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -444,9 +444,9 @@ class ByteMaskedArray(Content):
 
             nextmask = ak.index.Index8.empty(mask_length, self._nplike)
             assert (
-                nextmask.nplike is self._nplike
-                and mask.nplike is self._nplike
-                and self._mask.nplike is self._nplike
+                nextmask.index_nplike is self._index_nplike
+                and mask.index_nplike is self._index_nplike
+                and self._mask.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -472,7 +472,7 @@ class ByteMaskedArray(Content):
             return next.project()
 
         else:
-            assert numnull.nplike is self._nplike and self._mask.nplike is self._nplike
+            assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
             self._handle_error(
                 self.nplike[
                     "awkward_ByteMaskedArray_numnull",
@@ -487,7 +487,7 @@ class ByteMaskedArray(Content):
             )
             nextcarry = ak.index.Index64.empty(mask_length - numnull[0], self._nplike)
             assert (
-                nextcarry.nplike is self._nplike and self._mask.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -561,9 +561,9 @@ class ByteMaskedArray(Content):
                 )
 
                 assert (
-                    outoffsets.nplike is self._nplike
-                    and outindex.nplike is self._nplike
-                    and offsets.nplike is self._nplike
+                    outoffsets.index_nplike is self._index_nplike
+                    and outindex.index_nplike is self._index_nplike
+                    and offsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -740,7 +740,7 @@ class ByteMaskedArray(Content):
         mask_length = self._mask.length
 
         numnull = ak.index.Index64.empty(1, self._nplike)
-        assert numnull.nplike is self._nplike and self._mask.nplike is self._nplike
+        assert numnull.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ByteMaskedArray_numnull",
@@ -759,11 +759,11 @@ class ByteMaskedArray(Content):
         nextparents = ak.index.Index64.empty(next_length, self._nplike)
         outindex = ak.index.Index64.empty(mask_length, self._nplike)
         assert (
-            nextcarry.nplike is self._nplike
-            and nextparents.nplike is self._nplike
-            and outindex.nplike is self._nplike
-            and self._mask.nplike is self._nplike
-            and parents.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and nextparents.index_nplike is self._index_nplike
+            and outindex.index_nplike is self._index_nplike
+            and self._mask.index_nplike is self._index_nplike
+            and parents.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -790,8 +790,8 @@ class ByteMaskedArray(Content):
             nextshifts = ak.index.Index64.empty(next_length, self._nplike)
             if shifts is None:
                 assert (
-                    nextshifts.nplike is self._nplike
-                    and self._mask.nplike is self._nplike
+                    nextshifts.index_nplike is self._index_nplike
+                    and self._mask.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -807,8 +807,8 @@ class ByteMaskedArray(Content):
                 )
             else:
                 assert (
-                    nextshifts.nplike is self._nplike
-                    and self._mask.nplike is self._nplike
+                    nextshifts.index_nplike is self._index_nplike
+                    and self._mask.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -858,7 +858,7 @@ class ByteMaskedArray(Content):
                 )
 
             outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
-            assert outoffsets.nplike is self._nplike
+            assert outoffsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_reduce_next_fix_offsets_64",
@@ -911,7 +911,7 @@ class ByteMaskedArray(Content):
         elif posaxis == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(mask.length, self._nplike)
-            assert index.nplike is self._nplike and self._mask.nplike is self._nplike
+            assert index.index_nplike is self._index_nplike and self._mask.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedOptionArray_rpad_and_clip_mask_axis1",

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -388,7 +388,7 @@ class Content:
         index = index._to_nplike(self.nplike)
         outindex = ak.index.Index64.empty(index.length * length, self._nplike)
 
-        assert outindex.nplike is self._nplike and index.nplike is self._nplike
+        assert outindex.index_nplike is self._index_nplike and index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_missing_repeat", outindex.dtype.type, index.dtype.type
@@ -433,11 +433,11 @@ class Content:
         stops = ak.index.Index64.empty(index.length, self._nplike)
 
         assert (
-            index.nplike is self._nplike
-            and jagged._offsets.nplike is self._nplike
-            and outputmask.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and stops.nplike is self._nplike
+            index.index_nplike is self._index_nplike
+            and jagged._offsets.index_nplike is self._index_nplike
+            and outputmask.index_nplike is self._index_nplike
+            and starts.index_nplike is self._index_nplike
+            and stops.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -688,7 +688,7 @@ class Content:
         assert isinstance(carry, ak.index.Index)
 
         result = self._index_nplike.empty(1, dtype=np.bool_)
-        assert carry.nplike is self._nplike
+        assert carry.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_Index_iscontiguous",  # badly named
@@ -781,13 +781,13 @@ class Content:
         tags = ak.index.Index8.empty((mylength + theirlength), self._nplike)
         index = ak.index.Index64.empty((mylength + theirlength), self._nplike)
         contents = [self, other]
-        assert tags.nplike is self._nplike
+        assert tags.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_filltags_const", tags.dtype.type](
                 tags.data, 0, mylength, 0
             )
         )
-        assert index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_fillindex_count", index.dtype.type](
                 index.data, 0, mylength
@@ -1207,7 +1207,7 @@ class Content:
         toindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
         fromindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
 
-        assert toindex.nplike is self._nplike and fromindex.nplike is self._nplike
+        assert toindex.index_nplike is self._index_nplike and fromindex.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_RegularArray_combinations_64",
@@ -1497,7 +1497,7 @@ class Content:
         else:
             index = ak.index.Index64.empty(target, self._nplike)
 
-            assert index.nplike is self._nplike
+            assert index.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_index_rpad_and_clip_axis0",

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -383,12 +383,14 @@ class Content:
     ):
         # if this is in a tuple-slice and really should be 0, it will be trimmed later
         length = 1 if length == 0 else length
-        index = ak.index.Index64(head.index, nplike=self.nplike)
+        index = ak.index.Index64(head.index, nplike=self._index_nplike)
         indexlength = index.length
         index = index._to_nplike(self.nplike)
-        outindex = ak.index.Index64.empty(index.length * length, self._nplike)
+        outindex = ak.index.Index64.empty(index.length * length, self._index_nplike)
 
-        assert outindex.index_nplike is self._index_nplike and index.index_nplike is self._index_nplike
+        assert (
+            outindex.nplike is self._index_nplike and index.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_missing_repeat", outindex.dtype.type, index.dtype.type
@@ -417,7 +419,7 @@ class Content:
         head = head._to_nplike(self._nplike)
         jagged = head.content.to_ListOffsetArray64()
 
-        index = ak.index.Index64(head._index, nplike=self.nplike)
+        index = ak.index.Index64(head._index, nplike=self._index_nplike)
         content = that._getitem_at(0)
         if self._nplike.known_shape and content.length < index.length:
             raise ak._errors.index_error(
@@ -428,16 +430,16 @@ class Content:
                 ),
             )
 
-        outputmask = ak.index.Index64.empty(index.length, self._nplike)
-        starts = ak.index.Index64.empty(index.length, self._nplike)
-        stops = ak.index.Index64.empty(index.length, self._nplike)
+        outputmask = ak.index.Index64.empty(index.length, self._index_nplike)
+        starts = ak.index.Index64.empty(index.length, self._index_nplike)
+        stops = ak.index.Index64.empty(index.length, self._index_nplike)
 
         assert (
-            index.index_nplike is self._index_nplike
-            and jagged._offsets.index_nplike is self._index_nplike
-            and outputmask.index_nplike is self._index_nplike
-            and starts.index_nplike is self._index_nplike
-            and stops.index_nplike is self._index_nplike
+            index.nplike is self._index_nplike
+            and jagged._offsets.nplike is self._index_nplike
+            and outputmask.nplike is self._index_nplike
+            and starts.nplike is self._index_nplike
+            and stops.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -608,7 +610,7 @@ class Content:
             elif issubclass(where.dtype.type, (np.bool_, bool)):
                 if len(where.data.shape) == 1:
                     where = self._nplike.nonzero(where.data)[0]
-                    carry = ak.index.Index64(where, nplike=self.nplike)
+                    carry = ak.index.Index64(where, nplike=self._index_nplike)
                     allow_lazy = "copied"  # True, but also can be modified in-place
                 else:
                     wheres = self._nplike.nonzero(where.data)
@@ -644,7 +646,7 @@ class Content:
         elif ak._util.is_sized_iterable(where):
             layout = ak.operations.to_layout(where)._to_nplike(self._nplike)
             assert layout.nplike is self._nplike
-            assert layout.index_nplike is self._index_nplike
+            assert layout.nplike is self._index_nplike
             as_array = layout.maybe_to_array(layout.nplike)
             if as_array is None:
                 return self._getitem(layout)
@@ -688,7 +690,7 @@ class Content:
         assert isinstance(carry, ak.index.Index)
 
         result = self._index_nplike.empty(1, dtype=np.bool_)
-        assert carry.index_nplike is self._index_nplike
+        assert carry.nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_Index_iscontiguous",  # badly named
@@ -739,7 +741,7 @@ class Content:
         return axis
 
     def _local_index_axis0(self) -> ak.contents.NumpyArray:
-        localindex = ak.index.Index64.empty(self.length, self._nplike)
+        localindex = ak.index.Index64.empty(self.length, self._index_nplike)
         self._handle_error(
             self._nplike["awkward_localindex", np.int64](
                 localindex.data,
@@ -781,13 +783,13 @@ class Content:
         tags = ak.index.Index8.empty((mylength + theirlength), self._nplike)
         index = ak.index.Index64.empty((mylength + theirlength), self._nplike)
         contents = [self, other]
-        assert tags.index_nplike is self._index_nplike
+        assert tags.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_filltags_const", tags.dtype.type](
                 tags.data, 0, mylength, 0
             )
         )
-        assert index.index_nplike is self._index_nplike
+        assert index.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_fillindex_count", index.dtype.type](
                 index.data, 0, mylength
@@ -911,8 +913,8 @@ class Content:
                     )
                 )
 
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        starts = ak.index.Index64.zeros(1, self._index_nplike)
+        parents = ak.index.Index64.zeros(self.length, self._index_nplike)
         shifts = None
         next = self._reduce_next(
             reducer,
@@ -1079,8 +1081,8 @@ class Content:
                     )
                 )
 
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        starts = ak.index.Index64.zeros(1, self._index_nplike)
+        parents = ak.index.Index64.zeros(self.length, self._index_nplike)
         return self._argsort_next(
             negaxis,
             starts,
@@ -1146,8 +1148,8 @@ class Content:
                     )
                 )
 
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        starts = ak.index.Index64.zeros(1, self._index_nplike)
+        parents = ak.index.Index64.zeros(self.length, self._index_nplike)
         return self._sort_next(
             negaxis,
             starts,
@@ -1207,7 +1209,10 @@ class Content:
         toindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
         fromindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
 
-        assert toindex.index_nplike is self._index_nplike and fromindex.index_nplike is self._index_nplike
+        assert (
+            toindex.nplike is self._index_nplike
+            and fromindex.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_RegularArray_combinations_64",
@@ -1385,8 +1390,8 @@ class Content:
 
     def is_unique(self, axis: Integral | None = None) -> bool:
         negaxis = axis if axis is None else -axis
-        starts = ak.index.Index64.zeros(1, self._nplike)
-        parents = ak.index.Index64.zeros(self.length, self._nplike)
+        starts = ak.index.Index64.zeros(1, self._index_nplike)
+        parents = ak.index.Index64.zeros(self.length, self._index_nplike)
         return self._is_unique(negaxis, starts, parents, 1)
 
     def _is_unique(
@@ -1433,8 +1438,8 @@ class Content:
                             )
                         )
 
-            starts = ak.index.Index64.zeros(1, self._nplike)
-            parents = ak.index.Index64.zeros(self.length, self._nplike)
+            starts = ak.index.Index64.zeros(1, self._index_nplike)
+            parents = ak.index.Index64.zeros(self.length, self._index_nplike)
 
             return self._unique(negaxis, starts, parents, 1)
 
@@ -1495,9 +1500,9 @@ class Content:
             )
 
         else:
-            index = ak.index.Index64.empty(target, self._nplike)
+            index = ak.index.Index64.empty(target, self._index_nplike)
 
-            assert index.index_nplike is self._index_nplike
+            assert index.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_index_rpad_and_clip_axis0",

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -178,7 +178,7 @@ class EmptyArray(Content):
             else:
                 return out
         else:
-            out = ak.index.Index64.empty(0, self._nplike)
+            out = ak.index.Index64.empty(0, self._index_nplike)
             return ak.contents.NumpyArray(out, None, self._nplike, self._index_nplike)
 
     def _offsets_and_flattened(self, axis, depth):
@@ -188,7 +188,7 @@ class EmptyArray(Content):
                 np.AxisError(self, "axis=0 not allowed for flatten")
             )
         else:
-            offsets = ak.index.Index64.zeros(1, self._nplike)
+            offsets = ak.index.Index64.zeros(1, self._index_nplike)
             return (
                 offsets,
                 EmptyArray(self._parameters, self._nplike, self._index_nplike),

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -209,7 +209,7 @@ class IndexedArray(Content):
             )
 
         nextcarry = ak.index.Index64.empty(self.length, self._nplike)
-        assert nextcarry.nplike is self._nplike and self._index.nplike is self._nplike
+        assert nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_getitem_nextcarry",
@@ -243,7 +243,7 @@ class IndexedArray(Content):
 
             nextcarry = ak.index.Index64.empty(self._index.length, self._nplike)
             assert (
-                nextcarry.nplike is self._nplike and self._index.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -292,9 +292,9 @@ class IndexedArray(Content):
                 )
             nextindex = ak.index.Index64.empty(self._index.length, self._nplike)
             assert (
-                nextindex.nplike is self._nplike
-                and mask.nplike is self._nplike
-                and self._index.nplike is self._nplike
+                nextindex.index_nplike is self._index_nplike
+                and mask.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -319,7 +319,7 @@ class IndexedArray(Content):
         else:
             nextcarry = ak.index.Index64.empty(self.length, self._nplike)
             assert (
-                nextcarry.nplike is self._nplike and self._index.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -367,11 +367,13 @@ class IndexedArray(Content):
                 rawcontent = self._content.to_IndexedOptionArray64()
                 inner = rawcontent.index
                 result = ak.index.Index64.empty(self.index.length, self._nplike)
+            else:
+                assert False
 
             assert (
-                result.nplike is self._nplike
-                and self._index.nplike is self._nplike
-                and inner.nplike is self._nplike
+                result.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
+                and inner.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -491,7 +493,7 @@ class IndexedArray(Content):
         content = other.merge(self._content)
 
         # Fill `index` with a range starting at zero, up to `theirlength`
-        assert index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -502,7 +504,7 @@ class IndexedArray(Content):
         )
 
         # Fill remaining indices
-        assert index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_fill",
@@ -553,8 +555,8 @@ class IndexedArray(Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.nplike is self._nplike
-                    and array_index.nplike is self._nplike
+                    nextindex.index_nplike is self._index_nplike
+                    and array_index.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -576,7 +578,7 @@ class IndexedArray(Content):
                 pass
             else:
                 contents.append(array)
-                assert nextindex.nplike is self._nplike
+                assert nextindex.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_IndexedArray_fill_count",
@@ -637,7 +639,7 @@ class IndexedArray(Content):
             offsets = ak.index.Index64.empty(2, self._nplike)
             offsets[0] = 0
             offsets[1] = next.length
-            assert next.nplike is self._nplike and offsets.nplike is self._nplike
+            assert next.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -656,7 +658,7 @@ class IndexedArray(Content):
                 )
             )
 
-            assert next.nplike is self._nplike and length.nplike is self._nplike
+            assert next.index_nplike is self._index_nplike and length.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike["awkward_unique", next.dtype.type, length.dtype.type](
                     next.data,
@@ -667,9 +669,9 @@ class IndexedArray(Content):
 
         else:
             assert (
-                self._index.nplike is self._nplike
-                and next.nplike is self._nplike
-                and length.nplike is self._nplike
+                self._index.index_nplike is self._index_nplike
+                and next.index_nplike is self._index_nplike
+                and length.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -720,11 +722,11 @@ class IndexedArray(Content):
         nextparents = ak.index.Index64.empty(index_length, self._nplike)
         outindex = ak.index.Index64.empty(index_length, self._nplike)
         assert (
-            nextcarry.nplike is self._nplike
-            and nextparents.nplike is self._nplike
-            and outindex.nplike is self._nplike
-            and self._index.nplike is self._nplike
-            and parents.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and nextparents.index_nplike is self._index_nplike
+            and outindex.index_nplike is self._index_nplike
+            and self._index.index_nplike is self._index_nplike
+            and parents.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -754,10 +756,10 @@ class IndexedArray(Content):
         if branch or (negaxis is not None and negaxis != depth):
             nextoutindex = ak.index.Index64.empty(parents_length, self._nplike)
             assert (
-                nextoutindex.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and parents.nplike is self._nplike
-                and nextparents.nplike is self._nplike
+                nextoutindex.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and parents.index_nplike is self._index_nplike
+                and nextparents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -801,7 +803,7 @@ class IndexedArray(Content):
 
                 outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
                 assert (
-                    outoffsets.nplike is self._nplike and starts.nplike is self._nplike
+                    outoffsets.index_nplike is self._index_nplike and starts.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -208,8 +208,11 @@ class IndexedArray(Content):
                 ),
             )
 
-        nextcarry = ak.index.Index64.empty(self.length, self._nplike)
-        assert nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+        nextcarry = ak.index.Index64.empty(self.length, self._index_nplike)
+        assert (
+            nextcarry.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_getitem_nextcarry",
@@ -241,9 +244,10 @@ class IndexedArray(Content):
         ):
             nexthead, nexttail = ak._slicing.headtail(tail)
 
-            nextcarry = ak.index.Index64.empty(self._index.length, self._nplike)
+            nextcarry = ak.index.Index64.empty(self._index.length, self._index_nplike)
             assert (
-                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -290,11 +294,11 @@ class IndexedArray(Content):
                         )
                     )
                 )
-            nextindex = ak.index.Index64.empty(self._index.length, self._nplike)
+            nextindex = ak.index.Index64.empty(self._index.length, self._index_nplike)
             assert (
-                nextindex.index_nplike is self._index_nplike
-                and mask.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
+                nextindex.nplike is self._index_nplike
+                and mask.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -317,9 +321,10 @@ class IndexedArray(Content):
             return next.project()
 
         else:
-            nextcarry = ak.index.Index64.empty(self.length, self._nplike)
+            nextcarry = ak.index.Index64.empty(self.length, self._index_nplike)
             assert (
-                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -355,7 +360,7 @@ class IndexedArray(Content):
                 ),
             ):
                 inner = self._content.index
-                result = ak.index.Index64.empty(self.index.length, self._nplike)
+                result = ak.index.Index64.empty(self.index.length, self._index_nplike)
             elif isinstance(
                 self._content,
                 (
@@ -366,14 +371,14 @@ class IndexedArray(Content):
             ):
                 rawcontent = self._content.to_IndexedOptionArray64()
                 inner = rawcontent.index
-                result = ak.index.Index64.empty(self.index.length, self._nplike)
+                result = ak.index.Index64.empty(self.index.length, self._index_nplike)
             else:
-                assert False
+                raise ak._errors.wrap_error(AssertionError)
 
             assert (
-                result.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
-                and inner.index_nplike is self._index_nplike
+                result.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
+                and inner.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -493,7 +498,7 @@ class IndexedArray(Content):
         content = other.merge(self._content)
 
         # Fill `index` with a range starting at zero, up to `theirlength`
-        assert index.index_nplike is self._index_nplike
+        assert index.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -504,7 +509,7 @@ class IndexedArray(Content):
         )
 
         # Fill remaining indices
-        assert index.index_nplike is self._index_nplike
+        assert index.nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_fill",
@@ -535,7 +540,7 @@ class IndexedArray(Content):
         contents = []
         contentlength_so_far = 0
         length_so_far = 0
-        nextindex = ak.index.Index64.empty(total_length, self._nplike)
+        nextindex = ak.index.Index64.empty(total_length, self._index_nplike)
 
         parameters = self._parameters
         for array in head:
@@ -555,8 +560,8 @@ class IndexedArray(Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.index_nplike is self._index_nplike
-                    and array_index.index_nplike is self._index_nplike
+                    nextindex.nplike is self._index_nplike
+                    and array_index.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -578,7 +583,7 @@ class IndexedArray(Content):
                 pass
             else:
                 contents.append(array)
-                assert nextindex.index_nplike is self._index_nplike
+                assert nextindex.nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_IndexedArray_fill_count",
@@ -631,15 +636,18 @@ class IndexedArray(Content):
             return self.project()._local_index(posaxis, depth)
 
     def _unique_index(self, index, sorted=True):
-        next = ak.index.Index64.zeros(self.length, self._nplike)
-        length = ak.index.Index64.zeros(1, self._nplike)
+        next = ak.index.Index64.zeros(self.length, self._index_nplike)
+        length = ak.index.Index64.zeros(1, self._index_nplike)
 
         if not sorted:
             next = self._index
-            offsets = ak.index.Index64.empty(2, self._nplike)
+            offsets = ak.index.Index64.empty(2, self._index_nplike)
             offsets[0] = 0
             offsets[1] = next.length
-            assert next.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
+            assert (
+                next.nplike is self._index_nplike
+                and offsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -658,7 +666,10 @@ class IndexedArray(Content):
                 )
             )
 
-            assert next.index_nplike is self._index_nplike and length.index_nplike is self._index_nplike
+            assert (
+                next.nplike is self._index_nplike
+                and length.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike["awkward_unique", next.dtype.type, length.dtype.type](
                     next.data,
@@ -669,9 +680,9 @@ class IndexedArray(Content):
 
         else:
             assert (
-                self._index.index_nplike is self._index_nplike
-                and next.index_nplike is self._index_nplike
-                and length.index_nplike is self._index_nplike
+                self._index.nplike is self._index_nplike
+                and next.nplike is self._index_nplike
+                and length.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -718,15 +729,15 @@ class IndexedArray(Content):
         parents_length = parents.length
         next_length = index_length
 
-        nextcarry = ak.index.Index64.empty(index_length, self._nplike)
-        nextparents = ak.index.Index64.empty(index_length, self._nplike)
-        outindex = ak.index.Index64.empty(index_length, self._nplike)
+        nextcarry = ak.index.Index64.empty(index_length, self._index_nplike)
+        nextparents = ak.index.Index64.empty(index_length, self._index_nplike)
+        outindex = ak.index.Index64.empty(index_length, self._index_nplike)
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and nextparents.index_nplike is self._index_nplike
-            and outindex.index_nplike is self._index_nplike
-            and self._index.index_nplike is self._index_nplike
-            and parents.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and nextparents.nplike is self._index_nplike
+            and outindex.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -754,12 +765,12 @@ class IndexedArray(Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
-            nextoutindex = ak.index.Index64.empty(parents_length, self._nplike)
+            nextoutindex = ak.index.Index64.empty(parents_length, self._index_nplike)
             assert (
-                nextoutindex.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and parents.index_nplike is self._index_nplike
-                and nextparents.index_nplike is self._index_nplike
+                nextoutindex.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+                and nextparents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -801,9 +812,12 @@ class IndexedArray(Content):
                         )
                     )
 
-                outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
+                outoffsets = ak.index.Index64.empty(
+                    starts.length + 1, self._index_nplike
+                )
                 assert (
-                    outoffsets.index_nplike is self._index_nplike and starts.index_nplike is self._index_nplike
+                    outoffsets.nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1041,7 +1055,7 @@ class IndexedArray(Content):
         ):
             npindex = self._index.data
             indexmin = npindex.min()
-            index = ak.index.Index(npindex - indexmin, nplike=self._nplike)
+            index = ak.index.Index(npindex - indexmin, nplike=self._index_nplike)
             content = self._content[indexmin : npindex.max() + 1]
         else:
             index, content = self._index, self._content

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -143,7 +143,7 @@ class IndexedOptionArray(Content):
             )
 
     def to_ByteMaskedArray(self, valid_when):
-        mask = ak.index.Index8(self.mask_as_bool(valid_when, self._nplike))
+        mask = ak.index.Index8(self.mask_as_bool(valid_when, self._index_nplike))
 
         carry = self._index.data
         too_negative = carry < -1
@@ -235,9 +235,13 @@ class IndexedOptionArray(Content):
         )
 
     def _nextcarry_outindex(self, nplike):
-        numnull = ak.index.Index64.empty(1, nplike)
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
+        numnull = ak.index.Index64.empty(1, nplike=index_nplike)
 
-        assert numnull.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+        assert (
+            numnull.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
+        )
         self._handle_error(
             nplike[
                 "awkward_IndexedArray_numnull",
@@ -249,13 +253,17 @@ class IndexedOptionArray(Content):
                 self._index.length,
             )
         )
-        nextcarry = ak.index.Index64.empty(self._index.length - numnull[0], nplike)
-        outindex = ak.index.Index.empty(self._index.length, nplike, self._index.dtype)
+        nextcarry = ak.index.Index64.empty(
+            self._index.length - numnull[0], index_nplike
+        )
+        outindex = ak.index.Index.empty(
+            self._index.length, index_nplike, self._index.dtype
+        )
 
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and outindex.index_nplike is self._index_nplike
-            and self._index.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and outindex.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
         )
         self._handle_error(
             nplike[
@@ -289,14 +297,16 @@ class IndexedOptionArray(Content):
 
         numnull, nextcarry, outindex = self._nextcarry_outindex(self._nplike)
 
-        reducedstarts = ak.index.Index64.empty(self.length - numnull, self._nplike)
-        reducedstops = ak.index.Index64.empty(self.length - numnull, self._nplike)
+        reducedstarts = ak.index.Index64.empty(
+            self.length - numnull, self._index_nplike
+        )
+        reducedstops = ak.index.Index64.empty(self.length - numnull, self._index_nplike)
         assert (
-            outindex.index_nplike is self._index_nplike
-            and slicestarts.index_nplike is self._index_nplike
-            and slicestops.index_nplike is self._index_nplike
-            and reducedstarts.index_nplike is self._index_nplike
-            and reducedstops.index_nplike is self._index_nplike
+            outindex.nplike is self._index_nplike
+            and slicestarts.nplike is self._index_nplike
+            and slicestops.nplike is self._index_nplike
+            and reducedstarts.nplike is self._index_nplike
+            and reducedstops.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -371,11 +381,11 @@ class IndexedOptionArray(Content):
                         )
                     )
                 )
-            nextindex = ak.index.Index64.empty(self._index.length, self._nplike)
+            nextindex = ak.index.Index64.empty(self._index.length, self._index_nplike)
             assert (
-                nextindex.index_nplike is self._index_nplike
-                and mask.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
+                nextindex.nplike is self._index_nplike
+                and mask.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -397,9 +407,12 @@ class IndexedOptionArray(Content):
             )
             return next.project()
         else:
-            numnull = ak.index.Index64.empty(1, self._nplike)
+            numnull = ak.index.Index64.empty(1, self._index_nplike)
 
-            assert numnull.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+            assert (
+                numnull.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_numnull",
@@ -412,10 +425,13 @@ class IndexedOptionArray(Content):
                 )
             )
 
-            nextcarry = ak.index.Index64.empty(self.length - numnull[0], self._nplike)
+            nextcarry = ak.index.Index64.empty(
+                self.length - numnull[0], self._index_nplike
+            )
 
             assert (
-                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -452,7 +468,7 @@ class IndexedOptionArray(Content):
                 ),
             ):
                 inner = self._content.index
-                result = ak.index.Index64.empty(self.index.length, self._nplike)
+                result = ak.index.Index64.empty(self.index.length, self._index_nplike)
             elif isinstance(
                 self._content,
                 (
@@ -463,11 +479,11 @@ class IndexedOptionArray(Content):
             ):
                 rawcontent = self._content.to_IndexedOptionArray64()
                 inner = rawcontent.index
-                result = ak.index.Index64.empty(self.index.length, self._nplike)
+                result = ak.index.Index64.empty(self.index.length, self._index_nplike)
             assert (
-                result.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
-                and inner.index_nplike is self._index_nplike
+                result.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
+                and inner.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -530,9 +546,9 @@ class IndexedOptionArray(Content):
                 )
 
                 assert (
-                    outoffsets.index_nplike is self._index_nplike
-                    and outindex.index_nplike is self._index_nplike
-                    and offsets.index_nplike is self._index_nplike
+                    outoffsets.nplike is self._index_nplike
+                    and outindex.nplike is self._index_nplike
+                    and offsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -609,7 +625,7 @@ class IndexedOptionArray(Content):
 
         content = other.merge(self._content)
 
-        assert index.index_nplike is self._index_nplike
+        assert index.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -623,7 +639,8 @@ class IndexedOptionArray(Content):
         )
 
         assert (
-            index.index_nplike is self._index_nplike and reinterpreted_index.index_nplike is self._index_nplike
+            index.nplike is self._index_nplike
+            and reinterpreted_index.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -655,7 +672,7 @@ class IndexedOptionArray(Content):
         contents = []
         contentlength_so_far = 0
         length_so_far = 0
-        nextindex = ak.index.Index64.empty(total_length, self._nplike)
+        nextindex = ak.index.Index64.empty(total_length, self._index_nplike)
         parameters = self._parameters
 
         parameters = self._parameters
@@ -676,8 +693,8 @@ class IndexedOptionArray(Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.index_nplike is self._index_nplike
-                    and array_index.index_nplike is self._index_nplike
+                    nextindex.nplike is self._index_nplike
+                    and array_index.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -699,7 +716,7 @@ class IndexedOptionArray(Content):
                 pass
             else:
                 contents.append(array)
-                assert nextindex.index_nplike is self._index_nplike
+                assert nextindex.nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_IndexedArray_fill_count",
@@ -741,9 +758,12 @@ class IndexedOptionArray(Content):
 
         contents = [self._content, value]
         tags = ak.index.Index8(self.mask_as_bool(valid_when=False))
-        index = ak.index.Index64.empty(tags.length, self._nplike)
+        index = ak.index.Index64.empty(tags.length, self._index_nplike)
 
-        assert index.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+        assert (
+            index.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_fillna", index.dtype.type, self._index.dtype.type
@@ -771,17 +791,17 @@ class IndexedOptionArray(Content):
             return out2
 
     def _is_subrange_equal(self, starts, stops, length, sorted=True):
-        nextstarts = ak.index.Index64.empty(length, self._nplike)
-        nextstops = ak.index.Index64.empty(length, self._nplike)
+        nextstarts = ak.index.Index64.empty(length, self._index_nplike)
+        nextstops = ak.index.Index64.empty(length, self._index_nplike)
 
-        subranges_length = ak.index.Index64.empty(1, self._nplike)
+        subranges_length = ak.index.Index64.empty(1, self._index_nplike)
         assert (
-            self._index.index_nplike is self._index_nplike
-            and starts.index_nplike is self._index_nplike
-            and stops.index_nplike is self._index_nplike
-            and nextstarts.index_nplike is self._index_nplike
-            and nextstops.index_nplike is self._index_nplike
-            and subranges_length.index_nplike is self._index_nplike
+            self._index.nplike is self._index_nplike
+            and starts.nplike is self._index_nplike
+            and stops.nplike is self._index_nplike
+            and nextstarts.nplike is self._index_nplike
+            and nextstops.nplike is self._index_nplike
+            and subranges_length.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -803,12 +823,12 @@ class IndexedOptionArray(Content):
             )
         )
 
-        nextcarry = ak.index.Index64.empty(subranges_length[0], self._nplike)
+        nextcarry = ak.index.Index64.empty(subranges_length[0], self._index_nplike)
         assert (
-            self._index.index_nplike is self._index_nplike
-            and starts.index_nplike is self._index_nplike
-            and stops.index_nplike is self._index_nplike
-            and nextcarry.index_nplike is self._index_nplike
+            self._index.nplike is self._index_nplike
+            and starts.nplike is self._index_nplike
+            and stops.nplike is self._index_nplike
+            and nextcarry.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -867,12 +887,12 @@ class IndexedOptionArray(Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
-            nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
+            nextoutindex = ak.index.Index64.empty(parents.length, self._index_nplike)
             assert (
-                nextoutindex.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and parents.index_nplike is self._index_nplike
-                and nextparents.index_nplike is self._index_nplike
+                nextoutindex.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+                and nextparents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -898,12 +918,12 @@ class IndexedOptionArray(Content):
             ).simplify_optiontype()
 
         if isinstance(out, ak.contents.ListOffsetArray):
-            newnulls = ak.index.Index64.empty(self._index.length, self._nplike)
-            len_newnulls = ak.index.Index64.empty(1, self._nplike)
+            newnulls = ak.index.Index64.empty(self._index.length, self._index_nplike)
+            len_newnulls = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                newnulls.index_nplike is self._index_nplike
-                and len_newnulls.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
+                newnulls.nplike is self._index_nplike
+                and len_newnulls.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -922,12 +942,12 @@ class IndexedOptionArray(Content):
             newindex = ak.index.Index64.empty(
                 out._offsets[-1] + len_newnulls[0], self._nplike
             )
-            newoffsets = ak.index.Index64.empty(out._offsets.length, self._nplike)
+            newoffsets = ak.index.Index64.empty(out._offsets.length, self._index_nplike)
             assert (
-                newindex.index_nplike is self._index_nplike
-                and newoffsets.index_nplike is self._index_nplike
-                and out._offsets.index_nplike is self._index_nplike
-                and newnulls.index_nplike is self._index_nplike
+                newindex.nplike is self._index_nplike
+                and newoffsets.nplike is self._index_nplike
+                and out._offsets.nplike is self._index_nplike
+                and newnulls.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -962,8 +982,8 @@ class IndexedOptionArray(Content):
             # the unique _non null_ values. We therefore need to account for None
             # values in the result. We do this by creating an IndexedOptionArray
             # and tacking the index -1 onto the end
-            nextoutindex = ak.index.Index64.empty(out.length + 1, self._nplike)
-            assert nextoutindex.index_nplike is self._index_nplike
+            nextoutindex = ak.index.Index64.empty(out.length + 1, self._index_nplike)
+            assert nextoutindex.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_numnull_unique_64",
@@ -991,12 +1011,13 @@ class IndexedOptionArray(Content):
         return out
 
     def _rearrange_nextshifts(self, nextparents, shifts):
-        nextshifts = ak.index.Index64.empty(nextparents.length, self._nplike)
-        assert nextshifts.index_nplike is self._index_nplike
+        nextshifts = ak.index.Index64.empty(nextparents.length, self._index_nplike)
+        assert nextshifts.nplike is self._index_nplike
 
         if shifts is None:
             assert (
-                nextshifts.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
+                nextshifts.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1011,9 +1032,9 @@ class IndexedOptionArray(Content):
             )
         else:
             assert (
-                nextshifts.index_nplike is self._index_nplike
-                and self._index.index_nplike is self._index_nplike
-                and shifts.index_nplike is self._index_nplike
+                nextshifts.nplike is self._index_nplike
+                and self._index.nplike is self._index_nplike
+                and shifts.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1031,10 +1052,13 @@ class IndexedOptionArray(Content):
         return nextshifts
 
     def _rearrange_prepare_next(self, parents):
-        assert self._index.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+        assert (
+            self._index.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
+        )
         index_length = self._index.length
-        numnull = ak.index.Index64.empty(1, self._nplike)
-        assert numnull.index_nplike is self._index_nplike
+        numnull = ak.index.Index64.empty(1, self._index_nplike)
+        assert numnull.nplike is self._index_nplike
 
         self._handle_error(
             self._nplike[
@@ -1048,13 +1072,13 @@ class IndexedOptionArray(Content):
             )
         )
         next_length = index_length - numnull[0]
-        nextparents = ak.index.Index64.empty(next_length, self._nplike)
-        nextcarry = ak.index.Index64.empty(next_length, self._nplike)
-        outindex = ak.index.Index64.empty(index_length, self._nplike)
+        nextparents = ak.index.Index64.empty(next_length, self._index_nplike)
+        nextcarry = ak.index.Index64.empty(next_length, self._index_nplike)
+        outindex = ak.index.Index64.empty(index_length, self._index_nplike)
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and nextparents.index_nplike is self._index_nplike
-            and outindex.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and nextparents.nplike is self._index_nplike
+            and outindex.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1089,9 +1113,9 @@ class IndexedOptionArray(Content):
         order,
     ):
         assert (
-            starts.index_nplike is self._index_nplike
-            and parents.index_nplike is self._index_nplike
-            and self._index.index_nplike is self._index_nplike
+            starts.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
         )
 
         branch, depth = self.branch_depth
@@ -1120,8 +1144,8 @@ class IndexedOptionArray(Content):
         # to account for these None values. First, we locate these nones within
         # their sublists
         nulls_merged = False
-        nulls_index = ak.index.Index64.empty(numnull[0], self._nplike)
-        assert nulls_index.index_nplike is self._index_nplike
+        nulls_index = ak.index.Index64.empty(numnull[0], self._index_nplike)
+        assert nulls_index.nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_index_of_nulls",
@@ -1149,12 +1173,12 @@ class IndexedOptionArray(Content):
             out = out.merge(nulls_index_content)
             nulls_merged = True
 
-        nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
+        nextoutindex = ak.index.Index64.empty(parents.length, self._index_nplike)
         assert (
-            nextoutindex.index_nplike is self._index_nplike
-            and starts.index_nplike is self._index_nplike
-            and parents.index_nplike is self._index_nplike
-            and nextparents.index_nplike is self._index_nplike
+            nextoutindex.nplike is self._index_nplike
+            and starts.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
+            and nextparents.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1179,7 +1203,7 @@ class IndexedOptionArray(Content):
             # only when the `None` value indices are explicitly stored in out,
             # we need to mapping the -1 values to their corresponding indices
             # in `out`
-            assert nextoutindex.index_nplike is self._index_nplike
+            assert nextoutindex.nplike is self._index_nplike
             self._handle_error(
                 self._nplike["awkward_Index_nones_as_index", nextoutindex.dtype.type](
                     nextoutindex.data,
@@ -1216,7 +1240,9 @@ class IndexedOptionArray(Content):
     def _sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        assert starts.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+        assert (
+            starts.nplike is self._index_nplike and parents.nplike is self._index_nplike
+        )
         branch, depth = self.branch_depth
 
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
@@ -1232,8 +1258,8 @@ class IndexedOptionArray(Content):
             order,
         )
 
-        nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
-        assert nextoutindex.index_nplike is self._index_nplike
+        nextoutindex = ak.index.Index64.empty(parents.length, self._index_nplike)
+        assert nextoutindex.nplike is self._index_nplike
 
         self._handle_error(
             self._nplike[
@@ -1344,8 +1370,11 @@ class IndexedOptionArray(Content):
             # child of the returned `next._reduce_next(...)`, i.e. `out.content`. So, we unpack
             # the returned list type and wrap its child by a new `IndexedOptionArray`, before
             # re-wrapping the result to have the length and starts requested by the caller.
-            outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
-            assert outoffsets.index_nplike is self._index_nplike and starts.index_nplike is self._index_nplike
+            outoffsets = ak.index.Index64.empty(starts.length + 1, self._index_nplike)
+            assert (
+                outoffsets.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_reduce_next_fix_offsets_64",
@@ -1387,7 +1416,7 @@ class IndexedOptionArray(Content):
             return out2.simplify_optiontype()
 
     def _validity_error(self, path):
-        assert self.index.index_nplike is self._index_nplike
+        assert self.index.nplike is self._index_nplike
         error = self._nplike["awkward_IndexedArray_validity", self.index.dtype.type](
             self.index.data, self.index.length, self._content.length, True
         )
@@ -1426,8 +1455,10 @@ class IndexedOptionArray(Content):
             return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
-            index = ak.index.Index64.empty(mask.length, self._nplike)
-            assert index.index_nplike is self._index_nplike and mask.index_nplike is self._index_nplike
+            index = ak.index.Index64.empty(mask.length, self._index_nplike)
+            assert (
+                index.nplike is self._index_nplike and mask.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedOptionArray_rpad_and_clip_mask_axis1",
@@ -1543,7 +1574,7 @@ class IndexedOptionArray(Content):
             npselect = npindex >= 0
             if self._index_nplike.any(npselect):
                 indexmin = npindex[npselect].min()
-                index = ak.index.Index(npindex - indexmin, nplike=self._nplike)
+                index = ak.index.Index(npindex - indexmin, nplike=self._index_nplike)
                 content = self._content[indexmin : npindex.max() + 1]
             else:
                 index, content = self._index, self._content
@@ -1619,7 +1650,7 @@ class IndexedOptionArray(Content):
                 dtype=original_index.dtype,
             )
             return ak.contents.IndexedOptionArray(
-                ak.index.Index(new_index, nplike=self.nplike),
+                ak.index.Index(new_index, nplike=self._index_nplike),
                 self.project().packed(),
                 self._parameters,
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -237,7 +237,7 @@ class IndexedOptionArray(Content):
     def _nextcarry_outindex(self, nplike):
         numnull = ak.index.Index64.empty(1, nplike)
 
-        assert numnull.nplike is self._nplike and self._index.nplike is self._nplike
+        assert numnull.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
         self._handle_error(
             nplike[
                 "awkward_IndexedArray_numnull",
@@ -253,9 +253,9 @@ class IndexedOptionArray(Content):
         outindex = ak.index.Index.empty(self._index.length, nplike, self._index.dtype)
 
         assert (
-            nextcarry.nplike is self._nplike
-            and outindex.nplike is self._nplike
-            and self._index.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and outindex.index_nplike is self._index_nplike
+            and self._index.index_nplike is self._index_nplike
         )
         self._handle_error(
             nplike[
@@ -292,11 +292,11 @@ class IndexedOptionArray(Content):
         reducedstarts = ak.index.Index64.empty(self.length - numnull, self._nplike)
         reducedstops = ak.index.Index64.empty(self.length - numnull, self._nplike)
         assert (
-            outindex.nplike is self._nplike
-            and slicestarts.nplike is self._nplike
-            and slicestops.nplike is self._nplike
-            and reducedstarts.nplike is self._nplike
-            and reducedstops.nplike is self._nplike
+            outindex.index_nplike is self._index_nplike
+            and slicestarts.index_nplike is self._index_nplike
+            and slicestops.index_nplike is self._index_nplike
+            and reducedstarts.index_nplike is self._index_nplike
+            and reducedstops.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -373,9 +373,9 @@ class IndexedOptionArray(Content):
                 )
             nextindex = ak.index.Index64.empty(self._index.length, self._nplike)
             assert (
-                nextindex.nplike is self._nplike
-                and mask.nplike is self._nplike
-                and self._index.nplike is self._nplike
+                nextindex.index_nplike is self._index_nplike
+                and mask.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -399,7 +399,7 @@ class IndexedOptionArray(Content):
         else:
             numnull = ak.index.Index64.empty(1, self._nplike)
 
-            assert numnull.nplike is self._nplike and self._index.nplike is self._nplike
+            assert numnull.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_numnull",
@@ -415,7 +415,7 @@ class IndexedOptionArray(Content):
             nextcarry = ak.index.Index64.empty(self.length - numnull[0], self._nplike)
 
             assert (
-                nextcarry.nplike is self._nplike and self._index.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -465,9 +465,9 @@ class IndexedOptionArray(Content):
                 inner = rawcontent.index
                 result = ak.index.Index64.empty(self.index.length, self._nplike)
             assert (
-                result.nplike is self._nplike
-                and self._index.nplike is self._nplike
-                and inner.nplike is self._nplike
+                result.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
+                and inner.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -530,9 +530,9 @@ class IndexedOptionArray(Content):
                 )
 
                 assert (
-                    outoffsets.nplike is self._nplike
-                    and outindex.nplike is self._nplike
-                    and offsets.nplike is self._nplike
+                    outoffsets.index_nplike is self._index_nplike
+                    and outindex.index_nplike is self._index_nplike
+                    and offsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -609,7 +609,7 @@ class IndexedOptionArray(Content):
 
         content = other.merge(self._content)
 
-        assert index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -623,7 +623,7 @@ class IndexedOptionArray(Content):
         )
 
         assert (
-            index.nplike is self._nplike and reinterpreted_index.nplike is self._nplike
+            index.index_nplike is self._index_nplike and reinterpreted_index.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -676,8 +676,8 @@ class IndexedOptionArray(Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.nplike is self._nplike
-                    and array_index.nplike is self._nplike
+                    nextindex.index_nplike is self._index_nplike
+                    and array_index.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -699,7 +699,7 @@ class IndexedOptionArray(Content):
                 pass
             else:
                 contents.append(array)
-                assert nextindex.nplike is self._nplike
+                assert nextindex.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_IndexedArray_fill_count",
@@ -743,7 +743,7 @@ class IndexedOptionArray(Content):
         tags = ak.index.Index8(self.mask_as_bool(valid_when=False))
         index = ak.index.Index64.empty(tags.length, self._nplike)
 
-        assert index.nplike is self._nplike and self._index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_fillna", index.dtype.type, self._index.dtype.type
@@ -776,12 +776,12 @@ class IndexedOptionArray(Content):
 
         subranges_length = ak.index.Index64.empty(1, self._nplike)
         assert (
-            self._index.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and stops.nplike is self._nplike
-            and nextstarts.nplike is self._nplike
-            and nextstops.nplike is self._nplike
-            and subranges_length.nplike is self._nplike
+            self._index.index_nplike is self._index_nplike
+            and starts.index_nplike is self._index_nplike
+            and stops.index_nplike is self._index_nplike
+            and nextstarts.index_nplike is self._index_nplike
+            and nextstops.index_nplike is self._index_nplike
+            and subranges_length.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -805,10 +805,10 @@ class IndexedOptionArray(Content):
 
         nextcarry = ak.index.Index64.empty(subranges_length[0], self._nplike)
         assert (
-            self._index.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and stops.nplike is self._nplike
-            and nextcarry.nplike is self._nplike
+            self._index.index_nplike is self._index_nplike
+            and starts.index_nplike is self._index_nplike
+            and stops.index_nplike is self._index_nplike
+            and nextcarry.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -869,10 +869,10 @@ class IndexedOptionArray(Content):
         if branch or (negaxis is not None and negaxis != depth):
             nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
             assert (
-                nextoutindex.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and parents.nplike is self._nplike
-                and nextparents.nplike is self._nplike
+                nextoutindex.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and parents.index_nplike is self._index_nplike
+                and nextparents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -901,9 +901,9 @@ class IndexedOptionArray(Content):
             newnulls = ak.index.Index64.empty(self._index.length, self._nplike)
             len_newnulls = ak.index.Index64.empty(1, self._nplike)
             assert (
-                newnulls.nplike is self._nplike
-                and len_newnulls.nplike is self._nplike
-                and self._index.nplike is self._nplike
+                newnulls.index_nplike is self._index_nplike
+                and len_newnulls.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -924,10 +924,10 @@ class IndexedOptionArray(Content):
             )
             newoffsets = ak.index.Index64.empty(out._offsets.length, self._nplike)
             assert (
-                newindex.nplike is self._nplike
-                and newoffsets.nplike is self._nplike
-                and out._offsets.nplike is self._nplike
-                and newnulls.nplike is self._nplike
+                newindex.index_nplike is self._index_nplike
+                and newoffsets.index_nplike is self._index_nplike
+                and out._offsets.index_nplike is self._index_nplike
+                and newnulls.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -963,7 +963,7 @@ class IndexedOptionArray(Content):
             # values in the result. We do this by creating an IndexedOptionArray
             # and tacking the index -1 onto the end
             nextoutindex = ak.index.Index64.empty(out.length + 1, self._nplike)
-            assert nextoutindex.nplike is self._nplike
+            assert nextoutindex.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_numnull_unique_64",
@@ -992,11 +992,11 @@ class IndexedOptionArray(Content):
 
     def _rearrange_nextshifts(self, nextparents, shifts):
         nextshifts = ak.index.Index64.empty(nextparents.length, self._nplike)
-        assert nextshifts.nplike is self._nplike
+        assert nextshifts.index_nplike is self._index_nplike
 
         if shifts is None:
             assert (
-                nextshifts.nplike is self._nplike and self._index.nplike is self._nplike
+                nextshifts.index_nplike is self._index_nplike and self._index.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1011,9 +1011,9 @@ class IndexedOptionArray(Content):
             )
         else:
             assert (
-                nextshifts.nplike is self._nplike
-                and self._index.nplike is self._nplike
-                and shifts.nplike is self._nplike
+                nextshifts.index_nplike is self._index_nplike
+                and self._index.index_nplike is self._index_nplike
+                and shifts.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1031,10 +1031,10 @@ class IndexedOptionArray(Content):
         return nextshifts
 
     def _rearrange_prepare_next(self, parents):
-        assert self._index.nplike is self._nplike and parents.nplike is self._nplike
+        assert self._index.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
         index_length = self._index.length
         numnull = ak.index.Index64.empty(1, self._nplike)
-        assert numnull.nplike is self._nplike
+        assert numnull.index_nplike is self._index_nplike
 
         self._handle_error(
             self._nplike[
@@ -1052,9 +1052,9 @@ class IndexedOptionArray(Content):
         nextcarry = ak.index.Index64.empty(next_length, self._nplike)
         outindex = ak.index.Index64.empty(index_length, self._nplike)
         assert (
-            nextcarry.nplike is self._nplike
-            and nextparents.nplike is self._nplike
-            and outindex.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and nextparents.index_nplike is self._index_nplike
+            and outindex.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1089,9 +1089,9 @@ class IndexedOptionArray(Content):
         order,
     ):
         assert (
-            starts.nplike is self._nplike
-            and parents.nplike is self._nplike
-            and self._index.nplike is self._nplike
+            starts.index_nplike is self._index_nplike
+            and parents.index_nplike is self._index_nplike
+            and self._index.index_nplike is self._index_nplike
         )
 
         branch, depth = self.branch_depth
@@ -1121,7 +1121,7 @@ class IndexedOptionArray(Content):
         # their sublists
         nulls_merged = False
         nulls_index = ak.index.Index64.empty(numnull[0], self._nplike)
-        assert nulls_index.nplike is self._nplike
+        assert nulls_index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_IndexedArray_index_of_nulls",
@@ -1151,10 +1151,10 @@ class IndexedOptionArray(Content):
 
         nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
         assert (
-            nextoutindex.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and parents.nplike is self._nplike
-            and nextparents.nplike is self._nplike
+            nextoutindex.index_nplike is self._index_nplike
+            and starts.index_nplike is self._index_nplike
+            and parents.index_nplike is self._index_nplike
+            and nextparents.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1179,7 +1179,7 @@ class IndexedOptionArray(Content):
             # only when the `None` value indices are explicitly stored in out,
             # we need to mapping the -1 values to their corresponding indices
             # in `out`
-            assert nextoutindex.nplike is self._nplike
+            assert nextoutindex.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike["awkward_Index_nones_as_index", nextoutindex.dtype.type](
                     nextoutindex.data,
@@ -1216,7 +1216,7 @@ class IndexedOptionArray(Content):
     def _sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        assert starts.nplike is self._nplike and parents.nplike is self._nplike
+        assert starts.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
         branch, depth = self.branch_depth
 
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
@@ -1233,7 +1233,7 @@ class IndexedOptionArray(Content):
         )
 
         nextoutindex = ak.index.Index64.empty(parents.length, self._nplike)
-        assert nextoutindex.nplike is self._nplike
+        assert nextoutindex.index_nplike is self._index_nplike
 
         self._handle_error(
             self._nplike[
@@ -1345,7 +1345,7 @@ class IndexedOptionArray(Content):
             # the returned list type and wrap its child by a new `IndexedOptionArray`, before
             # re-wrapping the result to have the length and starts requested by the caller.
             outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
-            assert outoffsets.nplike is self._nplike and starts.nplike is self._nplike
+            assert outoffsets.index_nplike is self._index_nplike and starts.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedArray_reduce_next_fix_offsets_64",
@@ -1387,7 +1387,7 @@ class IndexedOptionArray(Content):
             return out2.simplify_optiontype()
 
     def _validity_error(self, path):
-        assert self.index.nplike is self._nplike
+        assert self.index.index_nplike is self._index_nplike
         error = self._nplike["awkward_IndexedArray_validity", self.index.dtype.type](
             self.index.data, self.index.length, self._content.length, True
         )
@@ -1427,7 +1427,7 @@ class IndexedOptionArray(Content):
         elif posaxis == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(mask.length, self._nplike)
-            assert index.nplike is self._nplike and mask.nplike is self._nplike
+            assert index.index_nplike is self._index_nplike and mask.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_IndexedOptionArray_rpad_and_clip_mask_axis1",

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -260,9 +260,9 @@ class ListArray(Content):
         starts_len = self._starts.length
         out = ak.index.Index64.empty(starts_len + 1, self._nplike)
         assert (
-            out.nplike is self._nplike
-            and self._starts.nplike is self._nplike
-            and self._stops.nplike is self._nplike
+            out.index_nplike is self._index_nplike
+            and self._starts.index_nplike is self._index_nplike
+            and self._stops.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -297,11 +297,11 @@ class ListArray(Content):
         if isinstance(slicecontent, ak.contents.ListOffsetArray):
             outoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
             assert (
-                outoffsets.nplike is self._nplike
-                and slicestarts.nplike is self._nplike
-                and slicestops.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                outoffsets.index_nplike is self._index_nplike
+                and slicestarts.index_nplike is self._index_nplike
+                and slicestops.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -338,9 +338,9 @@ class ListArray(Content):
         elif isinstance(slicecontent, ak.contents.NumpyArray):
             carrylen = ak.index.Index64.empty(1, self._nplike)
             assert (
-                carrylen.nplike is self._nplike
-                and slicestarts.nplike is self._nplike
-                and slicestops.nplike is self._nplike
+                carrylen.index_nplike is self._index_nplike
+                and slicestarts.index_nplike is self._index_nplike
+                and slicestops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -361,13 +361,13 @@ class ListArray(Content):
             nextcarry = ak.index.Index64.empty(carrylen[0], self._nplike)
 
             assert (
-                outoffsets.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
-                and slicestarts.nplike is self._nplike
-                and slicestops.nplike is self._nplike
-                and sliceindex.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                outoffsets.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
+                and slicestarts.index_nplike is self._index_nplike
+                and slicestops.index_nplike is self._index_nplike
+                and sliceindex.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -410,10 +410,10 @@ class ListArray(Content):
             missing = ak.index.Index64(slicecontent._index)
             numvalid = ak.index.Index64.empty(1, self._nplike)
             assert (
-                numvalid.nplike is self._nplike
-                and slicestarts.nplike is self._nplike
-                and slicestops.nplike is self._nplike
-                and missing.nplike is self._nplike
+                numvalid.index_nplike is self._index_nplike
+                and slicestarts.index_nplike is self._index_nplike
+                and slicestops.index_nplike is self._index_nplike
+                and missing.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -439,12 +439,12 @@ class ListArray(Content):
             largeoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
 
             assert (
-                nextcarry.nplike is self._nplike
-                and smalloffsets.nplike is self._nplike
-                and largeoffsets.nplike is self._nplike
-                and slicestarts.nplike is self._nplike
-                and slicestops.nplike is self._nplike
-                and missing.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike
+                and smalloffsets.index_nplike is self._index_nplike
+                and largeoffsets.index_nplike is self._index_nplike
+                and slicestarts.index_nplike is self._index_nplike
+                and slicestops.index_nplike is self._index_nplike
+                and missing.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -534,9 +534,9 @@ class ListArray(Content):
             lenstarts = self._starts.length
             nextcarry = ak.index.Index64.empty(lenstarts, self._nplike)
             assert (
-                nextcarry.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -570,9 +570,9 @@ class ListArray(Content):
             if self._nplike.known_shape:
                 carrylength = ak.index.Index64.empty(1, self._nplike)
                 assert (
-                    carrylength.nplike is self._nplike
-                    and self._starts.nplike is self._nplike
-                    and self._stops.nplike is self._nplike
+                    carrylength.index_nplike is self._index_nplike
+                    and self._starts.index_nplike is self._index_nplike
+                    and self._stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -605,10 +605,10 @@ class ListArray(Content):
                 nextoffsets = ak.index.IndexU32.empty(lenstarts + 1, self._nplike)
 
             assert (
-                nextoffsets.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                nextoffsets.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -642,8 +642,8 @@ class ListArray(Content):
                 if self._nplike.known_shape:
                     total = ak.index.Index64.empty(1, self._nplike)
                     assert (
-                        total.nplike is self._nplike
-                        and nextoffsets.nplike is self._nplike
+                        total.index_nplike is self._index_nplike
+                        and nextoffsets.index_nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -664,9 +664,9 @@ class ListArray(Content):
                     )
                 advanced = advanced._to_nplike(self.nplike)
                 assert (
-                    nextadvanced.nplike is self._nplike
-                    and advanced.nplike is self._nplike
-                    and nextoffsets.nplike is self._nplike
+                    nextadvanced.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
+                    and nextoffsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -714,11 +714,11 @@ class ListArray(Content):
                     lenstarts * flathead.shape[0], self._nplike
                 )
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and self._starts.nplike is self._nplike
-                    and self._stops.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and self._starts.index_nplike is self._index_nplike
+                    and self._stops.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -755,12 +755,12 @@ class ListArray(Content):
                 nextadvanced = ak.index.Index64.empty(lenstarts, self._nplike)
                 advanced = advanced._to_nplike(self.nplike)
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and self._starts.nplike is self._nplike
-                    and self._stops.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
-                    and advanced.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and self._starts.index_nplike is self._index_nplike
+                    and self._stops.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -804,12 +804,12 @@ class ListArray(Content):
             nextcarry = ak.index.Index64.empty(head.length * length, self._nplike)
 
             assert (
-                multistarts.nplike is self._nplike
-                and multistops.nplike is self._nplike
-                and singleoffsets.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                multistarts.index_nplike is self._index_nplike
+                and multistops.index_nplike is self._index_nplike
+                and singleoffsets.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -861,9 +861,9 @@ class ListArray(Content):
         elif posaxis == depth + 1:
             tonum = ak.index.Index64.empty(self.length, self._nplike)
             assert (
-                tonum.nplike is self._nplike
-                and self._starts.nplike is self._nplike
-                and self._stops.nplike is self._nplike
+                tonum.index_nplike is self._index_nplike
+                and self._starts.index_nplike is self._index_nplike
+                and self._stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -971,10 +971,10 @@ class ListArray(Content):
                 array_stops = ak.index.Index(array.stops)
 
                 assert (
-                    nextstarts.nplike is self._nplike
-                    and nextstops.nplike is self._nplike
-                    and array_starts.nplike is self._nplike
-                    and array_stops.nplike is self._nplike
+                    nextstarts.index_nplike is self._index_nplike
+                    and nextstops.index_nplike is self._index_nplike
+                    and array_starts.index_nplike is self._index_nplike
+                    and array_stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1004,10 +1004,10 @@ class ListArray(Content):
                 array_stops = ak.index.Index64(listoffsetarray.stops)
 
                 assert (
-                    nextstarts.nplike is self._nplike
-                    and nextstops.nplike is self._nplike
-                    and array_starts.nplike is self._nplike
-                    and array_stops.nplike is self._nplike
+                    nextstarts.index_nplike is self._index_nplike
+                    and nextstops.index_nplike is self._index_nplike
+                    and array_starts.index_nplike is self._index_nplike
+                    and array_stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1063,7 +1063,7 @@ class ListArray(Content):
             else:
                 innerlength = ak._typetracer.UnknownLength
             localindex = ak.index.Index64.empty(innerlength, self._nplike)
-            assert localindex.nplike is self._nplike and offsets.nplike is self._nplike
+            assert localindex.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListArray_localindex",
@@ -1183,7 +1183,7 @@ class ListArray(Content):
     def _validity_error(self, path):
         if self._nplike.known_shape and self.stops.length < self.starts.length:
             return f'at {path} ("{type(self)}"): len(stops) < len(starts)'
-        assert self.starts.nplike is self._nplike and self.stops.nplike is self._nplike
+        assert self.starts.index_nplike is self._index_nplike and self.stops.index_nplike is self._index_nplike
         error = self._nplike[
             "awkward_ListArray_validity", self.starts.dtype.type, self.stops.dtype.type
         ](
@@ -1227,9 +1227,9 @@ class ListArray(Content):
             elif posaxis == depth + 1:
                 min_ = ak.index.Index64.empty(1, self._nplike)
                 assert (
-                    min_.nplike is self._nplike
-                    and self._starts.nplike is self._nplike
-                    and self._stops.nplike is self._nplike
+                    min_.index_nplike is self._index_nplike
+                    and self._starts.index_nplike is self._index_nplike
+                    and self._stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1251,9 +1251,9 @@ class ListArray(Content):
                 else:
                     tolength = ak.index.Index64.empty(1, self._nplike)
                     assert (
-                        tolength.nplike is self._nplike
-                        and self._starts.nplike is self._nplike
-                        and self._stops.nplike is self._nplike
+                        tolength.index_nplike is self._index_nplike
+                        and self._starts.index_nplike is self._index_nplike
+                        and self._stops.index_nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -1274,11 +1274,11 @@ class ListArray(Content):
                     starts_ = ak.index.Index64.empty(self._starts.length, self._nplike)
                     stops_ = ak.index.Index64.empty(self._stops.length, self._nplike)
                     assert (
-                        index.nplike is self._nplike
-                        and self._starts.nplike is self._nplike
-                        and self._stops.nplike is self._nplike
-                        and starts_.nplike is self._nplike
-                        and stops_.nplike is self._nplike
+                        index.index_nplike is self._index_nplike
+                        and self._starts.index_nplike is self._index_nplike
+                        and self._stops.index_nplike is self._index_nplike
+                        and starts_.index_nplike is self._index_nplike
+                        and stops_.index_nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -171,7 +171,7 @@ class ListArray(Content):
         if not self._nplike.known_data:
             offsets = self._index_nplike.empty(starts.shape[0] + 1, dtype=starts.dtype)
             return ListOffsetArray(
-                ak.index.Index(offsets, nplike=self._nplike),
+                ak.index.Index(offsets, nplike=self._index_nplike),
                 self._content,
                 self._parameters,
             )
@@ -184,7 +184,7 @@ class ListArray(Content):
                 offsets[:-1] = starts
                 offsets[-1] = stops[-1]
             return ListOffsetArray(
-                ak.index.Index(offsets, nplike=self._nplike),
+                ak.index.Index(offsets, nplike=self._index_nplike),
                 self._content,
                 self._parameters,
             ).to_ListOffsetArray64(start_at_zero=start_at_zero)
@@ -258,11 +258,11 @@ class ListArray(Content):
 
     def _compact_offsets64(self, start_at_zero):
         starts_len = self._starts.length
-        out = ak.index.Index64.empty(starts_len + 1, self._nplike)
+        out = ak.index.Index64.empty(starts_len + 1, self._index_nplike)
         assert (
-            out.index_nplike is self._index_nplike
-            and self._starts.index_nplike is self._index_nplike
-            and self._stops.index_nplike is self._index_nplike
+            out.nplike is self._index_nplike
+            and self._starts.nplike is self._index_nplike
+            and self._stops.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -295,13 +295,15 @@ class ListArray(Content):
             )
 
         if isinstance(slicecontent, ak.contents.ListOffsetArray):
-            outoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
+            outoffsets = ak.index.Index64.empty(
+                slicestarts.length + 1, self._index_nplike
+            )
             assert (
-                outoffsets.index_nplike is self._index_nplike
-                and slicestarts.index_nplike is self._index_nplike
-                and slicestops.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                outoffsets.nplike is self._index_nplike
+                and slicestarts.nplike is self._index_nplike
+                and slicestops.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -336,11 +338,11 @@ class ListArray(Content):
             return ak.contents.ListOffsetArray(outoffsets, outcontent, self._parameters)
 
         elif isinstance(slicecontent, ak.contents.NumpyArray):
-            carrylen = ak.index.Index64.empty(1, self._nplike)
+            carrylen = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                carrylen.index_nplike is self._index_nplike
-                and slicestarts.index_nplike is self._index_nplike
-                and slicestops.index_nplike is self._index_nplike
+                carrylen.nplike is self._index_nplike
+                and slicestarts.nplike is self._index_nplike
+                and slicestops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -357,17 +359,19 @@ class ListArray(Content):
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
             sliceindex = ak.index.Index64(slicecontent._data)
-            outoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
-            nextcarry = ak.index.Index64.empty(carrylen[0], self._nplike)
+            outoffsets = ak.index.Index64.empty(
+                slicestarts.length + 1, self._index_nplike
+            )
+            nextcarry = ak.index.Index64.empty(carrylen[0], self._index_nplike)
 
             assert (
-                outoffsets.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
-                and slicestarts.index_nplike is self._index_nplike
-                and slicestops.index_nplike is self._index_nplike
-                and sliceindex.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                outoffsets.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+                and slicestarts.nplike is self._index_nplike
+                and slicestops.nplike is self._index_nplike
+                and sliceindex.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -408,12 +412,12 @@ class ListArray(Content):
                 )
 
             missing = ak.index.Index64(slicecontent._index)
-            numvalid = ak.index.Index64.empty(1, self._nplike)
+            numvalid = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                numvalid.index_nplike is self._index_nplike
-                and slicestarts.index_nplike is self._index_nplike
-                and slicestops.index_nplike is self._index_nplike
-                and missing.index_nplike is self._index_nplike
+                numvalid.nplike is self._index_nplike
+                and slicestarts.nplike is self._index_nplike
+                and slicestops.nplike is self._index_nplike
+                and missing.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -433,18 +437,22 @@ class ListArray(Content):
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
 
-            nextcarry = ak.index.Index64.empty(numvalid[0], self._nplike)
+            nextcarry = ak.index.Index64.empty(numvalid[0], self._index_nplike)
 
-            smalloffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
-            largeoffsets = ak.index.Index64.empty(slicestarts.length + 1, self._nplike)
+            smalloffsets = ak.index.Index64.empty(
+                slicestarts.length + 1, self._index_nplike
+            )
+            largeoffsets = ak.index.Index64.empty(
+                slicestarts.length + 1, self._index_nplike
+            )
 
             assert (
-                nextcarry.index_nplike is self._index_nplike
-                and smalloffsets.index_nplike is self._index_nplike
-                and largeoffsets.index_nplike is self._index_nplike
-                and slicestarts.index_nplike is self._index_nplike
-                and slicestops.index_nplike is self._index_nplike
-                and missing.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and smalloffsets.nplike is self._index_nplike
+                and largeoffsets.nplike is self._index_nplike
+                and slicestarts.nplike is self._index_nplike
+                and slicestops.nplike is self._index_nplike
+                and missing.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -532,11 +540,11 @@ class ListArray(Content):
             assert advanced is None
             nexthead, nexttail = ak._slicing.headtail(tail)
             lenstarts = self._starts.length
-            nextcarry = ak.index.Index64.empty(lenstarts, self._nplike)
+            nextcarry = ak.index.Index64.empty(lenstarts, self._index_nplike)
             assert (
-                nextcarry.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -568,11 +576,11 @@ class ListArray(Content):
             stop = ak._util.kSliceNone if stop is None else stop
 
             if self._nplike.known_shape:
-                carrylength = ak.index.Index64.empty(1, self._nplike)
+                carrylength = ak.index.Index64.empty(1, self._index_nplike)
                 assert (
-                    carrylength.index_nplike is self._index_nplike
-                    and self._starts.index_nplike is self._index_nplike
-                    and self._stops.index_nplike is self._index_nplike
+                    carrylength.nplike is self._index_nplike
+                    and self._starts.nplike is self._index_nplike
+                    and self._stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -591,24 +599,24 @@ class ListArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcarry = ak.index.Index64.empty(carrylength[0], self._nplike)
+                nextcarry = ak.index.Index64.empty(carrylength[0], self._index_nplike)
             else:
                 nextcarry = ak.index.Index64.empty(
                     ak._typetracer.UnknownLength, self._nplike
                 )
 
             if self._starts.dtype == "int64":
-                nextoffsets = ak.index.Index64.empty(lenstarts + 1, self._nplike)
+                nextoffsets = ak.index.Index64.empty(lenstarts + 1, self._index_nplike)
             elif self._starts.dtype == "int32":
-                nextoffsets = ak.index.Index32.empty(lenstarts + 1, self._nplike)
+                nextoffsets = ak.index.Index32.empty(lenstarts + 1, self._index_nplike)
             elif self._starts.dtype == "uint32":
                 nextoffsets = ak.index.IndexU32.empty(lenstarts + 1, self._nplike)
 
             assert (
-                nextoffsets.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                nextoffsets.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -640,10 +648,10 @@ class ListArray(Content):
                 )
             else:
                 if self._nplike.known_shape:
-                    total = ak.index.Index64.empty(1, self._nplike)
+                    total = ak.index.Index64.empty(1, self._index_nplike)
                     assert (
-                        total.index_nplike is self._index_nplike
-                        and nextoffsets.index_nplike is self._index_nplike
+                        total.nplike is self._index_nplike
+                        and nextoffsets.nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -657,16 +665,16 @@ class ListArray(Content):
                         ),
                         slicer=head,
                     )
-                    nextadvanced = ak.index.Index64.empty(total[0], self._nplike)
+                    nextadvanced = ak.index.Index64.empty(total[0], self._index_nplike)
                 else:
                     nextadvanced = ak.index.Index64.empty(
                         ak._typetracer.UnknownLength, self._nplike
                     )
                 advanced = advanced._to_nplike(self.nplike)
                 assert (
-                    nextadvanced.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
-                    and nextoffsets.index_nplike is self._index_nplike
+                    nextadvanced.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
+                    and nextoffsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -705,7 +713,7 @@ class ListArray(Content):
 
             nexthead, nexttail = ak._slicing.headtail(tail)
             flathead = self._index_nplike.asarray(head.data.reshape(-1))
-            regular_flathead = ak.index.Index64(flathead, nplike=self.nplike)
+            regular_flathead = ak.index.Index64(flathead, nplike=self._index_nplike)
             if advanced is None or advanced.length == 0:
                 nextcarry = ak.index.Index64.empty(
                     lenstarts * flathead.shape[0], self._nplike
@@ -714,11 +722,11 @@ class ListArray(Content):
                     lenstarts * flathead.shape[0], self._nplike
                 )
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and self._starts.index_nplike is self._index_nplike
-                    and self._stops.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and self._starts.nplike is self._index_nplike
+                    and self._stops.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -751,16 +759,16 @@ class ListArray(Content):
                     return out
 
             else:
-                nextcarry = ak.index.Index64.empty(lenstarts, self._nplike)
-                nextadvanced = ak.index.Index64.empty(lenstarts, self._nplike)
+                nextcarry = ak.index.Index64.empty(lenstarts, self._index_nplike)
+                nextadvanced = ak.index.Index64.empty(lenstarts, self._index_nplike)
                 advanced = advanced._to_nplike(self.nplike)
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and self._starts.index_nplike is self._index_nplike
-                    and self._stops.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and self._starts.nplike is self._index_nplike
+                    and self._stops.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -799,17 +807,21 @@ class ListArray(Content):
                 )
             length = self.length
             singleoffsets = ak.index.Index64(head.offsets.data)
-            multistarts = ak.index.Index64.empty(head.length * length, self._nplike)
-            multistops = ak.index.Index64.empty(head.length * length, self._nplike)
-            nextcarry = ak.index.Index64.empty(head.length * length, self._nplike)
+            multistarts = ak.index.Index64.empty(
+                head.length * length, self._index_nplike
+            )
+            multistops = ak.index.Index64.empty(
+                head.length * length, self._index_nplike
+            )
+            nextcarry = ak.index.Index64.empty(head.length * length, self._index_nplike)
 
             assert (
-                multistarts.index_nplike is self._index_nplike
-                and multistops.index_nplike is self._index_nplike
-                and singleoffsets.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                multistarts.nplike is self._index_nplike
+                and multistops.nplike is self._index_nplike
+                and singleoffsets.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -859,11 +871,11 @@ class ListArray(Content):
             else:
                 return out
         elif posaxis == depth + 1:
-            tonum = ak.index.Index64.empty(self.length, self._nplike)
+            tonum = ak.index.Index64.empty(self.length, self._index_nplike)
             assert (
-                tonum.index_nplike is self._index_nplike
-                and self._starts.index_nplike is self._index_nplike
-                and self._stops.index_nplike is self._index_nplike
+                tonum.nplike is self._index_nplike
+                and self._starts.nplike is self._index_nplike
+                and self._stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -953,8 +965,8 @@ class ListArray(Content):
         tail_contents = contents[1:]
         nextcontent = contents[0].mergemany(tail_contents)
 
-        nextstarts = ak.index.Index64.empty(total_length, self._nplike)
-        nextstops = ak.index.Index64.empty(total_length, self._nplike)
+        nextstarts = ak.index.Index64.empty(total_length, self._index_nplike)
+        nextstops = ak.index.Index64.empty(total_length, self._index_nplike)
 
         contentlength_so_far = 0
         length_so_far = 0
@@ -971,10 +983,10 @@ class ListArray(Content):
                 array_stops = ak.index.Index(array.stops)
 
                 assert (
-                    nextstarts.index_nplike is self._index_nplike
-                    and nextstops.index_nplike is self._index_nplike
-                    and array_starts.index_nplike is self._index_nplike
-                    and array_stops.index_nplike is self._index_nplike
+                    nextstarts.nplike is self._index_nplike
+                    and nextstops.nplike is self._index_nplike
+                    and array_starts.nplike is self._index_nplike
+                    and array_stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1004,10 +1016,10 @@ class ListArray(Content):
                 array_stops = ak.index.Index64(listoffsetarray.stops)
 
                 assert (
-                    nextstarts.index_nplike is self._index_nplike
-                    and nextstops.index_nplike is self._index_nplike
-                    and array_starts.index_nplike is self._index_nplike
-                    and array_stops.index_nplike is self._index_nplike
+                    nextstarts.nplike is self._index_nplike
+                    and nextstops.nplike is self._index_nplike
+                    and array_starts.nplike is self._index_nplike
+                    and array_stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1062,8 +1074,11 @@ class ListArray(Content):
                 innerlength = offsets[offsets.length - 1]
             else:
                 innerlength = ak._typetracer.UnknownLength
-            localindex = ak.index.Index64.empty(innerlength, self._nplike)
-            assert localindex.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
+            localindex = ak.index.Index64.empty(innerlength, self._index_nplike)
+            assert (
+                localindex.nplike is self._index_nplike
+                and offsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListArray_localindex",
@@ -1183,7 +1198,10 @@ class ListArray(Content):
     def _validity_error(self, path):
         if self._nplike.known_shape and self.stops.length < self.starts.length:
             return f'at {path} ("{type(self)}"): len(stops) < len(starts)'
-        assert self.starts.index_nplike is self._index_nplike and self.stops.index_nplike is self._index_nplike
+        assert (
+            self.starts.nplike is self._index_nplike
+            and self.stops.nplike is self._index_nplike
+        )
         error = self._nplike[
             "awkward_ListArray_validity", self.starts.dtype.type, self.stops.dtype.type
         ](
@@ -1225,11 +1243,11 @@ class ListArray(Content):
             if posaxis == depth:
                 return self.pad_none_axis0(target, clip)
             elif posaxis == depth + 1:
-                min_ = ak.index.Index64.empty(1, self._nplike)
+                min_ = ak.index.Index64.empty(1, self._index_nplike)
                 assert (
-                    min_.index_nplike is self._index_nplike
-                    and self._starts.index_nplike is self._index_nplike
-                    and self._stops.index_nplike is self._index_nplike
+                    min_.nplike is self._index_nplike
+                    and self._starts.nplike is self._index_nplike
+                    and self._stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1249,11 +1267,11 @@ class ListArray(Content):
                 if target < min_[0]:
                     return self
                 else:
-                    tolength = ak.index.Index64.empty(1, self._nplike)
+                    tolength = ak.index.Index64.empty(1, self._index_nplike)
                     assert (
-                        tolength.index_nplike is self._index_nplike
-                        and self._starts.index_nplike is self._index_nplike
-                        and self._stops.index_nplike is self._index_nplike
+                        tolength.nplike is self._index_nplike
+                        and self._starts.nplike is self._index_nplike
+                        and self._stops.nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -1270,15 +1288,19 @@ class ListArray(Content):
                         )
                     )
 
-                    index = ak.index.Index64.empty(tolength[0], self._nplike)
-                    starts_ = ak.index.Index64.empty(self._starts.length, self._nplike)
-                    stops_ = ak.index.Index64.empty(self._stops.length, self._nplike)
+                    index = ak.index.Index64.empty(tolength[0], self._index_nplike)
+                    starts_ = ak.index.Index64.empty(
+                        self._starts.length, self._index_nplike
+                    )
+                    stops_ = ak.index.Index64.empty(
+                        self._stops.length, self._index_nplike
+                    )
                     assert (
-                        index.index_nplike is self._index_nplike
-                        and self._starts.index_nplike is self._index_nplike
-                        and self._stops.index_nplike is self._index_nplike
-                        and starts_.index_nplike is self._index_nplike
-                        and stops_.index_nplike is self._index_nplike
+                        index.nplike is self._index_nplike
+                        and self._starts.nplike is self._index_nplike
+                        and self._stops.nplike is self._index_nplike
+                        and starts_.nplike is self._index_nplike
+                        and stops_.nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -1352,8 +1374,12 @@ class ListArray(Content):
             and self._starts.length != 0
         ):
             startsmin = self._starts.data.min()
-            starts = ak.index.Index(self._starts.data - startsmin, nplike=self._nplike)
-            stops = ak.index.Index(self._stops.data - startsmin, nplike=self._nplike)
+            starts = ak.index.Index(
+                self._starts.data - startsmin, nplike=self._index_nplike
+            )
+            stops = ak.index.Index(
+                self._stops.data - startsmin, nplike=self._index_nplike
+            )
             content = self._content[startsmin : self._stops.data.max()]
         else:
             starts, stops, content = self._starts, self._stops, self._content

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -171,8 +171,11 @@ class ListOffsetArray(Content):
     def to_RegularArray(self):
         start, stop = self._offsets[0], self._offsets[self._offsets.length - 1]
         content = self._content._getitem_range(slice(start, stop))
-        size = ak.index.Index64.empty(1, self._nplike)
-        assert size.index_nplike is self._index_nplike and self._offsets.index_nplike is self._index_nplike
+        size = ak.index.Index64.empty(1, self._index_nplike)
+        assert (
+            size.nplike is self._index_nplike
+            and self._offsets.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_toRegularArray",
@@ -255,8 +258,11 @@ class ListOffsetArray(Content):
 
     def _compact_offsets64(self, start_at_zero):
         offsets_len = self._offsets.length - 1
-        out = ak.index.Index64.empty(offsets_len + 1, self._nplike)
-        assert out.index_nplike is self._index_nplike and self._offsets.index_nplike is self._index_nplike
+        out = ak.index.Index64.empty(offsets_len + 1, self._index_nplike)
+        assert (
+            out.nplike is self._index_nplike
+            and self._offsets.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_compact_offsets",
@@ -287,12 +293,12 @@ class ListOffsetArray(Content):
 
         starts, stops = self.starts, self.stops
 
-        nextcarry = ak.index.Index64.empty(offsets[-1], self._nplike)
+        nextcarry = ak.index.Index64.empty(offsets[-1], self._index_nplike)
         assert (
-            nextcarry.index_nplike is self._index_nplike
-            and offsets.index_nplike is self._index_nplike
-            and starts.index_nplike is self._index_nplike
-            and stops.index_nplike is self._index_nplike
+            nextcarry.nplike is self._index_nplike
+            and offsets.nplike is self._index_nplike
+            and starts.nplike is self._index_nplike
+            and stops.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -334,12 +340,12 @@ class ListOffsetArray(Content):
             lenstarts = self._offsets.length - 1
             starts, stops = self.starts, self.stops
             nexthead, nexttail = ak._slicing.headtail(tail)
-            nextcarry = ak.index.Index64.empty(lenstarts, self._nplike)
+            nextcarry = ak.index.Index64.empty(lenstarts, self._index_nplike)
 
             assert (
-                nextcarry.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and stops.index_nplike is self._index_nplike
+                nextcarry.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -368,11 +374,11 @@ class ListOffsetArray(Content):
             start = ak._util.kSliceNone if start is None else start
             stop = ak._util.kSliceNone if stop is None else stop
 
-            carrylength = ak.index.Index64.empty(1, self._nplike)
+            carrylength = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                carrylength.index_nplike is self._index_nplike
-                and self.starts.index_nplike is self._index_nplike
-                and self.stops.index_nplike is self._index_nplike
+                carrylength.nplike is self._index_nplike
+                and self.starts.nplike is self._index_nplike
+                and self.stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -393,18 +399,18 @@ class ListOffsetArray(Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = ak.index.Index64.empty(lenstarts + 1, self._nplike)
+                nextoffsets = ak.index.Index64.empty(lenstarts + 1, self._index_nplike)
             elif self._starts.dtype == "int32":
-                nextoffsets = ak.index.Index32.empty(lenstarts + 1, self._nplike)
+                nextoffsets = ak.index.Index32.empty(lenstarts + 1, self._index_nplike)
             elif self._starts.dtype == "uint32":
                 nextoffsets = ak.index.IndexU32.empty(lenstarts + 1, self._nplike)
-            nextcarry = ak.index.Index64.empty(carrylength[0], self._nplike)
+            nextcarry = ak.index.Index64.empty(carrylength[0], self._index_nplike)
 
             assert (
-                nextoffsets.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
-                and self.starts.index_nplike is self._index_nplike
-                and self.stops.index_nplike is self._index_nplike
+                nextoffsets.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+                and self.starts.nplike is self._index_nplike
+                and self.stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -436,9 +442,10 @@ class ListOffsetArray(Content):
                 )
 
             else:
-                total = ak.index.Index64.empty(1, self._nplike)
+                total = ak.index.Index64.empty(1, self._index_nplike)
                 assert (
-                    total.index_nplike is self._index_nplike and nextoffsets.index_nplike is self._index_nplike
+                    total.nplike is self._index_nplike
+                    and nextoffsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -453,11 +460,11 @@ class ListOffsetArray(Content):
                     slicer=head,
                 )
 
-                nextadvanced = ak.index.Index64.empty(total[0], self._nplike)
+                nextadvanced = ak.index.Index64.empty(total[0], self._index_nplike)
                 assert (
-                    nextadvanced.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
-                    and nextoffsets.index_nplike is self._index_nplike
+                    nextadvanced.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
+                    and nextoffsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -505,9 +512,9 @@ class ListOffsetArray(Content):
                     lenstarts * flathead.length, self._nplike
                 )
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -538,15 +545,15 @@ class ListOffsetArray(Content):
                     return out
 
             else:
-                nextcarry = ak.index.Index64.empty(self.length, self._nplike)
-                nextadvanced = ak.index.Index64.empty(self.length, self._nplike)
+                nextcarry = ak.index.Index64.empty(self.length, self._index_nplike)
+                nextadvanced = ak.index.Index64.empty(self.length, self._index_nplike)
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and self.starts.index_nplike is self._index_nplike
-                    and self.stops.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and self.starts.nplike is self._index_nplike
+                    and self.stops.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -597,11 +604,11 @@ class ListOffsetArray(Content):
             else:
                 return out
         elif posaxis == depth + 1:
-            tonum = ak.index.Index64.empty(self.length, self._nplike)
+            tonum = ak.index.Index64.empty(self.length, self._index_nplike)
             assert (
-                tonum.index_nplike is self._index_nplike
-                and self.starts.index_nplike is self._index_nplike
-                and self.stops.index_nplike is self._index_nplike
+                tonum.nplike is self._index_nplike
+                and self.starts.nplike is self._index_nplike
+                and self.stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -657,9 +664,9 @@ class ListOffsetArray(Content):
                     self._offsets.length, self._nplike, dtype=np.int64
                 )
                 assert (
-                    tooffsets.index_nplike is self._index_nplike
-                    and self._offsets.index_nplike is self._index_nplike
-                    and inneroffsets.index_nplike is self._index_nplike
+                    tooffsets.nplike is self._index_nplike
+                    and self._offsets.nplike is self._index_nplike
+                    and inneroffsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -739,8 +746,11 @@ class ListOffsetArray(Content):
                 innerlength = offsets[offsets.length - 1]
             else:
                 innerlength = ak._typetracer.UnknownLength
-            localindex = ak.index.Index64.empty(innerlength, self._nplike)
-            assert localindex.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
+            localindex = ak.index.Index64.empty(innerlength, self._index_nplike)
+            assert (
+                localindex.nplike is self._index_nplike
+                and offsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListArray_localindex",
@@ -810,8 +820,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
+                nextparents.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -882,8 +892,11 @@ class ListOffsetArray(Content):
                 maxnextparents[0] + 1,
             )
 
-            outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
+            outcarry = ak.index.Index64.empty(nextcarry.length, self._index_nplike)
+            assert (
+                outcarry.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -908,8 +921,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
+                nextparents.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -973,11 +986,11 @@ class ListOffsetArray(Content):
 
                 self_starts, self_stops = self._offsets[:-1], self._offsets[1:]
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
                     and self._content.nplike is self._nplike
-                    and self_starts.index_nplike is self._index_nplike
-                    and self_stops.index_nplike is self._index_nplike
+                    and self_starts.nplike is self._index_nplike
+                    and self_stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1024,17 +1037,17 @@ class ListOffsetArray(Content):
                 nextstarts,
             ) = self._rearrange_prepare_next(outlength, parents)
 
-            nummissing = ak.index.Index64.empty(maxcount, self._nplike)
-            missing = ak.index.Index64.empty(self._offsets[-1], self._nplike)
-            nextshifts = ak.index.Index64.empty(nextcarry.length, self._nplike)
+            nummissing = ak.index.Index64.empty(maxcount, self._index_nplike)
+            missing = ak.index.Index64.empty(self._offsets[-1], self._index_nplike)
+            nextshifts = ak.index.Index64.empty(nextcarry.length, self._index_nplike)
             assert (
-                nummissing.index_nplike is self._index_nplike
-                and missing.index_nplike is self._index_nplike
-                and nextshifts.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and parents.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
+                nummissing.nplike is self._index_nplike
+                and missing.nplike is self._index_nplike
+                and nextshifts.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
             )
 
             self._handle_error(
@@ -1074,8 +1087,11 @@ class ListOffsetArray(Content):
                 order,
             )
 
-            outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
+            outcarry = ak.index.Index64.empty(nextcarry.length, self._index_nplike)
+            assert (
+                outcarry.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -1101,8 +1117,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
+                nextparents.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1158,11 +1174,11 @@ class ListOffsetArray(Content):
 
                 starts, stops = self._offsets[:-1], self._offsets[1:]
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
                     and self._content.nplike is self._nplike
-                    and starts.index_nplike is self._index_nplike
-                    and stops.index_nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
+                    and stops.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1219,8 +1235,11 @@ class ListOffsetArray(Content):
                 order,
             )
 
-            outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
+            outcarry = ak.index.Index64.empty(nextcarry.length, self._index_nplike)
+            assert (
+                outcarry.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -1244,8 +1263,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
+                nextparents.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1300,9 +1319,9 @@ class ListOffsetArray(Content):
                 self.length + 1, self._nplike, dtype=np.int64
             )
             assert (
-                offsets.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and stops.index_nplike is self._index_nplike
+                offsets.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1334,10 +1353,10 @@ class ListOffsetArray(Content):
             toindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
             fromindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
             assert (
-                toindex.index_nplike is self._index_nplike
-                and fromindex.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and stops.index_nplike is self._index_nplike
+                toindex.nplike is self._index_nplike
+                and fromindex.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1415,12 +1434,12 @@ class ListOffsetArray(Content):
                 nextstarts,
             ) = self._rearrange_prepare_next(outlength, parents)
 
-            outstarts = ak.index.Index64.empty(outlength, self._nplike)
-            outstops = ak.index.Index64.empty(outlength, self._nplike)
+            outstarts = ak.index.Index64.empty(outlength, self._index_nplike)
+            outstops = ak.index.Index64.empty(outlength, self._index_nplike)
             assert (
-                outstarts.index_nplike is self._index_nplike
-                and outstops.index_nplike is self._index_nplike
-                and distincts.index_nplike is self._index_nplike
+                outstarts.nplike is self._index_nplike
+                and outstops.nplike is self._index_nplike
+                and distincts.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1438,17 +1457,19 @@ class ListOffsetArray(Content):
             )
 
             if reducer.needs_position:
-                nextshifts = ak.index.Index64.empty(nextcarry.length, self._nplike)
-                nummissing = ak.index.Index64.empty(maxcount, self._nplike)
-                missing = ak.index.Index64.empty(self._offsets[-1], self._nplike)
+                nextshifts = ak.index.Index64.empty(
+                    nextcarry.length, self._index_nplike
+                )
+                nummissing = ak.index.Index64.empty(maxcount, self._index_nplike)
+                missing = ak.index.Index64.empty(self._offsets[-1], self._index_nplike)
                 assert (
-                    nummissing.index_nplike is self._index_nplike
-                    and missing.index_nplike is self._index_nplike
-                    and nextshifts.index_nplike is self._index_nplike
-                    and self._offsets.index_nplike is self._index_nplike
-                    and starts.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
-                    and nextcarry.index_nplike is self._index_nplike
+                    nummissing.nplike is self._index_nplike
+                    and missing.nplike is self._index_nplike
+                    and nextshifts.nplike is self._index_nplike
+                    and self._offsets.nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
+                    and nextcarry.nplike is self._index_nplike
                 )
 
                 self._handle_error(
@@ -1509,11 +1530,11 @@ class ListOffsetArray(Content):
 
         else:
             nextlen = self._offsets[-1] - self._offsets[0]
-            nextparents = ak.index.Index64.empty(nextlen, self._nplike)
+            nextparents = ak.index.Index64.empty(nextlen, self._index_nplike)
 
             assert (
-                nextparents.index_nplike is self._index_nplike
-                and self._offsets.index_nplike is self._index_nplike
+                nextparents.nplike is self._index_nplike
+                and self._offsets.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1542,8 +1563,11 @@ class ListOffsetArray(Content):
                 behavior,
             )
 
-            outoffsets = ak.index.Index64.empty(outlength + 1, self._nplike)
-            assert outoffsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            outoffsets = ak.index.Index64.empty(outlength + 1, self._index_nplike)
+            assert (
+                outoffsets.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_reduce_local_outoffsets_64",
@@ -1576,12 +1600,12 @@ class ListOffsetArray(Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nextlen = self._offsets[-1] - self._offsets[0]
-        maxcount = ak.index.Index64.empty(1, self._nplike)
-        offsetscopy = ak.index.Index64.empty(self.offsets.length, self._nplike)
+        maxcount = ak.index.Index64.empty(1, self._index_nplike)
+        offsetscopy = ak.index.Index64.empty(self.offsets.length, self._index_nplike)
         assert (
-            maxcount.index_nplike is self._index_nplike
-            and offsetscopy.index_nplike is self._index_nplike
-            and self._offsets.index_nplike is self._index_nplike
+            maxcount.nplike is self._index_nplike
+            and offsetscopy.nplike is self._index_nplike
+            and self._offsets.nplike is self._index_nplike
         ), (self._nplike, maxcount.nplike, offsetscopy.nplike, self._offsets.nplike)
         self._handle_error(
             self._nplike[
@@ -1600,14 +1624,14 @@ class ListOffsetArray(Content):
         # A "stable" sort is essential for the subsequent steps.
         nextcarry = ak.index.Index64.empty(nextlen, nplike=self._nplike)
         nextparents = ak.index.Index64.empty(nextlen, nplike=self._nplike)
-        maxnextparents = ak.index.Index64.empty(1, self._nplike)
-        distincts = ak.index.Index64.empty(outlength * maxcount[0], self._nplike)
+        maxnextparents = ak.index.Index64.empty(1, self._index_nplike)
+        distincts = ak.index.Index64.empty(outlength * maxcount[0], self._index_nplike)
         assert (
-            maxnextparents.index_nplike is self._index_nplike
-            and distincts.index_nplike is self._index_nplike
-            and self._offsets.index_nplike is self._index_nplike
-            and offsetscopy.index_nplike is self._index_nplike
-            and parents.index_nplike is self._index_nplike
+            maxnextparents.nplike is self._index_nplike
+            and distincts.nplike is self._index_nplike
+            and self._offsets.nplike is self._index_nplike
+            and offsetscopy.nplike is self._index_nplike
+            and parents.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1633,8 +1657,11 @@ class ListOffsetArray(Content):
                 maxcount[0],
             )
         )
-        nextstarts = ak.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
-        assert nextstarts.index_nplike is self._index_nplike and nextparents.index_nplike is self._index_nplike
+        nextstarts = ak.index.Index64.empty(maxnextparents[0] + 1, self._index_nplike)
+        assert (
+            nextstarts.nplike is self._index_nplike
+            and nextparents.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
@@ -1658,7 +1685,10 @@ class ListOffsetArray(Content):
     def _validity_error(self, path):
         if self.offsets.length < 1:
             return f'at {path} ("{type(self)}"): len(offsets) < 1'
-        assert self.starts.index_nplike is self._index_nplike and self.stops.index_nplike is self._index_nplike
+        assert (
+            self.starts.nplike is self._index_nplike
+            and self.stops.nplike is self._index_nplike
+        )
         error = self._nplike[
             "awkward_ListArray_validity", self.starts.dtype.type, self.stops.dtype.type
         ](
@@ -1696,12 +1726,14 @@ class ListOffsetArray(Content):
             return self.pad_none_axis0(target, clip)
         if posaxis == depth + 1:
             if not clip:
-                tolength = ak.index.Index64.empty(1, self._nplike)
-                offsets_ = ak.index.Index64.empty(self._offsets.length, self._nplike)
+                tolength = ak.index.Index64.empty(1, self._index_nplike)
+                offsets_ = ak.index.Index64.empty(
+                    self._offsets.length, self._index_nplike
+                )
                 assert (
-                    offsets_.index_nplike is self._index_nplike
-                    and self._offsets.index_nplike is self._index_nplike
-                    and tolength.index_nplike is self._index_nplike
+                    offsets_.nplike is self._index_nplike
+                    and self._offsets.nplike is self._index_nplike
+                    and tolength.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1718,10 +1750,10 @@ class ListOffsetArray(Content):
                     )
                 )
 
-                outindex = ak.index.Index64.empty(tolength[0], self._nplike)
+                outindex = ak.index.Index64.empty(tolength[0], self._index_nplike)
                 assert (
-                    outindex.index_nplike is self._index_nplike
-                    and self._offsets.index_nplike is self._index_nplike
+                    outindex.nplike is self._index_nplike
+                    and self._offsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1746,9 +1778,16 @@ class ListOffsetArray(Content):
                     self._parameters,
                 )
             else:
-                starts_ = ak.index.Index64.empty(self._offsets.length - 1, self._nplike)
-                stops_ = ak.index.Index64.empty(self._offsets.length - 1, self._nplike)
-                assert starts_.index_nplike is self._index_nplike and stops_.index_nplike is self._index_nplike
+                starts_ = ak.index.Index64.empty(
+                    self._offsets.length - 1, self._index_nplike
+                )
+                stops_ = ak.index.Index64.empty(
+                    self._offsets.length - 1, self._index_nplike
+                )
+                assert (
+                    starts_.nplike is self._index_nplike
+                    and stops_.nplike is self._index_nplike
+                )
                 self._handle_error(
                     self._nplike[
                         "awkward_index_rpad_and_clip_axis1",
@@ -1766,8 +1805,8 @@ class ListOffsetArray(Content):
                     target * (self._offsets.length - 1), self._nplike
                 )
                 assert (
-                    outindex.index_nplike is self._index_nplike
-                    and self._offsets.index_nplike is self._index_nplike
+                    outindex.nplike is self._index_nplike
+                    and self._offsets.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -2078,7 +2117,9 @@ class ListOffsetArray(Content):
                 content = ak.contents.NumpyArray(numbers)
 
                 if has_another_string:
-                    union_tags = ak.index.Index8.zeros(content.length, self._nplike)
+                    union_tags = ak.index.Index8.zeros(
+                        content.length, self._index_nplike
+                    )
                     content._nplike.isnan(content._data, union_tags._data)
                     union_index = ak.index.Index64(
                         self._index_nplike.arange(content.length, dtype=np.int64),

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -172,7 +172,7 @@ class ListOffsetArray(Content):
         start, stop = self._offsets[0], self._offsets[self._offsets.length - 1]
         content = self._content._getitem_range(slice(start, stop))
         size = ak.index.Index64.empty(1, self._nplike)
-        assert size.nplike is self._nplike and self._offsets.nplike is self._nplike
+        assert size.index_nplike is self._index_nplike and self._offsets.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_toRegularArray",
@@ -256,7 +256,7 @@ class ListOffsetArray(Content):
     def _compact_offsets64(self, start_at_zero):
         offsets_len = self._offsets.length - 1
         out = ak.index.Index64.empty(offsets_len + 1, self._nplike)
-        assert out.nplike is self._nplike and self._offsets.nplike is self._nplike
+        assert out.index_nplike is self._index_nplike and self._offsets.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_compact_offsets",
@@ -289,10 +289,10 @@ class ListOffsetArray(Content):
 
         nextcarry = ak.index.Index64.empty(offsets[-1], self._nplike)
         assert (
-            nextcarry.nplike is self._nplike
-            and offsets.nplike is self._nplike
-            and starts.nplike is self._nplike
-            and stops.nplike is self._nplike
+            nextcarry.index_nplike is self._index_nplike
+            and offsets.index_nplike is self._index_nplike
+            and starts.index_nplike is self._index_nplike
+            and stops.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -337,9 +337,9 @@ class ListOffsetArray(Content):
             nextcarry = ak.index.Index64.empty(lenstarts, self._nplike)
 
             assert (
-                nextcarry.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and stops.nplike is self._nplike
+                nextcarry.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -370,9 +370,9 @@ class ListOffsetArray(Content):
 
             carrylength = ak.index.Index64.empty(1, self._nplike)
             assert (
-                carrylength.nplike is self._nplike
-                and self.starts.nplike is self._nplike
-                and self.stops.nplike is self._nplike
+                carrylength.index_nplike is self._index_nplike
+                and self.starts.index_nplike is self._index_nplike
+                and self.stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -401,10 +401,10 @@ class ListOffsetArray(Content):
             nextcarry = ak.index.Index64.empty(carrylength[0], self._nplike)
 
             assert (
-                nextoffsets.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
-                and self.starts.nplike is self._nplike
-                and self.stops.nplike is self._nplike
+                nextoffsets.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
+                and self.starts.index_nplike is self._index_nplike
+                and self.stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -438,7 +438,7 @@ class ListOffsetArray(Content):
             else:
                 total = ak.index.Index64.empty(1, self._nplike)
                 assert (
-                    total.nplike is self._nplike and nextoffsets.nplike is self._nplike
+                    total.index_nplike is self._index_nplike and nextoffsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -455,9 +455,9 @@ class ListOffsetArray(Content):
 
                 nextadvanced = ak.index.Index64.empty(total[0], self._nplike)
                 assert (
-                    nextadvanced.nplike is self._nplike
-                    and advanced.nplike is self._nplike
-                    and nextoffsets.nplike is self._nplike
+                    nextadvanced.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
+                    and nextoffsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -505,9 +505,9 @@ class ListOffsetArray(Content):
                     lenstarts * flathead.length, self._nplike
                 )
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -541,12 +541,12 @@ class ListOffsetArray(Content):
                 nextcarry = ak.index.Index64.empty(self.length, self._nplike)
                 nextadvanced = ak.index.Index64.empty(self.length, self._nplike)
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and self.starts.nplike is self._nplike
-                    and self.stops.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
-                    and advanced.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and self.starts.index_nplike is self._index_nplike
+                    and self.stops.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -599,9 +599,9 @@ class ListOffsetArray(Content):
         elif posaxis == depth + 1:
             tonum = ak.index.Index64.empty(self.length, self._nplike)
             assert (
-                tonum.nplike is self._nplike
-                and self.starts.nplike is self._nplike
-                and self.stops.nplike is self._nplike
+                tonum.index_nplike is self._index_nplike
+                and self.starts.index_nplike is self._index_nplike
+                and self.stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -657,9 +657,9 @@ class ListOffsetArray(Content):
                     self._offsets.length, self._nplike, dtype=np.int64
                 )
                 assert (
-                    tooffsets.nplike is self._nplike
-                    and self._offsets.nplike is self._nplike
-                    and inneroffsets.nplike is self._nplike
+                    tooffsets.index_nplike is self._index_nplike
+                    and self._offsets.index_nplike is self._index_nplike
+                    and inneroffsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -740,7 +740,7 @@ class ListOffsetArray(Content):
             else:
                 innerlength = ak._typetracer.UnknownLength
             localindex = ak.index.Index64.empty(innerlength, self._nplike)
-            assert localindex.nplike is self._nplike and offsets.nplike is self._nplike
+            assert localindex.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListArray_localindex",
@@ -810,8 +810,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
+                nextparents.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -883,7 +883,7 @@ class ListOffsetArray(Content):
             )
 
             outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
+            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -908,8 +908,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
+                nextparents.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -973,11 +973,11 @@ class ListOffsetArray(Content):
 
                 self_starts, self_stops = self._offsets[:-1], self._offsets[1:]
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and parents.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
                     and self._content.nplike is self._nplike
-                    and self_starts.nplike is self._nplike
-                    and self_stops.nplike is self._nplike
+                    and self_starts.index_nplike is self._index_nplike
+                    and self_stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1028,13 +1028,13 @@ class ListOffsetArray(Content):
             missing = ak.index.Index64.empty(self._offsets[-1], self._nplike)
             nextshifts = ak.index.Index64.empty(nextcarry.length, self._nplike)
             assert (
-                nummissing.nplike is self._nplike
-                and missing.nplike is self._nplike
-                and nextshifts.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and parents.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
+                nummissing.index_nplike is self._index_nplike
+                and missing.index_nplike is self._index_nplike
+                and nextshifts.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and parents.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
             )
 
             self._handle_error(
@@ -1075,7 +1075,7 @@ class ListOffsetArray(Content):
             )
 
             outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
+            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -1101,8 +1101,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
+                nextparents.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1158,11 +1158,11 @@ class ListOffsetArray(Content):
 
                 starts, stops = self._offsets[:-1], self._offsets[1:]
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and parents.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
                     and self._content.nplike is self._nplike
-                    and starts.nplike is self._nplike
-                    and stops.nplike is self._nplike
+                    and starts.index_nplike is self._index_nplike
+                    and stops.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1220,7 +1220,7 @@ class ListOffsetArray(Content):
             )
 
             outcarry = ak.index.Index64.empty(nextcarry.length, self._nplike)
-            assert outcarry.nplike is self._nplike and nextcarry.nplike is self._nplike
+            assert outcarry.index_nplike is self._index_nplike and nextcarry.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_local_preparenext_64",
@@ -1244,8 +1244,8 @@ class ListOffsetArray(Content):
             )
 
             assert (
-                nextparents.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
+                nextparents.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1300,9 +1300,9 @@ class ListOffsetArray(Content):
                 self.length + 1, self._nplike, dtype=np.int64
             )
             assert (
-                offsets.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and stops.nplike is self._nplike
+                offsets.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1334,10 +1334,10 @@ class ListOffsetArray(Content):
             toindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
             fromindex = ak.index.Index64.empty(n, self._nplike, dtype=np.int64)
             assert (
-                toindex.nplike is self._nplike
-                and fromindex.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and stops.nplike is self._nplike
+                toindex.index_nplike is self._index_nplike
+                and fromindex.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1418,9 +1418,9 @@ class ListOffsetArray(Content):
             outstarts = ak.index.Index64.empty(outlength, self._nplike)
             outstops = ak.index.Index64.empty(outlength, self._nplike)
             assert (
-                outstarts.nplike is self._nplike
-                and outstops.nplike is self._nplike
-                and distincts.nplike is self._nplike
+                outstarts.index_nplike is self._index_nplike
+                and outstops.index_nplike is self._index_nplike
+                and distincts.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1442,13 +1442,13 @@ class ListOffsetArray(Content):
                 nummissing = ak.index.Index64.empty(maxcount, self._nplike)
                 missing = ak.index.Index64.empty(self._offsets[-1], self._nplike)
                 assert (
-                    nummissing.nplike is self._nplike
-                    and missing.nplike is self._nplike
-                    and nextshifts.nplike is self._nplike
-                    and self._offsets.nplike is self._nplike
-                    and starts.nplike is self._nplike
-                    and parents.nplike is self._nplike
-                    and nextcarry.nplike is self._nplike
+                    nummissing.index_nplike is self._index_nplike
+                    and missing.index_nplike is self._index_nplike
+                    and nextshifts.index_nplike is self._index_nplike
+                    and self._offsets.index_nplike is self._index_nplike
+                    and starts.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
+                    and nextcarry.index_nplike is self._index_nplike
                 )
 
                 self._handle_error(
@@ -1512,8 +1512,8 @@ class ListOffsetArray(Content):
             nextparents = ak.index.Index64.empty(nextlen, self._nplike)
 
             assert (
-                nextparents.nplike is self._nplike
-                and self._offsets.nplike is self._nplike
+                nextparents.index_nplike is self._index_nplike
+                and self._offsets.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1543,7 +1543,7 @@ class ListOffsetArray(Content):
             )
 
             outoffsets = ak.index.Index64.empty(outlength + 1, self._nplike)
-            assert outoffsets.nplike is self._nplike and parents.nplike is self._nplike
+            assert outoffsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_reduce_local_outoffsets_64",
@@ -1579,9 +1579,9 @@ class ListOffsetArray(Content):
         maxcount = ak.index.Index64.empty(1, self._nplike)
         offsetscopy = ak.index.Index64.empty(self.offsets.length, self._nplike)
         assert (
-            maxcount.nplike is self._nplike
-            and offsetscopy.nplike is self._nplike
-            and self._offsets.nplike is self._nplike
+            maxcount.index_nplike is self._index_nplike
+            and offsetscopy.index_nplike is self._index_nplike
+            and self._offsets.index_nplike is self._index_nplike
         ), (self._nplike, maxcount.nplike, offsetscopy.nplike, self._offsets.nplike)
         self._handle_error(
             self._nplike[
@@ -1603,11 +1603,11 @@ class ListOffsetArray(Content):
         maxnextparents = ak.index.Index64.empty(1, self._nplike)
         distincts = ak.index.Index64.empty(outlength * maxcount[0], self._nplike)
         assert (
-            maxnextparents.nplike is self._nplike
-            and distincts.nplike is self._nplike
-            and self._offsets.nplike is self._nplike
-            and offsetscopy.nplike is self._nplike
-            and parents.nplike is self._nplike
+            maxnextparents.index_nplike is self._index_nplike
+            and distincts.index_nplike is self._index_nplike
+            and self._offsets.index_nplike is self._index_nplike
+            and offsetscopy.index_nplike is self._index_nplike
+            and parents.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -1634,7 +1634,7 @@ class ListOffsetArray(Content):
             )
         )
         nextstarts = ak.index.Index64.empty(maxnextparents[0] + 1, self._nplike)
-        assert nextstarts.nplike is self._nplike and nextparents.nplike is self._nplike
+        assert nextstarts.index_nplike is self._index_nplike and nextparents.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
@@ -1658,7 +1658,7 @@ class ListOffsetArray(Content):
     def _validity_error(self, path):
         if self.offsets.length < 1:
             return f'at {path} ("{type(self)}"): len(offsets) < 1'
-        assert self.starts.nplike is self._nplike and self.stops.nplike is self._nplike
+        assert self.starts.index_nplike is self._index_nplike and self.stops.index_nplike is self._index_nplike
         error = self._nplike[
             "awkward_ListArray_validity", self.starts.dtype.type, self.stops.dtype.type
         ](
@@ -1699,9 +1699,9 @@ class ListOffsetArray(Content):
                 tolength = ak.index.Index64.empty(1, self._nplike)
                 offsets_ = ak.index.Index64.empty(self._offsets.length, self._nplike)
                 assert (
-                    offsets_.nplike is self._nplike
-                    and self._offsets.nplike is self._nplike
-                    and tolength.nplike is self._nplike
+                    offsets_.index_nplike is self._index_nplike
+                    and self._offsets.index_nplike is self._index_nplike
+                    and tolength.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1720,8 +1720,8 @@ class ListOffsetArray(Content):
 
                 outindex = ak.index.Index64.empty(tolength[0], self._nplike)
                 assert (
-                    outindex.nplike is self._nplike
-                    and self._offsets.nplike is self._nplike
+                    outindex.index_nplike is self._index_nplike
+                    and self._offsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1748,7 +1748,7 @@ class ListOffsetArray(Content):
             else:
                 starts_ = ak.index.Index64.empty(self._offsets.length - 1, self._nplike)
                 stops_ = ak.index.Index64.empty(self._offsets.length - 1, self._nplike)
-                assert starts_.nplike is self._nplike and stops_.nplike is self._nplike
+                assert starts_.index_nplike is self._index_nplike and stops_.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_index_rpad_and_clip_axis1",
@@ -1766,8 +1766,8 @@ class ListOffsetArray(Content):
                     target * (self._offsets.length - 1), self._nplike
                 )
                 assert (
-                    outindex.nplike is self._nplike
-                    and self._offsets.nplike is self._nplike
+                    outindex.index_nplike is self._index_nplike
+                    and self._offsets.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -354,8 +354,8 @@ class NumpyArray(Content):
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )
 
-        tonum = ak.index.Index64.empty(reps, self._nplike)
-        assert tonum.nplike is self._nplike
+        tonum = ak.index.Index64.empty(reps, self._index_nplike)
+        assert tonum.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_RegularArray_num", tonum.dtype.type](
                 tonum.data, size, reps
@@ -508,7 +508,7 @@ class NumpyArray(Content):
         return self._nplike.is_c_contiguous(self._data)
 
     def _subranges_equal(self, starts, stops, length, sorted=True):
-        is_equal = ak.index.Index64.zeros(1, self._nplike)
+        is_equal = ak.index.Index64.zeros(1, self._index_nplike)
 
         tmp = self._index_nplike.empty(length, self.dtype)
         self._handle_error(
@@ -525,14 +525,18 @@ class NumpyArray(Content):
         )
 
         if not sorted:
-            tmp_beg_ptr = ak.index.Index64.empty(ak._util.kMaxLevels, self._nplike)
-            tmp_end_ptr = ak.index.Index64.empty(ak._util.kMaxLevels, self._nplike)
+            tmp_beg_ptr = ak.index.Index64.empty(
+                ak._util.kMaxLevels, self._index_nplike
+            )
+            tmp_end_ptr = ak.index.Index64.empty(
+                ak._util.kMaxLevels, self._index_nplike
+            )
 
             assert (
-                tmp_beg_ptr.index_nplike is self._index_nplike
-                and tmp_end_ptr.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
-                and stops.index_nplike is self._index_nplike
+                tmp_beg_ptr.nplike is self._index_nplike
+                and tmp_end_ptr.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
+                and stops.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -553,7 +557,9 @@ class NumpyArray(Content):
                     ak._util.kMaxLevels,
                 )
             )
-        assert starts.index_nplike is self._index_nplike and stops.index_nplike is self._index_nplike
+        assert (
+            starts.nplike is self._index_nplike and stops.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_NumpyArray_subrange_equal",
@@ -574,10 +580,13 @@ class NumpyArray(Content):
 
     def _as_unique_strings(self, offsets):
         offsets = ak.index.Index64(offsets.data, nplike=offsets.nplike)
-        outoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
+        outoffsets = ak.index.Index64.empty(offsets.length, self._index_nplike)
         out = self._nplike.empty(self.shape[0], self.dtype)
 
-        assert offsets.index_nplike is self._index_nplike and outoffsets.index_nplike is self._index_nplike
+        assert (
+            offsets.nplike is self._index_nplike
+            and outoffsets.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_NumpyArray_sort_asstrings_uint8",
@@ -596,12 +605,12 @@ class NumpyArray(Content):
             )
         )
 
-        outlength = ak.index.Index64.empty(1, self._nplike)
-        nextoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
+        outlength = ak.index.Index64.empty(1, self._index_nplike)
+        nextoffsets = ak.index.Index64.empty(offsets.length, self._index_nplike)
         assert (
-            outoffsets.index_nplike is self._index_nplike
-            and nextoffsets.index_nplike is self._index_nplike
-            and outlength.index_nplike is self._index_nplike
+            outoffsets.nplike is self._index_nplike
+            and nextoffsets.nplike is self._index_nplike
+            and outlength.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -672,7 +681,7 @@ class NumpyArray(Content):
             for s in contiguous_self.shape:
                 flattened_shape = flattened_shape * s
 
-            offsets = ak.index.Index64.zeros(2, self._nplike)
+            offsets = ak.index.Index64.zeros(2, self._index_nplike)
             offsets[1] = flattened_shape
             dtype = (
                 np.dtype(np.int64)
@@ -680,7 +689,7 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             out = self._nplike.empty(offsets[1], dtype)
-            assert offsets.index_nplike is self._index_nplike
+            assert offsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -699,8 +708,8 @@ class NumpyArray(Content):
                 )
             )
 
-            nextlength = ak.index.Index64.empty(1, self._nplike)
-            assert nextlength.index_nplike is self._index_nplike
+            nextlength = ak.index.Index64.empty(1, self._index_nplike)
+            assert nextlength.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_unique",
@@ -732,9 +741,10 @@ class NumpyArray(Content):
         else:
 
             parents_length = parents.length
-            offsets_length = ak.index.Index64.empty(1, self._nplike)
+            offsets_length = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+                offsets_length.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -748,8 +758,11 @@ class NumpyArray(Content):
                 )
             )
 
-            offsets = ak.index.Index64.empty(offsets_length[0], self._nplike)
-            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            offsets = ak.index.Index64.empty(offsets_length[0], self._index_nplike)
+            assert (
+                offsets.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -764,7 +777,7 @@ class NumpyArray(Content):
             )
 
             out = self._nplike.empty(self.length, self.dtype)
-            assert offsets.index_nplike is self._index_nplike
+            assert offsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -783,8 +796,11 @@ class NumpyArray(Content):
                 )
             )
 
-            nextoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
-            assert offsets.index_nplike is self._index_nplike and nextoffsets.index_nplike is self._index_nplike
+            nextoffsets = ak.index.Index64.empty(offsets.length, self._index_nplike)
+            assert (
+                offsets.nplike is self._index_nplike
+                and nextoffsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_unique_ranges",
@@ -800,12 +816,12 @@ class NumpyArray(Content):
                 )
             )
 
-            outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
+            outoffsets = ak.index.Index64.empty(starts.length + 1, self._index_nplike)
 
             assert (
-                outoffsets.index_nplike is self._index_nplike
-                and nextoffsets.index_nplike is self._index_nplike
-                and starts.index_nplike is self._index_nplike
+                outoffsets.nplike is self._index_nplike
+                and nextoffsets.nplike is self._index_nplike
+                and starts.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -858,9 +874,10 @@ class NumpyArray(Content):
 
         else:
             parents_length = parents.length
-            offsets_length = ak.index.Index64.empty(1, self._nplike)
+            offsets_length = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+                offsets_length.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -875,8 +892,11 @@ class NumpyArray(Content):
             )
             offsets_length = offsets_length[0]
 
-            offsets = ak.index.Index64.empty(offsets_length, self._nplike)
-            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            offsets = ak.index.Index64.empty(offsets_length, self._index_nplike)
+            assert (
+                offsets.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -896,7 +916,10 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             nextcarry = ak.index.Index64.empty(self.__len__(), self._nplike)
-            assert nextcarry.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
+            assert (
+                nextcarry.nplike is self._index_nplike
+                and offsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_argsort",
@@ -916,11 +939,11 @@ class NumpyArray(Content):
 
             if shifts is not None:
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and shifts.index_nplike is self._index_nplike
-                    and offsets.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
-                    and starts.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and shifts.nplike is self._index_nplike
+                    and offsets.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -968,9 +991,10 @@ class NumpyArray(Content):
 
         else:
             parents_length = parents.length
-            offsets_length = ak.index.Index64.empty(1, self._nplike)
+            offsets_length = ak.index.Index64.empty(1, self._index_nplike)
             assert (
-                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+                offsets_length.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -984,9 +1008,12 @@ class NumpyArray(Content):
                 )
             )
 
-            offsets = ak.index.Index64.empty(offsets_length[0], self._nplike)
+            offsets = ak.index.Index64.empty(offsets_length[0], self._index_nplike)
 
-            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            assert (
+                offsets.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -1006,7 +1033,7 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             out = self._nplike.empty(self.length, dtype)
-            assert offsets.index_nplike is self._index_nplike
+            assert offsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -1094,9 +1121,9 @@ class NumpyArray(Content):
         if reducer.needs_position:
             if shifts is None:
                 assert (
-                    out.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
-                    and starts.index_nplike is self._index_nplike
+                    out.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1113,10 +1140,10 @@ class NumpyArray(Content):
                 )
             else:
                 assert (
-                    out.index_nplike is self._index_nplike
-                    and parents.index_nplike is self._index_nplike
-                    and starts.index_nplike is self._index_nplike
-                    and shifts.index_nplike is self._index_nplike
+                    out.nplike is self._index_nplike
+                    and parents.nplike is self._index_nplike
+                    and starts.nplike is self._index_nplike
+                    and shifts.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1135,8 +1162,11 @@ class NumpyArray(Content):
                 )
 
         if mask:
-            outmask = ak.index.Index8.empty(outlength, self._nplike)
-            assert outmask.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            outmask = ak.index.Index8.empty(outlength, self._index_nplike)
+            assert (
+                outmask.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_NumpyArray_reduce_mask_ByteMaskedArray_64",

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -529,10 +529,10 @@ class NumpyArray(Content):
             tmp_end_ptr = ak.index.Index64.empty(ak._util.kMaxLevels, self._nplike)
 
             assert (
-                tmp_beg_ptr.nplike is self._nplike
-                and tmp_end_ptr.nplike is self._nplike
-                and starts.nplike is self._nplike
-                and stops.nplike is self._nplike
+                tmp_beg_ptr.index_nplike is self._index_nplike
+                and tmp_end_ptr.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
+                and stops.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -553,7 +553,7 @@ class NumpyArray(Content):
                     ak._util.kMaxLevels,
                 )
             )
-        assert starts.nplike is self._nplike and stops.nplike is self._nplike
+        assert starts.index_nplike is self._index_nplike and stops.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_NumpyArray_subrange_equal",
@@ -577,7 +577,7 @@ class NumpyArray(Content):
         outoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
         out = self._nplike.empty(self.shape[0], self.dtype)
 
-        assert offsets.nplike is self._nplike and outoffsets.nplike is self._nplike
+        assert offsets.index_nplike is self._index_nplike and outoffsets.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_NumpyArray_sort_asstrings_uint8",
@@ -599,9 +599,9 @@ class NumpyArray(Content):
         outlength = ak.index.Index64.empty(1, self._nplike)
         nextoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
         assert (
-            outoffsets.nplike is self._nplike
-            and nextoffsets.nplike is self._nplike
-            and outlength.nplike is self._nplike
+            outoffsets.index_nplike is self._index_nplike
+            and nextoffsets.index_nplike is self._index_nplike
+            and outlength.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -680,7 +680,7 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             out = self._nplike.empty(offsets[1], dtype)
-            assert offsets.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -700,7 +700,7 @@ class NumpyArray(Content):
             )
 
             nextlength = ak.index.Index64.empty(1, self._nplike)
-            assert nextlength.nplike is self._nplike
+            assert nextlength.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_unique",
@@ -734,7 +734,7 @@ class NumpyArray(Content):
             parents_length = parents.length
             offsets_length = ak.index.Index64.empty(1, self._nplike)
             assert (
-                offsets_length.nplike is self._nplike and parents.nplike is self._nplike
+                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -749,7 +749,7 @@ class NumpyArray(Content):
             )
 
             offsets = ak.index.Index64.empty(offsets_length[0], self._nplike)
-            assert offsets.nplike is self._nplike and parents.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -764,7 +764,7 @@ class NumpyArray(Content):
             )
 
             out = self._nplike.empty(self.length, self.dtype)
-            assert offsets.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -784,7 +784,7 @@ class NumpyArray(Content):
             )
 
             nextoffsets = ak.index.Index64.empty(offsets.length, self._nplike)
-            assert offsets.nplike is self._nplike and nextoffsets.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike and nextoffsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_unique_ranges",
@@ -803,9 +803,9 @@ class NumpyArray(Content):
             outoffsets = ak.index.Index64.empty(starts.length + 1, self._nplike)
 
             assert (
-                outoffsets.nplike is self._nplike
-                and nextoffsets.nplike is self._nplike
-                and starts.nplike is self._nplike
+                outoffsets.index_nplike is self._index_nplike
+                and nextoffsets.index_nplike is self._index_nplike
+                and starts.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -860,7 +860,7 @@ class NumpyArray(Content):
             parents_length = parents.length
             offsets_length = ak.index.Index64.empty(1, self._nplike)
             assert (
-                offsets_length.nplike is self._nplike and parents.nplike is self._nplike
+                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -876,7 +876,7 @@ class NumpyArray(Content):
             offsets_length = offsets_length[0]
 
             offsets = ak.index.Index64.empty(offsets_length, self._nplike)
-            assert offsets.nplike is self._nplike and parents.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -896,7 +896,7 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             nextcarry = ak.index.Index64.empty(self.__len__(), self._nplike)
-            assert nextcarry.nplike is self._nplike and offsets.nplike is self._nplike
+            assert nextcarry.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_argsort",
@@ -916,11 +916,11 @@ class NumpyArray(Content):
 
             if shifts is not None:
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and shifts.nplike is self._nplike
-                    and offsets.nplike is self._nplike
-                    and parents.nplike is self._nplike
-                    and starts.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and shifts.index_nplike is self._index_nplike
+                    and offsets.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
+                    and starts.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -970,7 +970,7 @@ class NumpyArray(Content):
             parents_length = parents.length
             offsets_length = ak.index.Index64.empty(1, self._nplike)
             assert (
-                offsets_length.nplike is self._nplike and parents.nplike is self._nplike
+                offsets_length.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -986,7 +986,7 @@ class NumpyArray(Content):
 
             offsets = ak.index.Index64.empty(offsets_length[0], self._nplike)
 
-            assert offsets.nplike is self._nplike and parents.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sorting_ranges",
@@ -1006,7 +1006,7 @@ class NumpyArray(Content):
                 else self._data.dtype
             )
             out = self._nplike.empty(self.length, dtype)
-            assert offsets.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_sort",
@@ -1094,9 +1094,9 @@ class NumpyArray(Content):
         if reducer.needs_position:
             if shifts is None:
                 assert (
-                    out.nplike is self._nplike
-                    and parents.nplike is self._nplike
-                    and starts.nplike is self._nplike
+                    out.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
+                    and starts.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1113,10 +1113,10 @@ class NumpyArray(Content):
                 )
             else:
                 assert (
-                    out.nplike is self._nplike
-                    and parents.nplike is self._nplike
-                    and starts.nplike is self._nplike
-                    and shifts.nplike is self._nplike
+                    out.index_nplike is self._index_nplike
+                    and parents.index_nplike is self._index_nplike
+                    and starts.index_nplike is self._index_nplike
+                    and shifts.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -1136,7 +1136,7 @@ class NumpyArray(Content):
 
         if mask:
             outmask = ak.index.Index8.empty(outlength, self._nplike)
-            assert outmask.nplike is self._nplike and parents.nplike is self._nplike
+            assert outmask.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_NumpyArray_reduce_mask_ByteMaskedArray_64",

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -385,7 +385,7 @@ class RecordArray(Content):
             if self._index_nplike.any(where >= self._length, prefer=False):
                 raise ak._errors.index_error(self, where)
 
-            nextindex = ak.index.Index64(where, nplike=self.nplike)
+            nextindex = ak.index.Index64(where, nplike=self._index_nplike)
             return ak.contents.IndexedArray(
                 nextindex,
                 self,
@@ -474,7 +474,7 @@ class RecordArray(Content):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             npsingle = self._index_nplike.full((1,), self.length, np.int64)
-            single = ak.index.Index64(npsingle, nplike=self._nplike)
+            single = ak.index.Index64(npsingle, nplike=self._index_nplike)
             singleton = ak.contents.NumpyArray(
                 single, None, self._nplike, self._index_nplike
             )
@@ -525,7 +525,7 @@ class RecordArray(Content):
                         )
                     )
                 contents.append(flattened)
-            offsets = ak.index.Index64.zeros(1, self._nplike, dtype=np.int64)
+            offsets = ak.index.Index64.zeros(1, self._index_nplike, dtype=np.int64)
             return (
                 offsets,
                 RecordArray(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -235,9 +235,11 @@ class RegularArray(Content):
         if self._index_nplike.any(where >= self._length, prefer=False):
             raise ak._errors.index_error(self, where)
 
-        nextcarry = ak.index.Index64.empty(where.shape[0] * self._size, self._nplike)
+        nextcarry = ak.index.Index64.empty(
+            where.shape[0] * self._size, self._index_nplike
+        )
 
-        assert nextcarry.index_nplike is self._index_nplike
+        assert nextcarry.nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_RegularArray_getitem_carry",
@@ -260,8 +262,8 @@ class RegularArray(Content):
         )
 
     def _compact_offsets64(self, start_at_zero):
-        out = ak.index.Index64.empty(self._length + 1, self._nplike)
-        assert out.index_nplike is self._index_nplike
+        out = ak.index.Index64.empty(self._length + 1, self._index_nplike)
+        assert out.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_RegularArray_compact_offsets", out.dtype.type](
                 out.data,
@@ -292,8 +294,11 @@ class RegularArray(Content):
 
         if self._size == 1:
             carrylen = offsets[-1]
-            nextcarry = ak.index.Index64.empty(carrylen, self._nplike)
-            assert nextcarry.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
+            nextcarry = ak.index.Index64.empty(carrylen, self._index_nplike)
+            assert (
+                nextcarry.nplike is self._index_nplike
+                and offsets.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_broadcast_tooffsets_size1",
@@ -309,7 +314,7 @@ class RegularArray(Content):
             return ak.contents.ListOffsetArray(offsets, nextcontent, self._parameters)
 
         else:
-            assert offsets.index_nplike is self._index_nplike
+            assert offsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_broadcast_tooffsets", offsets.dtype.type
@@ -338,8 +343,8 @@ class RegularArray(Content):
 
         elif isinstance(head, int):
             nexthead, nexttail = ak._slicing.headtail(tail)
-            nextcarry = ak.index.Index64.empty(self._length, self._nplike)
-            assert nextcarry.index_nplike is self._index_nplike
+            nextcarry = ak.index.Index64.empty(self._length, self._index_nplike)
+            assert nextcarry.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_at", nextcarry.dtype.type
@@ -370,8 +375,10 @@ class RegularArray(Content):
                 if diff % step != 0:
                     nextsize += 1
 
-            nextcarry = ak.index.Index64.empty(self._length * nextsize, self._nplike)
-            assert nextcarry.index_nplike is self._index_nplike
+            nextcarry = ak.index.Index64.empty(
+                self._length * nextsize, self._index_nplike
+            )
+            assert nextcarry.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_range",
@@ -402,8 +409,8 @@ class RegularArray(Content):
                 )
                 advanced = advanced._to_nplike(self._nplike)
                 assert (
-                    nextadvanced.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
+                    nextadvanced.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -442,8 +449,10 @@ class RegularArray(Content):
             nexthead, nexttail = ak._slicing.headtail(tail)
             flathead = self._index_nplike.asarray(head.data.reshape(-1))
 
-            regular_flathead = ak.index.Index64.empty(flathead.shape[0], self._nplike)
-            assert regular_flathead.index_nplike is self._index_nplike
+            regular_flathead = ak.index.Index64.empty(
+                flathead.shape[0], self._index_nplike
+            )
+            assert regular_flathead.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_array_regularize",
@@ -466,9 +475,9 @@ class RegularArray(Content):
                     self._length * flathead.shape[0], self._nplike
                 )
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -497,20 +506,20 @@ class RegularArray(Content):
                     return out
 
             elif self._size == 0:
-                nextcarry = ak.index.Index64.empty(0, self._nplike)
-                nextadvanced = ak.index.Index64.empty(0, self._nplike)
+                nextcarry = ak.index.Index64.empty(0, self._index_nplike)
+                nextadvanced = ak.index.Index64.empty(0, self._index_nplike)
                 nextcontent = self._content._carry(nextcarry, True)
                 return nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
 
             else:
-                nextcarry = ak.index.Index64.empty(self._length, self._nplike)
-                nextadvanced = ak.index.Index64.empty(self._length, self._nplike)
+                nextcarry = ak.index.Index64.empty(self._length, self._index_nplike)
+                nextadvanced = ak.index.Index64.empty(self._length, self._index_nplike)
                 advanced = advanced._to_nplike(self._nplike)
                 assert (
-                    nextcarry.index_nplike is self._index_nplike
-                    and nextadvanced.index_nplike is self._index_nplike
-                    and advanced.index_nplike is self._index_nplike
-                    and regular_flathead.index_nplike is self._index_nplike
+                    nextcarry.nplike is self._index_nplike
+                    and nextadvanced.nplike is self._index_nplike
+                    and advanced.nplike is self._index_nplike
+                    and regular_flathead.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -536,7 +545,7 @@ class RegularArray(Content):
         elif isinstance(head, ak.contents.ListOffsetArray):
             headlength = head.length
             head = head._to_nplike(self._nplike)
-            assert head.index_nplike is self._index_nplike
+            assert head.nplike is self._index_nplike
 
             if advanced is not None:
                 raise ak._errors.index_error(
@@ -563,7 +572,7 @@ class RegularArray(Content):
                 head.length * regularlength, self._nplike
             )
 
-            assert singleoffsets.index_nplike is self._index_nplike
+            assert singleoffsets.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_jagged_expand",
@@ -600,8 +609,8 @@ class RegularArray(Content):
             else:
                 return out
         elif posaxis == depth + 1:
-            tonum = ak.index.Index64.empty(self._length, self._nplike)
-            assert tonum.index_nplike is self._index_nplike
+            tonum = ak.index.Index64.empty(self._length, self._index_nplike)
+            assert tonum.nplike is self._index_nplike
             self._handle_error(
                 self._nplike["awkward_RegularArray_num", tonum.dtype.type](
                     tonum.data, self._size, self._length
@@ -693,7 +702,9 @@ class RegularArray(Content):
         if posaxis == depth:
             return self._local_index_axis0()
         elif posaxis == depth + 1:
-            localindex = ak.index.Index64.empty(self._length * self._size, self._nplike)
+            localindex = ak.index.Index64.empty(
+                self._length * self._size, self._index_nplike
+            )
             self._handle_error(
                 self._nplike["awkward_RegularArray_localindex", np.int64](
                     localindex.data,
@@ -865,7 +876,8 @@ class RegularArray(Content):
 
             if self._size != 0:
                 assert (
-                    toindex.index_nplike is self._index_nplike and fromindex.index_nplike is self._index_nplike
+                    toindex.nplike is self._index_nplike
+                    and fromindex.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -943,9 +955,9 @@ class RegularArray(Content):
             nextcarry = ak.index.Index64.empty(nextlen, nplike=self._nplike)
             nextparents = ak.index.Index64.empty(nextlen, nplike=self._nplike)
             assert (
-                parents.index_nplike is self._index_nplike
-                and nextcarry.index_nplike is self._index_nplike
-                and nextparents.index_nplike is self._index_nplike
+                parents.nplike is self._index_nplike
+                and nextcarry.nplike is self._index_nplike
+                and nextparents.nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -965,7 +977,9 @@ class RegularArray(Content):
             if reducer.needs_position:
                 # Regular arrays have the same length rows, so there can be no "missing" values
                 # unlike ragged list types
-                nextshifts = ak.index.Index64.zeros(nextcarry.length, self._nplike)
+                nextshifts = ak.index.Index64.zeros(
+                    nextcarry.length, self._index_nplike
+                )
             else:
                 nextshifts = None
 
@@ -999,9 +1013,9 @@ class RegularArray(Content):
                 )
             return out
         else:
-            nextparents = ak.index.Index64.empty(nextlen, self._nplike)
+            nextparents = ak.index.Index64.empty(nextlen, self._index_nplike)
 
-            assert nextparents.index_nplike is self._index_nplike
+            assert nextparents.nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_reduce_local_nextparents",
@@ -1089,8 +1103,11 @@ class RegularArray(Content):
                 else:
                     assert outcontent.is_regular
 
-            outoffsets = ak.index.Index64.empty(outlength + 1, self._nplike)
-            assert outoffsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
+            outoffsets = ak.index.Index64.empty(outlength + 1, self._index_nplike)
+            assert (
+                outoffsets.nplike is self._index_nplike
+                and parents.nplike is self._index_nplike
+            )
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_reduce_local_outoffsets_64",
@@ -1137,8 +1154,10 @@ class RegularArray(Content):
                     return self._pad_none(target, posaxis, depth, True)
 
             else:
-                index = ak.index.Index64.empty(self._length * target, self._nplike)
-                assert index.index_nplike is self._index_nplike
+                index = ak.index.Index64.empty(
+                    self._length * target, self._index_nplike
+                )
+                assert index.nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_RegularArray_rpad_and_clip_axis1", index.dtype.type

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -237,7 +237,7 @@ class RegularArray(Content):
 
         nextcarry = ak.index.Index64.empty(where.shape[0] * self._size, self._nplike)
 
-        assert nextcarry.nplike is self._nplike
+        assert nextcarry.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_RegularArray_getitem_carry",
@@ -261,7 +261,7 @@ class RegularArray(Content):
 
     def _compact_offsets64(self, start_at_zero):
         out = ak.index.Index64.empty(self._length + 1, self._nplike)
-        assert out.nplike is self._nplike
+        assert out.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_RegularArray_compact_offsets", out.dtype.type](
                 out.data,
@@ -293,7 +293,7 @@ class RegularArray(Content):
         if self._size == 1:
             carrylen = offsets[-1]
             nextcarry = ak.index.Index64.empty(carrylen, self._nplike)
-            assert nextcarry.nplike is self._nplike and offsets.nplike is self._nplike
+            assert nextcarry.index_nplike is self._index_nplike and offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_broadcast_tooffsets_size1",
@@ -309,7 +309,7 @@ class RegularArray(Content):
             return ak.contents.ListOffsetArray(offsets, nextcontent, self._parameters)
 
         else:
-            assert offsets.nplike is self._nplike
+            assert offsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_broadcast_tooffsets", offsets.dtype.type
@@ -339,7 +339,7 @@ class RegularArray(Content):
         elif isinstance(head, int):
             nexthead, nexttail = ak._slicing.headtail(tail)
             nextcarry = ak.index.Index64.empty(self._length, self._nplike)
-            assert nextcarry.nplike is self._nplike
+            assert nextcarry.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_at", nextcarry.dtype.type
@@ -371,7 +371,7 @@ class RegularArray(Content):
                     nextsize += 1
 
             nextcarry = ak.index.Index64.empty(self._length * nextsize, self._nplike)
-            assert nextcarry.nplike is self._nplike
+            assert nextcarry.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_range",
@@ -402,8 +402,8 @@ class RegularArray(Content):
                 )
                 advanced = advanced._to_nplike(self._nplike)
                 assert (
-                    nextadvanced.nplike is self._nplike
-                    and advanced.nplike is self._nplike
+                    nextadvanced.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -443,7 +443,7 @@ class RegularArray(Content):
             flathead = self._index_nplike.asarray(head.data.reshape(-1))
 
             regular_flathead = ak.index.Index64.empty(flathead.shape[0], self._nplike)
-            assert regular_flathead.nplike is self._nplike
+            assert regular_flathead.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_next_array_regularize",
@@ -466,9 +466,9 @@ class RegularArray(Content):
                     self._length * flathead.shape[0], self._nplike
                 )
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -507,10 +507,10 @@ class RegularArray(Content):
                 nextadvanced = ak.index.Index64.empty(self._length, self._nplike)
                 advanced = advanced._to_nplike(self._nplike)
                 assert (
-                    nextcarry.nplike is self._nplike
-                    and nextadvanced.nplike is self._nplike
-                    and advanced.nplike is self._nplike
-                    and regular_flathead.nplike is self._nplike
+                    nextcarry.index_nplike is self._index_nplike
+                    and nextadvanced.index_nplike is self._index_nplike
+                    and advanced.index_nplike is self._index_nplike
+                    and regular_flathead.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -563,7 +563,7 @@ class RegularArray(Content):
                 head.length * regularlength, self._nplike
             )
 
-            assert singleoffsets.nplike is self._nplike
+            assert singleoffsets.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_getitem_jagged_expand",
@@ -601,7 +601,7 @@ class RegularArray(Content):
                 return out
         elif posaxis == depth + 1:
             tonum = ak.index.Index64.empty(self._length, self._nplike)
-            assert tonum.nplike is self._nplike
+            assert tonum.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike["awkward_RegularArray_num", tonum.dtype.type](
                     tonum.data, self._size, self._length
@@ -865,7 +865,7 @@ class RegularArray(Content):
 
             if self._size != 0:
                 assert (
-                    toindex.nplike is self._nplike and fromindex.nplike is self._nplike
+                    toindex.index_nplike is self._index_nplike and fromindex.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -943,9 +943,9 @@ class RegularArray(Content):
             nextcarry = ak.index.Index64.empty(nextlen, nplike=self._nplike)
             nextparents = ak.index.Index64.empty(nextlen, nplike=self._nplike)
             assert (
-                parents.nplike is self._nplike
-                and nextcarry.nplike is self._nplike
-                and nextparents.nplike is self._nplike
+                parents.index_nplike is self._index_nplike
+                and nextcarry.index_nplike is self._index_nplike
+                and nextparents.index_nplike is self._index_nplike
             )
             self._handle_error(
                 self._nplike[
@@ -1001,7 +1001,7 @@ class RegularArray(Content):
         else:
             nextparents = ak.index.Index64.empty(nextlen, self._nplike)
 
-            assert nextparents.nplike is self._nplike
+            assert nextparents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_RegularArray_reduce_local_nextparents",
@@ -1090,7 +1090,7 @@ class RegularArray(Content):
                     assert outcontent.is_regular
 
             outoffsets = ak.index.Index64.empty(outlength + 1, self._nplike)
-            assert outoffsets.nplike is self._nplike and parents.nplike is self._nplike
+            assert outoffsets.index_nplike is self._index_nplike and parents.index_nplike is self._index_nplike
             self._handle_error(
                 self._nplike[
                     "awkward_ListOffsetArray_reduce_local_outoffsets_64",
@@ -1138,7 +1138,7 @@ class RegularArray(Content):
 
             else:
                 index = ak.index.Index64.empty(self._length * target, self._nplike)
-                assert index.nplike is self._nplike
+                assert index.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_RegularArray_rpad_and_clip_axis1", index.dtype.type

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -308,10 +308,10 @@ class UnionArray(Content):
         lenout = ak.index.Index64.empty(1, self._nplike)
         tmpcarry = ak.index.Index64.empty(lentags, self._nplike)
         assert (
-            lenout.nplike is self._nplike
-            and tmpcarry.nplike is self._nplike
-            and self._tags.nplike is self._nplike
-            and self._index.nplike is self._nplike
+            lenout.index_nplike is self._index_nplike
+            and tmpcarry.index_nplike is self._index_nplike
+            and self._tags.index_nplike is self._index_nplike
+            and self._index.index_nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -512,12 +512,12 @@ class UnionArray(Content):
                     for k in range(len(contents)):
                         if merge and contents[k].mergeable(inner_cont, mergebool):
                             assert (
-                                tags.nplike is self._nplike
-                                and index.nplike is self._nplike
-                                and self._tags.nplike is self._nplike
-                                and self._index.nplike is self._nplike
-                                and innertags.nplike is self._nplike
-                                and innerindex.nplike is self._nplike
+                                tags.index_nplike is self._index_nplike
+                                and index.index_nplike is self._index_nplike
+                                and self._tags.index_nplike is self._index_nplike
+                                and self._index.index_nplike is self._index_nplike
+                                and innertags.index_nplike is self._index_nplike
+                                and innerindex.index_nplike is self._index_nplike
                             )
                             self._handle_error(
                                 self._nplike[
@@ -548,12 +548,12 @@ class UnionArray(Content):
 
                     if unmerged:
                         assert (
-                            tags.nplike is self._nplike
-                            and index.nplike is self._nplike
-                            and self._tags.nplike is self._nplike
-                            and self._index.nplike is self._nplike
-                            and innertags.nplike is self._nplike
-                            and innerindex.nplike is self._nplike
+                            tags.index_nplike is self._index_nplike
+                            and index.index_nplike is self._index_nplike
+                            and self._tags.index_nplike is self._index_nplike
+                            and self._index.index_nplike is self._index_nplike
+                            and innertags.index_nplike is self._index_nplike
+                            and innerindex.index_nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -585,10 +585,10 @@ class UnionArray(Content):
                 for k in range(len(contents)):
                     if contents[k] is self_cont:
                         assert (
-                            tags.nplike is self._nplike
-                            and index.nplike is self._nplike
-                            and self._tags.nplike is self._nplike
-                            and self._index.nplike is self._nplike
+                            tags.index_nplike is self._index_nplike
+                            and index.index_nplike is self._index_nplike
+                            and self._tags.index_nplike is self._index_nplike
+                            and self._index.index_nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -613,10 +613,10 @@ class UnionArray(Content):
 
                     elif merge and contents[k].mergeable(self_cont, mergebool):
                         assert (
-                            tags.nplike is self._nplike
-                            and index.nplike is self._nplike
-                            and self._tags.nplike is self._nplike
-                            and self._index.nplike is self._nplike
+                            tags.index_nplike is self._index_nplike
+                            and index.index_nplike is self._index_nplike
+                            and self._tags.index_nplike is self._index_nplike
+                            and self._index.index_nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -642,10 +642,10 @@ class UnionArray(Content):
 
                 if unmerged:
                     assert (
-                        tags.nplike is self._nplike
-                        and index.nplike is self._nplike
-                        and self._tags.nplike is self._nplike
-                        and self._index.nplike is self._nplike
+                        tags.index_nplike is self._index_nplike
+                        and index.index_nplike is self._index_nplike
+                        and self._tags.index_nplike is self._index_nplike
+                        and self._index.index_nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -731,9 +731,9 @@ class UnionArray(Content):
             if has_offsets:
                 total_length = ak.index.Index64.empty(1, self._nplike)
                 assert (
-                    total_length.nplike is self._nplike
-                    and self._tags.nplike is self._nplike
-                    and self._index.nplike is self._nplike
+                    total_length.index_nplike is self._index_nplike
+                    and self._tags.index_nplike is self._index_nplike
+                    and self._index.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -758,11 +758,11 @@ class UnionArray(Content):
                 tooffsets = ak.index.Index64.empty(self._tags.length + 1, self._nplike)
 
                 assert (
-                    totags.nplike is self._nplike
-                    and toindex.nplike is self._nplike
-                    and tooffsets.nplike is self._nplike
-                    and self._tags.nplike is self._nplike
-                    and self._index.nplike is self._nplike
+                    totags.index_nplike is self._index_nplike
+                    and toindex.index_nplike is self._index_nplike
+                    and tooffsets.index_nplike is self._index_nplike
+                    and self._tags.index_nplike is self._index_nplike
+                    and self._index.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -851,7 +851,7 @@ class UnionArray(Content):
         contents = [other]
         contents.extend(self.contents)
 
-        assert tags.nplike is self._nplike
+        assert tags.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_filltags_const", tags.dtype.type](
                 tags.data,
@@ -861,7 +861,7 @@ class UnionArray(Content):
             )
         )
 
-        assert index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_fillindex_count", index.dtype.type](
                 index.data,
@@ -870,7 +870,7 @@ class UnionArray(Content):
             )
         )
 
-        assert tags.nplike is self._nplike and self.tags.nplike is self._nplike
+        assert tags.index_nplike is self._index_nplike and self.tags.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_filltags",
@@ -885,7 +885,7 @@ class UnionArray(Content):
             )
         )
 
-        assert index.nplike is self._nplike and self.index.nplike is self._nplike
+        assert index.index_nplike is self._index_nplike and self.index.index_nplike is self._index_nplike
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_fillindex",
@@ -934,8 +934,8 @@ class UnionArray(Content):
                 union_index = ak.index.Index(array.index)
                 union_contents = array.contents
                 assert (
-                    nexttags.nplike is self._nplike
-                    and union_tags.nplike is self._nplike
+                    nexttags.index_nplike is self._index_nplike
+                    and union_tags.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -951,8 +951,8 @@ class UnionArray(Content):
                     )
                 )
                 assert (
-                    nextindex.nplike is self._nplike
-                    and union_index.nplike is self._nplike
+                    nextindex.index_nplike is self._index_nplike
+                    and union_index.index_nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -973,7 +973,7 @@ class UnionArray(Content):
                 pass
 
             else:
-                assert nexttags.nplike is self._nplike
+                assert nexttags.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_UnionArray_filltags_const",
@@ -986,7 +986,7 @@ class UnionArray(Content):
                     )
                 )
 
-                assert nextindex.nplike is self._nplike
+                assert nextindex.index_nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_UnionArray_fillindex_count", nextindex.dtype.type

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -305,13 +305,13 @@ class UnionArray(Content):
     def project(self, index):
         lentags = self._tags.length
         assert not self._index.length < lentags
-        lenout = ak.index.Index64.empty(1, self._nplike)
-        tmpcarry = ak.index.Index64.empty(lentags, self._nplike)
+        lenout = ak.index.Index64.empty(1, self._index_nplike)
+        tmpcarry = ak.index.Index64.empty(lentags, self._index_nplike)
         assert (
-            lenout.index_nplike is self._index_nplike
-            and tmpcarry.index_nplike is self._index_nplike
-            and self._tags.index_nplike is self._index_nplike
-            and self._index.index_nplike is self._index_nplike
+            lenout.nplike is self._index_nplike
+            and tmpcarry.nplike is self._index_nplike
+            and self._tags.nplike is self._index_nplike
+            and self._index.nplike is self._index_nplike
         )
         self._handle_error(
             self._nplike[
@@ -329,7 +329,9 @@ class UnionArray(Content):
                 index,
             )
         )
-        nextcarry = ak.index.Index64(tmpcarry.data[: lenout[0]], nplike=self._nplike)
+        nextcarry = ak.index.Index64(
+            tmpcarry.data[: lenout[0]], nplike=self._index_nplike
+        )
         return self._contents[index]._carry(nextcarry, False)
 
     @staticmethod
@@ -497,8 +499,8 @@ class UnionArray(Content):
             )
 
         length = self._tags.length
-        tags = ak.index.Index8.empty(length, self._nplike)
-        index = ak.index.Index64.empty(length, self._nplike)
+        tags = ak.index.Index8.empty(length, self._index_nplike)
+        index = ak.index.Index64.empty(length, self._index_nplike)
         contents = []
 
         for i, self_cont in enumerate(self._contents):
@@ -512,12 +514,12 @@ class UnionArray(Content):
                     for k in range(len(contents)):
                         if merge and contents[k].mergeable(inner_cont, mergebool):
                             assert (
-                                tags.index_nplike is self._index_nplike
-                                and index.index_nplike is self._index_nplike
-                                and self._tags.index_nplike is self._index_nplike
-                                and self._index.index_nplike is self._index_nplike
-                                and innertags.index_nplike is self._index_nplike
-                                and innerindex.index_nplike is self._index_nplike
+                                tags.nplike is self._index_nplike
+                                and index.nplike is self._index_nplike
+                                and self._tags.nplike is self._index_nplike
+                                and self._index.nplike is self._index_nplike
+                                and innertags.nplike is self._index_nplike
+                                and innerindex.nplike is self._index_nplike
                             )
                             self._handle_error(
                                 self._nplike[
@@ -548,12 +550,12 @@ class UnionArray(Content):
 
                     if unmerged:
                         assert (
-                            tags.index_nplike is self._index_nplike
-                            and index.index_nplike is self._index_nplike
-                            and self._tags.index_nplike is self._index_nplike
-                            and self._index.index_nplike is self._index_nplike
-                            and innertags.index_nplike is self._index_nplike
-                            and innerindex.index_nplike is self._index_nplike
+                            tags.nplike is self._index_nplike
+                            and index.nplike is self._index_nplike
+                            and self._tags.nplike is self._index_nplike
+                            and self._index.nplike is self._index_nplike
+                            and innertags.nplike is self._index_nplike
+                            and innerindex.nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -585,10 +587,10 @@ class UnionArray(Content):
                 for k in range(len(contents)):
                     if contents[k] is self_cont:
                         assert (
-                            tags.index_nplike is self._index_nplike
-                            and index.index_nplike is self._index_nplike
-                            and self._tags.index_nplike is self._index_nplike
-                            and self._index.index_nplike is self._index_nplike
+                            tags.nplike is self._index_nplike
+                            and index.nplike is self._index_nplike
+                            and self._tags.nplike is self._index_nplike
+                            and self._index.nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -613,10 +615,10 @@ class UnionArray(Content):
 
                     elif merge and contents[k].mergeable(self_cont, mergebool):
                         assert (
-                            tags.index_nplike is self._index_nplike
-                            and index.index_nplike is self._index_nplike
-                            and self._tags.index_nplike is self._index_nplike
-                            and self._index.index_nplike is self._index_nplike
+                            tags.nplike is self._index_nplike
+                            and index.nplike is self._index_nplike
+                            and self._tags.nplike is self._index_nplike
+                            and self._index.nplike is self._index_nplike
                         )
                         self._handle_error(
                             self._nplike[
@@ -642,10 +644,10 @@ class UnionArray(Content):
 
                 if unmerged:
                     assert (
-                        tags.index_nplike is self._index_nplike
-                        and index.index_nplike is self._index_nplike
-                        and self._tags.index_nplike is self._index_nplike
-                        and self._index.index_nplike is self._index_nplike
+                        tags.nplike is self._index_nplike
+                        and index.nplike is self._index_nplike
+                        and self._tags.nplike is self._index_nplike
+                        and self._index.nplike is self._index_nplike
                     )
                     self._handle_error(
                         self._nplike[
@@ -729,11 +731,11 @@ class UnionArray(Content):
                 has_offsets = offsets.length != 0
 
             if has_offsets:
-                total_length = ak.index.Index64.empty(1, self._nplike)
+                total_length = ak.index.Index64.empty(1, self._index_nplike)
                 assert (
-                    total_length.index_nplike is self._index_nplike
-                    and self._tags.index_nplike is self._index_nplike
-                    and self._index.index_nplike is self._index_nplike
+                    total_length.nplike is self._index_nplike
+                    and self._tags.nplike is self._index_nplike
+                    and self._index.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -753,16 +755,18 @@ class UnionArray(Content):
                     )
                 )
 
-                totags = ak.index.Index8.empty(total_length[0], self._nplike)
-                toindex = ak.index.Index64.empty(total_length[0], self._nplike)
-                tooffsets = ak.index.Index64.empty(self._tags.length + 1, self._nplike)
+                totags = ak.index.Index8.empty(total_length[0], self._index_nplike)
+                toindex = ak.index.Index64.empty(total_length[0], self._index_nplike)
+                tooffsets = ak.index.Index64.empty(
+                    self._tags.length + 1, self._index_nplike
+                )
 
                 assert (
-                    totags.index_nplike is self._index_nplike
-                    and toindex.index_nplike is self._index_nplike
-                    and tooffsets.index_nplike is self._index_nplike
-                    and self._tags.index_nplike is self._index_nplike
-                    and self._index.index_nplike is self._index_nplike
+                    totags.nplike is self._index_nplike
+                    and toindex.nplike is self._index_nplike
+                    and tooffsets.nplike is self._index_nplike
+                    and self._tags.nplike is self._index_nplike
+                    and self._index.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -845,13 +849,13 @@ class UnionArray(Content):
         theirlength = other.length
         mylength = self.length
 
-        tags = ak.index.Index8.empty(theirlength + mylength, self._nplike)
-        index = ak.index.Index64.empty(theirlength + mylength, self._nplike)
+        tags = ak.index.Index8.empty(theirlength + mylength, self._index_nplike)
+        index = ak.index.Index64.empty(theirlength + mylength, self._index_nplike)
 
         contents = [other]
         contents.extend(self.contents)
 
-        assert tags.index_nplike is self._index_nplike
+        assert tags.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_filltags_const", tags.dtype.type](
                 tags.data,
@@ -861,7 +865,7 @@ class UnionArray(Content):
             )
         )
 
-        assert index.index_nplike is self._index_nplike
+        assert index.nplike is self._index_nplike
         self._handle_error(
             self._nplike["awkward_UnionArray_fillindex_count", index.dtype.type](
                 index.data,
@@ -870,7 +874,9 @@ class UnionArray(Content):
             )
         )
 
-        assert tags.index_nplike is self._index_nplike and self.tags.index_nplike is self._index_nplike
+        assert (
+            tags.nplike is self._index_nplike and self.tags.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_filltags",
@@ -885,7 +891,10 @@ class UnionArray(Content):
             )
         )
 
-        assert index.index_nplike is self._index_nplike and self.index.index_nplike is self._index_nplike
+        assert (
+            index.nplike is self._index_nplike
+            and self.index.nplike is self._index_nplike
+        )
         self._handle_error(
             self._nplike[
                 "awkward_UnionArray_fillindex",
@@ -919,8 +928,8 @@ class UnionArray(Content):
         for array in head:
             total_length += array.length
 
-        nexttags = ak.index.Index8.empty(total_length, self._nplike)
-        nextindex = ak.index.Index64.empty(total_length, self._nplike)
+        nexttags = ak.index.Index8.empty(total_length, self._index_nplike)
+        nextindex = ak.index.Index64.empty(total_length, self._index_nplike)
 
         nextcontents = []
         length_so_far = 0
@@ -934,8 +943,8 @@ class UnionArray(Content):
                 union_index = ak.index.Index(array.index)
                 union_contents = array.contents
                 assert (
-                    nexttags.index_nplike is self._index_nplike
-                    and union_tags.index_nplike is self._index_nplike
+                    nexttags.nplike is self._index_nplike
+                    and union_tags.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -951,8 +960,8 @@ class UnionArray(Content):
                     )
                 )
                 assert (
-                    nextindex.index_nplike is self._index_nplike
-                    and union_index.index_nplike is self._index_nplike
+                    nextindex.nplike is self._index_nplike
+                    and union_index.nplike is self._index_nplike
                 )
                 self._handle_error(
                     self._nplike[
@@ -973,7 +982,7 @@ class UnionArray(Content):
                 pass
 
             else:
-                assert nexttags.index_nplike is self._index_nplike
+                assert nexttags.nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_UnionArray_filltags_const",
@@ -986,7 +995,7 @@ class UnionArray(Content):
                     )
                 )
 
-                assert nextindex.index_nplike is self._index_nplike
+                assert nextindex.nplike is self._index_nplike
                 self._handle_error(
                     self._nplike[
                         "awkward_UnionArray_fillindex_count", nextindex.dtype.type
@@ -1439,8 +1448,8 @@ class UnionArray(Content):
             contents[tag] = contents[tag].packed()
 
         return UnionArray(
-            ak.index.Index8(tags, nplike=self.nplike),
-            ak.index.Index(index, nplike=self.nplike),
+            ak.index.Index8(tags, nplike=self._index_nplike),
+            ak.index.Index(index, nplike=self._index_nplike),
             contents,
             self._parameters,
             self._nplike,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -135,13 +135,13 @@ class UnmaskedArray(Content):
         )
 
     def mask_as_bool(self, valid_when=True, nplike=None):
-        if nplike is None:
-            nplike = self._nplike
+        nplike = nplike or self._nplike
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
 
         if valid_when:
-            return nplike.index_nplike.ones(self._content.length, dtype=np.bool_)
+            return index_nplike.ones(self._content.length, dtype=np.bool_)
         else:
-            return nplike.index_nplike.zeros(self._content.length, dtype=np.bool_)
+            return index_nplike.zeros(self._content.length, dtype=np.bool_)
 
     def _getitem_nothing(self):
         return self._content._getitem_range(slice(0, 0))

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -103,7 +103,7 @@ class UnmaskedArray(Content):
     def to_IndexedOptionArray64(self):
         arange = self._index_nplike.arange(self._content.length, dtype=np.int64)
         return ak.contents.IndexedOptionArray(
-            ak.index.Index64(arange, nplike=self.nplike),
+            ak.index.Index64(arange, nplike=self._index_nplike),
             self._content,
             self._parameters,
         )

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -202,7 +202,9 @@ class Index:
     def _to_nplike(self, nplike):
         # if isinstance(nplike, ak.nplikes.Jax):
         #     print("YES OFFICER, this nplike right here")
-        return Index(self.raw(nplike), metadata=self.metadata, nplike=nplike)
+        return Index(
+            self.raw(nplike.index_nplike), metadata=self.metadata, nplike=nplike
+        )
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         if index_dtype:

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -27,7 +27,7 @@ class Index:
                 TypeError("Index metadata must be None or a dict")
             )
         self._metadata = metadata
-        self._data = self._nplike.index_nplike.asarray(
+        self._data = self._nplike.asarray(
             data, dtype=self._expected_dtype, order="C"
         )
         if len(self._data.shape) != 1:
@@ -67,17 +67,21 @@ class Index:
                     )
                 )
 
+    @property
+    def index_nplike(self):
+        return self.nplike
+
     @classmethod
     def zeros(cls, length, nplike, dtype=None):
         if dtype is None:
             dtype = cls._expected_dtype
-        return Index(nplike.index_nplike.zeros(length, dtype=dtype), nplike=nplike)
+        return Index(nplike.zeros(length, dtype=dtype), nplike=nplike)
 
     @classmethod
     def empty(cls, length, nplike, dtype=None):
         if dtype is None:
             dtype = cls._expected_dtype
-        return Index(nplike.index_nplike.empty(length, dtype=dtype), nplike=nplike)
+        return Index(nplike.empty(length, dtype=dtype), nplike=nplike)
 
     @property
     def data(self):
@@ -114,13 +118,13 @@ class Index:
         return type(self)(data.forget_length(), metadata=self._metadata, nplike=tt)
 
     def raw(self, nplike):
-        return self.nplike.index_nplike.raw(self.data, nplike.index_nplike)
+        return self.nplike.raw(self.data, nplike)
 
     def __len__(self):
         return self.length
 
     def __array__(self, *args, **kwargs):
-        return self._nplike.index_nplike.asarray(self._data, *args, **kwargs)
+        return self._nplike.asarray(self._data, *args, **kwargs)
 
     def __repr__(self):
         return self._repr("", "", "")
@@ -131,11 +135,11 @@ class Index:
         out.append(" len=")
         out.append(repr(str(self._data.shape[0])))
 
-        arraystr_lines = self._nplike.index_nplike.array_str(
+        arraystr_lines = self._nplike.array_str(
             self._data, max_line_width=30
         ).split("\n")
         if len(arraystr_lines) > 1 or self._metadata is not None:
-            arraystr_lines = self._nplike.index_nplike.array_str(
+            arraystr_lines = self._nplike.array_str(
                 self._data, max_line_width=max(80 - len(indent) - 4, 40)
             ).split("\n")
             if len(arraystr_lines) > 5:
@@ -203,17 +207,17 @@ class Index:
         # if isinstance(nplike, ak.nplikes.Jax):
         #     print("YES OFFICER, this nplike right here")
         return Index(
-            self.raw(nplike.index_nplike), metadata=self.metadata, nplike=nplike
+            self.raw(nplike), metadata=self.metadata, nplike=nplike
         )
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         if index_dtype:
             return (
-                self.nplike.index_nplike.array_equal(self.data, other.data)
+                self.nplike.array_equal(self.data, other.data)
                 and self._data.dtype == other.data.dtype
             )
         else:
-            return self.nplike.index_nplike.array_equal(self.data, other.data)
+            return self.nplike.array_equal(self.data, other.data)
 
 
 class Index8(Index):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -27,9 +27,7 @@ class Index:
                 TypeError("Index metadata must be None or a dict")
             )
         self._metadata = metadata
-        self._data = self._nplike.asarray(
-            data, dtype=self._expected_dtype, order="C"
-        )
+        self._data = self._nplike.asarray(data, dtype=self._expected_dtype, order="C")
         if len(self._data.shape) != 1:
             raise ak._errors.wrap_error(TypeError("Index data must be one-dimensional"))
 
@@ -66,10 +64,6 @@ class Index:
                         "while developing, we want to catch these errors"
                     )
                 )
-
-    @property
-    def index_nplike(self):
-        return self.nplike
 
     @classmethod
     def zeros(cls, length, nplike, dtype=None):
@@ -135,9 +129,9 @@ class Index:
         out.append(" len=")
         out.append(repr(str(self._data.shape[0])))
 
-        arraystr_lines = self._nplike.array_str(
-            self._data, max_line_width=30
-        ).split("\n")
+        arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
+            "\n"
+        )
         if len(arraystr_lines) > 1 or self._metadata is not None:
             arraystr_lines = self._nplike.array_str(
                 self._data, max_line_width=max(80 - len(indent) - 4, 40)
@@ -206,9 +200,7 @@ class Index:
     def _to_nplike(self, nplike):
         # if isinstance(nplike, ak.nplikes.Jax):
         #     print("YES OFFICER, this nplike right here")
-        return Index(
-            self.raw(nplike), metadata=self.metadata, nplike=nplike
-        )
+        return Index(self.raw(nplike), metadata=self.metadata, nplike=nplike)
 
     def layout_equal(self, other, index_dtype=True, numpyarray=True):
         if index_dtype:

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -474,10 +474,6 @@ class CupyKernel(NumpyKernel):
 
 
 class Numpy(NumpyLike):
-    @property
-    def index_nplike(self):
-        return self
-
     def to_rectilinear(self, array, *args, **kwargs):
         if isinstance(array, numpy.ndarray):
             return array
@@ -558,10 +554,6 @@ class Numpy(NumpyLike):
 
 class Cupy(NumpyLike):
     is_eager = False
-
-    @property
-    def index_nplike(self):
-        return self
 
     def to_rectilinear(self, array, *args, **kwargs):
         return ak.operations.ak_to_cupy.to_cupy(array, *args, **kwargs)
@@ -781,10 +773,6 @@ class Cupy(NumpyLike):
 
 
 class Jax(NumpyLike):
-    @property
-    def index_nplike(self):
-        return ak.nplikes.Numpy.instance()
-
     def to_rectilinear(self, array, *args, **kwargs):
         if isinstance(array, self._module.DeviceArray):
             return array

--- a/src/awkward/nplikes.py
+++ b/src/awkward/nplikes.py
@@ -987,7 +987,7 @@ def nplike_of(*arrays, default=_UNSET):
     if any(isinstance(x, ak._typetracer.TypeTracer) for x in nplikes):
         return ak._typetracer.TypeTracer.instance()
 
-    if nplikes == set():
+    if len(nplikes) == 0:
         if default is _UNSET:
             return Numpy.instance()
         else:
@@ -1005,3 +1005,14 @@ def nplike_of(*arrays, default=_UNSET):
 to move one or the other to main memory or the GPU(s)."""
             )
         )
+
+
+def index_nplike_for(nplike: NumpyLike) -> NumpyLike:
+    if isinstance(nplike, ak.nplikes.Jax):
+        return ak.nplikes.Numpy.instance()
+    elif isinstance(
+        nplike, (ak.nplikes.Numpy, ak.nplikes.Cupy, ak._typetracer.TypeTracer)
+    ):
+        return nplike
+    else:
+        raise ak._errors.wrap_error(TypeError(f"Unknown typetracer {type(nplike)}"))

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -250,6 +250,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 ak.operations.to_layout(x, allow_record=False, allow_other=False)
             )
 
+    index_nplike = ak.nplikes.index_nplike_for(nplike)
+
     if with_name is not None:
         if parameters is None:
             parameters = {}
@@ -319,8 +321,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
         indexes = [
             ak.index.Index64(x.reshape(-1), nplike=nplike)
-            for x in nplike.index_nplike.meshgrid(
-                *[nplike.index_nplike.arange(len(x), dtype=np.int64) for x in layouts],
+            for x in index_nplike.meshgrid(
+                *[index_nplike.arange(len(x), dtype=np.int64) for x in layouts],
                 indexing="ij",
             )
         ]

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -159,6 +159,8 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                 or not isinstance(x, ak.contents.Content)
                 for x in inputs
             ):
+                nplike = ak.nplikes.nplike_of(*inputs)
+                index_nplike = ak.nplikes.index_nplike_for(nplike)
                 regulararrays = []
                 sizes = []
                 for x in inputs:
@@ -170,7 +172,9 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                         regulararrays.append(
                             ak.contents.RegularArray(
                                 ak.contents.NumpyArray(
-                                    nplike.broadcast_to(nplike.array([x]), (length,))
+                                    nplike.broadcast_to(nplike.array([x]), (length,)),
+                                    nplike=nplike,
+                                    index_nplike=index_nplike,
                                 ),
                                 1,
                             )

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -214,9 +214,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                         nextinputs.append(
                             ak.contents.ListOffsetArray(
                                 ak.index.Index64(
-                                    index_nplike.arange(
-                                        length + 1, dtype=np.int64
-                                    ),
+                                    index_nplike.arange(length + 1, dtype=np.int64),
                                     nplike=nplike,
                                 ),
                                 ak.contents.NumpyArray(
@@ -237,9 +235,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
                     all_counts.append(c)
                     all_flatten.append(f)
 
-                offsets = index_nplike.empty(
-                    len(nextinputs[0]) + 1, dtype=np.int64
-                )
+                offsets = index_nplike.empty(len(nextinputs[0]) + 1, dtype=np.int64)
                 offsets[0] = 0
                 index_nplike.cumsum(counts, out=offsets[1:])
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -129,9 +129,7 @@ def _impl(array, axis, highlevel, behavior):
                     return layout
 
                 tags = index_nplike.asarray(layout.tags)
-                index = index_nplike.array(
-                    nplike.asarray(layout.index), copy=True
-                )
+                index = index_nplike.array(nplike.asarray(layout.index), copy=True)
                 bigmask = index_nplike.empty(len(index), dtype=np.bool_)
                 for tag, content in enumerate(layout.contents):
                     if content.is_option and not isinstance(

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -100,6 +100,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     nplike = ak.nplikes.nplike_of(layout)
+    index_nplike = ak.nplikes.index_nplike_for(nplike)
 
     if axis is None:
         out = layout.completely_flatten(function_name="ak.flatten")
@@ -127,17 +128,17 @@ def _impl(array, axis, highlevel, behavior):
                 ):
                     return layout
 
-                tags = nplike.index_nplike.asarray(layout.tags)
-                index = nplike.index_nplike.array(
+                tags = index_nplike.asarray(layout.tags)
+                index = index_nplike.array(
                     nplike.asarray(layout.index), copy=True
                 )
-                bigmask = nplike.index_nplike.empty(len(index), dtype=np.bool_)
+                bigmask = index_nplike.empty(len(index), dtype=np.bool_)
                 for tag, content in enumerate(layout.contents):
                     if content.is_option and not isinstance(
                         content, ak.contents.UnmaskedArray
                     ):
                         bigmask[:] = False
-                        bigmask[tags == tag] = nplike.index_nplike.asarray(
+                        bigmask[tags == tag] = index_nplike.asarray(
                             content.mask_as_bool(valid_when=False)
                         ).view(np.bool_)
                         index[bigmask] = -1

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -197,7 +197,7 @@ def reconstitute(form, length, container, getkey, nplike, index_nplike):
             index_nplike, raw_array, _index_to_dtype[form.index], length
         )
         next_length = (
-            0 if len(index) == 0 else max(0, nplike.index_nplike.max(index) + 1)
+            0 if len(index) == 0 else max(0, index_nplike.max(index) + 1)
         )
         return ak.contents.IndexedOptionArray(
             ak.index.Index(index),
@@ -212,7 +212,7 @@ def reconstitute(form, length, container, getkey, nplike, index_nplike):
         index = from_buffer_or_array(
             index_nplike, raw_array, _index_to_dtype[form.index], length
         )
-        next_length = 0 if len(index) == 0 else nplike.index_nplike.max(index) + 1
+        next_length = 0 if len(index) == 0 else index_nplike.max(index) + 1
         return ak.contents.IndexedArray(
             ak.index.Index(index),
             reconstitute(
@@ -231,7 +231,7 @@ def reconstitute(form, length, container, getkey, nplike, index_nplike):
             index_nplike, raw_stops, _index_to_dtype[form.starts], length
         )
         reduced_stops = stops[starts != stops]
-        next_length = 0 if len(starts) == 0 else nplike.index_nplike.max(reduced_stops)
+        next_length = 0 if len(starts) == 0 else index_nplike.max(reduced_stops)
         return ak.contents.ListArray(
             ak.index.Index(starts),
             ak.index.Index(stops),
@@ -292,7 +292,7 @@ def reconstitute(form, length, container, getkey, nplike, index_nplike):
             if len(selected_index) == 0:
                 lengths.append(0)
             else:
-                lengths.append(nplike.index_nplike.max(selected_index) + 1)
+                lengths.append(index_nplike.max(selected_index) + 1)
         return ak.contents.UnionArray(
             ak.index.Index(tags),
             ak.index.Index(index),

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -196,9 +196,7 @@ def reconstitute(form, length, container, getkey, nplike, index_nplike):
         index = from_buffer_or_array(
             index_nplike, raw_array, _index_to_dtype[form.index], length
         )
-        next_length = (
-            0 if len(index) == 0 else max(0, index_nplike.max(index) + 1)
-        )
+        next_length = 0 if len(index) == 0 else max(0, index_nplike.max(index) + 1)
         return ak.contents.IndexedOptionArray(
             ak.index.Index(index),
             reconstitute(

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -100,16 +100,18 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
     behavior = ak._util.behavior_of(array, behavior=behavior)
 
     def action(layout, **kwargs):
+        nplike = ak.nplikes.nplike_of(layout)
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
         if layout.parameter("__array__") == "bytestring" and fill_value is _ZEROS:
-            nplike = ak.nplikes.nplike_of(layout)
+
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
@@ -117,7 +119,6 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "bytestring":
-            nplike = ak.nplikes.nplike_of(layout)
             if isinstance(fill_value, bytes):
                 asbytes = fill_value
             else:
@@ -126,26 +127,25 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.index.Index64(
-                    nplike.index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
+                    index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
                 parameters={"__array__": "bytestring"},
             )
 
         elif layout.parameter("__array__") == "string" and fill_value is _ZEROS:
-            nplike = ak.nplikes.nplike_of(layout)
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
@@ -153,23 +153,21 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             )
 
         elif layout.parameter("__array__") == "string":
-            nplike = ak.nplikes.nplike_of(layout)
             asstr = str(fill_value).encode("utf-8", "surrogateescape")
             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    nplike.index_nplike.zeros(len(layout), dtype=np.int64),
+                    index_nplike.zeros(len(layout), dtype=np.int64),
                     nplike=nplike,
                 ),
                 ak.index.Index64(
-                    nplike.index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
+                    index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
                 parameters={"__array__": "string"},
             )
 
         elif isinstance(layout, ak.contents.NumpyArray):
-            nplike = ak.nplikes.nplike_of(layout)
             original = nplike.asarray(layout.data)
 
             if fill_value == 0 or fill_value is _ZEROS:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -37,14 +37,15 @@ def _impl(array, axis, highlevel, behavior):
             return
 
         nplike = ak.nplikes.nplike_of(layout)
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
 
         if layout.is_option:
             layout = layout.to_IndexedOptionArray64()
 
             # Convert the option type into a union, using the mask
             # as a tag.
-            tag = nplike.index_nplike.asarray(layout.mask_as_bool(valid_when=False))
-            index = nplike.index_nplike.where(tag, 0, nplike.asarray(layout.index))
+            tag = index_nplike.asarray(layout.mask_as_bool(valid_when=False))
+            index = index_nplike.where(tag, 0, nplike.asarray(layout.index))
 
             return ak.contents.UnionArray(
                 ak.index.Index8(tag),

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -96,10 +96,11 @@ def run_lengths(array, *, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     nplike = ak.nplikes.nplike_of(array)
+    index_nplike = ak.nplikes.index_nplike_for(nplike)
 
     def lengths_of(data, offsets):
         if len(data) == 0:
-            return nplike.index_nplike.empty(0, np.int64), offsets
+            return index_nplike.empty(0, np.int64), offsets
         else:
             diffs = data[1:] != data[:-1]
 
@@ -120,8 +121,8 @@ def _impl(array, highlevel, behavior):
                 is_interior = nplike.logical_and(0 < offsets, offsets < len(data) - 1)
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True
-            positions = nplike.index_nplike.nonzero(diffs)[0]
-            full_positions = nplike.index_nplike.empty(len(positions) + 2, np.int64)
+            positions = index_nplike.nonzero(diffs)[0]
+            full_positions = index_nplike.empty(len(positions) + 2, np.int64)
             full_positions[0] = 0
             full_positions[-1] = len(data)
             full_positions[1:-1] = positions + 1
@@ -130,7 +131,7 @@ def _impl(array, highlevel, behavior):
             if offsets is None:
                 nextoffsets = None
             else:
-                nextoffsets = nplike.index_nplike.searchsorted(
+                nextoffsets = index_nplike.searchsorted(
                     full_positions, offsets, side="left"
                 )
             return nextcontent, nextoffsets
@@ -171,7 +172,7 @@ def _impl(array, highlevel, behavior):
                 # We also want to trim the _upper_ bound of content,
                 # so we manually convert the list type to zero-based
                 listoffsetarray = layout.to_ListOffsetArray64(False)
-                offsets = nplike.index_nplike.asarray(listoffsetarray.offsets)
+                offsets = index_nplike.asarray(listoffsetarray.offsets)
                 content = listoffsetarray.content[offsets[0] : offsets[-1]]
 
                 if content.is_indexed:
@@ -186,7 +187,7 @@ def _impl(array, highlevel, behavior):
                 )
 
             listoffsetarray = layout.to_ListOffsetArray64(False)
-            offsets = nplike.index_nplike.asarray(listoffsetarray.offsets)
+            offsets = index_nplike.asarray(listoffsetarray.offsets)
             content = listoffsetarray.content[offsets[0] : offsets[-1]]
 
             if content.is_indexed:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -39,9 +39,9 @@ def _impl(array, highlevel, behavior):
         index_nplike = ak.nplikes.index_nplike_for(nplike)
 
         if layout.is_option:
-            nulls = index_nplike.asarray(
-                layout.mask_as_bool(valid_when=False)
-            ).view(np.bool_)
+            nulls = index_nplike.asarray(layout.mask_as_bool(valid_when=False)).view(
+                np.bool_
+            )
             offsets = index_nplike.ones(len(layout) + 1, dtype=np.int64)
             offsets[0] = 0
             offsets[1:][nulls] = 0

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -36,15 +36,16 @@ def singletons(array, *, highlevel=True, behavior=None):
 def _impl(array, highlevel, behavior):
     def action(layout, **kwargs):
         nplike = ak.nplikes.nplike_of(layout)
+        index_nplike = ak.nplikes.index_nplike_for(nplike)
 
         if layout.is_option:
-            nulls = nplike.index_nplike.asarray(
+            nulls = index_nplike.asarray(
                 layout.mask_as_bool(valid_when=False)
             ).view(np.bool_)
-            offsets = nplike.index_nplike.ones(len(layout) + 1, dtype=np.int64)
+            offsets = index_nplike.ones(len(layout) + 1, dtype=np.int64)
             offsets[0] = 0
             offsets[1:][nulls] = 0
-            nplike.index_nplike.cumsum(offsets, out=offsets)
+            index_nplike.cumsum(offsets, out=offsets)
             return ak.contents.ListOffsetArray(
                 ak.index.Index64(offsets), layout.project()
             )

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -122,7 +122,12 @@ def _impl(array, allow_record, allow_other, numpytype):
                 )
             )
 
-        return ak.contents.NumpyArray(array, parameters=None, nplike=typetracer)
+        return ak.contents.NumpyArray(
+            array,
+            parameters=None,
+            nplike=typetracer,
+            index_nplike=ak.nplikes.index_nplike_for(typetracer),
+        )
 
     elif isinstance(array, (str, bytes)):
         return _impl(

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -170,14 +170,10 @@ def _impl(array, counts, axis, highlevel, behavior):
                     inneroffsets = index_nplike.asarray(content.offsets)
 
                 positions = (
-                    index_nplike.searchsorted(
-                        inneroffsets, outeroffsets, side="right"
-                    )
+                    index_nplike.searchsorted(inneroffsets, outeroffsets, side="right")
                     - 1
                 )
-                if not index_nplike.array_equal(
-                    inneroffsets[positions], outeroffsets
-                ):
+                if not index_nplike.array_equal(inneroffsets[positions], outeroffsets):
                     raise ak._errors.wrap_error(
                         ValueError(
                             "structure imposed by 'counts' does not fit in the array or partition "

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -107,14 +107,15 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
     if isinstance(right, ak.contents.Content):
         good_arrays.append(right)
     nplike = ak.nplikes.nplike_of(*good_arrays)
+    index_nplike = ak.nplikes.index_nplike_for(nplike)
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
         if isinstance(akcondition, ak.contents.NumpyArray):
-            npcondition = nplike.index_nplike.asarray(akcondition)
+            npcondition = index_nplike.asarray(akcondition)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(
-                nplike.index_nplike.arange(len(tags), dtype=np.int64), nplike=nplike
+                index_nplike.arange(len(tags), dtype=np.int64), nplike=nplike
             )
             if not isinstance(left, ak.contents.Content):
                 left = ak.contents.NumpyArray(nplike.repeat(left, len(tags)))

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -102,12 +102,13 @@ def _impl(base, what, where, highlevel, behavior):
 
             def action(inputs, **kwargs):
                 nplike = ak.nplikes.nplike_of(*inputs)
+                index_nplike = ak.nplikes.index_nplike_for(nplike)
                 base, what = inputs
                 if isinstance(base, ak.contents.RecordArray):
                     if what is None:
                         what = ak.contents.IndexedOptionArray(
                             ak.index.Index64(
-                                nplike.index_nplike.full(len(base), -1, np.int64),
+                                index_nplike.full(len(base), -1, np.int64),
                                 nplike=nplike,
                             ),
                             ak.contents.EmptyArray(),


### PR DESCRIPTION
Our `nplike` mechanism encodes two different things; a NumPy abstraction, and a higher-level index-content abstraction through `index_nplike`. This is problematic for several reasons:
- accidental confusion of nplikes is easier, as it's hard to tell whether a function uses `nplike` or `nplike.index_nplike`
- index nplikes shouldn't also have `index_nplike`

Additionally, we don't need to pass around `nplike` everywhere now that we know we can only have a single nplike family per layout. This does have consequences for our JAX integration, which cheats and stores the *wrong* nplike in the layout. We need to tackle this anyway.