### PR TITLE
fix!: always broadcast `with_field` assignments against existing array

### DIFF
--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import copy
-from collections.abc import Iterable
+from collections.abc import Sequence
 
 import awkward as ak
 
@@ -13,9 +13,9 @@ def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         what: Array-like data (anything #ak.to_layout recognizes) to add as a new field.
-        where (None or str or non-empy iterable of str): If None, the new field
+        where (None or str or non-empy sequence of str): If None, the new field
             has no name (can be accessed as an integer slot number in a
-            string); If str, the name of the new field. If iterable, it is
+            string); If str, the name of the new field. If a sequence, it is
             interpreted as a path where to add the field in a nested record.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
@@ -44,7 +44,11 @@ def _impl(base, what, where, highlevel, behavior):
     if not (
         where is None
         or isinstance(where, str)
-        or (isinstance(where, Iterable) and all(isinstance(x, str) for x in where))
+        or (
+            ak._util.is_non_string_iterable(where)
+            and isinstance(where, Sequence)
+            and all(isinstance(x, str) for x in where)
+        )
     ):
         raise ak._errors.wrap_error(
             TypeError(
@@ -53,15 +57,7 @@ def _impl(base, what, where, highlevel, behavior):
             )
         )
 
-    if not isinstance(where, str) and isinstance(where, Iterable):
-        where = list(where)
-
-    if (
-        not isinstance(where, str)
-        and isinstance(where, Iterable)
-        and all(isinstance(x, str) for x in where)
-        and len(where) > 1
-    ):
+    if ak._util.is_non_string_iterable(where) and len(where) > 1:
         return _impl(
             base,
             _impl(
@@ -76,8 +72,8 @@ def _impl(base, what, where, highlevel, behavior):
             behavior,
         )
     else:
-
-        if not (isinstance(where, str) or where is None):
+        # If we have an iterable here, pull out the only ti
+        if ak._util.is_non_string_iterable(where):
             where = where[0]
 
         behavior = ak._util.behavior_of(base, what, behavior=behavior)
@@ -94,54 +90,50 @@ def _impl(base, what, where, highlevel, behavior):
         if where in base.fields:
             keys.remove(where)
 
-        if len(keys) == 0:
-            # the only key was removed, so just create new Record
-            out = (
-                ak.contents.RecordArray([what], [where], parameters=base.parameters),
-            )
+        def action(inputs, **kwargs):
+            base, what = inputs
+            backend = base.backend
 
-        else:
-
-            def action(inputs, **kwargs):
-                base, what = inputs
-                backend = base.backend
-
-                if isinstance(base, ak.contents.RecordArray):
-                    if what is None:
-                        what = ak.contents.IndexedOptionArray(
-                            ak.index.Index64(
-                                backend.index_nplike.full(len(base), -1, np.int64),
-                                nplike=backend.index_nplike,
-                            ),
-                            ak.contents.EmptyArray(),
-                        )
-                    elif not isinstance(what, ak.contents.Content):
-                        what = ak.contents.NumpyArray(
-                            backend.nplike.repeat(what, len(base))
-                        )
-                    if base.is_tuple and where is None:
+            if isinstance(base, ak.contents.RecordArray):
+                if what is None:
+                    what = ak.contents.IndexedOptionArray(
+                        ak.index.Index64(
+                            backend.index_nplike.full(len(base), -1, np.int64),
+                            nplike=backend.index_nplike,
+                        ),
+                        ak.contents.EmptyArray(),
+                    )
+                elif not isinstance(what, ak.contents.Content):
+                    what = ak.contents.NumpyArray(
+                        backend.nplike.repeat(what, len(base))
+                    )
+                if base.is_tuple:
+                    # Preserve tuple-ness
+                    if where is None:
                         fields = None
-                    elif base.is_tuple:
-                        fields = keys + [where]
-                    elif where is None:
-                        fields = keys + [str(len(keys))]
+                    # Otherwise the tuple becomes a record
                     else:
                         fields = keys + [where]
-                    out = ak.contents.RecordArray(
-                        [base[k] for k in keys] + [what],
-                        fields,
-                        parameters=base.parameters,
-                    )
-                    return (out,)
+                # Records with `where=None` will create a tuple-like key
+                elif where is None:
+                    fields = keys + [str(len(keys))]
                 else:
-                    return None
+                    fields = keys + [where]
+                out = ak.contents.RecordArray(
+                    [base[k] for k in keys] + [what],
+                    fields,
+                    parameters=base.parameters,
+                )
+                return (out,)
+            else:
+                return None
 
-            out = ak._broadcasting.broadcast_and_apply(
-                [base, what],
-                action,
-                behavior,
-                right_broadcast=False,
-            )
+        out = ak._broadcasting.broadcast_and_apply(
+            [base, what],
+            action,
+            behavior,
+            right_broadcast=False,
+        )
 
         assert isinstance(out, tuple) and len(out) == 1
 

--- a/tests/test_1936-with-field-broadcasting.py
+++ b/tests/test_1936-with-field-broadcasting.py
@@ -1,0 +1,26 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_scalar():
+    array = ak.Array({"x": [1, 2, 3]})
+    array["x"] = 4
+    assert array.to_list() == [{"x": 4}, {"x": 4}, {"x": 4}]
+
+
+def test_array():
+    array = ak.Array({"x": [1, 2, 3]})
+    array["x"] = [4]
+    assert array.to_list() == [{"x": 4}, {"x": 4}, {"x": 4}]
+
+
+def test_where_non_sequence():
+    array = ak.Array({"x": [{"y": 1}, {"y": 2}, {"y": 3}]})
+    result = ak.with_field(array, 4, ("x", "y"))
+    assert result.to_list() == [{"x": {"y": 4}}, {"x": {"y": 4}}, {"x": {"y": 4}}]
+
+    with pytest.raises(TypeError, match=r"New fields may only be assigned "):
+        result = ak.with_field(array, 4, iter(("x", "y")))


### PR DESCRIPTION
This PR fixes #1936 by removing the branch in which no broadcasting takes place.

It also narrows the acceptable type of `where` from an `iterable` (of strings) to a `sequence`, 

### Note
This is a small change, but I want to justify it in the wider context of Awkward.

We currently do iterable→sequence conversion internally, and I don't think there's any benefit to accepting an iterable. My view is that unless you can naturally express an algorithm without consuming the iterable, then it's better just to accept sequences. 

If we wanted to retain the iterable type without converting the iterable to a sequence, then we'd need to do something like
```python
if ak._util.is_sized_iterable(where):
    tail = iter(where)
    head = next(tail)
    if not isinstance(head, str):
        raise ...    
```
There's no performance benefit for the user, or readability benefit for us.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-fix-item-assignment/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->