### PR TITLE
docs: cleanup docstrings

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -42,7 +42,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         check_valid (bool): If True, verify that the #layout is valid.
         backend (None, `"cpu"`, `"jax"`, `"cuda"`): If `"cpu"`, the Array will be placed in
             main memory for use with other `"cpu"` Arrays and Records; if `"cuda"`,
-            the Array will be placed in GPU global memory using CUDA; if "jax", the structure
+            the Array will be placed in GPU global memory using CUDA; if `"jax"`, the structure
             is copied to the CPU for use with JAX. if None, the `data` are left untouched.
 
     High-level array that can contain data of any type.

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2096,9 +2096,9 @@ class ArrayBuilder(Sized):
         behavior (None or dict): Custom #ak.behavior for arrays built by
             this ArrayBuilder.
         initial (int): Initial size (in bytes) of buffers used by the
-            [ak::ArrayBuilder](_static/classawkward_1_1ArrayBuilder.html).
+            [ak::ArrayBuilder](../_static/doxygen/classawkward_1_1ArrayBuilder.html).
         resize (float): Resize multiplier for buffers used by the
-            [ak::ArrayBuilder](_static/classawkward_1_1ArrayBuilder.html);
+            [ak::ArrayBuilder](../_static/doxygen/classawkward_1_1ArrayBuilder.html);
             should be strictly greater than 1.
 
     General tool for building arrays of nested data structures from a sequence

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -296,14 +296,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         but `array.layout` is presented as
 
-            <ListOffsetArray64>
+            <ListOffsetArray>
                 <offsets>
                     <Index64 i="[0 3 3 5]" offset="0" length="4" at="0x55a26df62590"/>
                 </offsets>
                 <content>
                     <NumpyArray format="d" shape="5" data="1.1 2.2 3.3 4.4 5.5" at="0x55a26e0c5f50"/>
                 </content>
-            </ListOffsetArray64>
+            </ListOffsetArray>
 
         (with truncation for large arrays).
         """

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -272,10 +272,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         arrays that have the same logical meaning (i.e. same JSON output and
         high-level #type) but different
 
-           * node types, such as #ak.contents.ListArray and
+        * node types, such as #ak.contents.ListArray and
              #ak.contents.ListOffsetArray,
-           * integer type specialization, such as `int64` vs `int32`
-           * or specific values, such as gaps in a #ak.contents.ListArray.
+        * integer type specialization, such as `int64` vs `int32`
+        * or specific values, such as gaps in a #ak.contents.ListArray.
 
         The #ak.contents.Content elements are fully composable, whereas an
         Array is not; the high-level Array is a single-layer "shell" around
@@ -320,14 +320,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         The `behavior` parameter passed into this Array's constructor.
 
-           * If a dict, this `behavior` overrides the global #ak.behavior.
+        * If a dict, this `behavior` overrides the global #ak.behavior.
              Any keys in the global #ak.behavior but not this `behavior` are
              still valid, but any keys in both are overridden by this
              `behavior`. Keys with a None value are equivalent to missing keys,
              so this `behavior` can effectively remove keys from the
              global #ak.behavior.
 
-           * If None, the Array defaults to the global #ak.behavior.
+        * If None, the Array defaults to the global #ak.behavior.
 
         See #ak.behavior for a list of recognized key patterns and their
         meanings.
@@ -565,7 +565,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         The `where` parameter can be any of the following or a tuple of
         the following.
 
-           * **An integer** selects one element. Like Python/NumPy, it is
+        * **An integer** selects one element. Like Python/NumPy, it is
              zero-indexed: `0` is the first item, `1` is the second, etc.
              Negative indexes count from the end of the list: `-1` is the
              last, `-2` is the second-to-last, etc.
@@ -573,14 +573,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
              large or because they're too negative, raise errors. In
              particular, some nested lists might contain a desired element
              while others don't; this would raise an error.
-           * **A slice** (either a Python `slice` object or the
+        * **A slice** (either a Python `slice` object or the
              `start:stop:step` syntax) selects a range of elements. The
              `start` and `stop` values are zero-indexed; `start` is inclusive
              and `stop` is exclusive, like Python/NumPy. Negative `step`
              values are allowed, but a `step` of `0` is an error. Slices
              beyond the size of the array are not errors but are truncated,
              like Python/NumPy.
-           * **A string** selects a tuple or record field, even if its
+        * **A string** selects a tuple or record field, even if its
              position in the tuple is to the left of the dimension where the
              tuple/record is defined. (See <<projection>> below.) This is
              similar to NumPy's
@@ -590,36 +590,36 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
              integer strings, such as `"0"`, `"1"`, `"2"` (always
              non-negative). Be careful to distinguish these from non-string
              integers.
-           * **An iterable of strings** (not the top-level tuple) selects
+        * **An iterable of strings** (not the top-level tuple) selects
              multiple tuple/record fields.
-           * **An ellipsis** (either the Python `Ellipsis` object or the
+        * **An ellipsis** (either the Python `Ellipsis` object or the
              `...` syntax) skips as many dimensions as needed to put the
              rest of the slice items to the innermost dimensions.
-           * **A np.newaxis** or its equivalent, None, does not select items
+        * **A np.newaxis** or its equivalent, None, does not select items
              but introduces a new regular dimension in the output with size
              `1`. This is a convenient way to explicitly choose a dimension
              for broadcasting.
-           * **A boolean array** with the same length as the current dimension
+        * **A boolean array** with the same length as the current dimension
              (or any iterable, other than the top-level tuple) selects elements
              corresponding to each True value in the array, dropping those
              that correspond to each False. The behavior is similar to
              NumPy's
              [compress](https://docs.scipy.org/doc/numpy/reference/generated/numpy.compress.html)
              function.
-           * **An integer array** (or any iterable, other than the top-level
+        * **An integer array** (or any iterable, other than the top-level
              tuple) selects elements like a single integer, but produces a
              regular dimension of as many as are desired. The array can have
              any length, any order, and it can have duplicates and incomplete
              coverage. The behavior is similar to NumPy's
              [take](https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html)
              function.
-           * **An integer Array with missing (None) items** selects multiple
+        * **An integer Array with missing (None) items** selects multiple
              values by index, as above, but None values are passed through
              to the output. This behavior matches pyarrow's
              [Array.take](https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.take)
              which also manages arrays with missing values. See
              <<option indexing>> below.
-           * **An Array of nested lists**, ultimately containing booleans or
+        * **An Array of nested lists**, ultimately containing booleans or
              integers and having the same lengths of lists at each level as
              the Array to which they're applied, selects by boolean or by
              integer at the deeply nested level. Missing items at any level
@@ -1084,10 +1084,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         Fields can't be accessed as attributes when
 
-           * #ak.Array methods or properties take precedence,
-           * a domain-specific behavior has methods or properties that take
+        * #ak.Array methods or properties take precedence,
+        * a domain-specific behavior has methods or properties that take
              precedence, or
-           * the field name is not a valid Python identifier or is a Python
+        * the field name is not a valid Python identifier or is a Python
              keyword.
 
         Note that while fields can be accessed as attributes, they cannot be
@@ -1606,14 +1606,14 @@ class Record(NDArrayOperatorsMixin):
         """
         The `behavior` parameter passed into this Record's constructor.
 
-           * If a dict, this `behavior` overrides the global #ak.behavior.
+        * If a dict, this `behavior` overrides the global #ak.behavior.
              Any keys in the global #ak.behavior but not this `behavior` are
              still valid, but any keys in both are overridden by this
              `behavior`. Keys with a None value are equivalent to missing keys,
              so this `behavior` can effectively remove keys from the
              global #ak.behavior.
 
-           * If None, the Record defaults to the global #ak.behavior.
+        * If None, the Record defaults to the global #ak.behavior.
 
         See #ak.behavior for a list of recognized key patterns and their
         meanings.
@@ -1817,10 +1817,10 @@ class Record(NDArrayOperatorsMixin):
 
         Fields can't be accessed as attributes when
 
-           * #ak.Record methods or properties take precedence,
-           * a domain-specific behavior has methods or properties that take
+        * #ak.Record methods or properties take precedence,
+        * a domain-specific behavior has methods or properties that take
              precedence, or
-           * the field name is not a valid Python identifier or is a Python
+        * the field name is not a valid Python identifier or is a Python
              keyword.
         """
         if hasattr(type(self), where):
@@ -2145,32 +2145,32 @@ class ArrayBuilder(Sized):
 
     The full set of filling commands is the following.
 
-       * #null: appends a None value.
-       * #boolean: appends True or False.
-       * #integer: appends an integer.
-       * #real: appends a floating-point value.
-       * #complex: appends a complex value.
-       * #datetime: appends a datetime value.
-       * #timedelta: appends a timedelta value.
-       * #bytestring: appends an unencoded string (raw bytes).
-       * #string: appends a UTF-8 encoded string.
-       * #begin_list: begins filling a list; must be closed with #end_list.
-       * #end_list: ends a list.
-       * #begin_tuple: begins filling a tuple; must be closed with #end_tuple.
-       * #index: selects a tuple slot to fill; must be followed by a command
+    * #null: appends a None value.
+    * #boolean: appends True or False.
+    * #integer: appends an integer.
+    * #real: appends a floating-point value.
+    * #complex: appends a complex value.
+    * #datetime: appends a datetime value.
+    * #timedelta: appends a timedelta value.
+    * #bytestring: appends an unencoded string (raw bytes).
+    * #string: appends a UTF-8 encoded string.
+    * #begin_list: begins filling a list; must be closed with #end_list.
+    * #end_list: ends a list.
+    * #begin_tuple: begins filling a tuple; must be closed with #end_tuple.
+    * #index: selects a tuple slot to fill; must be followed by a command
          that actually fills that slot.
-       * #end_tuple: ends a tuple.
-       * #begin_record: begins filling a record; must be closed with
+    * #end_tuple: ends a tuple.
+    * #begin_record: begins filling a record; must be closed with
          #end_record.
-       * #field: selects a record field to fill; must be followed by a command
+    * #field: selects a record field to fill; must be followed by a command
          that actually fills that field.
-       * #end_record: ends a record.
-       * #append: generic method for filling #null, #boolean, #integer, #real,
+    * #end_record: ends a record.
+    * #append: generic method for filling #null, #boolean, #integer, #real,
          #bytestring, #string, #ak.Array, #ak.Record, or arbitrary Python data.
-       * #extend: appends all the items from an iterable.
-       * #list: context manager for #begin_list and #end_list.
-       * #tuple: context manager for #begin_tuple and #end_tuple.
-       * #record: context manager for #begin_record and #end_record.
+    * #extend: appends all the items from an iterable.
+    * #list: context manager for #begin_list and #end_list.
+    * #tuple: context manager for #begin_tuple and #end_tuple.
+    * #record: context manager for #begin_record and #end_record.
 
     ArrayBuilders can be used in [Numba](http://numba.pydata.org/): they can
     be passed as arguments to a Numba-compiled function or returned as return
@@ -2245,14 +2245,14 @@ class ArrayBuilder(Sized):
         """
         The `behavior` parameter passed into this ArrayBuilder's constructor.
 
-           * If a dict, this `behavior` overrides the global #ak.behavior.
+        * If a dict, this `behavior` overrides the global #ak.behavior.
              Any keys in the global #ak.behavior but not this `behavior` are
              still valid, but any keys in both are overridden by this
              `behavior`. Keys with a None value are equivalent to missing keys,
              so this `behavior` can effectively remove keys from the
              global #ak.behavior.
 
-           * If None, the Array defaults to the global #ak.behavior.
+        * If None, the Array defaults to the global #ak.behavior.
 
         See #ak.behavior for a list of recognized key patterns and their
         meanings.

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1474,13 +1474,10 @@ class Record(NDArrayOperatorsMixin):
         with_name (None or str): Gives the record type a name that can be
             used to override its behavior (see below).
         check_valid (bool): If True, verify that the #layout is valid.
-        kernels (None, `"cpu"`, or `"cuda"`): If `"cpu"`, the Record will be placed in
+        backend (None, `"cpu"`, `"jax"`, `"cuda"`): If `"cpu"`, the Array will be placed in
             main memory for use with other `"cpu"` Arrays and Records; if `"cuda"`,
-            the Record will be placed in GPU global memory using CUDA; if None,
-            the `data` are left untouched. For `"cuda"`,
-            [awkward-cuda-kernels](https://pypi.org/project/awkward-cuda-kernels)
-            must be installed, which can be invoked with
-            `pip install awkward[cuda] --upgrade`.
+            the Array will be placed in GPU global memory using CUDA; if `"jax"`, the structure
+            is copied to the CPU for use with JAX. if None, the `data` are left untouched.
 
     High-level record that can contain fields of any type.
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -40,13 +40,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         with_name (None or str): Gives tuples and records a name that can be
             used to override their behavior (see below).
         check_valid (bool): If True, verify that the #layout is valid.
-        backend (None, `"cpu"`, or `"cuda"`): If `"cpu"`, the Array will be placed in
+        backend (None, `"cpu"`, `"jax"`, `"cuda"`): If `"cpu"`, the Array will be placed in
             main memory for use with other `"cpu"` Arrays and Records; if `"cuda"`,
-            the Array will be placed in GPU global memory using CUDA; if None,
-            the `data` are left untouched. For `"cuda"`,
-            [awkward-cuda-kernels](https://pypi.org/project/awkward-cuda-kernels)
-            must be installed, which can be invoked with
-            `pip install awkward[cuda] --upgrade`.
+            the Array will be placed in GPU global memory using CUDA; if "jax", the structure
+            is copied to the CPU for use with JAX. if None, the `data` are left untouched.
 
     High-level array that can contain data of any type.
 
@@ -277,8 +274,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
            * node types, such as #ak.contents.ListArray and
              #ak.contents.ListOffsetArray,
-           * integer type specialization, such as #ak.contents.ListArray
-             and #ak.contents.ListArray,
+           * integer type specialization, such as `int64` vs `int32`
            * or specific values, such as gaps in a #ak.contents.ListArray.
 
         The #ak.contents.Content elements are fully composable, whereas an

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -39,6 +39,8 @@ def argcombinations(
             (overriding `parameters`, if necessary).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
     Computes a Cartesian product (i.e. cross product) of `array` with itself
     that is restricted to combinations sampled without replacement,

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -7,11 +7,11 @@ def backend(*arrays) -> str:
     """
     Returns the names of the backend used by `arrays`. May be
 
-       * `"cpu"` for arrays backed by NumPy;
-       * `"cuda"` for arrays backed by CuPy;
-       * `"jax"` for arrays backed by JAX;
-       * None if the objects are not Awkward, NumPy, JAX, or CuPy arrays (e.g.
-         Python numbers, booleans, strings).
+    * `"cpu"` for arrays backed by NumPy;
+    * `"cuda"` for arrays backed by CuPy;
+    * `"jax"` for arrays backed by JAX;
+    * None if the objects are not Awkward, NumPy, JAX, or CuPy arrays (e.g.
+      Python numbers, booleans, strings).
 
     See #ak.to_backend.
     """

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -101,12 +101,12 @@ def broadcast_arrays(*arrays, **kwargs):
     Awkward Array's broadcasting manages to have it both ways by applying the
     following rules:
 
-       * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
-         implicit broadcasting aligns to the right, like NumPy.
-       * If any dimension is variable (i.e. #ak.types.ListType), which can
-         never be true of NumPy, implicit broadcasting aligns to the left.
-       * Explicit broadcasting with a length-1 regular dimension always
-         broadcasts, like NumPy.
+    * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
+      implicit broadcasting aligns to the right, like NumPy.
+    * If any dimension is variable (i.e. #ak.types.ListType), which can
+      never be true of NumPy, implicit broadcasting aligns to the left.
+    * Explicit broadcasting with a length-1 regular dimension always
+      broadcasts, like NumPy.
 
     Thus, it is important to be aware of the distinction between a dimension
     that is declared to be regular in the type specification and a dimension

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -14,14 +14,14 @@ def broadcast_arrays(*arrays, **kwargs):
             left-broadcasting, as described below.
         right_broadcast (bool): If True, follow rules for implicit
             right-broadcasting, as described below.
-        highlevel (bool, default is True): If True, return an #ak.Array;
-            otherwise, return a low-level #ak.contents.Content subclass.
-        behavior (None or dict): Custom #ak.behavior for the output array, if
-            high-level.
         depth_limit (None or int, default is None): If None, attempt to fully
             broadcast the `arrays` to all levels. If an int, limit the number
             of dimensions that get broadcasted. The minimum value is `1`,
             for no broadcasting.
+        highlevel (bool, default is True): If True, return an #ak.Array;
+            otherwise, return a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
     Like NumPy's
     [broadcast_arrays](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast_arrays.html)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -10,6 +10,9 @@ np = ak._nplikes.NumpyMetadata.instance()
 @ak._connect.numpy.implements("copy")
 def copy(array):
     """
+    Args:
+        array: Array to be copied.
+
     Returns a deep copy of the array (no memory shared with original).
 
     This is identical to `np.copy` and `copy.deepcopy`.

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -7,6 +7,9 @@ np = ak._nplikes.NumpyMetadata.instance()
 
 def fields(array):
     """
+    Args:
+        array: Array to determine the fields of.
+
     Extracts record fields or tuple slot numbers from `array` (many types
     supported, including all Awkward Arrays and Records).
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -75,15 +75,15 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
     In that case, the flattened data is simply the array node's `content`.
 
         >>> array.layout
-        <ListOffsetArray64>
+        <ListOffsetArray>
             <offsets><Index64 i="[0 4 4 6]" offset="0" length="4"/></offsets>
-            <content><ListOffsetArray64>
+            <content><ListOffsetArray>
                 <offsets><Index64 i="[0 3 3 5 6 7 9]" offset="0" length="7"/></offsets>
                 <content>
                     <NumpyArray format="d" shape="9" data="1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9"/>
                 </content>
-            </ListOffsetArray64></content>
-        </ListOffsetArray64>
+            </ListOffsetArray></content>
+        </ListOffsetArray>
         >>> np.asarray(array.layout.content.content)
         array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -8,9 +8,8 @@ np = ak._nplikes.NumpyMetadata.instance()
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:
-        array (`pyarrow.Array`, `pyarrow.ChunkedArray`, `pyarrow.RecordBatch`,
-            or `pyarrow.Table`): Apache Arrow array to convert into an
-            Awkward Array.
+        array (`pyarrow.Array`, `pyarrow.ChunkedArray`, `pyarrow.RecordBatch`, or `pyarrow.Table`):
+            Apache Arrow array to convert into an  Awkward Array.
         generate_bitmasks (bool): If enabled and Arrow/Parquet does not have Awkward
             metadata, `generate_bitmasks=True` creates empty bitmasks for nullable
             types that don't have bitmasks in the Arrow/Parquet data, so that the

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -20,6 +20,7 @@ def from_avro_file(
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
+
     Reads Avro files as Awkward Arrays.
 
     Internally this function uses AwkwardForth DSL. The function recursively parses the Avro schema, generates

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -22,8 +22,8 @@ def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     The resulting layout may involve the following #ak.contents.Content types
     (only):
 
-       * #ak.contents.NumpyArray
-       * #ak.contents.RegularArray if `regulararray=True`.
+    * #ak.contents.NumpyArray
+    * #ak.contents.RegularArray if `regulararray=True`.
 
     See also #ak.to_cupy, #ak.from_numpy and #ak.from_jax.
     """

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -42,19 +42,19 @@ def from_iter(
 
     The following Python types are supported.
 
-       * bool, including `np.bool_`: converted into #ak.contents.NumpyArray.
-       * int, including `np.integer`: converted into #ak.contents.NumpyArray.
-       * float, including `np.floating`: converted into #ak.contents.NumpyArray.
-       * bytes: converted into #ak.contents.ListOffsetArray with parameter
-         `"__array__"` equal to `"bytestring"` (unencoded bytes).
-       * str: converted into #ak.contents.ListOffsetArray with parameter
-         `"__array__"` equal to `"string"` (UTF-8 encoded string).
-       * tuple: converted into #ak.contents.RecordArray without field names
-         (i.e. homogeneously typed, uniform sized tuples).
-       * dict: converted into #ak.contents.RecordArray with field names
-         (i.e. homogeneously typed records with the same sets of fields).
-       * iterable, including np.ndarray: converted into
-         #ak.contents.ListOffsetArray.
+    * bool, including `np.bool_`: converted into #ak.contents.NumpyArray.
+    * int, including `np.integer`: converted into #ak.contents.NumpyArray.
+    * float, including `np.floating`: converted into #ak.contents.NumpyArray.
+    * bytes: converted into #ak.contents.ListOffsetArray with parameter
+      `"__array__"` equal to `"bytestring"` (unencoded bytes).
+    * str: converted into #ak.contents.ListOffsetArray with parameter
+      `"__array__"` equal to `"string"` (UTF-8 encoded string).
+    * tuple: converted into #ak.contents.RecordArray without field names
+      (i.e. homogeneously typed, uniform sized tuples).
+    * dict: converted into #ak.contents.RecordArray with field names
+      (i.e. homogeneously typed records with the same sets of fields).
+    * iterable, including np.ndarray: converted into
+      #ak.contents.ListOffsetArray.
 
     See also #ak.to_list.
     """

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -22,8 +22,8 @@ def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     The resulting layout may involve the following #ak.contents.Content types
     (only):
 
-       * #ak.contents.NumpyArray
-       * #ak.contents.RegularArray if `regulararray=True`.
+    * #ak.contents.NumpyArray
+    * #ak.contents.RegularArray if `regulararray=True`.
 
     See also #ak.to_jax, #ak.from_numpy and #ak.from_jax.
     """

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -154,7 +154,7 @@ def from_json(
     (`line_delimited=True`) only results in #ak.Array:
 
         >>> ak.from_json(
-        ...     '{"x": 1.1, "y": [1]}\n{"x": 2.2, "y": [1, 2]}\n{"x": 3.3, "y": [1, 2, 3]}',
+        ...     '{"x": 1.1, "y": [1]}\\n{"x": 2.2, "y": [1, 2]}\\n{"x": 3.3, "y": [1, 2, 3]}',
         ...     line_delimited=True,
         ... )
         <Array [{x: 1.1, y: [1]}, ..., {x: 3.3, ...}] type='3 * {x: float64, y: var...'>
@@ -191,7 +191,7 @@ def from_json(
         <Record {x: 1.1, y: [1, ..., 3]} type='{x: float64, y: var * int64}'>
 
         >>> ak.from_json(
-        ...     '{"x": 1.1, "y": [1]}\n{"x": 2.2, "y": [1, 2]}\n{"x": 3.3, "y": [1, 2, 3]}',
+        ...     '{"x": 1.1, "y": [1]}\\n{"x": 2.2, "y": [1, 2]}\\n{"x": 3.3, "y": [1, 2, 3]}',
         ...     schema=schema,
         ...     line_delimited=True,
         ... )

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -72,14 +72,14 @@ def from_json(
     There are a few different dichotomies in JSON-reading; all of the combinations
     are supported:
 
-      * Reading from in-memory str/bytes, on-disk or over-network file, or an
-        arbitrary Python object with a `read(num_bytes)` method.
-      * Reading a single JSON document or a sequence of line-delimited documents.
-      * Unknown schema (slow and general) or with a provided JSONSchema (fast, but
-        not all possible cases are supported).
-      * Conversion of strings representing not-a-number, plus and minus infinity
-        into the appropriate floating-point numbers.
-      * Conversion of records with a real and imaginary part into complex numbers.
+    * Reading from in-memory str/bytes, on-disk or over-network file, or an
+      arbitrary Python object with a `read(num_bytes)` method.
+    * Reading a single JSON document or a sequence of line-delimited documents.
+    * Unknown schema (slow and general) or with a provided JSONSchema (fast, but
+      not all possible cases are supported).
+    * Conversion of strings representing not-a-number, plus and minus infinity
+      into the appropriate floating-point numbers.
+    * Conversion of records with a real and imaginary part into complex numbers.
 
     Non-JSON features not allowed, including literals for not-a-number or infinite
     numbers; they must be quoted strings for `nan_string`, `posinf_string`, and
@@ -207,29 +207,29 @@ def from_json(
     as JSON text or as Python lists and dicts representing JSON, but the following
     conditions apply:
 
-      * The root of the schema must be `"type": "array"` or `"type": "object"`.
-      * Every level must have a `"type"`, which can only name one type (as a string
-        or length-1 list) or one type and `"null"` (as a length-2 list).
-      * `"type": "boolean"` \u2192 1-byte boolean values.
-      * `"type": "integer"` \u2192 8-byte integer values. If a part of the schema
-        is declared to have integer type but the JSON numbers are expressed as
-        floating-point, such as `3.14`, `3.0`, or `3e0`, this function raises an
-        error.
-      * `"type": "number"` \u2192 8-byte floating-point values. If used with
-        this function's `nan_string`, `posinf_string`, and/or `neginf_string`, the
-        value in the JSON could be a string, as long as it matches one of these
-        three.
-      * `"type": "string"` \u2192 UTF-8 encoded strings. All JSON escape sequences are
-        supported. Remember that the `source` data are ASCII; Unicode is derived from
-        "`\\uXXXX`" escape sequences. If an `"enum"` is given, strings are represented
-        as categorical values (#ak.contents.IndexedArray or #ak.contents.IndexedOptionArray).
-      * `"type": "array"` \u2192 nested lists. The `"items"` must be specified. If
-        `"minItems"` and `"maxItems"` are specified and equal to each other, the
-        list has regular-type (#ak.types.RegularType); otherwise, it has variable-length
-        type (#ak.types.ListType).
-      * `"type": "object"` \u2192 nested records. The `"properties"` must be specified,
-        and any properties in the data not described by `"properties"` will not
-        appear in the output.
+    * The root of the schema must be `"type": "array"` or `"type": "object"`.
+    * Every level must have a `"type"`, which can only name one type (as a string
+      or length-1 list) or one type and `"null"` (as a length-2 list).
+    * `"type": "boolean"` \u2192 1-byte boolean values.
+    * `"type": "integer"` \u2192 8-byte integer values. If a part of the schema
+      is declared to have integer type but the JSON numbers are expressed as
+      floating-point, such as `3.14`, `3.0`, or `3e0`, this function raises an
+      error.
+    * `"type": "number"` \u2192 8-byte floating-point values. If used with
+      this function's `nan_string`, `posinf_string`, and/or `neginf_string`, the
+      value in the JSON could be a string, as long as it matches one of these
+      three.
+    * `"type": "string"` \u2192 UTF-8 encoded strings. All JSON escape sequences are
+      supported. Remember that the `source` data are ASCII; Unicode is derived from
+      "`\\uXXXX`" escape sequences. If an `"enum"` is given, strings are represented
+      as categorical values (#ak.contents.IndexedArray or #ak.contents.IndexedOptionArray).
+    * `"type": "array"` \u2192 nested lists. The `"items"` must be specified. If
+      `"minItems"` and `"maxItems"` are specified and equal to each other, the
+      list has regular-type (#ak.types.RegularType); otherwise, it has variable-length
+      type (#ak.types.ListType).
+    * `"type": "object"` \u2192 nested records. The `"properties"` must be specified,
+      and any properties in the data not described by `"properties"` will not
+      appear in the output.
 
     Substitutions for non-finite and complex numbers
     ================================================

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -40,7 +40,7 @@ def from_json(
         line_delimited (bool): If False, a single JSON document is read as an
             entire array or record. If True, this function reads line-delimited
             JSON into an array (regardless of how many there are). The line
-            delimiter is not actually checked, so it may be `"\n"`, `"\r\n"`
+            delimiter is not actually checked, so it may be `"\\n"`, `"\\r\\n"`
             or anything else.
         schema (None, JSON str or equivalent lists/dicts): If None, the data type
             is discovered while parsing. If a JSONSchema

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -29,11 +29,11 @@ def from_numpy(
 
     The resulting layout can only involve the following #ak.contents.Content types:
 
-       * #ak.contents.NumpyArray
-       * #ak.contents.ByteMaskedArray or #ak.contents.UnmaskedArray if the
-         `array` is an np.ma.MaskedArray.
-       * #ak.contents.RegularArray if `regulararray=True`.
-       * #ak.contents.RecordArray if `recordarray=True`.
+    * #ak.contents.NumpyArray
+    * #ak.contents.ByteMaskedArray or #ak.contents.UnmaskedArray if the
+      `array` is an np.ma.MaskedArray.
+    * #ak.contents.RegularArray if `regulararray=True`.
+    * #ak.contents.RecordArray if `recordarray=True`.
 
     See also #ak.to_numpy and #ak.from_cupy.
     """

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -7,8 +7,9 @@ def from_rdataframe(data_frame, columns):
     """
     Args:
         data_frame (`ROOT.RDataFrame`): ROOT RDataFrame to convert into an
-             Awkward Array.
-         columns (str or tuple of str): A column or multiple columns to be converted to Awkward Array.
+            Awkward Array.
+        columns (str or tuple of str): A column or multiple columns to be
+            converted to Awkward Array.
 
      Converts ROOT Data Frame columns into an Awkward Array.
 

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -11,9 +11,9 @@ def from_rdataframe(data_frame, columns):
         columns (str or tuple of str): A column or multiple columns to be
             converted to Awkward Array.
 
-     Converts ROOT Data Frame columns into an Awkward Array.
+    Converts ROOT Data Frame columns into an Awkward Array.
 
-     See also #ak.to_rdataframe.
+    See also #ak.to_rdataframe.
     """
     with ak._errors.OperationErrorContext(
         "ak.from_rdataframe",

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -12,8 +12,8 @@ def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
     Args:
         array: Array to use as a model for a replacement that contains only
             `fill_value`.
-        fill_value: Value to fill new new array with.
-        dtype (None or NumPy dtype)): Overrides the data type of the result.
+        fill_value: Value to fill the new array with.
+        dtype (None or NumPy dtype): Overrides the data type of the result.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -21,8 +21,8 @@ def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
 
     This is the equivalent of NumPy's `np.full_like` for Awkward Arrays.
 
-    Although it's possible to produce an array of `fill_value` with the structure
-    of an `array` using #ak.broadcast_arrays:
+    Although it's possible to produce an array of `fill_value` with the
+    structure of an `array` using #ak.broadcast_arrays:
 
         >>> array = ak.Array([[1, 2, 3], [], [4, 5]])
         >>> ak.broadcast_arrays(array, 1)

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -6,7 +6,7 @@ import awkward as ak
 def is_categorical(array):
     """
     Args:
-        array: A possibly-categorical Awkward Array.
+        array: A possibly-categorical array.
 
     If the `array` is categorical (contains #ak.contents.IndexedArray or
     #ak.contents.IndexedOptionArray labeled with parameter

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -6,8 +6,9 @@ import awkward as ak
 def is_tuple(array):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
-            Array or record to check.
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record,
+               #ak.ArrayBuilder):
+            Array or record to check for a tuple type.
 
     If `array` is a record, this returns True if the record is a tuple.
     If `array` is an array, this returns True if the outermost record is a tuple.

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -6,8 +6,7 @@ import awkward as ak
 def is_tuple(array):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record,
-               #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
             Array or record to check for a tuple type.
 
     If `array` is a record, this returns True if the record is a tuple.

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -6,7 +6,8 @@ import awkward as ak
 def is_valid(array, *, exception=False):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record,
+               #ak.ArrayBuilder):
             Array or record to check.
         exception (bool): If True, validity errors raise exceptions.
 

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -6,8 +6,7 @@ import awkward as ak
 def is_valid(array, *, exception=False):
     """
     Args:
-        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record,
-               #ak.ArrayBuilder):
+        array (#ak.Array, #ak.Record, #ak.contents.Content, #ak.record.Record, #ak.ArrayBuilder):
             Array or record to check.
         exception (bool): If True, validity errors raise exceptions.
 

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -15,8 +15,8 @@ def isclose(
         b: Array-like data (anything #ak.to_layout recognizes).
         rtol (float): The relative tolerance parameter.
         atol (float): The absolute tolerance parameter.
-        equal_nan (bool): Whether to compare `NaN` as equal. If True, `NaN` in `a`
-            will be considered equal to `NaN` in `b`.
+        equal_nan (bool): Whether to compare `NaN` as equal. If True, `NaN` in
+            `a` will be considered equal to `NaN` in `b`.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -36,8 +36,8 @@ def linear_fit(
             empty lists results in None (an option type); otherwise, the
             calculation is followed through with the reducers' identities,
             usually resulting in floating-point `nan`.
-        flatten_records (bool): If True, axis=None combines fields from different
-            records; otherwise, records raise an error.
+        flatten_records (bool): If True, axis=None combines fields from
+            different records; otherwise, records raise an error.
 
     Computes the linear fit of `y` with respect to `x` (many types supported,
     including all Awkward Arrays and Records, must be broadcastable to each

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -22,18 +22,23 @@ def metadata_from_parquet(
     scan_files=True
 ):
     """
-    This function differs from ak.from_parquet._metadata as follows:
-
-      * this function will always use a _metadata file, if present
-      * if there is no _metadata, the schema comes from _common_metadata or the first
-        data file
-      * the total number of rows is always known  # TODO: is this true?
-
     Args:
         path (str): Local filename or remote URL, passed to fsspec for resolution.
             May contain glob patterns. A list of paths is also allowed, but they
             must be data files, not directories.
-        storage_options: Passed to `fsspec`.
+        storage_options: Passed to `fsspec.parquet.open_parquet_file`.
+        row_groups (None or set of int): Row groups to read; must be non-negative.
+            Order is ignored: the output array is presented in the order specified
+            by Parquet metadata. If None, all row groups/all rows are read.
+        ignore_metadata (bool): ignore the dedicated _metadata file if found
+            and instead derive metadata from the first data file.
+        scan_files (bool): TODO
+
+    This function differs from ak.from_parquet._metadata as follows:
+      * this function will always use a _metadata file, if present
+      * if there is no _metadata, the schema comes from _common_metadata or
+        the first data file
+      * the total number of rows is always known
 
     Returns dict containing
 

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -35,11 +35,11 @@ def packed(array, *, highlevel=True, behavior=None):
         >>> b
         <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
         >>> b.layout
-        <ListArray64>
+        <ListArray>
             <starts><Index64 i="[6 5 3 3 0]" offset="0" length="5" at="0x55e091c2b1f0"/></starts>
             <stops><Index64 i="[10 6 5 3 3]" offset="0" length="5" at="0x55e091a6ce80"/></stops>
             <content><NumpyArray format="l" shape="10" data="1 2 3 4 5 6 7 8 9 10" at="0x55e091c47260"/></content>
-        </ListArray64>
+        </ListArray>
         >>> c = ak.packed(b)
         >>> c
         <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -44,10 +44,10 @@ def packed(array, *, highlevel=True, behavior=None):
         >>> c
         <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
         >>> c.layout
-        <ListOffsetArray64>
+        <ListOffsetArray>
             <offsets><Index64 i="[0 4 5 7 7 10]" offset="0" length="6" at="0x55e091b077a0"/></offsets>
             <content><NumpyArray format="l" shape="10" data="7 8 9 10 6 4 5 1 2 3" at="0x55e091d04d30"/></content>
-        </ListOffsetArray64>
+        </ListOffsetArray>
 
     Performing these operations will minimize the output size of data sent to
     #ak.to_buffers (though conversions through Arrow, #ak.to_arrow and

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -95,9 +95,9 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
     at least `target` or exactly `target`, it also determines the type of the
     output:
 
-       * `clip=True` returns regular lists (#ak.types.RegularType), and
-       * `clip=False` returns in-principle variable lengths
-         (#ak.types.ListType).
+    * `clip=True` returns regular lists (#ak.types.RegularType), and
+    * `clip=False` returns in-principle variable lengths
+      (#ak.types.ListType).
 
     The in-principle variable-length lists might, in fact, all have the same
     length, but the type difference is significant, for instance in

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -12,6 +12,9 @@ np = ak._nplikes.NumpyMetadata.instance()
 
 def parameters(array):
     """
+    Args:
+        array: Array to determine the parameters of.
+
     Extracts parameters from the outermost array node of `array` (many types
     supported, including all Awkward Arrays and Records).
 
@@ -41,7 +44,7 @@ def _impl(array):
         return _copy(array.parameters)
 
     elif isinstance(array, ak.highlevel.ArrayBuilder):
-        form = ak.forms.from_json(array._layout.form())
+        form = ak.forms.from_json(array.layout.form())
         return form.parameters
 
     elif isinstance(array, _ext.ArrayBuilder):

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -38,8 +38,8 @@ def ravel(array, *, highlevel=True, behavior=None):
         >>> print(ak.ravel(array))
         [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]
 
-    Missing values are not eliminated by flattening. See #ak.flatten with `axis=None`
-    for an equivalent function that eliminates the option type.
+    Missing values are not eliminated by flattening. See #ak.flatten with
+    `axis=None` for an equivalent function that eliminates the option type.
     """
     with ak._errors.OperationErrorContext(
         "ak.ravel",

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -7,7 +7,6 @@ cpu = ak._backends.NumpyBackend.instance()
 
 
 def run_lengths(array, *, highlevel=True, behavior=None):
-
     """
     Args:
         array: Data containing runs of numbers to count.

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -5,6 +5,9 @@ import awkward as ak
 
 def to_cupy(array):
     """
+    Args:
+        array: Array to convert to CuPy.
+
     Converts `array` (many types supported) into a CuPy array, if possible.
 
     If the data are numerical and regular (nested lists have equal lengths

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -5,6 +5,9 @@ from awkward import _errors, _util, jax
 
 def to_jax(array):
     """
+    Args:
+        array: Array to convert to JAX.
+
     Converts `array` (many types supported) into a JAX Device Array, if possible.
 
     If the data are numerical and regular (nested lists have equal lengths

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -83,17 +83,17 @@ def to_json(
 
     Awkward Array types have the following JSON translations.
 
-       * #ak.types.PrimitiveType: converted into JSON booleans and numbers.
-       * #ak.types.OptionType: missing values are converted into None.
-       * #ak.types.ListType: converted into JSON lists.
-       * #ak.types.RegularType: also converted into JSON lists. JSON (and
-         Python) forms lose information about the regularity of list lengths.
-       * #ak.types.ListType or #ak.types.RegularType with parameter `"__array__"`
-         equal to `"string"`: converted into JSON strings.
-       * #ak.types.RecordArray without field names: converted into JSON
-         objects with numbers as strings for keys.
-       * #ak.types.RecordArray with field names: converted into JSON objects.
-       * #ak.types.UnionArray: JSON data are naturally heterogeneous.
+    * #ak.types.PrimitiveType: converted into JSON booleans and numbers.
+    * #ak.types.OptionType: missing values are converted into None.
+    * #ak.types.ListType: converted into JSON lists.
+    * #ak.types.RegularType: also converted into JSON lists. JSON (and
+      Python) forms lose information about the regularity of list lengths.
+    * #ak.types.ListType or #ak.types.RegularType with parameter `"__array__"`
+      equal to `"string"`: converted into JSON strings.
+    * #ak.types.RecordArray without field names: converted into JSON
+      objects with numbers as strings for keys.
+    * #ak.types.RecordArray with field names: converted into JSON objects.
+    * #ak.types.UnionArray: JSON data are naturally heterogeneous.
 
     If the array contains any NaN (not a number), infinite values, or
     imaginary/complex types, `nan_string`, `posinf_string`, and/or `neginf_string`

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -40,7 +40,7 @@ def to_json(
         line_delimited (bool or str): If False, a single JSON document is written,
             representing the entire array or record. If True, each element of the
             array (or just the one record) is written on a separate line of text,
-            separated by `"\n"`. If a string, such as `"\r\n"`, it is taken as a
+            separated by `"\\n"`. If a string, such as `"\\r\\n"`, it is taken as a
             custom line delimiter. (Use `os.linesep` for a platform-dependent
             line delimiter.)
         num_indent_spaces (None or nonnegative int): Number of spaces to indent nested
@@ -74,7 +74,7 @@ def to_json(
     `convert_other`), then uses `json.dumps` to return a string or `json.dump`
     to write to a file (depending on the value of `file`).
 
-    If `line_delimited` is True or a line-delimiter string like `"\r\n"`/`os.linesep`,
+    If `line_delimited` is True or a line-delimiter string like `"\\r\\n"`/`os.linesep`,
     the output is line-delimited JSON, variously referred to as "ldjson", "ndjson", and
     "jsonl". (Use an appropriate file extension!)
 

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -83,17 +83,16 @@ def to_json(
 
     Awkward Array types have the following JSON translations.
 
-    * #ak.types.PrimitiveType: converted into JSON booleans and numbers.
     * #ak.types.OptionType: missing values are converted into None.
     * #ak.types.ListType: converted into JSON lists.
     * #ak.types.RegularType: also converted into JSON lists. JSON (and
       Python) forms lose information about the regularity of list lengths.
     * #ak.types.ListType or #ak.types.RegularType with parameter `"__array__"`
       equal to `"string"`: converted into JSON strings.
-    * #ak.types.RecordArray without field names: converted into JSON
+    * #ak.types.RecordType without field names: converted into JSON
       objects with numbers as strings for keys.
-    * #ak.types.RecordArray with field names: converted into JSON objects.
-    * #ak.types.UnionArray: JSON data are naturally heterogeneous.
+    * #ak.types.RecordType with field names: converted into JSON objects.
+    * #ak.types.UnionType: JSON data are naturally heterogeneous.
 
     If the array contains any NaN (not a number), infinite values, or
     imaginary/complex types, `nan_string`, `posinf_string`, and/or `neginf_string`

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -20,19 +20,19 @@ def to_list(array):
 
     Awkward Array types have the following Pythonic translations.
 
-       * #ak.types.NumpyType: converted into bool, int, float, datetimes, etc.
-         (Same as NumPy's `ndarray.tolist`.)
-       * #ak.types.OptionType: missing values are converted into None.
-       * #ak.types.ListType: converted into list.
-       * #ak.types.RegularType: also converted into list. Python (and JSON)
-         forms lose information about the regularity of list lengths.
-       * #ak.types.ListType with parameter `"__array__"` equal to
-         `"__bytestring__"`: converted into bytes.
-       * #ak.types.ListType with parameter `"__array__"` equal to
-         `"__string__"`: converted into str.
-       * #ak.types.RecordArray without field names: converted into tuple.
-       * #ak.types.RecordArray with field names: converted into dict.
-       * #ak.types.UnionArray: Python data are naturally heterogeneous.
+    * #ak.types.NumpyType: converted into bool, int, float, datetimes, etc.
+      (Same as NumPy's `ndarray.tolist`.)
+    * #ak.types.OptionType: missing values are converted into None.
+    * #ak.types.ListType: converted into list.
+    * #ak.types.RegularType: also converted into list. Python (and JSON)
+      forms lose information about the regularity of list lengths.
+    * #ak.types.ListType with parameter `"__array__"` equal to
+      `"__bytestring__"`: converted into bytes.
+    * #ak.types.ListType with parameter `"__array__"` equal to
+      `"__string__"`: converted into str.
+    * #ak.types.RecordArray without field names: converted into tuple.
+    * #ak.types.RecordArray with field names: converted into dict.
+    * #ak.types.UnionArray: Python data are naturally heterogeneous.
 
     See also #ak.from_iter and #ak.Array.tolist.
     """

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -11,6 +11,9 @@ np = ak._nplikes.NumpyMetadata.instance()
 
 def to_list(array):
     """
+    Args:
+        array: Array to convert to a list.
+
     Converts `array` (many types supported, including all Awkward Arrays and
     Records) into Python objects. If `array` is not recognized as an array, it
     is passed through as-is.

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -7,6 +7,10 @@ import awkward as ak
 
 def to_numpy(array, *, allow_missing=True):
     """
+    Args:
+        array: Array to convert to NumPy.
+        allow_missing (bool): allow missing (None) values.
+
     Converts `array` (many types supported, including all Awkward Arrays and
     Records) into a NumPy array, if possible.
 

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -62,6 +62,7 @@ def to_parquet(
         parquet_compliant_nested:
         parquet_extra_options:
         hook_after_write: callable
+        storage_options:
 
     Returns:
 

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -36,7 +36,6 @@ def to_parquet(
     storage_options=None,
 ):
     """
-
     Args:
         data: ak.Array or ak.Record
         destination: str
@@ -65,8 +64,27 @@ def to_parquet(
         storage_options:
 
     Returns:
-
     ``pyarrow._parquet.FileMetaData`` instance
+
+    Writes an Awkward Array to a Parquet file (through pyarrow).
+
+        >>> array1 = ak.Array([[1, 2, 3], [], [4, 5], [], [], [6, 7, 8, 9]])
+        >>> ak.to_parquet(array1, "array1.parquet")
+
+    If the `array` does not contain records at top-level, the Arrow table will consist
+    of one field whose name is `""` iff. `extensionarray` is False.
+
+    If `extensionarray` is True`, use a custom Arrow extension to store this array.
+    Otherwise, generic Arrow arrays are used, and if the `array` does not
+    contain records at top-level, the Arrow table will consist of one field whose
+    name is `""`. See #ak.to_arrow_table for more details.
+
+    Parquet files can maintain the distinction between "option-type but no elements are
+    missing" and "not option-type" at all levels, including the top level. However,
+    there is no distinction between `?union[X, Y, Z]]` type and `union[?X, ?Y, ?Z]` type.
+    Be aware of these type distinctions when passing data through Arrow or Parquet.
+
+    See also #ak.to_arrow, which is used as an intermediate step.
     """
     import awkward._connect.pyarrow
 

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -61,6 +61,10 @@ def transform(
             calling `transformation`.
         regular_to_jagged (bool): If True, regular-type lists are converted into
             variable-length lists before calling `transformation`.
+        return_array (bool): If True, the result of calling `transformation`
+            replaces the original node in the new layout that is returned.
+            If False, the `transformation` function is expected to return
+            any results by modifying the `lateral_context` dict.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -149,27 +149,27 @@ def transform(
     All other arguments can be absorbed into a `**kwargs` because they will always
     be passed to your function by keyword. They are
 
-       * depth (int): The current list depth, where 1 is the outermost array and
-           higher numbers are deeper levels of list nesting. This does not count
-           nesting of other data structures, such as option-types and records.
-       * depth_context (None or dict): Any user-specified data. You can add to
-           this dict during transformation; changes would only be seen in the
-           subtree's nodes.
-       * lateral_context (None or dict): Any user-specified data. You can add to
-           this dict during transformation; changes would be seen in any node
-           visited later in the depth-first search.
-       * continuation (callable): Zero-argument function that continues the
-           recursion from this point in the walk, so that you can perform
-           post-processing instead of pre-processing.
+    * depth (int): The current list depth, where 1 is the outermost array and
+        higher numbers are deeper levels of list nesting. This does not count
+        nesting of other data structures, such as option-types and records.
+    * depth_context (None or dict): Any user-specified data. You can add to
+        this dict during transformation; changes would only be seen in the
+        subtree's nodes.
+    * lateral_context (None or dict): Any user-specified data. You can add to
+        this dict during transformation; changes would be seen in any node
+        visited later in the depth-first search.
+    * continuation (callable): Zero-argument function that continues the
+        recursion from this point in the walk, so that you can perform
+        post-processing instead of pre-processing.
 
     For completeness, the following arguments are also passed to `transformation`,
     but you usually won't need them:
 
-       * behavior (None or dict): Behavior that would be attached to the output
-           array(s) if `highlevel`.
-       * backend (array library / kernel library shim): Handle to the NumPy
-           library, CuPy, etc., depending on the type of arrays.
-       * options (dict): Options provided to #ak.transform.
+    * behavior (None or dict): Behavior that would be attached to the output
+        array(s) if `highlevel`.
+    * backend (array library / kernel library shim): Handle to the NumPy
+        library, CuPy, etc., depending on the type of arrays.
+    * options (dict): Options provided to #ak.transform.
 
     If there is only one array, the `transformation` function must either return
     None or return an array: #ak.contents.Content, #ak.Array, or a NumPy,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -19,7 +19,7 @@ def type(array):
     The high-level type of an `array` (many types supported, including all
     Awkward Arrays and Records) as #ak.types.Type objects.
 
-    The high-level type ignores #layout differences like
+    The high-level type ignores layout differences like
     #ak.contents.ListArray versus #ak.contents.ListOffsetArray, but
     not differences like "regular-sized lists" (i.e.
     #ak.contents.RegularArray) versus "variable-sized lists" (i.e.

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -13,6 +13,9 @@ np = ak._nplikes.NumpyMetadata.instance()
 
 def type(array):
     """
+    Args:
+        array: Array to determine the type of.
+
     The high-level type of an `array` (many types supported, including all
     Awkward Arrays and Records) as #ak.types.Type objects.
 

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -8,7 +8,7 @@ np = ak._nplikes.NumpyMetadata.instance()
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:
-        base: Data containing records or tuples.
+        array: Data containing records or tuples.
         name (str or None): Name to give to the records or tuples; this assigns
             the `"__record__"` parameter. If None, any existing name is unset.
         highlevel (bool): If True, return an #ak.Array; otherwise, return

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -13,7 +13,7 @@ def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
         array: Array to use as a model for a replacement that contains only `0`.
-        dtype (None or NumPy dtype)): Overrides the data type of the result.
+        dtype (None or NumPy dtype): Overrides the data type of the result.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -11,10 +11,10 @@ def zip(
     *,
     parameters=None,
     with_name=None,
-    highlevel=True,
-    behavior=None,
     right_broadcast=False,
     optiontype_outside_record=False,
+    highlevel=True,
+    behavior=None,
 ):
     """
     Args:
@@ -30,14 +30,14 @@ def zip(
         with_name (None or str): Assigns a `"__record__"` name to the new
             #ak.contents.RecordArray node that is created by this operation
             (overriding `parameters`, if necessary).
-        highlevel (bool): If True, return an #ak.Array; otherwise, return
-            a low-level #ak.contents.Content subclass.
-        behavior (None or dict): Custom #ak.behavior for the output array, if
-            high-level.
         right_broadcast (bool): If True, follow rules for implicit
             right-broadcasting, as described in #ak.broadcast_arrays.
         optiontype_outside_record (bool): If True, continue broadcasting past
             any option types before creating the new #ak.contents.RecordArray node.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
 
     Combines `arrays` into a single structure as the fields of a collection
     of records or the slots of a collection of tuples. If the `arrays` have
@@ -131,10 +131,10 @@ def zip(
             depth_limit=depth_limit,
             parameters=parameters,
             with_name=with_name,
-            highlevel=highlevel,
-            behavior=behavior,
             right_broadcast=right_broadcast,
             optiontype_outside_record=optiontype_outside_record,
+            highlevel=highlevel,
+            behavior=behavior,
         ),
     ):
         return _impl(
@@ -142,10 +142,10 @@ def zip(
             depth_limit,
             parameters,
             with_name,
-            highlevel,
-            behavior,
             right_broadcast,
             optiontype_outside_record,
+            highlevel,
+            behavior,
         )
 
 
@@ -154,10 +154,10 @@ def _impl(
     depth_limit,
     parameters,
     with_name,
-    highlevel,
-    behavior,
     right_broadcast,
     optiontype_outside_record,
+    highlevel,
+    behavior,
 ):
     if depth_limit is not None and depth_limit <= 0:
         raise ak._errors.wrap_error(


### PR DESCRIPTION
This PR cleans up docstrings that were wonky, or missing fields. I didn't check them hugely for meaning; this was just a quick pass over the arguments lists.

I need to ping Martin to check some of the parquet/arrow parts.

Partially addresses #1916
Fixes #1893

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-docs-cleanup-docstrings/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->