### PR TITLE
feat: ak.from_rdataframe should accept a single string 'columns'.

### DIFF
--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -8,10 +8,17 @@ def from_rdataframe(rdf, columns):
     Args:
         rdf (`ROOT.RDataFrame`): ROOT RDataFrame to convert into an
             Awkward Array.
-        columns (str or tuple of str): A column or multiple columns to be
+        columns (str or iterable of str): A column or multiple columns to be
             converted to Awkward Array.
 
-    Converts ROOT Data Frame columns into an Awkward Array.
+    Converts ROOT RDataFrame columns into an Awkward Array.
+
+    If `columns` is a string, the return value represents a single RDataFrame column.
+
+    If `columns` is any other iterable, the return value is a record array, in which
+    each field corresponds to an RDataFrame column. In particular, if the `columns`
+    iterable contains only one string, it is still a record array, which has only
+    one field.
 
     See also #ak.to_rdataframe.
     """
@@ -24,7 +31,26 @@ def from_rdataframe(rdf, columns):
 def _impl(data_frame, columns):
     import awkward._connect.rdataframe.from_rdataframe  # noqa: F401
 
-    return ak._connect.rdataframe.from_rdataframe.from_rdataframe(
+    if isinstance(columns, str):
+        columns = (columns,)
+        project = True
+    else:
+        columns = tuple(columns)
+        project = False
+
+    if not all(isinstance(x, str) for x in columns):
+        raise ak._errors.wrap_error(
+            TypeError(
+                f"'columns' must be a string or an iterable of strings, not {columns!r}"
+            )
+        )
+
+    out = ak._connect.rdataframe.from_rdataframe.from_rdataframe(
         data_frame,
         columns,
     )
+
+    if project:
+        return out[columns[0]]
+    else:
+        return out

--- a/tests/test_1473-from-rdataframe.py
+++ b/tests/test_1473-from-rdataframe.py
@@ -335,3 +335,18 @@ def test_to_from_data_frame_rvec_of_rvec_of_rvec():
     )
 
     assert ak_array_in.to_list() == ak_array_out["x"].to_list()
+
+
+def test_to_from_data_frame_columns_as_string():
+    ak_array_in = ak.Array(
+        [[[[1.1]]], [[[2.2], [3.3], [], [4.4]]], [[[], [5.5, 6.6], []]]]
+    )
+
+    data_frame = ak.to_rdataframe({"x": ak_array_in})
+
+    ak_array_out = ak.from_rdataframe(
+        data_frame,
+        columns="x",
+    )
+
+    assert ak_array_in.to_list() == ak_array_out.to_list()


### PR DESCRIPTION
This adds a guard, but it also introduces a way of calling `ak.from_rdataframe` (which was already partially in the documentation anyway).

It's to be expected that users will sometimes pass a single string into `columns`. When this happens, we could

  * raise an error to let them know that's wrong (it's already doing that, but the error message could be more clear)
  * turn a single string `x` into `(x,)`, squashing the distinction between a string and a length-1 tuple of strings
  * use the single string interface to mean "I want an Awkward Array _of_ a column" (what this function did before #1625) and the collection of strings (even if there's only one of them) to mean "I want an Awkward Array of multiple columns." The latter will always be a record array, and if the collection has only one string in it, the record array will have only one field in it.

In this PR, I opted for the third case. It seems to me to be the most useful one.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-from_rdataframe-should-accept-a-single-string/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->