### PR TITLE
docs: retested and modernized all the docstrings in highlevel.py.

### DIFF
--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -48,13 +48,13 @@ def combinations(
     represent the "upper triangle" of sets without repetition. If
     `replacement=True`, the diagonal of this "upper triangle" is included.
 
-    As a simple example with `axis=0`, consider the following `array`
+    As a simple example with `axis=0`, consider the following
 
-        ak.Array(["a", "b", "c", "d", "e"])
+        >>> array = ak.Array(["a", "b", "c", "d", "e"])
 
     The combinations choose `2` are:
 
-        >>> ak.to_list(ak.combinations(array, 2, axis=0))
+        >>> ak.combinations(array, 2, axis=0).show()
         [('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
                      ('b', 'c'), ('b', 'd'), ('b', 'e'),
                                  ('c', 'd'), ('c', 'e'),
@@ -62,7 +62,7 @@ def combinations(
 
     Including the diagonal allows pairs like `('a', 'a')`.
 
-        >>> ak.to_list(ak.combinations(array, 2, axis=0, replacement=True))
+        >>> ak.combinations(array, 2, axis=0, replacement=True).show()
         [('a', 'a'), ('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
                      ('b', 'b'), ('b', 'c'), ('b', 'd'), ('b', 'e'),
                                  ('c', 'c'), ('c', 'd'), ('c', 'e'),
@@ -72,41 +72,60 @@ def combinations(
     The combinations choose `3` can't be easily arranged as a triangle
     in two dimensions.
 
-        >>> ak.to_list(ak.combinations(array, 3, axis=0))
-        [('a', 'b', 'c'), ('a', 'b', 'd'), ('a', 'b', 'e'), ('a', 'c', 'd'), ('a', 'c', 'e'),
-         ('a', 'd', 'e'), ('b', 'c', 'd'), ('b', 'c', 'e'), ('b', 'd', 'e'), ('c', 'd', 'e')]
+        >>> ak.combinations(array, 3, axis=0).show()
+        [('a', 'b', 'c'),
+         ('a', 'b', 'd'),
+         ('a', 'b', 'e'),
+         ('a', 'c', 'd'),
+         ('a', 'c', 'e'),
+         ('a', 'd', 'e'),
+         ('b', 'c', 'd'),
+         ('b', 'c', 'e'),
+         ('b', 'd', 'e'),
+         ('c', 'd', 'e')]
 
     Including the (three-dimensional) diagonal allows triples like
     `('a', 'a', 'a')`, but also `('a', 'a', 'b')`, `('a', 'b', 'b')`, etc.,
     but not `('a', 'b', 'a')`. All combinations are in the same order as
     the original array.
 
-        >>> ak.to_list(ak.combinations(array, 3, axis=0, replacement=True))
-        [('a', 'a', 'a'), ('a', 'a', 'b'), ('a', 'a', 'c'), ('a', 'a', 'd'), ('a', 'a', 'e'),
-         ('a', 'b', 'b'), ('a', 'b', 'c'), ('a', 'b', 'd'), ('a', 'b', 'e'), ('a', 'c', 'c'),
-         ('a', 'c', 'd'), ('a', 'c', 'e'), ('a', 'd', 'd'), ('a', 'd', 'e'), ('a', 'e', 'e'),
-         ('b', 'b', 'b'), ('b', 'b', 'c'), ('b', 'b', 'd'), ('b', 'b', 'e'), ('b', 'c', 'c'),
-         ('b', 'c', 'd'), ('b', 'c', 'e'), ('b', 'd', 'd'), ('b', 'd', 'e'), ('b', 'e', 'e'),
-         ('c', 'c', 'c'), ('c', 'c', 'd'), ('c', 'c', 'e'), ('c', 'd', 'd'), ('c', 'd', 'e'),
-         ('c', 'e', 'e'), ('d', 'd', 'd'), ('d', 'd', 'e'), ('d', 'e', 'e'), ('e', 'e', 'e')]
+        >>> ak.combinations(array, 3, axis=0, replacement=True).show()
+        [('a', 'a', 'a'),
+         ('a', 'a', 'b'),
+         ('a', 'a', 'c'),
+         ('a', 'a', 'd'),
+         ('a', 'a', 'e'),
+         ('a', 'b', 'b'),
+         ('a', 'b', 'c'),
+         ('a', 'b', 'd'),
+         ('a', 'b', 'e'),
+         ('a', 'c', 'c'),
+         ...,
+         ('c', 'c', 'd'),
+         ('c', 'c', 'e'),
+         ('c', 'd', 'd'),
+         ('c', 'd', 'e'),
+         ('c', 'e', 'e'),
+         ('d', 'd', 'd'),
+         ('d', 'd', 'e'),
+         ('d', 'e', 'e'),
+         ('e', 'e', 'e')]
 
     The primary purpose of this function, however, is to compute a different
     set of combinations for each element of an array: in other words, `axis=1`.
-    The following `array` has a different number of items in each element.
+    The following has a different number of items in each element.
 
-        ak.Array([[1, 2, 3, 4], [], [5], [6, 7, 8]])
+        >>> array = ak.Array([[1, 2, 3, 4], [], [5], [6, 7, 8]])
 
     There are 6 ways to choose pairs from 4 elements, 0 ways to choose pairs
     from 0 elements, 0 ways to choose pairs from 1 element, and 3 ways to
     choose pairs from 3 elements.
 
-        >>> ak.to_list(ak.combinations(array, 2))
-        [
-         [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)],
+        >>> ak.combinations(array, 2).show()
+        [[(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)],
          [],
          [],
-         [(6, 7), (6, 8), (7, 8)]
-        ]
+         [(6, 7), (6, 8), (7, 8)]]
 
     Note, however, that the combinatorics isn't determined by equality of
     the data themselves, but by their placement in the array. For example,
@@ -114,17 +133,15 @@ def combinations(
     structure.
 
         >>> same = ak.Array([[7, 7, 7, 7], [], [7], [7, 7, 7]])
-        >>> ak.to_list(ak.combinations(same, 2))
-        [
-         [(7, 7), (7, 7), (7, 7), (7, 7), (7, 7), (7, 7)],
+        >>> ak.combinations(same, 2).show()
+        [[(7, 7), (7, 7), (7, 7), (7, 7), (7, 7), (7, 7)],
          [],
          [],
-         [(7, 7), (7, 7), (7, 7)]
-        ]
+         [(7, 7), (7, 7), (7, 7)]]
 
     To get records instead of tuples, pass a set of field names to `fields`.
 
-        >>> ak.to_list(ak.combinations(array, 2, fields=["x", "y"]))
+        >>> ak.combinations(array, 2, fields=["x", "y"]).show()
         [
          [{'x': 1, 'y': 2}, {'x': 1, 'y': 3}, {'x': 1, 'y': 4},
                             {'x': 2, 'y': 3}, {'x': 2, 'y': 4},
@@ -140,7 +157,7 @@ def combinations(
         >>> left, right = ak.unzip(ak.argcartesian([array, array]))
         >>> keep = left < right
         >>> result = ak.zip([array[left][keep], array[right][keep]])
-        >>> ak.to_list(result)
+        >>> result.show()
         [
          [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)],
          [],

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -41,13 +41,14 @@ def copy(array):
     affecting the underlying layout data (it *replaces* its layout), so a
     shallow copy will do:
 
+        >>> import copy
         >>> original = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}])
         >>> shallow_copy = copy.copy(original)
         >>> shallow_copy["y"] = original.x**2
         >>> shallow_copy
-        <Array [{x: 1, y: 1}, ... y: 4}, {x: 3, y: 9}] type='3 * {"x": int64, "y": int64}'>
+        <Array [{x: 1, y: 1}, {...}, {x: 3, y: 9}] type='3 * {x: int64, y: int64}'>
         >>> original
-        <Array [{x: 1}, {x: 2}, {x: 3}] type='3 * {"x": int64}'>
+        <Array [{x: 1}, {x: 2}, {x: 3}] type='3 * {x: int64}'>
 
     This is key to Awkward Array's efficiency (memory and speed): operations that
     only change part of a structure re-use pieces from the original ("structural

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -35,13 +35,13 @@ def count(
     [shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html).
 
     However, for nested lists of variable dimension and missing values, the
-    result of counting is non-trivial. For example, with this `array`,
+    result of counting is non-trivial. For example, with this
 
-        ak.Array([[ 0.1,  0.2      ],
-                  [None, 10.2, None],
-                  None,
-                  [20.1, 20.2, 20.3],
-                  [30.1, 30.2      ]])
+        >>> array = ak.Array([[ 0.1,  0.2      ],
+        ...                   [None, 10.2, None],
+        ...                    None,
+        ...                    [20.1, 20.2, 20.3],
+        ...                    [30.1, 30.2      ]])
 
     the result of counting over the innermost dimension is
 

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -39,9 +39,9 @@ def count(
 
         >>> array = ak.Array([[ 0.1,  0.2      ],
         ...                   [None, 10.2, None],
-        ...                    None,
-        ...                    [20.1, 20.2, 20.3],
-        ...                    [30.1, 30.2      ]])
+        ...                   None,
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [30.1, 30.2      ]])
 
     the result of counting over the innermost dimension is
 

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -26,9 +26,9 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
     Replaces missing values (None) with a given `value`.
 
-    For example, in the following `array`,
+    For example, in the following
 
-        ak.Array([[1.1, None, 2.2], [], [None, 3.3, 4.4]])
+        >>> array = ak.Array([[1.1, None, 2.2], [], [None, 3.3, 4.4]])
 
     The None values could be replaced with `0` by
 
@@ -40,12 +40,15 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     by a string.
 
         >>> ak.fill_none(array, "hi")
-        <Array [[1.1, 'hi', 2.2], ... ['hi', 3.3, 4.4]] type='3 * var * union[float64, s...'>
+        <Array [[1.1, 'hi', 2.2], [], ['hi', ...]] type='3 * var * union[float64, s...'>
 
     The list content now has a union type:
 
-        >>> ak.type(ak.fill_none(array, "hi"))
-        3 * var * union[float64, string]
+        >>> ak.fill_none(array, "hi").type.show()
+        3 * var * union[
+            float64,
+            string
+        ]
 
     The values could be floating-point numbers or strings.
     """

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -24,8 +24,15 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
     For example,
 
         >>> array = ak.Array([[1.1], [2.2], [], [3.3], [], [], [4.4], [5.5]])
-        >>> print(ak.firsts(array))
-        [1.1, 2.2, None, 3.3, None, None, 4.4, 5.5]
+        >>> ak.firsts(array).show()
+        [1.1,
+         2.2,
+         None,
+         3.3,
+         None,
+         None,
+         4.4,
+         5.5]
 
     See #ak.singletons to invert this function.
     """

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -98,6 +98,7 @@ def from_json(
     recognized by URI protocol (like "https://" or "s3://") and handled by fsspec
     (which must be installed).
 
+        >>> import pathlib
         >>> with open("tmp.json", "w") as file:
         ...     file.write("[[1.1, 2.2, 3.3], [], [4.4, 5.5]]")
         ...
@@ -136,6 +137,7 @@ def from_json(
 
     Consider
 
+        >>> import json
         >>> json_data = "[[1.1, 2.2, 3.3], [], [4.4, 5.5]]"
         >>> ak.from_iter(json.loads(json_data))
         <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>
@@ -144,11 +146,11 @@ def from_json(
 
     and
 
-        >>> json_data = '{"x": 1.1, "y": [1, 2, 3]}'
+        >>> json_data = '{"x": 1.1, "y": [1, 2]}'
         >>> ak.from_iter(json.loads(json_data))
-        <Record {x: 1.1, y: [1, 2, 3]} type='{"x": float64, "y": var * int64}'>
+        <Record {x: 1.1, y: [1, 2]} type='{x: float64, y: var * int64}'>
         >>> ak.from_json(json_data)
-        <Record {x: 1.1, y: [1, 2, 3]} type='{"x": float64, "y": var * int64}'>
+        <Record {x: 1.1, y: [1, 2]} type='{x: float64, y: var * int64}'>
 
     As shown above, reading JSON may result in #ak.Array or #ak.Record, but line-delimited
     (`line_delimited=True`) only results in #ak.Array:

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -22,13 +22,13 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     Converts a regular axis into an irregular one.
 
         >>> regular = ak.Array(np.arange(2*3*5).reshape(2, 3, 5))
-        >>> print(regular.type)
+        >>> regular.type.show()
         2 * 3 * 5 * int64
-        >>> print(ak.from_regular(regular).type)
+        >>> ak.from_regular(regular).type.show()
         2 * var * 5 * int64
-        >>> print(ak.from_regular(regular, axis=2).type)
+        >>> ak.from_regular(regular, axis=2).type.show()
         2 * 3 * var * int64
-        >>> print(ak.from_regular(regular, axis=-1).type)
+        >>> ak.from_regular(regular, axis=-1).type.show()
         2 * 3 * var * int64
 
     See also #ak.to_regular.

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -47,16 +47,10 @@ def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
         ...  False,
         ...  True,
         ...  {"x": 4.4, "y": [1, 2, None, 3, 4]}]])
-        >>> ak.to_list(ak.full_like(array, 12.3))
-        [[{"x": 12.3, "y": []},
-          {"x": 12.3, "y": [12]},
-          {"x": 12.3, "y": [12, 12]}],
+        >>> ak.full_like(array, 12.3).show()
+        [[{x: 12.3, y: []}, {x: 12.3, y: [12]}, {x: 12.3, y: [12, 12]}],
          [],
-         [{"x": 12.3, "y": [12, 12, None, 12]},
-          True,
-          True,
-          True,
-          {"x": 12.3, "y": [12, 12, None, 12, 12]}]]
+         [{x: 12.3, y: [12, 12, None, 12]}, True, ..., True, {x: 12.3, y: [12, ...]}]]
 
     The `"x"` values get filled in with `12.3` because they retain their type
     (`float64`) and the `"y"` list items get filled in with `12` because they

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -30,20 +30,18 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
         >>> ak.local_index(array, axis=1)
         <Array [[0, 1], [0], [], [0, 1, 2]] type='4 * var * int64'>
         >>> ak.local_index(array, axis=2)
-        <Array [[[0, 1, 2], []], ... [], [0, 1, 2, 3]]] type='4 * var * var * int64'>
+        <Array [[[0, 1, 2], []], ..., [[0], ..., [...]]] type='4 * var * var * int64'>
 
     Note that you can make a Pandas-style MultiIndex by calling this function on
     every axis.
 
         >>> multiindex = ak.zip([ak.local_index(array, i) for i in range(array.ndim)])
-        >>> multiindex
-        <Array [[[(0, 0, 0), (0, 0, ... ), (3, 2, 3)]]] type='4 * var * var * (int64, in...'>
-        >>> ak.to_list(multiindex)
+        >>> multiindex.show()
         [[[(0, 0, 0), (0, 0, 1), (0, 0, 2)], []],
          [[(1, 0, 0), (1, 0, 1)]],
          [],
          [[(3, 0, 0)], [], [(3, 2, 0), (3, 2, 1), (3, 2, 2), (3, 2, 3)]]]
-        >>> ak.to_list(ak.flatten(ak.flatten(multiindex)))
+        >>> ak.flatten(ak.flatten(multiindex)).show()
         [(0, 0, 0),
          (0, 0, 1),
          (0, 0, 2),

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -28,15 +28,15 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     calculations with it, such as
     [universal functions](https://docs.scipy.org/doc/numpy/reference/ufuncs.html).
 
-    For example, with an `array` like
+    For example, with
 
-        ak.Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        >>> array = ak.Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
     with a boolean selection of `good` elements like
 
         >>> good = (array % 2 == 1)
         >>> good
-        <Array [False, True, False, ... False, True] type='10 * bool'>
+        <Array [False, True, False, True, ..., True, False, True] type='10 * bool'>
 
     could be used to filter the original `array` (or another with the same
     length).
@@ -48,14 +48,14 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     where they were. If we instead use #ak.mask,
 
         >>> ak.mask(array, good)
-        <Array [None, 1, None, 3, ... None, 7, None, 9] type='10 * ?int64'>
+        <Array [None, 1, None, 3, None, 5, None, 7, None, 9] type='10 * ?int64'>
 
     this information and the length of the array is preserved, and it can be
     used in further calculations with the original `array` (or another with
     the same length).
 
         >>> ak.mask(array, good) + array
-        <Array [None, 2, None, 6, ... 14, None, 18] type='10 * ?int64'>
+        <Array [None, 2, None, 6, None, 10, None, 14, None, 18] type='10 * ?int64'>
 
     In particular, successive filters can be applied to the same array.
 
@@ -64,13 +64,13 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
         >>> array = ak.Array([[[0, 1, 2], [], [3, 4], [5]], [[6, 7, 8], [9]]])
         >>> good = (array % 2 == 1)
         >>> good
-        <Array [[[False, True, False], ... [True]]] type='2 * var * var * bool'>
+        <Array [[[False, True, False], ..., [True]], ...] type='2 * var * var * bool'>
 
     it can still be used with #ak.mask because the `array` and `mask`
     parameters are broadcasted.
 
         >>> ak.mask(array, good)
-        <Array [[[None, 1, None], ... None], [9]]] type='2 * var * var * ?int64'>
+        <Array [[[None, 1, None], [], ..., [5]], ...] type='2 * var * var * ?int64'>
 
     See #ak.broadcast_arrays for details about broadcasting and the generalized
     set of broadcasting rules.

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -52,14 +52,14 @@ def mean(
 
     For example, with an `array` like
 
-        ak.Array([[0, 1, 2, 3],
-                  [          ],
-                  [4, 5      ]])
+        >>> array = ak.Array([[0, 1, 2, 3],
+                              [          ],
+                              [4, 5      ]])
 
     The mean of the innermost lists is
 
         >>> ak.mean(array, axis=-1)
-        <Array [1.5, None, 4.5] type='3 * ?float64'>
+        <Array [1.5, nan, 4.5] type='3 * float64'>
 
     because there are three lists, the first has mean `1.5`, the second is
     empty, and the third has mean `4.5`.
@@ -67,7 +67,7 @@ def mean(
     The mean of the outermost lists is
 
         >>> ak.mean(array, axis=0)
-        <Array [2, 3, 2, 3] type='4 * ?float64'>
+        <Array [2, 3, 2, 3] type='4 * float64'>
 
     because the longest list has length 4, the mean of `0` and `4` is `2.0`,
     the mean of `1` and `5` is `3.0`, the mean of `2` (by itself) is `2.0`,

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -23,17 +23,15 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
 
     For instance, given the following doubly nested `array`,
 
-        ak.Array([[
-                   [1.1, 2.2, 3.3],
-                   [],
-                   [4.4, 5.5],
-                   [6.6]
-                  ],
-                  [],
-                  [
-                   [7.7],
-                   [8.8, 9.9]]
-                  ])
+        >>> array = ak.Array([[[1.1, 2.2, 3.3],
+        ...                    [],
+        ...                    [4.4, 5.5],
+        ...                    [6.6]
+        ...                   ],
+        ...                   [],
+        ...                   [[7.7],
+        ...                    [8.8, 9.9]]
+        ...                   ])
 
     The number of elements in `axis=1` is
 
@@ -63,7 +61,7 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
     To keep a placeholder (None) in each place we do not want to select,
     consider using #ak.mask instead of a #ak.Array.__getitem__.
 
-        >>> ak.mask(array, ak.num(array) > 0)[:, 0]
+        >>> array.mask[ak.num(array) > 0][:, 0]
         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
     """
     with ak._errors.OperationErrorContext(

--- a/src/awkward/operations/ak_packed.py
+++ b/src/awkward/operations/ak_packed.py
@@ -32,21 +32,26 @@ def packed(array, *, highlevel=True, behavior=None):
 
         >>> a = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
         >>> b = a[::-1]
-        >>> b
-        <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
         >>> b.layout
-        <ListArray>
-            <starts><Index64 i="[6 5 3 3 0]" offset="0" length="5" at="0x55e091c2b1f0"/></starts>
-            <stops><Index64 i="[10 6 5 3 3]" offset="0" length="5" at="0x55e091a6ce80"/></stops>
-            <content><NumpyArray format="l" shape="10" data="1 2 3 4 5 6 7 8 9 10" at="0x55e091c47260"/></content>
+        <ListArray len='5'>
+            <starts><Index dtype='int64' len='5'>
+                [6 5 3 3 0]
+            </Index></starts>
+            <stops><Index dtype='int64' len='5'>
+                [10  6  5  3  3]
+            </Index></stops>
+            <content><NumpyArray dtype='int64' len='10'>
+                [ 1  2  3  4  5  6  7  8  9 10]
+            </NumpyArray></content>
         </ListArray>
+
         >>> c = ak.packed(b)
-        >>> c
-        <Array [[7, 8, 9, 10], [6, ... [], [1, 2, 3]] type='5 * var * int64'>
         >>> c.layout
-        <ListOffsetArray>
-            <offsets><Index64 i="[0 4 5 7 7 10]" offset="0" length="6" at="0x55e091b077a0"/></offsets>
-            <content><NumpyArray format="l" shape="10" data="7 8 9 10 6 4 5 1 2 3" at="0x55e091d04d30"/></content>
+        <ListOffsetArray len='5'>
+            <offsets><Index dtype='int64' len='6'>[ 0  4  5  7  7 10]</Index></offsets>
+            <content><NumpyArray dtype='int64' len='10'>
+                [ 7  8  9 10  6  4  5  1  2  3]
+            </NumpyArray></content>
         </ListOffsetArray>
 
     Performing these operations will minimize the output size of data sent to

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -27,69 +27,40 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
 
     Increase the lengths of lists to a target length by adding None values.
 
-    Consider the following doubly nested `array`.
+    Consider the following
 
-        ak.Array([[
-                   [1.1, 2.2, 3.3],
-                   [],
-                   [4.4, 5.5],
-                   [6.6]],
-                  [],
-                  [
-                   [7.7],
-                   [8.8, 9.9]
-                  ]])
+        >>> array = ak.Array([[[1.1, 2.2, 3.3],
+        ...                    [],
+        ...                    [4.4, 5.5],
+        ...                    [6.6]],
+        ...                   [],
+        ...                   [[7.7],
+        ...                    [8.8, 9.9]
+        ...                   ]])
 
     At `axis=0`, this operation pads the whole array, adding None at the
     outermost level:
 
-        >>> ak.to_list(ak.pad_none(array, 5, axis=0))
-        [[
-          [1.1, 2.2, 3.3],
-          [],
-          [4.4, 5.5],
-          [6.6]],
+        >>> ak.pad_none(array, 5, axis=0).show()
+        [[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]],
          [],
-         [
-          [7.7],
-          [8.8, 9.9]
-         ],
+         [[7.7], [8.8, 9.9]],
          None,
          None]
 
     At `axis=1`, this operation pads the first nested level:
 
-        >>> ak.to_list(ak.pad_none(array, 3, axis=1))
-        [[
-          [1.1, 2.2, 3.3],
-          [],
-          [4.4, 5.5],
-          [6.6]
-         ],
-         [
-          None,
-          None,
-          None],
-         [
-          [7.7],
-          [8.8, 9.9],
-          None
-         ]]
+        >>> ak.pad_none(array, 3, axis=1).show()
+        [[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]],
+         [None, None, None],
+         [[7.7], [8.8, 9.9], None]]
 
     And so on for higher values of `axis`:
 
-        >>> ak.to_list(ak.pad_none(array, 2, axis=2))
-        [[
-          [1.1, 2.2, 3.3],
-          [None, None],
-          [4.4, 5.5],
-          [6.6, None]
-         ],
+        >>> ak.pad_none(array, 2, axis=2).show()
+        [[[1.1, 2.2, 3.3], [None, None], [4.4, 5.5], [6.6, None]],
          [],
-         [
-          [7.7, None],
-          [8.8, 9.9]
-         ]]
+         [[7.7, None], [8.8, 9.9]]]
 
     Note that the `clip` parameter not only determines whether the lengths are
     at least `target` or exactly `target`, it also determines the type of the
@@ -106,19 +77,19 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
     The difference between
 
         >>> ak.pad_none(array, 2, axis=2)
-        <Array [[[1.1, 2.2, 3.3], ... [8.8, 9.9]]] type='3 * var * var * ?float64'>
+        <Array [[[1.1, 2.2, 3.3], ..., [...]], ...] type='3 * var * var * ?float64'>
 
     and
 
         >>> ak.pad_none(array, 2, axis=2, clip=True)
-        <Array [[[1.1, 2.2], [None, ... [8.8, 9.9]]] type='3 * var * 2 * ?float64'>
+        <Array [[[1.1, 2.2], ..., [6.6, None]], ...] type='3 * var * 2 * ?float64'>
 
     is not just in the length of `[1.1, 2.2, 3.3]` vs `[1.1, 2.2]`, but also
     in the distinction between the following types.
 
-        >>> ak.type(ak.pad_none(array, 2, axis=2))
+        >>> ak.pad_none(array, 2, axis=2).type.show()
         3 * var * var * ?float64
-        >>> ak.type(ak.pad_none(array, 2, axis=2, clip=True))
+        >>> ak.pad_none(array, 2, axis=2, clip=True).type.show()
         3 * var *   2 * ?float64
     """
     with ak._errors.OperationErrorContext(

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -33,16 +33,16 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
     if all lists at a given dimension have the same length and no None values,
     but it generalizes to cases where they do not.
 
-    For example, with an `array` like
+    For example, with
 
-        ak.Array([[0, 1, 2, 3],
-                  [          ],
-                  [4, 5      ]])
+        >>> array = ak.Array([[0, 1, 2, 3],
+        ...                   [          ],
+        ...                   [4, 5      ]])
 
     The range of the innermost lists is
 
         >>> ak.ptp(array, axis=-1)
-        <Array [3, None, 1] type='3 * ?float64'>
+        <Array [3, None, 1] type='3 * ?int64'>
 
     because there are three lists, the first has a range of `3`, the second is
     `None` because the list is empty, and the third has a range of `1`. Similarly,

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -20,23 +20,29 @@ def ravel(array, *, highlevel=True, behavior=None):
 
     This is the equivalent of NumPy's `np.ravel` for Awkward Arrays.
 
-    Consider the following doubly nested `array`.
+    Consider the following:
 
-        ak.Array([[
-                   [1.1, 2.2, 3.3],
-                   [],
-                   [4.4, 5.5],
-                   [6.6]],
-                  [],
-                  [
-                   [7.7],
-                   [8.8, 9.9]
-                  ]])
+        >>> array = ak.Array([[[1.1, 2.2, 3.3],
+        ...                    [],
+        ...                    [4.4, 5.5],
+        ...                    [6.6]],
+        ...                   [],
+        ...                   [[7.7],
+        ...                    [8.8, 9.9]
+        ...                   ]])
 
     Ravelling the array produces a flat array
 
-        >>> print(ak.ravel(array))
-        [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]
+        >>> ak.ravel(array).show()
+        [1.1,
+         2.2,
+         3.3,
+         4.4,
+         5.5,
+         6.6,
+         7.7,
+         8.8,
+         9.9]
 
     Missing values are not eliminated by flattening. See #ak.flatten with
     `axis=None` for an equivalent function that eliminates the option type.

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -57,10 +57,10 @@ def run_lengths(array, *, highlevel=True, behavior=None):
         <Array [1, 1, 1, 2, 2, 3] type='6 * int64'>
         >>> ak.run_lengths(sorted.x)
         <Array [3, 2, 1] type='3 * int64'>
-        >>> ak.unflatten(sorted, ak.run_lengths(sorted.x)).tolist()
-        [[{'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}],
-         [{'x': 2, 'y': 2.2}, {'x': 2, 'y': 2.2}],
-         [{'x': 3, 'y': 3.3}]]
+        >>> ak.unflatten(sorted, ak.run_lengths(sorted.x)).show()
+        [[{x: 1, y: 1.1}, {x: 1, y: 1.1}, {x: 1, y: 1.1}],
+         [{x: 2, y: 2.2}, {x: 2, y: 2.2}],
+         [{x: 3, y: 3.3}]]
 
     Unlike a database "group by," this operation can be applied in bulk to many sublists
     (though the run lengths need to be fully flattened to be used as `counts` for
@@ -74,12 +74,9 @@ def run_lengths(array, *, highlevel=True, behavior=None):
         >>> ak.run_lengths(sorted.x)
         <Array [[2, 1], [1, 1, 1]] type='2 * var * int64'>
         >>> counts = ak.flatten(ak.run_lengths(sorted.x), axis=None)
-        >>> ak.unflatten(sorted, counts, axis=-1).tolist()
-        [[[{'x': 1, 'y': 1.1}, {'x': 1, 'y': 1.1}],
-          [{'x': 2, 'y': 2.2}]],
-         [[{'x': 1, 'y': 1.1}],
-          [{'x': 2, 'y': 2.2}],
-          [{'x': 3, 'y': 3.3}]]]
+        >>> ak.unflatten(sorted, counts, axis=-1).show()
+        [[[{x: 1, y: 1.1}, {x: 1, y: 1.1}], [{x: 2, y: 2.2}]],
+         [[{x: 1, y: 1.1}], [{x: 2, y: 2.2}], [{x: 3, y: 3.3}]]]
 
     See also #ak.num, #ak.argsort, #ak.unflatten.
     """

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -20,8 +20,15 @@ def singletons(array, *, highlevel=True, behavior=None):
     For example,
 
         >>> array = ak.Array([1.1, 2.2, None, 3.3, None, None, 4.4, 5.5])
-        >>> print(ak.singletons(array))
-        [[1.1], [2.2], [], [3.3], [], [], [4.4], [5.5]]
+        >>> ak.singletons(array).show()
+        [[1.1],
+         [2.2],
+         [],
+         [3.3],
+         [],
+         [],
+         [4.4],
+         [5.5]]
 
     See #ak.firsts to invert this function.
     """

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -37,10 +37,10 @@ def sum(
     For example, consider this `array`, in which all lists at a given dimension
     have the same length.
 
-        ak.Array([[ 0.1,  0.2,  0.3],
-                  [10.1, 10.2, 10.3],
-                  [20.1, 20.2, 20.3],
-                  [30.1, 30.2, 30.3]])
+        >>> array = ak.Array([[ 0.1,  0.2,  0.3],
+        ...                   [10.1, 10.2, 10.3],
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [30.1, 30.2, 30.3]])
 
     A sum over `axis=-1` combines the inner lists, leaving one value per
     outer list:
@@ -56,10 +56,10 @@ def sum(
 
     Now with some values missing,
 
-        ak.Array([[ 0.1,  0.2      ],
-                  [10.1            ],
-                  [20.1, 20.2, 20.3],
-                  [30.1, 30.2      ]])
+        >>> array = ak.Array([[ 0.1,  0.2      ],
+        ...                   [10.1            ],
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [30.1, 30.2      ]])
 
     The sum over `axis=-1` results in
 
@@ -90,10 +90,10 @@ def sum(
 
     The same is true if the values were None, rather than gaps:
 
-        ak.Array([[ 0.1,  0.2, None],
-                  [10.1, None, None],
-                  [20.1, 20.2, 20.3],
-                  [30.1, 30.2, None]])
+        >>> array = ak.Array([[ 0.1,  0.2, None],
+        ...                   [10.1, None, None],
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [30.1, 30.2, None]])
 
         >>> ak.sum(array, axis=-1)
         <Array [0.3, 10.1, 60.6, 60.3] type='4 * float64'>
@@ -103,10 +103,10 @@ def sum(
     However, the missing value placeholder, None, allows us to align the
     remaining data differently:
 
-        ak.Array([[None,  0.1,  0.2],
-                  [None, None, 10.1],
-                  [20.1, 20.2, 20.3],
-                  [None, 30.1, 30.2]])
+        >>> array = ak.Array([[None,  0.1,  0.2],
+        ...                   [None, None, 10.1],
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [None, 30.1, 30.2]])
 
     Now the `axis=-1` result is the same but the `axis=0` result has changed:
 
@@ -123,10 +123,10 @@ def sum(
 
     If, instead of missing numbers, we had missing lists,
 
-        ak.Array([[ 0.1,  0.2,  0.3],
-                  None,
-                  [20.1, 20.2, 20.3],
-                  [30.1, 30.2, 30.3]])
+        >>> array = ak.Array([[ 0.1,  0.2,  0.3],
+        ...                   None,
+        ...                   [20.1, 20.2, 20.3],
+        ...                   [30.1, 30.2, 30.3]])
 
     then the placeholder would pass through the `axis=-1` sum because summing
     over the inner dimension shouldn't change the length of the outer

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -100,8 +100,7 @@ def to_buffers(
         >>> length
         3
         >>> container
-        {'node0-offsets': array([0, 3, 3, 5], dtype=int64),
-         'node1-data': array([1, 2, 3, 4, 5])}
+        {'node0-offsets': array([0, 3, 3, 5]), 'node1-data': array([1, 2, 3, 4, 5])}
 
     which may be read back with
 

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -33,7 +33,7 @@ def to_categorical(array, *, highlevel=True, behavior=None):
         <Array [['one', 'two', 'three'], ..., [...]] type='3 * var * categorical[ty...'>
         >>> categorical.type.show()
         3 * var * categorical[type=string]
-        >>> categorical.tolist() == array.tolist()
+        >>> categorical.to_list() == array.to_list()
         True
         >>> ak.categories(categorical)
         <Array ['one', 'two', 'three'] type='3 * string'>
@@ -67,7 +67,7 @@ def to_categorical(array, *, highlevel=True, behavior=None):
             x: categorical[type=float64],
             y: categorical[type=string]
         }
-        >>> categorical_records.tolist() == records.tolist()
+        >>> categorical_records.to_list() == records.to_list()
         True
 
     The check for uniqueness is currently implemented in a Python loop, so

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -30,17 +30,17 @@ def to_categorical(array, *, highlevel=True, behavior=None):
         >>> array = ak.Array([["one", "two", "three"], [], ["three", "two"]])
         >>> categorical = ak.to_categorical(array)
         >>> categorical
-        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * categorical[type=str...'>
-        >>> ak.type(categorical)
+        <Array [['one', 'two', 'three'], ..., [...]] type='3 * var * categorical[ty...'>
+        >>> categorical.type.show()
         3 * var * categorical[type=string]
-        >>> ak.to_list(categorical) == ak.to_list(array)
+        >>> categorical.tolist() == array.tolist()
         True
         >>> ak.categories(categorical)
         <Array ['one', 'two', 'three'] type='3 * string'>
         >>> ak.is_categorical(categorical)
         True
         >>> ak.from_categorical(categorical)
-        <Array [['one', 'two', ... 'three', 'two']] type='3 * var * string'>
+        <Array [['one', 'two', 'three'], ..., ['three', ...]] type='3 * var * string'>
 
     This function descends through nested lists, but not into the fields of
     records, so records can be categories. To make categorical record
@@ -55,16 +55,19 @@ def to_categorical(array, *, highlevel=True, behavior=None):
         ...     {"x": 1.1, "y": "one"}
         ... ])
         >>> records
-        <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": float64, "y": string}'>
+            <Array [{x: 1.1, y: 'one'}, ..., {x: 1.1, ...}] type='5 * {x: float64, y: s...'>
         >>> categorical_records = ak.zip({
         ...     "x": ak.to_categorical(records["x"]),
         ...     "y": ak.to_categorical(records["y"]),
         ... })
         >>> categorical_records
         <Array [{x: 1.1, y: 'one'}, ... y: 'one'}] type='5 * {"x": categorical[type=floa...'>
-        >>> ak.type(categorical_records)
-        5 * {"x": categorical[type=float64], "y": categorical[type=string]}
-        >>> ak.to_list(categorical_records) == ak.to_list(records)
+        >>> categorical_records.type.show()
+        5 * {
+            x: categorical[type=float64],
+            y: categorical[type=string]
+        }
+        >>> categorical_records.tolist() == records.tolist()
         True
 
     The check for uniqueness is currently implemented in a Python loop, so

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -144,6 +144,13 @@ def to_parquet(
 
         >>> array1 = ak.Array([[1, 2, 3], [], [4, 5], [], [], [6, 7, 8, 9]])
         >>> ak.to_parquet(array1, "array1.parquet")
+        <pyarrow._parquet.FileMetaData object at 0x7f646c38ff40>
+          created_by: parquet-cpp-arrow version 9.0.0
+          num_columns: 1
+          num_rows: 6
+          num_row_groups: 1
+          format_version: 2.6
+          serialized_size: 0
 
     If the `array` does not contain records at top-level, the Arrow table will consist
     of one field whose name is `""` iff. `extensionarray` is False.

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -23,20 +23,26 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     Converts a variable-length axis into a regular one, if possible.
 
         >>> irregular = ak.from_iter(np.arange(2*3*5).reshape(2, 3, 5))
-        >>> print(irregular.type)
+        >>> irregular.type.show()
         2 * var * var * int64
-        >>> print(ak.to_regular(irregular).type)
+        >>> ak.to_regular(irregular).type.show()
         2 * 3 * var * int64
-        >>> print(ak.to_regular(irregular, axis=2).type)
+        >>> ak.to_regular(irregular, axis=2).type.show()
         2 * var * 5 * int64
-        >>> print(ak.to_regular(irregular, axis=-1).type)
+        >>> ak.to_regular(irregular, axis=-1).type.show()
         2 * var * 5 * int64
 
     But truly irregular data cannot be converted.
 
         >>> ak.to_regular(ak.Array([[1, 2, 3], [], [4, 5]]))
-        ValueError: in ListOffsetArray64, cannot convert to RegularArray because
-        subarray lengths are not regular
+        ValueError: while calling
+            ak.to_regular(
+                array = <Array [[1, 2, 3], [], [4, 5]] type='3 * var * int64'>
+                axis = 1
+                highlevel = True
+                behavior = None
+            )
+        Error details: cannot convert to RegularArray because subarray lengths are not regular
 
     See also #ak.from_regular.
     """

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -30,31 +30,41 @@ def type(array):
 
     For example,
 
-        ak.Array([[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [2, 2]}],
-                  [],
-                  [{"x": 3.3, "y": [3, 3, 3]}]])
+        >>> array = ak.Array([[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [2, 2]}],
+        ...                   [],
+        ...                   [{"x": 3.3, "y": [3, 3, 3]}]])
 
     has type
 
-        3 * var * {"x": float64, "y": var * int64}
+        >>> ak.type(array).show()
+        3 * var * {
+            x: float64,
+            y: var * int64
+        }
 
     but
 
-        ak.Array(np.arange(2*3*5).reshape(2, 3, 5))
+        >>> array = ak.Array(np.arange(2*3*5).reshape(2, 3, 5))
 
     has type
 
+        >>> ak.type(array).show()
         2 * 3 * 5 * int64
 
     Some cases, like heterogeneous data, require [extensions beyond the
     Datashape specification](https://github.com/blaze/datashape/issues/237).
     For example,
 
-        ak.Array([1, "two", [3, 3, 3]])
+        >>> array = ak.Array([1, "two", [3, 3, 3]])
 
     has type
 
-        3 * union[int64, string, var * int64]
+        >>> ak.type(array).show()
+        3 * union[
+            int64,
+            string,
+            var * int64
+        ]
 
     but "union" is not a Datashape type-constructor. (Its syntax is
     similar to existing type-constructors, so it's a plausible addition

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -37,7 +37,7 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
         >>> array
         <Array [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] type='10 * int64'>
         >>> ak.unflatten(array, counts)
-        <Array [[0, 1, 2], [], ... [5], [6, 7, 8, 9]] type='5 * var * int64'>
+        <Array [[0, 1, 2], [], [3, ...], [5], [6, 7, 8, 9]] type='5 * var * int64'>
 
     An inner dimension can be unflattened by setting the `axis` parameter, but
     operations like this constrain the `counts` more tightly.
@@ -45,16 +45,25 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     For example, we can subdivide an already divided list:
 
         >>> original = ak.Array([[1, 2, 3, 4], [], [5, 6, 7], [8, 9]])
-        >>> print(ak.unflatten(original, [2, 2, 1, 2, 1, 1], axis=1))
-        [[[1, 2], [3, 4]], [], [[5], [6, 7]], [[8], [9]]]
+        >>> ak.unflatten(original, [2, 2, 1, 2, 1, 1], axis=1).show()
+        [[[1, 2], [3, 4]],
+         [],
+         [[5], [6, 7]],
+         [[8], [9]]]
 
     But the counts have to add up to the lengths of those lists. We can't mix
     values from the first `[1, 2, 3, 4]` with values from the next `[5, 6, 7]`.
 
-        >>> print(ak.unflatten(original, [2, 1, 2, 2, 1, 1], axis=1))
-        Traceback (most recent call last):
-        ...
-        ValueError: structure imposed by 'counts' does not fit in the array at axis=1
+        >>> ak.unflatten(original, [2, 1, 2, 2, 1, 1], axis=1).show()
+        ValueError: while calling
+            ak.unflatten(
+                array = <Array [[1, 2, 3, 4], [], ..., [8, 9]] type='4 * var * int64'>
+                counts = [2, 1, 2, 2, 1, 1]
+                axis = 1
+                highlevel = True
+                behavior = None
+            )
+        Error details: structure imposed by 'counts' does not fit in the array or partition at axis=1
 
     Also note that new lists created by this function cannot cross partitions
     (which is only possible at `axis=0`, anyway).

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -37,13 +37,13 @@ def values_astype(array, to, *, highlevel=True, behavior=None):
 
         >>> array = ak.Array([1567416600000])
         >>> ak.values_astype(array, "datetime64[ms]")
-        <Array [2019-09-02T09:30:00.000] type='1 * datetime64'>
+        <Array [2019-09-02T09:30:00.000] type='1 * datetime64[ms]'>
 
     or
 
         >>> array = ak.Array([1567416600000])
         >>> ak.values_astype(array, np.dtype("M8[ms]"))
-        <Array [2019-09-02T09:30:00.000] type='1 * datetime64'>
+        <Array [2019-09-02T09:30:00.000] type='1 * datetime64[ms]['>
 
     See also #ak.strings_astype.
     """

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -56,36 +56,30 @@ def zip(
     Zipping them together using a dict creates a collection of records with
     the same nesting structure as `one` and `two`.
 
-        >>> ak.to_list(ak.zip({"x": one, "y": two}))
-        [
-         [{'x': 1.1, 'y': 'a'}, {'x': 2.2, 'y': 'b'}, {'x': 3.3, 'y': 'c'}],
+        >>> ak.zip({"x": one, "y": two}).show()
+        [[{x: 1.1, y: 'a'}, {x: 2.2, y: 'b'}, {x: 3.3, y: 'c'}],
          [],
-         [{'x': 4.4, 'y': 'd'}, {'x': 5.5, 'y': 'e'}],
-         [{'x': 6.6, 'y': 'f'}]
-        ]
+         [{x: 4.4, y: 'd'}, {x: 5.5, y: 'e'}],
+         [{x: 6.6, y: 'f'}]]
 
     Doing so with a list creates tuples, whose fields are not named.
 
-        >>> ak.to_list(ak.zip([one, two]))
-        [
-         [(1.1, 'a'), (2.2, 'b'), (3.3, 'c')],
+        >>> ak.zip([one, two]).show()
+        [[(1.1, 'a'), (2.2, 'b'), (3.3, 'c')],
          [],
          [(4.4, 'd'), (5.5, 'e')],
-         [(6.6, 'f')]
-        ]
+         [(6.6, 'f')]]
 
     Adding a third array with the same length as `one` and `two` but less
     internal structure is okay: it gets broadcasted to match the others.
     (See #ak.broadcast_arrays for broadcasting rules.)
 
         >>> three = ak.Array([100, 200, 300, 400])
-        >>> ak.to_list(ak.zip([one, two, three]))
-        [
-         [[(1.1, 97, 100)], [(2.2, 98, 100)], [(3.3, 99, 100)]],
+        >>> ak.zip([one, two, three]).show()
+        [[(1.1, 'a', 100), (2.2, 'b', 100), (3.3, 'c', 100)],
          [],
-         [[(4.4, 100, 300)], [(5.5, 101, 300)]],
-         [[(6.6, 102, 400)]]
-        ]
+         [(4.4, 'd', 300), (5.5, 'e', 300)],
+         [(6.6, 'f', 400)]]
 
     However, if arrays have the same depth but different lengths of nested
     lists, attempting to zip them together is a broadcasting error.
@@ -93,13 +87,24 @@ def zip(
         >>> one = ak.Array([[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]])
         >>> two = ak.Array([[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]])
         >>> ak.zip([one, two])
-        ValueError: in ListArray64, cannot broadcast nested list
+        ValueError: while calling
+            ak.zip(
+                arrays = [<Array [[[1, 2, 3], [], [4, ...], [6]], ...] type='3 * var ...
+                depth_limit = None
+                parameters = None
+                with_name = None
+                right_broadcast = False
+                optiontype_outside_record = False
+                highlevel = True
+                behavior = None
+            )
+        Error details: cannot broadcast nested list
 
     For this, one can set the `depth_limit` to prevent the operation from
     attempting to broadcast what can't be broadcasted.
 
-        >>> ak.to_list(ak.zip([one, two], depth_limit=1))
-        [([[1, 2, 3], [], [4, 5], [6]], [[1.1, 2.2], [3.3], [4.4], [5.5]]),
+        >>> ak.zip([one, two], depth_limit=1).show()
+        [([[1, 2, 3], [], [4, ...], [6]], [[1.1, ...], ...]),
          ([], []),
          ([[7, 8]], [[6.6]])]
 
@@ -215,8 +220,7 @@ def _impl(
                 x.purelist_depth == 1
                 or (
                     x.purelist_depth == 2
-                    and x.purelist_parameter("__array__")
-                    in ("string", "bytestring", "categorical")
+                    and x.purelist_parameter("__array__") in ("string", "bytestring")
                 )
                 for x in inputs
             )


### PR DESCRIPTION
This finishes the work started in #1946, commit dc0f91e1978ee3f364ed4b3c9abb5181798be99b.

All of the sample code in docstrings is being tested and modernized: `print` statements are being removed in favor of `show` and the output is being replaced with v2 output.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-modernize-highlevel-docstrings/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->