### PR TITLE
refactor: removed the 'ak._util.extra' argument helper.

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -441,18 +441,6 @@ def wrap(content, behavior=None, highlevel=True, like=None):
     return content
 
 
-def extra(args, kwargs, defaults):
-    out = []
-    for i, (name, default) in enumerate(defaults):
-        if i < len(args):
-            out.append(args[i])
-        elif name in kwargs:
-            out.append(kwargs[name])
-        else:
-            out.append(default)
-    return out
-
-
 def union_to_record(unionarray, anonymous):
     nplike = ak._nplikes.nplike_of(unionarray)
 

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -70,9 +70,12 @@ def broadcast_arrays(
             ak.broadcast_arrays(
                 arrays = (array([1, 2]), array([[ 0.1,  0.2,  0.3],
                [10. , 20....
-                depth_limit = None,
-                highlevel = True,
-                behavior = None,
+                depth_limit = None
+                broadcast_parameters_rule = 'one_to_one'
+                left_broadcast = True
+                right_broadcast = True
+                highlevel = True
+                behavior = None
             )
         Error details: cannot broadcast RegularArray of size 2 with RegularArray of size 3
 
@@ -145,9 +148,12 @@ def broadcast_arrays(
         ValueError: while calling
             ak.broadcast_arrays(
                 arrays = (<Array [[[1, 2, 3], [], [4, ...], [6]], ...] type='3 * var ...
-                depth_limit = None,
-                highlevel = True,
-                behavior = None,
+                depth_limit = None
+                broadcast_parameters_rule = 'one_to_one'
+                left_broadcast = True
+                right_broadcast = True
+                highlevel = True
+                behavior = None
             )
         Error details: cannot broadcast nested list
 

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -7,7 +7,7 @@ cpu = ak._backends.NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("where")
-def where(condition, *args, **kwargs):
+def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:
         condition: Array-like data (anything #ak.to_layout recognizes) of booleans.
@@ -38,10 +38,6 @@ def where(condition, *args, **kwargs):
     for all `i`. The structure of `x` and `y` do not need to be the same; if
     they are incompatible types, the output will have #ak.type.UnionType.
     """
-    mergebool, highlevel, behavior = ak._util.extra(
-        (), kwargs, [("mergebool", True), ("highlevel", True), ("behavior", None)]
-    )
-
     if len(args) == 0:
         with ak._errors.OperationErrorContext(
             "ak.where",


### PR DESCRIPTION
It was a vestige of Python 2: as you can see, we can express the keyword-only arguments after a `*arrays` without any trouble in Python 3. This is relevant because the documentation will be generated with more information now—these extra arguments and their defaults will appear in the HTML rendering of the function signatures.

Also, `ak.broadcast_arrays` was missing information about its `broadcast_parameters_rule` argument. Presumably, that was an oversight? (And it demonstrates the problem with `ak._util.extra`.)

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-remove-extra-argument-helper/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->