### PR TITLE
fix: UnionArray.simplified preserves parameters.

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -239,7 +239,16 @@ class UnionArray(Content):
                                     contents[k].length,
                                 )
                             )
-                            contents[k] = contents[k].merge(inner_cont)
+                            old_parameters = contents[k]._parameters
+                            contents[k] = (
+                                contents[k]
+                                .merge(inner_cont)
+                                .copy(
+                                    parameters=ak._util.merge_parameters(
+                                        old_parameters, inner_cont._parameters
+                                    )
+                                )
+                            )
                             unmerged = False
                             break
 
@@ -313,7 +322,16 @@ class UnionArray(Content):
                                 contents[k].length,
                             )
                         )
-                        contents[k] = contents[k].merge(self_cont)
+                        old_parameters = contents[k]._parameters
+                        contents[k] = (
+                            contents[k]
+                            .merge(self_cont)
+                            .copy(
+                                parameters=ak._util.merge_parameters(
+                                    old_parameters, self_cont._parameters
+                                )
+                            )
+                        )
                         unmerged = False
                         break
 
@@ -346,7 +364,10 @@ class UnionArray(Content):
             )
 
         if len(contents) == 1:
-            return contents[0]._carry(index, True)
+            next = contents[0]._carry(index, True)
+            return next.copy(
+                parameters=ak._util.merge_parameters(next._parameters, parameters)
+            )
 
         else:
             return cls(

--- a/tests/test_1686-UnionArray-simplified-preserve-parameters.py
+++ b/tests/test_1686-UnionArray-simplified-preserve-parameters.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    left = ak.contents.NumpyArray(
+        np.arange(10), parameters={"left": "leftie", "some": "A"}
+    )
+    right = ak.contents.NumpyArray(
+        np.arange(10), parameters={"right": "rightie", "some": "B"}
+    )
+    array = ak.contents.UnionArray.simplified(
+        ak.index.Index8(np.array([0, 0, 0, 0, 1, 1, 1, 1], np.int8)),
+        ak.index.Index32(np.array([0, 1, 2, 3, 0, 1, 2, 3], np.int32)),
+        [left, right],
+        parameters={"some": "other"},
+    )
+    assert array.parameter("some") == "other"
+    assert array.parameter("left") == "leftie"
+    assert array.parameter("right") == "rightie"


### PR DESCRIPTION


<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-unionarray-simplified-preserve-parameters/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->