### PR TITLE
fix: __array__ = 'sorted_map' should only be allowed on RecordArrays, not lists.

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -56,7 +56,6 @@ class Content:
             if not self.is_list and parameters.get("__array__") in (
                 "string",
                 "bytestring",
-                "sorted_map",
             ):
                 raise ak._errors.wrap_error(
                     TypeError(
@@ -76,6 +75,14 @@ class Content:
                     )
                 )
             if not self.is_indexed and parameters.get("__array__") == "categorical":
+                raise ak._errors.wrap_error(
+                    TypeError(
+                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                            type(self).__name__, parameters["__array__"]
+                        )
+                    )
+                )
+            if not self.is_record and parameters.get("__array__") == "sorted_map":
                 raise ak._errors.wrap_error(
                     TypeError(
                         '{} is not allowed to have parameters["__array__"] = "{}"'.format(


### PR DESCRIPTION
Oops: #1939 constrains `__array__ = 'sorted_map'` to be only allowed on list-types, when it is only allowed on record-types. There's no _implementation_ of sorted map behaviors yet, but Uproot produces them in anticipation.

This PR is necessary to fix Uproot. See the failure here ([raw logs](https://pipelines.actions.githubusercontent.com/serviceHosts/df871aa8-af7e-44b5-87e2-03f492c1b14d/_apis/pipelines/1/runs/2671/signedlogcontent/11?urlExpires=2022-12-06T01%3A56%3A49.9732796Z&urlSigningMethod=HMACV1&urlSignature=Bijv1gtbUt%2BekoBhGrpiN4ICPg6lHNNyEo7AmkAMHwU%3D)):

https://github.com/scikit-hep/uproot5/actions/runs/3625653080/jobs/6113923488

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-__array__-sorted_map-only-allowed-on-recordarray-not-lists/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->