### PR TITLE
feat: replace nplike with backend in `to_buffers`

### DIFF
--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -679,7 +679,7 @@ def gencudakerneltests(specdict):
                 )
 
                 f.write(
-                    "import cupy\nimport pytest\n\nimport awkward as ak\nimport awkward._connect.cuda as ak_cu\n\ncupy_nplike = ak.nplikes.Cupy.instance()\n\n"
+                    "import cupy\nimport pytest\n\nimport awkward as ak\nimport awkward._connect.cuda as ak_cu\n\ncupy_backend = ak._backends.CupyBackend.instance()\n\n"
                 )
                 num = 1
                 if spec.tests == []:
@@ -728,7 +728,7 @@ def gencudakerneltests(specdict):
                                 #     )
                                 # )
                     cuda_string = (
-                        "funcC = cupy_nplike['"
+                        "funcC = cupy_backend['"
                         + spec.templatized_kernel_name
                         + "', {}]\n".format(", ".join(dtypes))
                     )

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -4,7 +4,7 @@
 from awkward._version import __version__
 
 # NumPy-like alternatives
-import awkward.nplikes
+import awkward._nplikes
 import awkward._typetracer
 import awkward._backends
 

--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -5,8 +5,7 @@ from abc import abstractmethod
 import awkward_cpp
 
 import awkward as ak
-from awkward._typetracer import NoKernel, TypeTracer
-from awkward.nplikes import (
+from awkward._nplikes import (
     Cupy,
     CupyKernel,
     Jax,
@@ -18,6 +17,7 @@ from awkward.nplikes import (
     Singleton,
     nplike_of,
 )
+from awkward._typetracer import NoKernel, TypeTracer
 from awkward.typing import (
     Any,
     Callable,
@@ -155,7 +155,7 @@ class TypeTracerBackend(Singleton, Backend[Any]):
         return NoKernel(index)
 
 
-def _backend_for_nplike(nplike: ak.nplikes.NumpyLike) -> Backend:
+def _backend_for_nplike(nplike: ak._nplikes.NumpyLike) -> Backend:
     # Currently there exists a one-to-one relationship between the nplike
     # and the backend. In future, this might need refactoring
     if isinstance(nplike, Numpy):

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -30,8 +30,8 @@ from awkward.index import (  # IndexU8,  ; Index32,  ; IndexU32,  ; noqa: F401
 from awkward.record import Record
 from awkward.typing import Any, Callable, Dict, List, TypeAlias, Union
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 optiontypes = (IndexedOptionArray, ByteMaskedArray, BitMaskedArray, UnmaskedArray)
 listtypes = (ListOffsetArray, ListArray, RegularArray)
@@ -48,7 +48,7 @@ def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
     nextinputs = []
     for x in inputs:
         if isinstance(x, Record):
-            index = ak.nplikes.nplike_of(*inputs).full(maxlen, x.at, dtype=np.int64)
+            index = ak._nplikes.nplike_of(*inputs).full(maxlen, x.at, dtype=np.int64)
             nextinputs.append(RegularArray(x.array[index], maxlen, 1))
             isscalar.append(True)
         elif isinstance(x, Content):

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -8,8 +8,8 @@ from awkward_cpp import libawkward
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 cache = {}

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -5,7 +5,7 @@ import jax
 import awkward as ak
 from awkward._reducers import Reducer
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class ArgMin(Reducer):

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import jax
 
 import awkward as ak
-from awkward import _errors, contents, highlevel, nplikes, record
+from awkward import _errors, _nplikes, contents, highlevel, record
 from awkward.typing import Generic, TypeVar, Union
 
-numpy = nplikes.Numpy.instance()
-np = nplikes.NumpyMetadata.instance()
+numpy = _nplikes.Numpy.instance()
+np = _nplikes.NumpyMetadata.instance()
 
 
 def find_all_buffers(
@@ -32,7 +32,7 @@ def replace_all_buffers(
     backend: ak._backends.Backend,
 ):
     def action(node, **kwargs):
-        jaxlike = nplikes.Jax.instance()
+        jaxlike = _nplikes.Jax.instance()
         if isinstance(node, ak.contents.NumpyArray):
             buffer = buffers.pop(0)
             # JAX might give us non-buffers, so ignore them
@@ -96,7 +96,7 @@ class AuxData(Generic[T]):
         # layout = replace_all_buffers(
         #     layout,
         #     [create_placeholder_like(n) for n in buffers],
-        #     nplike=nplikes.Numpy.instance(),
+        #     nplike=_nplikes.Numpy.instance(),
         # )
 
         return buffers, AuxData(

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -8,7 +8,7 @@ import numba.core.typing.ctypes_utils
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def code_to_function(code, function_name, externals=None, debug=False):
@@ -871,7 +871,7 @@ def array_supported(dtype):
     ) or isinstance(dtype, (numba.types.NPDatetime, numba.types.NPTimedelta))
 
 
-@numba.extending.overload(ak.nplikes.numpy.array)
+@numba.extending.overload(ak._nplikes.numpy.array)
 def overload_np_array(array, dtype=None):
     if isinstance(array, ArrayViewType):
         ndim = array.type.ndim
@@ -936,11 +936,11 @@ def array_impl(array, dtype=None):
                     "\n    ".join(fill_array),
                 ),
                 "array_impl",
-                {"numpy": ak.nplikes.numpy},
+                {"numpy": ak._nplikes.numpy},
             )
 
 
-@numba.extending.type_callable(ak.nplikes.numpy.asarray)
+@numba.extending.type_callable(ak._nplikes.numpy.asarray)
 def type_asarray(context):
     def typer(arrayview):
         if (
@@ -954,7 +954,7 @@ def type_asarray(context):
     return typer
 
 
-@numba.extending.lower_builtin(ak.nplikes.numpy.asarray, ArrayViewType)
+@numba.extending.lower_builtin(ak._nplikes.numpy.asarray, ArrayViewType)
 def lower_asarray(context, builder, sig, args):
     rettype, (viewtype,) = sig.return_type, sig.args
     (viewval,) = args

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -7,7 +7,7 @@ from awkward_cpp import libawkward
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 dynamic_addrs = {}

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -6,8 +6,8 @@ import numba
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 @numba.extending.typeof_impl.register(ak.contents.Content)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -26,10 +26,10 @@ implemented = {}
 
 def _to_rectilinear(arg):
     if isinstance(arg, tuple):
-        nplike = ak.nplikes.nplike_of(*arg)
+        nplike = ak._nplikes.nplike_of(*arg)
         return tuple(nplike.to_rectilinear(x) for x in arg)
     else:
-        nplike = ak.nplikes.nplike_of(arg)
+        nplike = ak._nplikes.nplike_of(arg)
         nplike.to_rectilinear(arg)
 
 
@@ -39,7 +39,7 @@ def array_function(func, types, args, kwargs):
         args = tuple(_to_rectilinear(x) for x in args)
         kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
         out = func(*args, **kwargs)
-        nplike = ak.nplikes.nplike_of(out)
+        nplike = ak._nplikes.nplike_of(out)
         if isinstance(out, nplike.ndarray) and len(out.shape) != 0:
             return ak.Array(out)
         else:
@@ -167,7 +167,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                     else:
                         args.append(x)
 
-                if isinstance(nplike, ak.nplikes.Jax):
+                if isinstance(nplike, ak._nplikes.Jax):
                     from awkward._connect.jax import get_jax_ufunc
 
                     jax_ufunc = get_jax_ufunc(ufunc)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -7,7 +7,7 @@ import numpy
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 try:
     import pyarrow

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -29,8 +29,8 @@ cpp_type_of = {
     "timedelta64": "std::difftime",
 }
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 cppyy.add_include_path(
@@ -71,7 +71,7 @@ def from_rdataframe(data_frame, columns):
     def empty_buffers(cpp_buffers_self, names_nbytes):
         buffers = {}
         for item in names_nbytes:
-            buffers[item.first] = ak.nplikes.numpy.empty(item.second)
+            buffers[item.first] = ak._nplikes.numpy.empty(item.second)
             cpp_buffers_self.append(
                 item.first,
                 buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -5,9 +5,9 @@ import threading
 import warnings
 from collections.abc import Mapping, Sequence
 
-from awkward import nplikes
+from awkward import _nplikes
 
-np = nplikes.NumpyMetadata.instance()
+np = _nplikes.NumpyMetadata.instance()
 
 
 class PartialFunction:
@@ -128,7 +128,7 @@ class OperationErrorContext(ErrorContext):
 
     def __init__(self, name, arguments):
         if self.primary() is not None or all(
-            nplikes.nplike_of(x).is_eager for x in arguments
+            _nplikes.nplike_of(x).is_eager for x in arguments
         ):
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays
@@ -185,9 +185,7 @@ class SlicingErrorContext(ErrorContext):
     _width = 80 - 4
 
     def __init__(self, array, where):
-        if self.primary() is not None or (
-            nplikes.nplike_of(array).is_eager and nplikes.nplike_of(where).is_eager
-        ):
+        if self.primary() is not None or _nplikes.nplike_of(array, where).is_eager:
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays
             # --> in either case, delay string generation

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class Lookup:

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -835,11 +835,11 @@ class Jax(NumpyLike):
     def raw(self, array, nplike):
         if isinstance(nplike, Jax):
             return array
-        elif isinstance(nplike, ak.nplikes.Cupy):
-            cupy = ak.nplikes.Cupy.instance()
+        elif isinstance(nplike, ak._nplikes.Cupy):
+            cupy = ak._nplikes.Cupy.instance()
             return cupy.asarray(array)
-        elif isinstance(nplike, ak.nplikes.Numpy):
-            numpy = ak.nplikes.Numpy.instance()
+        elif isinstance(nplike, ak._nplikes.Numpy):
+            numpy = ak._nplikes.Numpy.instance()
             return numpy.asarray(array)
         elif isinstance(nplike, ak._typetracer.TypeTracer):
             return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
@@ -939,7 +939,7 @@ def nplike_of(*arrays, default: D = _UNSET) -> NumpyLike | D:
         *arrays: iterable of possible array objects
         default: default NumpyLike instance if no array objects found
 
-    Return the #ak.nplikes.NumpyLike that is best-suited to operating upon the given
+    Return the #ak._nplikes.NumpyLike that is best-suited to operating upon the given
     iterable of arrays. Return an instance of the `default_cls` if no known array types
     are found.
     """

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -6,7 +6,7 @@ import re
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def half(integer):

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class Reducer:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward.typing import Sequence
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def headtail(oldtail):
@@ -62,7 +62,7 @@ def prepare_advanced_indexing(items):
         )
 
     # Then broadcast the index items
-    nplike = ak.nplikes.nplike_of(*broadcastable)
+    nplike = ak._nplikes.nplike_of(*broadcastable)
     broadcasted = nplike.broadcast_arrays(*broadcastable)
 
     # And re-assemble the index with the broadcasted items
@@ -381,7 +381,7 @@ def normalise_item_bool_to_int(item):
         and issubclass(item.content.content.dtype.type, (bool, np.bool_))
     ):
         if item.backend.nplike.known_data or item.backend.nplike.known_shape:
-            if isinstance(item.backend.nplike, ak.nplikes.Jax):
+            if isinstance(item.backend.nplike, ak._nplikes.Jax):
                 raise ak._errors.wrap_error(
                     "This slice is not supported for JAX differentiation."
                 )
@@ -450,7 +450,7 @@ def normalise_item_bool_to_int(item):
             item.content.dtype.type, (bool, np.bool_)
         ):
             if item.backend.nplike.known_data or item.backend.nplike.known_shape:
-                if isinstance(item.backend.nplike, ak.nplikes.Jax):
+                if isinstance(item.backend.nplike, ak._nplikes.Jax):
                     raise ak._errors.wrap_error(
                         "This slice is not supported for JAX differentiation."
                     )

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -5,10 +5,10 @@ import numbers
 import numpy
 
 import awkward as ak
-from awkward import index, nplikes
+from awkward import _nplikes, index
 from awkward.typing import TypeVar
 
-np = nplikes.NumpyMetadata.instance()
+np = _nplikes.NumpyMetadata.instance()
 
 
 class NoError:
@@ -486,7 +486,7 @@ class TypeTracerArray:
         return self
 
 
-class TypeTracer(ak.nplikes.NumpyLike):
+class TypeTracer(ak._nplikes.NumpyLike):
     known_data = False
     known_shape = False
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -13,10 +13,10 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 win = os.name == "nt"
-bits32 = ak.nplikes.numpy.iinfo(np.intp).bits == 32
+bits32 = ak._nplikes.numpy.iinfo(np.intp).bits == 32
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1
@@ -454,7 +454,7 @@ def extra(args, kwargs, defaults):
 
 
 def union_to_record(unionarray, anonymous):
-    nplike = ak.nplikes.nplike_of(unionarray)
+    nplike = ak._nplikes.nplike_of(unionarray)
 
     contents = []
     for layout in unionarray.contents:
@@ -591,11 +591,11 @@ expand_braces.regex = re.compile(r"\{[^\{\}]*\}")
 
 
 def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
-    np = ak.nplikes.NumpyMetadata.instance()
-    numpy = ak.nplikes.Numpy.instance()
+    np = ak._nplikes.NumpyMetadata.instance()
+    numpy = ak._nplikes.Numpy.instance()
 
     def recurse(array, mask=None):
-        if ak.nplikes.Jax.is_tracer(array):
+        if ak._nplikes.Jax.is_tracer(array):
             raise ak._errors.wrap_error(
                 TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
             )
@@ -747,7 +747,7 @@ def to_arraylib(module, array, allow_missing):
             tags = module.asarray(array.tags)
             for tag, content in enumerate(contents):
                 mask = tags == tag
-                if ak.nplikes.Jax.is_own_array(out):
+                if ak._nplikes.Jax.is_own_array(out):
                     out = out.at[mask].set(content)
                 else:
                     out[mask] = content

--- a/src/awkward/behaviors/categorical.py
+++ b/src/awkward/behaviors/categorical.py
@@ -4,7 +4,7 @@
 import awkward as ak
 from awkward.highlevel import Array
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class CategoricalBehavior(Array):
@@ -61,8 +61,8 @@ def _categorical_equal(one, two):
     assert one.parameter("__array__") == "categorical"
     assert two.parameter("__array__") == "categorical"
 
-    one_index = ak.nplikes.numpy.asarray(one.index)
-    two_index = ak.nplikes.numpy.asarray(two.index)
+    one_index = ak._nplikes.numpy.asarray(one.index)
+    two_index = ak._nplikes.numpy.asarray(two.index)
     one_content = ak._util.wrap(one.content, behavior)
     two_content = ak._util.wrap(two.content, behavior)
 
@@ -78,7 +78,7 @@ def _categorical_equal(one, two):
         two_hashable = [as_hashable(x) for x in two_list]
         two_lookup = {x: i for i, x in enumerate(two_hashable)}
 
-        one_to_two = ak.nplikes.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
+        one_to_two = ak._nplikes.numpy.empty(len(one_hashable) + 1, dtype=np.int64)
         for i, x in enumerate(one_hashable):
             one_to_two[i] = two_lookup.get(x, len(two_hashable))
         one_to_two[-1] = -1
@@ -105,5 +105,5 @@ def _apply_ufunc(ufunc, method, inputs, kwargs):
 
 def register(behavior):
     behavior["categorical"] = CategoricalBehavior
-    behavior[ak.nplikes.numpy.equal, "categorical", "categorical"] = _categorical_equal
-    behavior[ak.nplikes.numpy.ufunc, "categorical"] = _apply_ufunc
+    behavior[ak._nplikes.numpy.equal, "categorical", "categorical"] = _categorical_equal
+    behavior[ak._nplikes.numpy.ufunc, "categorical"] = _apply_ufunc

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -3,14 +3,14 @@
 import awkward as ak
 from awkward.highlevel import Array
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class ByteBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.nplike_of(self.layout).asarray(self.layout)
+        tmp = ak._nplikes.nplike_of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -55,7 +55,7 @@ class CharBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = ak.nplikes.nplike_of(self.layout).asarray(self.layout)
+        tmp = ak._nplikes.nplike_of(self.layout).asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -109,7 +109,7 @@ class StringBehavior(Array):
 
 
 def _string_equal(one, two):
-    nplike = ak.nplikes.nplike_of(one, two)
+    nplike = ak._nplikes.nplike_of(one, two)
     behavior = ak._util.behavior_of(one, two)
 
     one, two = (
@@ -145,7 +145,7 @@ def _string_notequal(one, two):
 
 
 def _string_broadcast(layout, offsets):
-    nplike = ak.nplikes.nplike_of(offsets)
+    nplike = ak._nplikes.nplike_of(offsets)
     assert nplike is layout.backend.index_nplike
 
     offsets = nplike.asarray(offsets)
@@ -253,10 +253,10 @@ def register(behavior):
     behavior["string"] = StringBehavior
     behavior["__typestr__", "string"] = "string"
 
-    behavior[ak.nplikes.numpy.equal, "bytestring", "bytestring"] = _string_equal
-    behavior[ak.nplikes.numpy.equal, "string", "string"] = _string_equal
-    behavior[ak.nplikes.numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
-    behavior[ak.nplikes.numpy.not_equal, "string", "string"] = _string_notequal
+    behavior[ak._nplikes.numpy.equal, "bytestring", "bytestring"] = _string_equal
+    behavior[ak._nplikes.numpy.equal, "string", "string"] = _string_equal
+    behavior[ak._nplikes.numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
+    behavior[ak._nplikes.numpy.not_equal, "string", "string"] = _string_notequal
 
     behavior["__broadcast__", "bytestring"] = _string_broadcast
     behavior["__broadcast__", "string"] = _string_broadcast

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -13,8 +13,8 @@ from awkward.forms.bitmaskedform import BitMaskedForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class BitMaskedArray(Content):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -191,11 +191,11 @@ class BitMaskedArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "mask")
-        container[key] = ak._util.little_endian(self._mask.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key] = ak._util.little_endian(self._mask.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -12,8 +12,8 @@ from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class ByteMaskedArray(Content):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -139,11 +139,11 @@ class ByteMaskedArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "mask")
-        container[key] = ak._util.little_endian(self._mask.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key] = ak._util.little_endian(self._mask.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -10,7 +10,6 @@ import awkward as ak
 import awkward._reducers
 from awkward._backends import Backend, TypeTracerBackend
 from awkward.forms import form
-from awkward.nplikes import NumpyLike
 from awkward.typing import Any, Self, TypeAlias, TypeVar
 
 np = ak.nplikes.NumpyMetadata.instance()
@@ -150,13 +149,13 @@ class Content:
         buffer_key="{form_key}-{attribute}",
         form_key: str | None = "node{id}",
         id_start: Integral = 0,
-        nplike: NumpyLike | None = None,
+        backend: Backend = None,
     ) -> tuple[form.Form, int, Mapping[str, Any]]:
         if container is None:
             container = {}
-        if nplike is None:
-            nplike = self._backend.nplike
-        if not nplike.known_data:
+        if backend is None:
+            backend = self._backend
+        if not backend.nplike.known_data:
             raise ak._errors.wrap_error(
                 TypeError("cannot call 'to_buffers' on an array without concrete data")
             )
@@ -194,7 +193,7 @@ class Content:
 
         form = self.form_with_key(form_key=form_key, id_start=id_start)
 
-        self._to_buffers(form, getkey, container, nplike)
+        self._to_buffers(form, getkey, container, backend)
 
         return form, len(self), container
 
@@ -203,7 +202,7 @@ class Content:
         form: form.Form,
         getkey: Callable[[Content, form.Form, str], str],
         container: MutableMapping[str, Any] | None,
-        nplike: NumpyLike | None,
+        backend: Backend,
     ) -> tuple[form.Form, int, Mapping[str, Any]]:
         raise ak._errors.wrap_error(NotImplementedError)
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -12,8 +12,8 @@ from awkward._backends import Backend, TypeTracerBackend
 from awkward.forms import form
 from awkward.typing import Any, Self, TypeAlias, TypeVar
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)
 ActionType: TypeAlias = """Callable[

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -9,8 +9,8 @@ from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class EmptyArray(Content):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -48,7 +48,7 @@ class EmptyArray(Content):
     def _form_with_key(self, getkey):
         return self.Form(parameters=self._parameters, form_key=getkey(self))
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
 
     @property

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -133,11 +133,11 @@ class IndexedArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "index")
-        container[key] = ak._util.little_endian(self._index.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key] = ak._util.little_endian(self._index.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -10,8 +10,8 @@ from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class IndexedArray(Content):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -120,11 +120,11 @@ class IndexedOptionArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "index")
-        container[key] = ak._util.little_endian(self._index.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key] = ak._util.little_endian(self._index.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -10,8 +10,8 @@ from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class IndexedOptionArray(Content):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -11,7 +11,7 @@ from awkward.forms.listform import ListForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class ListArray(Content):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -114,13 +114,13 @@ class ListArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key1 = getkey(self, form, "starts")
         key2 = getkey(self, form, "stops")
-        container[key1] = ak._util.little_endian(self._starts.raw(nplike))
-        container[key2] = ak._util.little_endian(self._stops.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key1] = ak._util.little_endian(self._starts.raw(backend.index_nplike))
+        container[key2] = ak._util.little_endian(self._stops.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -100,11 +100,11 @@ class ListOffsetArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "offsets")
-        container[key] = ak._util.little_endian(self._offsets.raw(nplike))
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        container[key] = ak._util.little_endian(self._offsets.raw(backend.index_nplike))
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -10,8 +10,8 @@ from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class ListOffsetArray(Content):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -113,10 +113,10 @@ class NumpyArray(Content):
             form_key=getkey(self),
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key = getkey(self, form, "data")
-        container[key] = ak._util.little_endian(self.raw(nplike))
+        container[key] = ak._util.little_endian(self.raw(backend.nplike))
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,8 +10,8 @@ from awkward.forms.numpyform import NumpyForm
 from awkward.types.numpytype import primitive_to_dtype
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class NumpyArray(Content):
@@ -48,7 +48,7 @@ class NumpyArray(Content):
             data = data.data
         self._data = backend.nplike.asarray(data)
 
-        if not isinstance(backend.nplike, ak.nplikes.Jax):
+        if not isinstance(backend.nplike, ak._nplikes.Jax):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
         if len(self._data.shape) == 0:
             raise ak._errors.wrap_error(
@@ -83,11 +83,11 @@ class NumpyArray(Content):
 
     @property
     def ptr(self):
-        if isinstance(self._backend.nplike, ak.nplikes.Numpy):
+        if isinstance(self._backend.nplike, ak._nplikes.Numpy):
             return self._data.ctypes.data
-        elif isinstance(self._backend.nplike, ak.nplikes.Cupy):
+        elif isinstance(self._backend.nplike, ak._nplikes.Cupy):
             return self._data.data.ptr
-        elif isinstance(self._backend.nplike, ak.nplikes.Jax):
+        elif isinstance(self._backend.nplike, ak._nplikes.Jax):
             return self._data.device_buffer.unsafe_buffer_pointer()
         else:
             raise ak._errors.wrap_error(
@@ -1120,7 +1120,7 @@ class NumpyArray(Content):
         assert self.is_contiguous
         assert self._data.ndim == 1
 
-        if isinstance(self._backend.nplike, ak.nplikes.Jax):
+        if isinstance(self._backend.nplike, ak._nplikes.Jax):
             from awkward._connect.jax.reducers import get_jax_reducer
 
             reducer = get_jax_reducer(reducer)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -12,8 +12,8 @@ from awkward.forms.recordform import RecordForm
 from awkward.record import Record
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class RecordArray(Content):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -201,14 +201,14 @@ class RecordArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         if self._fields is None:
             for i, content in enumerate(self._contents):
-                content._to_buffers(form.content(i), getkey, container, nplike)
+                content._to_buffers(form.content(i), getkey, container, backend)
         else:
             for field, content in zip(self._fields, self._contents):
-                content._to_buffers(form.content(field), getkey, container, nplike)
+                content._to_buffers(form.content(field), getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -95,9 +95,9 @@ class RegularArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -9,8 +9,8 @@ from awkward.contents.content import Content
 from awkward.forms.regularform import RegularForm
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class RegularArray(Content):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -351,14 +351,14 @@ class UnionArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
         key1 = getkey(self, form, "tags")
         key2 = getkey(self, form, "index")
-        container[key1] = ak._util.little_endian(self._tags.raw(nplike))
-        container[key2] = ak._util.little_endian(self._index.raw(nplike))
+        container[key1] = ak._util.little_endian(self._tags.raw(backend.index_nplike))
+        container[key2] = ak._util.little_endian(self._index.raw(backend.index_nplike))
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey, container, nplike)
+            content._to_buffers(form.content(i), getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -14,8 +14,8 @@ from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class UnionArray(Content):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1585,10 +1585,11 @@ class UnionArray(Content):
         return out
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:
+        tags = self._tags.to_nplike(backend.index_nplike)
         index = self._index.to_nplike(backend.index_nplike)
         contents = [content.to_backend(backend) for content in self._contents]
         return UnionArray(
-            self._tags,
+            tags,
             index,
             contents,
             parameters=self.parameters,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,8 +9,8 @@ from awkward.contents.content import Content
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class UnmaskedArray(Content):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -71,9 +71,9 @@ class UnmaskedArray(Content):
             form_key=form_key,
         )
 
-    def _to_buffers(self, form, getkey, container, nplike):
+    def _to_buffers(self, form, getkey, container, backend):
         assert isinstance(form, self.Form)
-        self._content._to_buffers(form.content, getkey, container, nplike)
+        self._content._to_buffers(form.content, getkey, container, backend)
 
     @property
     def typetracer(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -8,7 +8,7 @@ import awkward as ak
 from awkward import _errors
 from awkward.typing import Any
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 numpy_backend = ak._backends.NumpyBackend.instance()
 
 

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward.forms.form import Form, _parameters_equal
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_dtype(dtype, parameters=None):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -12,8 +12,8 @@ from awkward_cpp.lib import _ext
 import awkward as ak
 from awkward._connect.numpy import NDArrayOperatorsMixin
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
@@ -200,10 +200,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         elif numpy.is_own_array(data) and data.dtype != np.dtype("O"):
             layout = ak.operations.from_numpy(data, highlevel=False)
 
-        elif ak.nplikes.Cupy.is_own_array(data):
+        elif ak._nplikes.Cupy.is_own_array(data):
             layout = ak.operations.from_cupy(data, highlevel=False)
 
-        elif ak.nplikes.Jax.is_own_array(data):
+        elif ak._nplikes.Jax.is_own_array(data):
             layout = ak.operations.from_jax(data, highlevel=False)
 
         elif ak._util.in_module(data, "pyarrow"):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -6,8 +6,8 @@ import copy
 import awkward as ak
 from awkward.typing import Self
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 _dtype_to_form = {
@@ -41,7 +41,7 @@ class Index:
 
     def __init__(self, data, *, metadata=None, nplike=None):
         if nplike is None:
-            nplike = ak.nplikes.nplike_of(data)
+            nplike = ak._nplikes.nplike_of(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
             raise ak._errors.wrap_error(
@@ -187,7 +187,7 @@ class Index:
         if hasattr(out, "shape") and len(out.shape) != 0:
             return Index(out, metadata=self.metadata, nplike=self._nplike)
         elif (
-            ak.nplikes.Jax.is_own_array(out) or ak.nplikes.Cupy.is_own_array(out)
+            ak._nplikes.Jax.is_own_array(out) or ak._nplikes.Cupy.is_own_array(out)
         ) and len(out.shape) == 0:
             return out.item()
         else:

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -5,10 +5,10 @@ import threading
 import weakref
 
 import awkward as ak
-from awkward import _errors, highlevel, nplikes
+from awkward import _errors, _nplikes, highlevel
 from awkward.typing import TypeVar
 
-numpy = nplikes.Numpy.instance()
+numpy = _nplikes.Numpy.instance()
 
 
 def assert_never(arg) -> None:

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("all")

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("any")

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def argcartesian(

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def argcombinations(

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmax")

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argmin")

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("argsort")

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("broadcast_arrays")
@@ -167,7 +167,7 @@ def _impl(arrays, kwargs):
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(ak.nplikes.nplike_of(*arrays).array([y]))
+            y = ak.contents.NumpyArray(ak._nplikes.nplike_of(*arrays).array([y]))
         inputs.append(y)
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
 
 

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def combinations(

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward.operations.ak_fill_none import fill_none
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
 
 
@@ -56,7 +56,7 @@ def _impl(arrays, axis, merge, mergebool, highlevel, behavior):
         # Is an Awkward Content
         isinstance(arrays, ak.contents.Content)
         # Is an array with a known NumpyLike
-        or ak.nplikes.nplike_of(arrays, default=None) is not None
+        or ak._nplikes.nplike_of(arrays, default=None) is not None
     ):
         # Convert the array to a layout object
         content = ak.operations.to_layout(arrays, allow_record=False, allow_other=False)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -4,7 +4,7 @@ import copy as _copy
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("copy")

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def corr(
@@ -128,5 +128,5 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        nplike = ak.nplikes.nplike_of(sumwxy, sumwxx, sumwyy)
+        nplike = ak._nplikes.nplike_of(sumwxy, sumwxx, sumwyy)
         return nplike.true_divide(sumwxy, nplike.sqrt(sumwxx * sumwyy))

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def count(

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("count_nonzero")

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def covar(
@@ -118,4 +118,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.nplike_of(sumwxy, sumw).true_divide(sumwxy, sumw)
+        return ak._nplikes.nplike_of(sumwxy, sumw).true_divide(sumwxy, sumw)

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def fields(array):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -4,7 +4,7 @@ import numbers
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
 
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def firsts(array, axis=1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def flatten(array, axis=1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_arrow_schema(schema):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -5,7 +5,7 @@ import pathlib
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_avro_file(

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -36,7 +36,7 @@ def from_buffers(
         backend (str): Library to use to generate values that are
             put into the new array. The default, cpu, makes NumPy
             arrays, which are in main memory (e.g. not GPU). If all the values in
-            `container` have the same `nplike` as this, they won't be copied.
+            `container` have the same `backend` as this, they won't be copied.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -6,8 +6,8 @@ import math
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def from_buffers(

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -4,7 +4,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_iter(

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -9,8 +9,8 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def from_json(

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -235,7 +235,7 @@ def _load(
         )
 
     if len(arrays) == 0:
-        numpy = ak.nplikes.Numpy.instance()
+        numpy = ak._nplikes.Numpy.instance()
         return ak.operations.ak_from_buffers._impl(
             subform, 0, _DictOfEmptyBuffers(), "", numpy, highlevel, behavior
         )

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward.operations.ak_zeros_like import _ZEROS
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("full_like")
@@ -88,7 +88,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         # In the case of strings and byte strings,
         # converting the fill avoids a ValueError.
         dtype = np.dtype(dtype)
-        nplike = ak.nplikes.nplike_of(array)
+        nplike = ak._nplikes.nplike_of(array)
         fill_value = nplike.array([fill_value], dtype=dtype)[0]
         # Also, if the fill_value cannot be converted to the dtype
         # this should throw a clear, early, error.

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def is_none(array, axis=0, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("isclose")

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def linear_fit(
@@ -101,7 +101,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        nplike = ak.nplikes.nplike_of(x, y, weight)
+        nplike = ak._nplikes.nplike_of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
@@ -102,7 +102,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, **kwargs):
         layoutarray, layoutmask = inputs
         if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = ak.nplikes.nplike_of(layoutmask).asarray(layoutmask)
+            m = ak._nplikes.nplike_of(layoutmask).asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ak._errors.wrap_error(
                     ValueError(

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("max")

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("mean")
@@ -185,4 +185,4 @@ def _impl(x, weight, axis, keepdims, mask_identity, flatten_records):
             sumwx = ak.operations.ak_sum._impl(
                 x * weight, axis, keepdims, mask_identity, flatten_records
             )
-        return ak.nplikes.nplike_of(sumwx, sumw).true_divide(sumwx, sumw)
+        return ak._nplikes.nplike_of(sumwx, sumw).true_divide(sumwx, sumw)

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -4,7 +4,7 @@ import collections
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 ParquetMetadata = collections.namedtuple(

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("min")

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def moment(
@@ -108,4 +108,4 @@ def _impl(x, n, weight, axis, keepdims, mask_identity, flatten_records):
                 mask_identity,
                 flatten_records,
             )
-        return ak.nplikes.nplike_of(sumwxn, sumw).true_divide(sumwxn, sumw)
+        return ak._nplikes.nplike_of(sumwxn, sumw).true_divide(sumwxn, sumw)

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def nan_to_none(array, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("nan_to_num")
@@ -75,7 +75,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
         broadcasting_ids[id(neginf)] = len(broadcasting)
         broadcasting.append(neginf_layout)
 
-    nplike = ak.nplikes.nplike_of(layout)
+    nplike = ak._nplikes.nplike_of(layout)
 
     if len(broadcasting) == 1:
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def num(array, axis=1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ones_like")

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def packed(array, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -7,7 +7,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def parameters(array):

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("prod")

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ptp")

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("ravel")

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
 
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def singletons(array, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def softmax(
@@ -63,7 +63,7 @@ def _impl(x, axis, keepdims, mask_identity, flatten_records):
     )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        nplike = ak.nplikes.nplike_of(x)
+        nplike = ak._nplikes.nplike_of(x)
         expx = nplike.exp(x)
         denom = ak.operations.ak_sum._impl(
             expx, axis, keepdims, mask_identity, flatten_records

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sort")

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("std")
@@ -155,7 +155,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        return ak.nplikes.nplike_of(x, weight).sqrt(
+        return ak._nplikes.nplike_of(x, weight).sqrt(
             ak.operations.ak_var._impl(
                 x,
                 weight,

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def strings_astype(array, to, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("sum")

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_arrow(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -4,7 +4,7 @@ import json
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_arrow_table(

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_backend(array, backend, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_buffers(

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -40,7 +40,7 @@ def to_buffers(
             generate values that are put into the `container`. The default,
             `"cpu"`, makes NumPy arrays, which are in main memory
             (e.g. not GPU) and satisfy Python's Buffer protocol. If all the
-            buffers in `array` have the same `nplike` as this, they won't be
+            buffers in `array` have the same `backend` as this, they won't be
             copied. If the backend is None, then the backend of the layout
             will be used to generate the buffers.
 

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_categorical(array, *, highlevel=True, behavior=None):
@@ -100,8 +100,8 @@ def _impl(array, highlevel, behavior):
             hashable = [ak.behaviors.categorical.as_hashable(x) for x in content_list]
 
             lookup = {}
-            is_first = ak.nplikes.numpy.empty(len(hashable), dtype=np.bool_)
-            mapping = ak.nplikes.numpy.empty(len(hashable), dtype=np.int64)
+            is_first = ak._nplikes.numpy.empty(len(hashable), dtype=np.bool_)
+            mapping = ak._nplikes.numpy.empty(len(hashable), dtype=np.int64)
             for i, x in enumerate(hashable):
                 if x in lookup:
                     is_first[i] = False
@@ -112,17 +112,17 @@ def _impl(array, highlevel, behavior):
                     mapping[i] = j
 
             if layout.is_indexed and layout.is_option:
-                original_index = ak.nplikes.numpy.asarray(layout.index)
+                original_index = ak._nplikes.numpy.asarray(layout.index)
                 index = mapping[original_index]
                 index[original_index < 0] = -1
                 index = ak.index.Index64(index)
 
             elif layout.is_indexed:
-                original_index = ak.nplikes.numpy.asarray(layout.index)
+                original_index = ak._nplikes.numpy.asarray(layout.index)
                 index = ak.index.Index64(mapping[original_index])
 
             elif layout.is_option:
-                mask = ak.nplikes.numpy.asarray(layout.mask_as_bool(valid_when=False))
+                mask = ak._nplikes.numpy.asarray(layout.mask_as_bool(valid_when=False))
                 mapping[mask.view(np.bool_)] = -1
                 index = ak.index.Index64(mapping)
 

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -2,9 +2,9 @@
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_dataframe(

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -9,8 +9,8 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def to_json(

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -7,8 +7,8 @@ from awkward_cpp.lib import _ext
 import awkward as ak
 from awkward import _errors
 
-np = ak.nplikes.NumpyMetadata.instance()
-numpy = ak.nplikes.Numpy.instance()
+np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def to_layout(
@@ -89,7 +89,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Cupy.is_own_array(array):
+    elif ak._nplikes.Cupy.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
             raise _errors.wrap_error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(
@@ -99,7 +99,7 @@ def _impl(array, allow_record, allow_other, numpytype):
             numpytype,
         )
 
-    elif ak.nplikes.Jax.is_own_array(array):
+    elif ak._nplikes.Jax.is_own_array(array):
         if not issubclass(array.dtype.type, numpytype):
             raise _errors.wrap_error(ValueError(f"dtype {array.dtype!r} not allowed"))
         return _impl(

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -6,7 +6,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_list(array):

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -163,8 +163,8 @@ def transform(
 
        * behavior (None or dict): Behavior that would be attached to the output
            array(s) if `highlevel`.
-       * nplike (array library shim): Handle to the NumPy library, CuPy, etc.,
-           depending on the type of arrays.
+       * backend (array library / kernel library shim): Handle to the NumPy
+           library, CuPy, etc., depending on the type of arrays.
        * options (dict): Options provided to #ak.transform.
 
     If there is only one array, the `transformation` function must either return

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -8,7 +8,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def type(array):

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -4,7 +4,7 @@ import numbers
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
@@ -87,7 +87,7 @@ def _impl(array, counts, axis, highlevel, behavior):
         if counts.is_option:
             mask = counts.mask_as_bool(valid_when=False)
             counts = counts.to_numpy(allow_missing=True)
-            counts = ak.nplikes.numpy.ma.filled(counts, 0)
+            counts = ak._nplikes.numpy.ma.filled(counts, 0)
         elif counts.is_numpy or counts.is_unknown:
             counts = counts.to_numpy(allow_missing=False)
             mask = False

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def unzip(array, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def values_astype(array, to, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 @ak._connect.numpy.implements("var")
@@ -191,8 +191,8 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, flatten_records):
                 flatten_records,
             )
         if ddof != 0:
-            return ak.nplikes.nplike_of(sumwxx, sumw).true_divide(
+            return ak._nplikes.nplike_of(sumwxx, sumw).true_divide(
                 sumwxx, sumw
-            ) * ak.nplikes.nplike_of(sumw).true_divide(sumw, sumw - ddof)
+            ) * ak._nplikes.nplike_of(sumw).true_divide(sumw, sumw - ddof)
         else:
-            return ak.nplikes.nplike_of(sumwxx, sumw).true_divide(sumwxx, sumw)
+            return ak._nplikes.nplike_of(sumwxx, sumw).true_divide(sumwxx, sumw)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
 
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def with_field(base, what, where=None, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def with_name(array, name, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def without_parameters(array, *, highlevel=True, behavior=None):

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 _ZEROS = object()

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def zip(

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward.contents.content import Content
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class Record:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 def is_primitive(primitive):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -6,7 +6,7 @@ import sys
 import awkward as ak
 from awkward.types._awkward_datashape_parser import Lark_StandAlone, Transformer
 
-np = ak.nplikes.NumpyMetadata.instance()
+np = ak._nplikes.NumpyMetadata.instance()
 
 
 class Type:

--- a/tests-cuda/test_1276-cuda-num.py
+++ b/tests-cuda/test_1276-cuda-num.py
@@ -7,6 +7,7 @@ import pytest
 import awkward as ak
 
 
+@pytest.mark.xfail(reason="unimplemented CUDA Kernels (awkward_ByteMaskedArray_numnull")
 def test_num_1():
     content = ak.Array(
         ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
@@ -21,6 +22,7 @@ def test_num_1():
         ak.num(cuda_array, 1)
 
 
+@pytest.mark.xfail(reason="unimplemented CUDA Kernels (awkward_ByteMaskedArray_numnull")
 def test_num_2():
     content = ak.Array(
         ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]

--- a/tests-cuda/test_1276-cupy-interop.py
+++ b/tests-cuda/test_1276-cupy-interop.py
@@ -8,23 +8,30 @@ import awkward as ak
 
 
 def test_cupy_interop():
-    c = cp.arange(10)
-    n = np.arange(10)
-    cupy_index_arr = ak.index.Index64(c)
-    np_index_arr = ak.index.Index64(n)
+    cupy = ak._nplikes.Cupy.instance()
+    numpy = ak._nplikes.Numpy.instance()
 
-    cupy = ak.nplikes.Cupy.instance()
-    numpy = ak.nplikes.Numpy.instance()
+    cupy_index_arr = ak.index.Index64(cp.arange(10))
+    assert cupy_index_arr.nplike is cupy
+
+    np_index_arr = ak.index.Index64(np.arange(10))
+    assert np_index_arr.nplike is numpy
+
+    cupy_as_numpy = cupy_index_arr.to_nplike(numpy)
+    assert isinstance(cupy_as_numpy.data, np.ndarray) and not isinstance(
+        cupy_as_numpy.data, cp.ndarray
+    )
+
+    numpy_as_cupy = np_index_arr.to_nplike(cupy)
+    assert isinstance(numpy_as_cupy.data, cp.ndarray)
 
     # GPU->CPU
-    assert ak.to_list(np.asarray(cupy_index_arr.to_nplike(cupy))) == ak.to_list(
-        np.asarray(np_index_arr)
-    )
+    assert cupy_as_numpy.data.tolist() == np.asarray(np_index_arr).tolist()
     # CPU->CPU
-    assert ak.to_list(np.asarray(np_index_arr.to_nplike(cupy))) == ak.to_list(
-        np.asarray(np_index_arr)
-    )
+    assert numpy_as_cupy.data.tolist() == np.asarray(np_index_arr).tolist()
+
+    numpy_round_trip = numpy_as_cupy.to_nplike(numpy)
+    assert isinstance(numpy_round_trip.data, np.ndarray)
+
     # CPU->GPU->CPU
-    assert ak.to_list(np.asarray(np_index_arr)) == ak.to_list(
-        np.asarray(np_index_arr.to_nplike(cupy).to_backend(numpy))
-    )
+    assert numpy_round_trip.data.tolist() == np.asarray(np_index_arr).tolist()

--- a/tests/test_0395-complex-type-arrays.py
+++ b/tests/test_0395-complex-type-arrays.py
@@ -227,7 +227,7 @@ def test_astype_complex():
         (5.5 + 0j),
     ]
     assert to_list(
-        ak.nplikes.nplike_of(array_complex64).asarray(
+        ak._nplikes.nplike_of(array_complex64).asarray(
             ak.highlevel.Array(array_complex64)
         )
     ) == [

--- a/tests/test_0884-index-and-identifier-refactoring.py
+++ b/tests/test_0884-index-and-identifier-refactoring.py
@@ -8,7 +8,7 @@ import awkward as ak
 
 def test_index32():
     py_array = ak.index.Index.zeros(
-        10, nplike=ak.nplikes.Numpy.instance(), dtype=np.int32
+        10, nplike=ak._nplikes.Numpy.instance(), dtype=np.int32
     )
 
     assert len(py_array) == 10
@@ -17,7 +17,7 @@ def test_index32():
 
 def test_index64():
     py_array = ak.index.Index.zeros(
-        10, nplike=ak.nplikes.Numpy.instance(), dtype=np.int64
+        10, nplike=ak._nplikes.Numpy.instance(), dtype=np.int64
     )
 
     assert len(py_array) == 10

--- a/tests/test_1247-numpy-to_rectilinear-ndarray.py
+++ b/tests/test_1247-numpy-to_rectilinear-ndarray.py
@@ -8,6 +8,6 @@ import awkward as ak
 
 def test():
     array = np.array([1, 2, 9, 0])
-    nplike = ak.nplikes.nplike_of(array)
+    nplike = ak._nplikes.nplike_of(array)
     ak_array = ak.operations.from_numpy(array)
     assert nplike.to_rectilinear(array).tolist() == ak_array.tolist()

--- a/tests/test_1672-broadcast-parameters.py
+++ b/tests/test_1672-broadcast-parameters.py
@@ -4,7 +4,7 @@ import pytest
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 @pytest.mark.skip("string broadcasting is broken")

--- a/tests/test_1688-pack-categorical.py
+++ b/tests/test_1688-pack-categorical.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def test():

--- a/tests/test_1707-broadcast-parameters-ufunc.py
+++ b/tests/test_1707-broadcast-parameters-ufunc.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 def test_numpy_1d():

--- a/tests/test_1709-ak-array-constructor-behavior.py
+++ b/tests/test_1709-ak-array-constructor-behavior.py
@@ -4,7 +4,7 @@ import pytest  # noqa: F401
 
 import awkward as ak
 
-numpy = ak.nplikes.Numpy.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 
 class MyBehavior(ak.Array):


### PR DESCRIPTION
This follows up #1922 to remove any reference of `nplike` in the high level API, and renames `nplikes` to `_nplikes`

I also fixed the CUDA test generation, which I failed to fix in #1922

Note-to-self, write a git hook to run those.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-feat-to-buffers-backend/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->