### PR TITLE
test: cover the failure modes of unflatten

### DIFF
--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -91,9 +91,16 @@ def _impl(array, counts, axis, highlevel, behavior):
         elif counts.is_numpy or counts.is_unknown:
             counts = counts.to_numpy(allow_missing=False)
             mask = False
+        else:
+            raise ak._errors.wrap_error(
+                ValueError(
+                    "counts must be an integer or a one-dimensional array of integers"
+                )
+            )
 
         if counts.ndim != 1:
             raise ak._errors.wrap_error(ValueError("counts must be one-dimensional"))
+
         if not issubclass(counts.dtype.type, np.integer):
             raise ak._errors.wrap_error(ValueError("counts must be integers"))
 

--- a/tests/test_1930-unflatten-counts-checks.py
+++ b/tests/test_1930-unflatten-counts-checks.py
@@ -1,0 +1,30 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak
+import awkward._connect.cling
+import awkward._lookup
+
+
+def test():
+    array = ak.Array([[0, 1, 2, 3], [8, 9, 10, 11]])
+
+    with pytest.raises(ValueError, match=r"one-dimensional"):
+        ak.unflatten(array, [[4, 2, 2]], axis=-1)
+
+    with pytest.raises(ValueError, match=r"negative counts"):
+        ak.unflatten(array, -40, axis=-1)
+
+    with pytest.raises(ValueError, match=r"does not fit"):
+        ak.unflatten(array, [-40], axis=-1)
+
+    with pytest.raises(ValueError, match=r"must be integers"):
+        ak.unflatten(array, [4.0, 2.0, 2.0], axis=-1)
+
+    with pytest.raises(ValueError, match=r"too large"):
+        ak.unflatten(array, 100, axis=-1)
+
+    with pytest.raises(ValueError, match=r"does not fit"):
+        ak.unflatten(array, [100], axis=-1)


### PR DESCRIPTION
`ak.unflatten` throws a secondary error if a 2D ragged array is passed for `counts`. This PR fixes that by catching the `else` case, and adds tests to try out the various improper `count` values.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-ndim-unflatten/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->