### PR TITLE
fix: add IPython as Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,6 @@ import os
 import json
 import datetime
 import runpy
-import sys
-import subprocess
 import pathlib
 
 # -- Project information -----------------------------------------------------
@@ -38,6 +36,8 @@ extensions = [
     # Preserve old links
     "sphinx_reredirects",
     "jupyterlite_sphinx",
+    'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,6 @@ sphinx-reredirects
 jupyterlite-sphinx
 ipyleaflet
 jupyterlite>=0.1.0b12
-ipython
 
 numpy>=1.13.1
 numba>=0.50.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ sphinx-reredirects
 jupyterlite-sphinx
 ipyleaflet
 jupyterlite>=0.1.0b12
+ipython
 
 numpy>=1.13.1
 numba>=0.50.0

--- a/docs/user-guide/how-to-convert-arrow.md
+++ b/docs/user-guide/how-to-convert-arrow.md
@@ -18,7 +18,7 @@ The [Apache Arrow](https://arrow.apache.org/) data format is very similar to Awk
 
 The [Apache Parquet](https://parquet.apache.org/) file format has strong connections to Arrow with a large overlap in available tools, and while it's also a columnar format like Awkward and Arrow, it is implemented in a different way, which emphasizes compact storage over random access.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import pyarrow as pa
 import pyarrow.csv
@@ -39,18 +39,18 @@ The argument to this function can be any of the following types from the pyarrow
 
 and they are converted into non-partitioned, non-virtual Awkward Arrays. (Any disjoint chunks in the Arrow array are concatenated.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_array = pa.array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
 pa_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_arrow(pa_array)
 ```
 
 Here is an example of an Arrow Table, derived from CSV. (Printing a table shows its field types.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 pokemon = urllib.request.urlopen(
     "https://gist.githubusercontent.com/armgilles/194bcff35001e7eb53a2a8b441e8b2c6/raw/92200bc0a673d5ce2110aaad4544ed6c4010f687/pokemon.csv"
 )
@@ -60,24 +60,24 @@ table
 
 Awkward Array doesn't make a deep distinction between "arrays" and "tables" the way Arrow does: the Awkward equivalent of an Arrow table is just an Awkward Array of record type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.from_arrow(table)
 array
 ```
 
 The Awkward equivalent of Arrow's schemas is {func}`ak.type`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(array[0])
 ```
 
 This array is ready for data analysis.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[array.Legendary].Attack - array[array.Legendary].Defense
 ```
 
@@ -90,29 +90,29 @@ The function for Awkward → Arrow conversion is {func}`ak.to_arrow`. This funct
 
 type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}]
 )
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_array = ak.to_arrow(ak_array)
 pa_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 type(pa_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 isinstance(pa_array, pa.lib.Array)
 ```
 
 If you need {class}`pyarrow.lib.RecordBatch`, you can build this using pyarrow:
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_batch = pa.RecordBatch.from_arrays(
     [
         ak.to_arrow(ak_array.x),
@@ -125,18 +125,18 @@ pa_batch
 
 If you need {class}`pyarrow.lib.Table`, you can build this using pyarrow:
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_table = pa.Table.from_batches([pa_batch])
 pa_table
 ```
 
 The columns of this Table are {class}`pa.lib.ChunkedArray` instances:
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_table[0]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_table[1]
 ```
 
@@ -153,14 +153,14 @@ When following those instructions, remember that {func}`ak.from_arrow` can accep
 
 For instance, when writing to an IPC stream, Arrow requires {class}`pyarrow.lib.RecordBatch`, so you need to build them:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}]
 )
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 first_batch = pa.RecordBatch.from_arrays(
     [
         ak.to_arrow(ak_array.x),
@@ -171,7 +171,7 @@ first_batch = pa.RecordBatch.from_arrays(
 first_batch.schema
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 sink = pa.BufferOutputStream()
 writer = pa.ipc.new_stream(sink, first_batch.schema)
 
@@ -191,18 +191,18 @@ for i in range(5):
 writer.close()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 bytes(sink.getvalue())
 ```
 
 But when reading them back, we can just pass the record batches (yielded by the {class}`pyarrow.lib.RecordBatchStreamReader` `reader`) to {func}`ak.from_arrow`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 reader = pa.ipc.open_stream(sink.getvalue())
 reader.schema
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 for batch in reader:
     print(repr(ak.from_arrow(batch)))
 ```
@@ -216,14 +216,14 @@ When following those instructions, remember that {func}`ak.from_arrow` can accep
 
 For instance, when writing to a Feather file, Arrow requires {class}`pyarrow.lib.Table`, so you need to build them:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}]
 )
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_batch = pa.RecordBatch.from_arrays(
     [
         ak.to_arrow(ak_array.x),
@@ -236,7 +236,7 @@ pa_table = pa.Table.from_batches([pa_batch])
 pa_table
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 import pyarrow.feather
 
 pyarrow.feather.write_feather(pa_table, "/tmp/example.feather")
@@ -244,16 +244,16 @@ pyarrow.feather.write_feather(pa_table, "/tmp/example.feather")
 
 But when reading them back, we can just pass the Arrow Table to {func}`ak.from_arrow`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 from_feather = pyarrow.feather.read_table("/tmp/example.feather")
 from_feather
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 type(from_feather)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_arrow(from_feather)
 ```
 
@@ -264,20 +264,20 @@ With data converted to and from Arrow, it can then be saved and loaded from Parq
 
 The {func}`ak.to_parquet` function writes Awkward Arrays as Parquet files. It has relatively few options.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}]
 )
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_parquet(ak_array, "/tmp/example.parquet")
 ```
 
 The {func}`ak.from_parquet` function reads Parquet files as Awkward Arrays, with quite a few more options. Basic usage just gives you the Awkward Array back.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_parquet("/tmp/example.parquet")
 ```
 
@@ -288,7 +288,7 @@ Since the data in a Parquet file may be huge, there are `columns` and `row_group
 
 For instance, the expression
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_parquet("/tmp/example.parquet", columns=["x"])
 ```
 

--- a/docs/user-guide/how-to-convert-buffers.md
+++ b/docs/user-guide/how-to-convert-buffers.md
@@ -16,7 +16,7 @@ Generic buffers
 
 Most of the conversion functions target a particular library: NumPy, Arrow, Pandas, or Python itself. As a catch-all for other storage formats, Awkward Arrays can be converted to and from sets of named buffers. The buffers are not (usually) intelligible on their own; the length of the array and a JSON document are needed to reconstitute the original structure. This section will demonstrate how an array-set can be used to store an Awkward Array in an HDF5 file, which ordinarily wouldn't be able to represent nested, irregular data structures.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 import h5py
@@ -28,7 +28,7 @@ From Awkward to buffers
 
 Consider the following complex array:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
@@ -41,7 +41,7 @@ ak_array
 
 The {func}`ak.to_buffers` function decomposes it into a set of one-dimensional arrays (a zero-copy operation).
 
-```{code-cell} python3
+```{code-cell} ipython3
 form, length, container = ak.to_buffers(ak_array)
 ```
 
@@ -55,19 +55,19 @@ The {class}`ak.forms.Form` is like an Awkward {class}`ak.types.Type` in that it 
 
 It is usually presented as JSON, and has a compact JSON format (when {meth}`ak.forms.Form.tojson` is invoked).
 
-```{code-cell} python3
+```{code-cell} ipython3
 form
 ```
 
 In this case, the `length` is just an integer. It would be a list of integers if `ak_array` was partitioned.
 
-```{code-cell} python3
+```{code-cell} ipython3
 length
 ```
 
 This `container` is a new dict, but it could have been a user-specified {class}`collections.abc.MutableMapping` if passed into {func}`ak.to_buffers` as an argument.
 
-```{code-cell} python3
+```{code-cell} ipython3
 container
 ```
 
@@ -76,7 +76,7 @@ From buffers to Awkward
 
 The function that reverses {func}`ak.to_buffers` is {func}`ak.from_buffers`. Its first three arguments are `form`, `length`, and `container`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_buffers(form, length, container)
 ```
 
@@ -87,7 +87,7 @@ The {func}`ak.to_buffers`/{func}`ak.from_buffers` functions exactly preserve an 
 
 Here is an example of an array in need of packing:
 
-```{code-cell} python3
+```{code-cell} ipython3
 unpacked = ak.Array(
     ak.contents.ListArray(
         ak.index.Index64(np.array([4, 10, 1])),
@@ -102,30 +102,30 @@ This {class}`ak.contents.ListArray` is in a strange order and the `999` values a
 
 The {func}`ak.to_buffers` function dutifully writes the `999` values into the output, even though they're not visible in the array.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_buffers(unpacked)
 ```
 
 If the intended purpose of calling {func}`ak.to_buffers` is to write to a file or send data over a network, this is wasted space. It can be trimmed by calling the {func}`ak.packed` function.
 
-```{code-cell} python3
+```{code-cell} ipython3
 packed = ak.packed(unpacked)
 packed
 ```
 
 At high-level, the array appears to be the same, but its low-level structure is quite different:
 
-```{code-cell} python3
+```{code-cell} ipython3
 unpacked.layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 packed.layout
 ```
 
 This version of the array is more concise when written with {func}`ak.to_buffers`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_buffers(packed)
 ```
 
@@ -134,7 +134,7 @@ Saving Awkward Arrays to HDF5
 
 The [h5py](https://www.h5py.org/) library presents each group in an HDF5 file as a {class}`collections.abc.MutableMapping`, which we can use as a container for an array-set. We must also save the `form` and `length` as metadata for the array to be retrievable.
 
-```{code-cell} python3
+```{code-cell} ipython3
 file = h5py.File("/tmp/example.hdf5", "w")
 group = file.create_group("awkward")
 group
@@ -142,34 +142,34 @@ group
 
 We can fill this `group` as a `container` by passing it in to {func}`ak.to_buffers`. (See the previous section for more on {func}`ak.packed`.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 form, length, container = ak.to_buffers(ak.packed(ak_array), container=group)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 container
 ```
 
 Now the HDF5 group has been filled with array pieces.
 
-```{code-cell} python3
+```{code-cell} ipython3
 container.keys()
 ```
 
 Here's one.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.asarray(container["node0-offsets"])
 ```
 
 Now we need to add the other information to the group as metadata. Since HDF5 accepts string-valued metadata, we can put it all in as JSON or numbers.
 
-```{code-cell} python3
+```{code-cell} ipython3
 group.attrs["form"] = form.to_json()
 group.attrs["form"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 group.attrs["length"] = json.dumps(length)  # JSON-encode it because it might be a list
 group.attrs["length"]
 ```
@@ -181,7 +181,7 @@ With that, we can reconstitute the array by supplying {func}`ak.from_buffers` th
 
 The group can't be used as a `container` as-is, since subscripting it returns {class}`h5py.Dataset` objects, rather than arrays.
 
-```{code-cell} python3
+```{code-cell} ipython3
 reconstituted = ak.from_buffers(
     ak.forms.from_json(group.attrs["form"]),
     json.loads(group.attrs["length"]),

--- a/docs/user-guide/how-to-convert-json.md
+++ b/docs/user-guide/how-to-convert-json.md
@@ -16,7 +16,7 @@ How to convert to/from JSON
 
 Any JSON data can be converted to Awkward Arrays and any Awkward Arrays can be converted to JSON. Awkward type information, such as the distinction between fixed-size and variable-length lists, is lost in the transformation to JSON, however.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import pathlib
 ```
@@ -28,23 +28,23 @@ The function for JSON → Awkward conversion is {func}`ak.from_json`.
 
 It can be given a JSON string:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_json("[[1.1, 2.2, 3.3], [], [4.4, 5.5]]")
 ```
 
 or a file name:
 
-```{code-cell} python3
+```{code-cell} ipython3
 !echo "[[1.1, 2.2, 3.3], [], [4.4, 5.5]]" > /tmp/awkward-example-1.json
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_json(pathlib.Path("/tmp/awkward-example-1.json"))
 ```
 
 If the dataset contains a single JSON object, an {class}`ak.Record` is returned, rather than an {class}`ak.Array`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_json('{"x": 1, "y": [1, 2], "z": "hello"}')
 ```
 
@@ -55,17 +55,17 @@ The function for Awkward → JSON conversion is {func}`ak.to_json`.
 
 With one argument, it returns a string.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_json(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
 ```
 
 But if a `destination` is given, it is taken to be a filename for output.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_json(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]), "/tmp/awkward-example-2.json")
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 !cat /tmp/awkward-example-2.json
 ```
 

--- a/docs/user-guide/how-to-convert-numpy.md
+++ b/docs/user-guide/how-to-convert-numpy.md
@@ -16,7 +16,7 @@ How to convert to/from NumPy
 
 As a generalization of NumPy, any NumPy array can be converted to an Awkward Array, but not vice-versa.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -26,19 +26,19 @@ From NumPy to Awkward
 
 The function for NumPy → Awkward conversion is {func}`ak.from_numpy`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_numpy(np_array)
 ak_array
 ```
 
 However, NumPy arrays are also recognized by the {class}`ak.Array` constructor, so you can use that unless your goal is to explicitly draw the reader's attention to the fact that the input is a NumPy array.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(np_array)
 ak_array
 ```
@@ -48,25 +48,25 @@ Fixed-size vs variable-length dimensions
 
 If the NumPy array is multidimensional, the Awkward Array will be as well.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([[100, 200], [101, 201], [103, 203]])
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(np_array)
 ak_array
 ```
 
 It's important to notice that the type is `3 * 2 * int64`, not `3 * var * int64`. The second dimension has a fixed size—it is guaranteed to have exactly two items—just like a NumPy array. This differs from an Awkward Array constructed from Python lists:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[100, 200], [101, 201], [103, 203]])
 ```
 
 or JSON:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array("[[100, 200], [101, 201], [103, 203]]")
 ```
 
@@ -79,35 +79,35 @@ From Awkward to NumPy
 
 The function for Awkward → NumPy conversion is {func}`ak.to_numpy`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
 ak_array = ak.Array(np_array)
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array)
 ```
 
 Awkward Arrays that happen to have regular structure can be converted to NumPy, even if their type is formally "variable length lists" (`var`):
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1, 2, 3], [4, 5, 6]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array)
 ```
 
 But if the lengths of nested lists do vary, attempts to convert to NumPy fail:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1, 2, 3], [], [4, 5]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 ak.to_numpy(ak_array)
@@ -117,7 +117,7 @@ One might argue that such arrays should become NumPy arrays with `dtype="O"`. Ho
 
 If you do want this, use {func}`ak.to_list` with the {class}`np.ndarray` constructor.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.array(ak.to_list(ak_array), dtype="O")
 ```
 
@@ -126,18 +126,18 @@ Implicit Awkward to NumPy conversion
 
 Awkward Arrays satisfy NumPy's `__array__` protocol, so simply passing an Awkward Array to the {class}`np.ndarray` constructor calls {func}`ak.to_numpy`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1, 2, 3], [4, 5, 6]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.array(ak_array)
 ```
 
 Libraries that expect NumPy arrays as input, such as Matplotlib, use this.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 
 plt.plot(ak_array);
@@ -145,12 +145,12 @@ plt.plot(ak_array);
 
 Implicit conversion to NumPy inherits the same restrictions as {func}`ak.to_numpy`, namely that variable-length lists cannot be converted to NumPy.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1, 2, 3], [], [4, 5]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 np.array(ak_array)
@@ -161,55 +161,55 @@ NumPy's structured arrays
 
 [NumPy's structured arrays](https://numpy.org/doc/stable/user/basics.rec.html) correspond to Awkward's "record type."
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array(
     [(1, 1.1), (2, 2.2), (3, 3.3), (4, 4.4), (5, 5.5)], dtype=[("x", int), ("y", float)]
 )
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_numpy(np_array)
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array)
 ```
 
 Awkward Arrays with record type can be sliced by field name like NumPy structured arrays:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array["x"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array["x"]
 ```
 
 But Awkward Arrays can be sliced by field name _and_ index within the same square brackets, whereas NumPy requires two sets of square brackets.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array["x", 2]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 np_array["x", 2]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array["x"][2]
 ```
 
 They have the same commutivity, however. In this example, slicing `"x"` and then `2` returns the same result as `2` and then `"x"`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array[2, "x"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array[2]["x"]
 ```
 
@@ -218,18 +218,18 @@ NumPy's masked arrays
 
 [NumPy's masked arrays](https://numpy.org/doc/stable/reference/maskedarray.generic.html) correspond to Awkward's "option type."
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.ma.MaskedArray(
     [[1, 2, 3], [4, 5, 6]], mask=[[False, True, False], [True, True, False]]
 )
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array.tolist()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_numpy(np_array)
 ak_array
 ```
@@ -238,17 +238,17 @@ The `?` before `int64` (expands to `option[...]` for more complex contents) refe
 
 It is possible for a dataset to have no missing data, yet still have option type, just as it's possible to have a NumPy masked array with no mask.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_numpy(np.ma.MaskedArray([[1, 2, 3], [4, 5, 6]], mask=False))
 ```
 
 Awkward Arrays with option type are converted to NumPy masked arrays.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array).tolist()
 ```
 
@@ -256,29 +256,29 @@ Note, however, that the structure of an Awkward Array's option type is not alway
 
 For example, an array of type `var * ?int64` can be converted into an identical NumPy structure:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array1 = ak.Array([[1, None, 3], [None, None, 6]])
 ak_array1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array1).tolist()
 ```
 
 But an array of type `option[var * int64]` must have its missing lists expanded into lists of missing numbers.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array2 = ak.Array([[1, 2, 3], None, [4, 5, 6]])
 ak_array2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak_array2).tolist()
 ```
 
 Finally, it is possible to prevent the {func}`ak.to_numpy` function from creating NumPy masked arrays by passing `allow_missing=False`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 ak.to_numpy(ak_array, allow_missing=False)
@@ -299,7 +299,7 @@ One reason you might want to use {func}`ak.from_numpy` directly is to control ho
 
 Inside of an {class}`ak.Array`, data structures are represented by "layout nodes" such as {class}`ak.contents.NumpyArray` and {class}`ak.contents.RegularArray`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]], dtype="i1")
 ak_array1 = ak.from_numpy(np_array)
 ak_array1.layout
@@ -307,7 +307,7 @@ ak_array1.layout
 
 In the above, the shape is represented as part of the {class}`ak.contents.NumpyArray` node, but it could also have been represented in {class}`ak.contents.RegularArray` nodes.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array2 = ak.from_numpy(np_array, regulararray=True)
 ak_array2.layout
 ```
@@ -316,19 +316,19 @@ In the above, the internal {class}`ak.contents.NumpyArray` is one-dimensional an
 
 This distinction is technical: `ak_array1` and `ak_array2` have the same {func}`ak.type` and behave identically (including broadcasting rules).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(ak_array1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(ak_array2)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array1 == ak_array2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.all(ak_array1 == ak_array2)
 ```
 
@@ -341,23 +341,23 @@ Advanced topic: unless you're willing to investigate subtleties of when a NumPy 
 
 Awkward Arrays are not supposed to be changed in place ("mutated"), and all of the functions in the Awkward Array library return new values, rather than changing the old. However, it is possible to create an Awkward Array from a NumPy array and modify the NumPy array in place, thus modifying the Awkward Array. Wherever possible, Awkward Arrays are _views_ of the NumPy data, not _copies_.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([[1, 2, 3], [4, 5, 6]])
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_numpy(np_array)
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Change the NumPy array in place.
 np_array *= 100
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # The Awkward Array changes as well.
 ak_array
 ```
@@ -366,58 +366,58 @@ You might want to do this in some performance-critical applications. However, no
 
 For example, if a NumPy array is not C-contiguous and is internally represented as a {class}`ak.contents.RegularArray` (see previous section), it must be copied.
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Slicing the inner dimension of this NumPy array makes it not C-contiguous.
 np_array = np.array([[1, 2, 3], [4, 5, 6]])
 np_array.flags["C_CONTIGUOUS"], np_array[:, :-1].flags["C_CONTIGUOUS"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 1: C-contiguous and not RegularArray (should view).
 ak_array1 = ak.from_numpy(np_array)
 ak_array1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 2: C-contiguous and RegularArray (should view).
 ak_array2 = ak.from_numpy(np_array, regulararray=True)
 ak_array2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 3: not C-contiguous and not RegularArray (should view).
 ak_array3 = ak.from_numpy(np_array[:, :-1])
 ak_array3
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 4: not C-contiguous and RegularArray (has to copy).
 ak_array4 = ak.from_numpy(np_array[:, :-1], regulararray=True)
 ak_array4
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Change the NumPy array in place.
 np_array *= 100
 np_array[:, :-1]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 1 changes as well because it is a view.
 ak_array1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 2 changes as well because it is a view.
 ak_array2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 3 changes as well because it is a view.
 ak_array3
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Case 4 does not change because it is a copy.
 ak_array4
 ```
@@ -435,46 +435,46 @@ Advanced topic: unless you're willing to investigate subtleties of when an Awkwa
 
 The considerations described above also apply to NumPy arrays created from Awkward Arrays. If possible, they are _views_, rather than _copies_, but these semantics are not guaranteed.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1, 2, 3], [4, 5, 6]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = ak.to_numpy(ak_array)
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Change the NumPy array in place.
 np_array *= 100
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # The Awkward Array that it came from is changed as well.
 ak_array
 ```
 
 As a counter-example, a NumPy array constructed from an Awkward Array with missing data _might not_ be a view. (It depends on the internal representation; the most common case of an {class}`ak.contents.IndexedOptionArray` is not.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array1 = ak.Array([[1, None, 3], [None, None, 6]])
 ak_array1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = ak.to_numpy(ak_array1)
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Change the NumPy array in place.
 np_array *= 100
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: []
 
 # The Awkward Array that it came from is not changed in this case.

--- a/docs/user-guide/how-to-convert-pandas.md
+++ b/docs/user-guide/how-to-convert-pandas.md
@@ -16,7 +16,7 @@ How to convert to Pandas
 
 [Pandas](https://pandas.pydata.org/) is a data analysis library for ordered time-series and relational data. In general, Pandas does not define operations for manipulating nested data structures, but in some cases, [MultiIndex/advanced indexing](https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html) can do equivalent things.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import pandas as pd
 import pyarrow as pa
@@ -37,7 +37,7 @@ From Awkward to Pandas
 
 The function for Awkward → Pandas conversion is {func}`ak.to_dataframe`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         {"x": 1.1, "y": 1, "z": "one"},
@@ -50,13 +50,13 @@ ak_array = ak.Array(
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array)
 ```
 
 Awkward record field names are converted into Pandas column names, even if nested within lists.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         [
@@ -71,7 +71,7 @@ ak_array = ak.Array(
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array)
 ```
 
@@ -79,7 +79,7 @@ In this case, we see that the `"x"`, `"y"`, and `"z"` fields are separate column
 
 Here is an example with three levels of depth:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         [[1.1, 2.2], [], [3.3]],
@@ -92,13 +92,13 @@ ak_array = ak.Array(
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array)
 ```
 
 And here is an example with nested records/hierarchical columns:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         {"I": {"a": _, "b": {"i": _}}, "II": {"x": {"y": {"z": _}}}}
@@ -108,13 +108,13 @@ ak_array = ak.Array(
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array)
 ```
 
 Although nested lists and records can be represented using Pandas's MultiIndex, different-length lists in the same data structure can only be translated without loss into multiple DataFrames. This is because a DataFrame can have only one MultiIndex, but lists of different lengths require different MultiIndexes.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         {"x": [], "y": [4.4, 3.3, 2.2, 1.1]},
@@ -131,19 +131,19 @@ To avoid losing any data, {func}`ak.to_dataframe` can be used with `how=None` (t
 
 In `how=None` mode, {func}`ak.to_dataframe` always returns a list (sometimes with only one item).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array, how=None)
 ```
 
 The default `how="inner"` combines the above into a single DataFrame using [pd.merge](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html). This operation is lossy.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array, how="inner")
 ```
 
 The value of `how` is passed to [pd.merge](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html), so outer joins are possible as well.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array, how="outer")
 ```
 
@@ -154,7 +154,7 @@ Since [Apache Arrow](https://arrow.apache.org/) can be converted to and from Awk
 
 As described in the tutorial on Arrow, the {func}`ak.to_arrow` function returns a {class}`pyarrow.lib.Arrow` object. Arrow's conversion to Pandas requires a {class}`pyarrow.lib.Table`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array(
     [
         [
@@ -169,14 +169,14 @@ ak_array = ak.Array(
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_array = ak.to_arrow(ak_array)
 pa_array
 ```
 
 We can build a Table manually, ensuring that we set `extensionarray=False`. The `extensionarray` flag is normally `True`, and enables Awkward to preserve metadata through Arrow transformations. However, tools like Arrow's Pandas conversion do not recognise Awkward's special extension type, so we must take care to provide Arrow with native types:
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_table = pa.Table.from_batches(
     [
         pa.RecordBatch.from_arrays(
@@ -192,13 +192,13 @@ pa_table = pa.Table.from_batches(
 pa_table
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pa_table.to_pandas()
 ```
 
 Note that this is different from the output of {func}`ak.to_pandas`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_dataframe(ak_array)
 ```
 
@@ -206,7 +206,7 @@ The Awkward → Arrow → Pandas route leaves the lists as nested data within ea
 
 Finally, the Pandas → Arrow → Awkward is currently the only means of turning Pandas DataFrames into Awkward Arrays.
 
-```{code-cell} python3
+```{code-cell} ipython3
 pokemon = urllib.request.urlopen(
     "https://gist.githubusercontent.com/armgilles/194bcff35001e7eb53a2a8b441e8b2c6/raw/92200bc0a673d5ce2110aaad4544ed6c4010f687/pokemon.csv"
 )
@@ -214,21 +214,21 @@ df = pd.read_csv(pokemon)
 df
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_arrow(pa.Table.from_pandas(df))
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(ak_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(ak_array[0])
 ```
 
 This array is ready for data analysis.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array[ak_array.Legendary].Attack - ak_array[ak_array.Legendary].Defense
 ```

--- a/docs/user-guide/how-to-convert-python.md
+++ b/docs/user-guide/how-to-convert-python.md
@@ -16,7 +16,7 @@ How to convert to/from Python objects
 
 Builtin Python objects like dicts and lists can be converted into Awkward Arrays, and all Awkward Arrays can be converted into Python objects. Awkward type information, such as the distinction between fixed-size and variable-length lists, is lost in the transformation to Python objects.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 import pandas as pd
@@ -27,12 +27,12 @@ From Python to Awkward
 
 The function for Python → Awkward conversion is {func}`ak.from_iter`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 py_objects = [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 py_objects
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.from_iter(py_objects)
 ak_array
 ```
@@ -43,11 +43,11 @@ Note that this should be considered a slow, memory-intensive function: not only 
 
 This is also the fallback operation of the {class}`ak.Array` and {class}`ak.Record` constructors. Usually, small examples are built by passing Python objects directly to these constructors.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Record({"x": 1, "y": [1.1, 2.2]})
 ```
 
@@ -56,21 +56,21 @@ From Awkward to Python
 
 The function for Awkward → Python conversion is {func}`ak.to_list`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(ak_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_record = ak.Record({"x": 1, "y": [1.1, 2.2]})
 ak_record
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(ak_record)
 ```
 
@@ -78,18 +78,18 @@ Note that this should be considered a slow, memory-intensive function, like {fun
 
 Awkward Arrays and Records have a `to_list` method. For small datasets (or a small slice of a dataset), this is a convenient way to get a quick view.
 
-```{code-cell} python3
+```{code-cell} ipython3
 x = ak.Array(np.arange(1000))
 y = ak.Array(np.tile(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]), 100))
 ak_array = ak.zip({"x": x, "y": y})
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array[100].to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array[100:110].to_list()
 ```
 
@@ -98,59 +98,59 @@ Pandas-style constructor
 
 As we have seen, the {class}`ak.Array`) constructor interprets an iterable argument as the data that it is meant to represent, as in:
 
-```{code-cell} python3
+```{code-cell} ipython3
 py_objects1 = [[1.1, 2.2, 3.3], [], [4.4, 5.5]]
 py_objects1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(py_objects1)
 ```
 
 But sometimes, you have several iterables that you want to use as columns of a table. The [Pandas DataFrame constructor](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) interprets a dict of iterables as columns:
 
-```{code-cell} python3
+```{code-cell} ipython3
 py_objects2 = ["one", "two", "three"]
 py_objects2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 pd.DataFrame({"x": py_objects1, "y": py_objects2})
 ```
 
 And so does the {class}`ak.Array` constructor:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array = ak.Array({"x": py_objects1, "y": py_objects2})
 ak_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(ak_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(ak_array)
 ```
 
 Note that this is the transpose of the way the data would be interpreted if it were in a list, rather than a dict. The `"x"` and `"y"` values are interpreted as being interleaved in each record. There is no potential for conflict between the {func}`ak.from_iter`-style and Pandas-style constructors because {func}`ak.from_iter` applied to a dict would always return an {class}`ak.Record`, rather than an {class}`ak.Array`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_record = ak.from_iter({"x": py_objects1, "y": py_objects2})
 ak_record
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(ak_record)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(ak_record)
 ```
 
 The {func}`ak.from_iter` function applied to a dict is also equivalent to the {class}`ak.Record` constructor.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Record({"x": py_objects1, "y": py_objects2})
 ```
 
@@ -161,27 +161,27 @@ Python `float`, `int`, and `bool` (so-called "primitive" types) are converted to
 
 All floating-point Awkward types are converted to Python's `float`, all integral Awkward types are converted to Python's `int`, and Awkward's boolean type is converted to Python's `bool`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, 3.3])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, 3.3]).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1, 2, 3, 4, 5])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1, 2, 3, 4, 5]).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([True, False, True, False, False])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([True, False, True, False, False]).to_list()
 ```
 
@@ -192,19 +192,19 @@ Python lists, as well as iterables other than dict, tuple, str, and bytes, are c
 
 Awkward's variable-length and fixed-size lists are converted into Python lists with {func}`ak.to_list`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1, 2, 3], [4, 5, 6]])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1, 2, 3], [4, 5, 6]]).to_list()
 ```
 
@@ -214,16 +214,16 @@ Advanced topic: the rest of this section may be skipped if you don't care about 
 
 Note that a NumPy array is an iterable, so {func}`ak.from_iter` iterates over it, constructing variable-length Awkward lists. By contrast, {func}`ak.from_numpy` casts the data (without iteration) into fixed-size Awkward lists.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([[100, 200], [101, 201], [103, 203]])
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_iter(np_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_numpy(np_array)
 ```
 
@@ -231,53 +231,53 @@ Note that the types differ: `var * int64` vs `2 * int64`. The {class}`ak.Array` 
 
 This can be particularly subtle when NumPy arrays are nested within iterables.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array = np.array([[100, 200], [101, 201], [103, 203]])
 np_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # This is a NumPy array: constructor uses ak.from_numpy to get an array of fixed-size lists.
 ak.Array(np_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 py_objects = [np.array([100, 200]), np.array([101, 201]), np.array([103, 203])]
 py_objects
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # This is a list that contains NumPy arrays: constructor uses ak.from_iter to get an array of variable-length lists.
 ak.Array(py_objects)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array_dtype_O = np.array([[100, 200], [101, 201], [103, 203]], dtype="O")
 np_array_dtype_O
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # This NumPy array has dtype="O", so it cannot be cast without iteration: constructor uses ak.from_iter.
 ak.Array(np_array_dtype_O)
 ```
 
 The logic behind this policy is that only NumPy arrays with `dtype != "O"` are guaranteed to have fixed-size contents. Other cases must have `var` type lists.
 
-```{code-cell} python3
+```{code-cell} ipython3
 py_objects = [np.array([1.1, 2.2, 3.3]), np.array([]), np.array([4.4, 5.5])]
 py_objects
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(py_objects)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np_array_dtype_O = np.array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], dtype="O")
 np_array_dtype_O
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(np_array_dtype_O)
 ```
 
@@ -286,19 +286,19 @@ Conversion of strings and bytestrings
 
 Python strings (type `str`) are converted to and from Awkward's UTF-8 encoded strings and Python bytestrings (type `bytes`) are converted to and from Awkward's unencoded bytestrings.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(["one", "two", "three", "four"])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(["one", "two", "three", "four"]).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([b"one", b"two", b"three", b"four"])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([b"one", b"two", b"three", b"four"]).to_list()
 ```
 
@@ -308,23 +308,23 @@ Advanced topic: the rest of this section may be skipped if you don't care about 
 
 Awkward's strings and bytestrings are not distinct types, but specializations of variable-length lists. Whereas a list might be internally represented by a {class}`ak.contents.ListArray` or a {class}`ak.contents.ListOffsetArray`,
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).layout
 ```
 
 Strings and bytestrings are just {class}`ak.contents.ListArray`s and {class}`ak.contents.ListOffsetArray`s of one-byte integers with special parameters:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(["one", "two", "three", "four"]).layout
 ```
 
 These parameters indicate that the arrays of strings should have special behaviors, such as equality-per-string, rather than equality-per-character.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1.1, 2.2], [], [3.3]]) == ak.Array([[1.1, 200], [], [3.3]])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(["one", "two", "three", "four"]) == ak.Array(
     ["one", "TWO", "thirty three", "four"]
 )
@@ -334,15 +334,15 @@ ak.Array(["one", "two", "three", "four"]) == ak.Array(
 
 Special behaviors for strings are implemented using the same {data}`ak.behavior` mechanism that you might use to give special behaviors to Arrays and Records.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.behavior["string"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.behavior["bytestring"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.behavior[np.equal, "string", "string"]
 ```
 
@@ -359,23 +359,23 @@ Python tuples are converted to and from Awkward's record type with unnamed field
 
 In the following example, the `"x"` field has type `int64` and the `"y"` field has type `var * int64`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_rec = ak.Array([{"x": 1, "y": [1, 2]}, {"x": 2, "y": []}])
 ak_array_rec
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_rec.to_list()
 ```
 
 Here is the corresponding example with tuples:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_tup = ak.Array([(1, [1, 2]), (2, [])])
 ak_array_tup
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_tup.to_list()
 ```
 
@@ -383,30 +383,30 @@ Both of these Awkward types, `{"x": int64, "y": var * int64}` and `(int64, var *
 
 Both can be extracted using strings between square brackets, though the strings must be `"0"` and `"1"` for the tuple.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_rec["y"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_rec["y", 1]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_tup["1"]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak_array_tup["1", 1]
 ```
 
 Note the difference in meaning between the `"1"` and the `1` in the above example. For safety, you may want to use {func}`ak.unzip`
 
-```{code-cell} python3
+```{code-cell} ipython3
 x, y = ak.unzip(ak_array_rec)
 y
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 slot0, slot1 = ak.unzip(ak_array_tup)
 slot1
 ```
@@ -415,25 +415,25 @@ That way, you can name the variables anything you like.
 
 If fields are missing from some records, the missing values are filled in with None (option type: more on that below).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([{"x": 1, "y": [1, 2]}, {"x": 2}])
 ```
 
 If some tuples have different lengths, the resulting Awkward Array is taken to be heterogeneous (union type: more on that below).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([(1, [1, 2]), (2,)])
 ```
 
 An Awkward Record is a scalar drawn from a record array, so an {class}`ak.Record` can be built from a single dict with string-valued keys.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Record({"x": 1, "y": [1, 2], "z": 3.3})
 ```
 
 The same is not true for tuples. The {class}`ak.Record` constructor expects named fields.
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 ak.Record((1, [1, 2], 3.3))
@@ -444,11 +444,11 @@ Missing values: Python None
 
 Python's None can appear anywhere in the structure parsed by {func}`ak.from_iter`. It makes all data at that level of nesting have option type and is represented in {func}`ak.to_list` as None.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, None, 3.3, None, 4.4])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, None, 3.3, None, 4.4]).to_list()
 ```
 
@@ -458,7 +458,7 @@ Advanced topic: the rest of this section describes the equivalence of missing re
 
 As described above, fields that are absent from some records but not others are filled in with None. As a consequence, conversions from Python to Awkward Array back to Python don't necessarily result in the original expression:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     [
         {"x": 1.1, "y": [1]},
@@ -470,7 +470,7 @@ ak.Array(
 
 This is a deliberate choice. It would have been possible to convert records with missing fields into arrays with union type (more on that below), for which {class}`ak.to_list` would result in the original expression,
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate(
     [
         ak.Array([{"x": 1.1, "y": [1]}]),
@@ -486,7 +486,7 @@ The memory use of union arrays scales with the number of different types, up to 
 
 Tuples of different lengths, on the other hand, are assumed to be different types because mistaking slot $i$ for slot $i + 1$ would create unions anyway.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     [
         (1.1, [1]),
@@ -505,37 +505,37 @@ Most Awkward operations are defined on union typed Arrays, but they're not gener
 
 The following example mixes numbers (`float64`) with lists (`var * int64`).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, [], [1], [1, 2], 3.3])
 ```
 
 The {func}`ak.to_list` function converts it back into a heterogeneous Python list.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1.1, 2.2, [], [1], [1, 2], 3.3]).to_list()
 ```
 
 Any types may be mixed: numbers and lists, lists and records, missing data, etc.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[1, 2, 3], {"x": 1, "y": 2}, None])
 ```
 
 One exception is that numerical data are merged without creating a union type: integers are expanded to floating point numbers.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1, 2, 3, 4, 5.5, 6.6, 7.7, 8, 9])
 ```
 
 But booleans are not merged with integers.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1, 2, 3, True, True, False, 4, 5])
 ```
 
 As described above, records with different sets of fields are presumed to be a single record type with missing values.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(
     ak.Array(
         [
@@ -549,7 +549,7 @@ ak.type(
 
 But tuples with different lengths are presumed to be distinct types.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(
     ak.Array(
         [

--- a/docs/user-guide/how-to-convert-rdataframe.md
+++ b/docs/user-guide/how-to-convert-rdataframe.md
@@ -16,7 +16,7 @@ How to convert to/from ROOT RDataFrame
 
 The [ROOT RDataFrame](https://root.cern.ch/doc/master/classROOT_1_1RDataFrame.html) is a declarative, parallel framework for data analysis and manipulation. `RDataFrame` reads columnar data via a data source. The transformations can be applied to the data to select rows and/or to define new columns, and to produce results: histograms, etc.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import ROOT
 ```
@@ -32,7 +32,7 @@ The argument to this function requires a dictionary: `{ <column name string> : <
 
 object.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array_x = ak.Array(
     [
         {"x": [1.1, 1.2, 1.3]},
@@ -48,13 +48,13 @@ array_z = ak.Array([[1.1], [2.1, 2.3, 2.4], [3.1], [4.1, 4.2, 4.3], [5.1]])
 
 The arrays given for each column have to be equal length:
 
-```{code-cell} python3
+```{code-cell} ipython3
 assert len(array_x) == len(array_y) == len(array_z)
 ```
 
 The dictionary key defines a column name in RDataFrame.
 
-```{code-cell} python3
+```{code-cell} ipython3
 df = ak.to_rdataframe({"x": array_x, "y": array_y, "z": array_z})
 ```
 
@@ -62,7 +62,7 @@ The {func} `ak.to_rdataframe` function presents a generated on demand Awkward Ar
 
 The column readers are generated based on the run-time type of the views. Here is a description of the `RDataFrame` columns:
 
-```{code-cell} python3
+```{code-cell} ipython3
 df.Describe().Print()
 ```
 
@@ -80,7 +80,7 @@ The function for `RDataFrame`  → Awkward conversion is {func}`ak.from_rdatafra
 
 type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.from_rdataframe(
     df,
     columns=(

--- a/docs/user-guide/how-to-create-arraybuilder.md
+++ b/docs/user-guide/how-to-create-arraybuilder.md
@@ -23,55 +23,55 @@ The biggest difference between an {class}`ak.ArrayBuilder` and an {class}`ak.Arr
 Appending
 ---------
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 ```
 
 When a builder is first created, it has zero length and unknown type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 builder
 ```
 
 Calling its `append` method adds data and also determines its type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append(1)
 builder
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append(2.2)
 builder
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append(3 + 1j)
 builder
 ```
 
 Note that this can include missing data by promoting to an {class}`option-type <ak.types.OptionType>`,
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append(None)
 builder
 ```
 
 and mix types by promoting to a {class}`union-type <ak.types.UnionType>`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append("five")
 builder
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.type.show()
 ```
 
 We've been using "`append`" because it is generic (it recognizes the types of its arguments and builds that), but there are also methods for building structure explicitly.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 builder.boolean(False)
 builder.integer(1)
@@ -82,7 +82,7 @@ builder.string("five")
 builder
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.type.show()
 ```
 
@@ -91,7 +91,7 @@ Snapshot
 
 To turn an {class}`ak.ArrayBuilder` into an {class}`ak.Array`, call `snapshot`. This is an inexpensive operation (may be done multiple times; the builder is unaffected).
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = builder.snapshot()
 array
 ```
@@ -111,7 +111,7 @@ The most useful of these create nested data structures:
 
 which switch into a mode that starts filling inside of a list, record, or tuple. For records and tuples, you additionally have to specify the `field` or `index` of the record or tuple (respectively).
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 builder.begin_list()
@@ -133,20 +133,20 @@ builder
 
 Appending after the `begin_list` puts data inside the list, rather than outside:
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.append(9.9)
 builder
 ```
 
 This `9.9` is outside of the lists, and hence the type is now "lists of numbers *or* numbers."
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder.type.show()
 ```
 
 Since `begin_list` and `end_list` are imperative, the nesting structure of an array can be determined by program flow:
 
-```{code-cell} python3
+```{code-cell} ipython3
 def arbitrary_nesting(builder, depth):
     if depth == 0:
         builder.append(1)
@@ -165,7 +165,7 @@ builder
 
 Often, you'll know the exact depth of nesting you want. The Python `with` statement can be used to restrict the generality (nd free you from having to remember to `end` what you `begin`).
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.list():
@@ -188,7 +188,7 @@ When using `begin_record`/`end_record` (or the equivalent `record` in the `with`
 
    * `field("fieldname")`: switches to fill a field with a given name (and returns the builder, for convenience).
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.record():
@@ -201,7 +201,7 @@ builder
 
 The record type can also be given a name.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.record("Point"):
@@ -214,7 +214,7 @@ builder
 
 This gives the resulting records a type named "`Point`", which might have specialized behaviors.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = builder.snapshot()
 array
 ```
@@ -224,7 +224,7 @@ Nested tuples
 
 The same is true for tuples, but the next field to fill is selected by "`index`" (integer), rather than "`field`" (string), and the tuple size has to be given up-front.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.tuple(3):
@@ -245,7 +245,7 @@ If the set of fields changes while collecting records, the builder algorithm cou
 
 By default, {class}`ak.ArrayBuilder` follows policy (1), but it can be made to follow policy (2) if the names of the records are different.
 
-```{code-cell} python3
+```{code-cell} ipython3
 policy1 = ak.ArrayBuilder()
 
 with policy1.record():
@@ -259,7 +259,7 @@ with policy1.record():
 policy1.type.show()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 policy2 = ak.ArrayBuilder()
 
 with policy2.record("First"):
@@ -278,16 +278,16 @@ Comments on union-type
 
 Although it's easy to make {class}`union-type <ak.types.UnionType>` data with {class}`ak.ArrayBuilder`, the applications of union-type data are more limited. For instance, we can select a field that belongs to _all_ types of the union, but not any fields that don't share that field.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array2 = policy2.snapshot()
 array2
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array2.y
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 array2.x
@@ -295,16 +295,16 @@ array2.x
 
 The above would be no problem for records collected using policy 1 (see previous section).
 
-```{code-cell} python3
+```{code-cell} ipython3
 array1 = policy1.snapshot()
 array1
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array1.y
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array1.x
 ```
 
@@ -325,7 +325,7 @@ There are a few limitations, though:
 
 Therefore, a common pattern is:
 
-```{code-cell} python3
+```{code-cell} ipython3
 import numba as nb
 
 
@@ -353,7 +353,7 @@ Setting the type of empty lists
 -------------------------------
 In addition to supporting type-discovery at execution time, {class}`ak.ArrayBuilder` also makes it convenient to work with complex, ragged arrays when the type is known ahead of time. Although it is not the most performant means of constructing an array whose type is already known, it provides a readable abstraction in the event that building the array is not a limiting factor for performance. However, due to this "on-line" type-discovery, it is possible that for certain data the result of {meth}`ak.ArrayBuilder.snapshot` will have different types. Consider this function that builds an array from the contents of some iterable:
 
-```{code-cell} python3
+```{code-cell} ipython3
 def process_data(builder, data):
     for item in data:
         if item < 0:
@@ -365,7 +365,7 @@ def process_data(builder, data):
 
 If we pass in only positive integers, the result is an array of integers:
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [1, 2, 3, 4],
@@ -374,7 +374,7 @@ process_data(
 
 If we pass in only negative integers, the result is an array of `None`s with an unknown type:
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [-1, -2, -3, -4],
@@ -383,7 +383,7 @@ process_data(
 
 It is only if we pass in a mix of these values that we see the "full" array type:
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [1, 2, 3, 4, -1, -2, -3, -4],
@@ -392,7 +392,7 @@ process_data(
 
 A simple way to solve this problem is to explore all code branches explicitly, and remove the generated entry(ies) from the final array:
 
-```{code-cell} python3
+```{code-cell} ipython3
 def process_data(builder, data):
     for item in data:
         if item < 0:
@@ -408,21 +408,21 @@ def process_data(builder, data):
 
 The previous examples now have the same type:
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [1, 2, 3, 4],
 )
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [-1, -2, -3, -4],
 )
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 process_data(
     ak.ArrayBuilder(),
     [1, 2, 3, 4, -1, -2, -3, -4],

--- a/docs/user-guide/how-to-create-constructors.md
+++ b/docs/user-guide/how-to-create-constructors.md
@@ -18,12 +18,12 @@ If you're willing to think about your data in a columnar way, directly construct
 
 "Thinking about data in a columnar way" is the crucial difference between this method and [using ArrayBuilder](how-to-create-arraybuilder.md). The builder method lets you think about a data structure the way you would think about Python objects, in which all fields of a given record or elements of a list are "together" and one record or list is "separate" from another record or list. For example,
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.list():
@@ -62,7 +62,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.to_list()
 ```
 
@@ -70,7 +70,7 @@ gets all of the items in the first list separately from the items in the second 
 
 By contrast, the physical data are laid out in columns, with all _x_ values next to each other, regardless of which records or lists they're in, and all the _y_ values next to each other in another buffer.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.layout
 ```
 
@@ -126,17 +126,17 @@ Content >: EmptyArray
 
 EmptyArray is a trivial node type: it can only represent empty arrays with unknown type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.EmptyArray()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(ak.contents.EmptyArray())
 ```
 
 Since this is such a simple node type, let's use it to show examples of adding parameters.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.EmptyArray(
     parameters={"name1": "value1", "name2": {"more": ["complex", "value"]}}
 )
@@ -149,19 +149,19 @@ Content >: NumpyArray
 
 NumpyArray represents data the same way as a NumPy [np.ndarray](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html). That is, it can be multidimensional, but only rectilinear arrays.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.NumpyArray(np.array([[1, 2, 3], [4, 5, 6]], np.int16))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])[::2])
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.contents.NumpyArray(np.array([[1, 2, 3], [4, 5, 6]], np.int16)[:, 1:])
 ```
 
@@ -169,13 +169,13 @@ In most array structures, the NumpyArrays only need to be 1-dimensional, since r
 
 The {class}`ak.from_numpy` function has a `regulararray` argument to choose between putting multiple dimensions into the NumpyArray node or nesting a 1-dimensional NumpyArray in RegularArray nodes.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_numpy(
     np.array([[1, 2, 3], [4, 5, 6]], np.int16), regulararray=False, highlevel=False
 )
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.from_numpy(
     np.array([[1, 2, 3], [4, 5, 6]], np.int16), regulararray=True, highlevel=False
 )
@@ -183,11 +183,11 @@ ak.from_numpy(
 
 All of these representations look the same in an {class}`ak.Array` (high-level view).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(ak.contents.NumpyArray(np.array([[1, 2, 3], [4, 5, 6]])))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.RegularArray(ak.contents.NumpyArray(np.array([1, 2, 3, 4, 5, 6])), 3)
 )
@@ -202,7 +202,7 @@ Content >: RegularArray
 
 {class}`ak.contents.RegularArray` represents regular-length lists (lists with all the same length). This was shown above as being equivalent to dimensions in a {class}`ak.contents.NumpyArray`, but it can also contain irregular data.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RegularArray(
     ak.from_iter([1, 2, 3, 4, 5, 6], highlevel=False),
     3,
@@ -210,11 +210,11 @@ layout = ak.contents.RegularArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RegularArray(
     ak.from_iter(
         [[], [1], [1, 2], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]], highlevel=False
@@ -224,7 +224,7 @@ layout = ak.contents.RegularArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -236,7 +236,7 @@ The "`var *`" is the type of variable-length lists, nested inside of the Regular
 
 RegularArray is the first array type that can have unreachable data: the length of its nested content might not evenly divide the RegularArray's regular `size`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.RegularArray(
         ak.contents.NumpyArray(np.array([1, 2, 3, 4, 5, 6, 7])),
@@ -254,7 +254,7 @@ Content >: ListArray
 
 {class}`ak.contents.ListArray` and {class}`ak.contents.ListOffsetArray` are the two node types that describe variable-length lists ({class}`ak.types.ListType`, represented in type strings as "`var *`"). {class}`ak.contents.ListArray` is the most general. It takes two Indexes, `starts` and `stops`, which indicate where each nested list starts and stops.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.ListArray(
     ak.index.Index64(np.array([0, 3, 3])),
     ak.index.Index64(np.array([3, 3, 5])),
@@ -263,7 +263,7 @@ layout = ak.contents.ListArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -283,7 +283,7 @@ stops  = offsets[1:]
 
 for a single array `offsets`. If we were only representing arrays and not doing computations on them, we would always use ListOffsetArrays, because they are the most compact. Knowing that a node is a ListOffsetArray can also simplify the implementation of some operations. In a sense, operations that produce ListArrays (previous section) can be thought of as delaying the part of the operation that would propagate down into the `content`, as an optimization.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.ListOffsetArray(
     ak.index.Index64(np.array([0, 3, 3, 5])),
     ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
@@ -291,7 +291,7 @@ layout = ak.contents.ListOffsetArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -299,7 +299,7 @@ The length of the `offsets` array is one larger than the length of the array its
 
 However, the `offsets` does not need to start at `0` or stop at `len(content)`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([1, 3, 3, 4])),
@@ -319,7 +319,7 @@ As with all non-leaf Content nodes, arbitrarily deep nested lists can be built b
 
 For example, here is an array of 5 lists, whose length is approximately 20 each.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.ListOffsetArray(
     ak.index.Index64(np.array([0, 18, 42, 59, 83, 100])),
     ak.contents.NumpyArray(np.arange(100)),
@@ -330,7 +330,7 @@ array[0], array[1], array[2], array[3], array[4]
 
 Making an array of 3 lists that contains these 5 lists requires us to make indexes that go up to 5, not 100.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 3, 5])),
@@ -358,7 +358,7 @@ The {class}`ak.contents.NumpyArray` must be directly nested within the list-type
 
 Here is an example of a raw bytestring:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 8, 11, 15])),
@@ -392,7 +392,7 @@ ak.Array(
 
 And here is an example of a Unicode-encoded string (UTF-8):
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 12, 15, 19])),
@@ -430,7 +430,7 @@ ak.Array(
 
 As with any other lists, strings can be nested within lists. Only the {class}`ak.contents.RegularArray`/{class}`ak.contents.ListArray`/{class}`ak.contents.ListOffsetArray` corresponding to the strings should have the `"__array__": "string"` or `"bytestring"` parameter.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.ListOffsetArray(
         ak.index.Index64([0, 2, 4]),
@@ -480,7 +480,7 @@ RecordArrays have no {class}`ak.index.Index`-valued properties; they may be thou
 
 RecordArray fields are ordered and provided as an ordered list of `contents` and field names (the `recordlookup`).
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RecordArray(
     [
         ak.from_iter([1.1, 2.2, 3.3, 4.4, 5.5], highlevel=False),
@@ -494,17 +494,17 @@ layout = ak.contents.RecordArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(layout)
 ```
 
 RecordArray fields do not need to have names. If the `recordlookup` is `None`, the RecordArray is interpreted as an array of tuples. (The word "tuple," in statically typed environments, usually means a fixed-length type in which each element may be a different type.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RecordArray(
     [
         ak.from_iter([1.1, 2.2, 3.3, 4.4, 5.5], highlevel=False),
@@ -515,17 +515,17 @@ layout = ak.contents.RecordArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(layout)
 ```
 
 Since the RecordArray node holds an array for each of its fields, it is possible for these arrays to have different lengths. In such a case, the length of the RecordArray can be given explicitly or it is taken to be the length of the shortest field-array.
 
-```{code-cell} python3
+```{code-cell} ipython3
 content0 = ak.contents.NumpyArray(np.array([1, 2, 3, 4, 5, 6, 7, 8]))
 content1 = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
 content2 = ak.from_iter(
@@ -537,7 +537,7 @@ layout = ak.contents.RecordArray([content0, content1, content2], ["x", "y", "z"]
 print(f"{len(layout) = }")
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RecordArray(
     [content0, content1, content2], ["x", "y", "z"], length=3
 )
@@ -546,11 +546,11 @@ print(f"{len(layout) = }")
 
 RecordArrays are also allowed to have zero fields. This is an unusual case, but it is one that allows a RecordArray to be a leaf node (like {class}`ak.contents.EmptyArray` and {class}`ak.contents.NumpyArray`). If a RecordArray has no fields, a length _must_ be given.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(ak.contents.RecordArray([], [], length=5))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(ak.contents.RecordArray([], None, length=5))
 ```
 
@@ -559,7 +559,7 @@ Scalar Records
 
 An {class}`ak.contents.RecordArray` is an _array_ of records. Just as you can extract a scalar number from an array of numbers, you can extract a scalar record. Unlike numbers, records may still be sliced in some ways like Awkward Arrays:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     ak.contents.RecordArray(
         [
@@ -576,7 +576,7 @@ record = array[2]
 record
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 record["y", -1]
 ```
 
@@ -584,13 +584,13 @@ Therefore, we need an {class}`ak.record.Record` type, but this Record is not an 
 
 Due to the columnar orientation of Awkward Array, a RecordArray does not contain Records, a Record contains a RecordArray.
 
-```{code-cell} python3
+```{code-cell} ipython3
 record.layout
 ```
 
 It can be built by passing a RecordArray as its first argument and the item of interest in its second argument.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.record.Record(
     ak.contents.RecordArray(
         [
@@ -615,7 +615,7 @@ The records discussed so far are generic. Naming a record not only makes it easi
 
 A name is given to an {class}`ak.contents.RecordArray` node through its "`__record__`" parameter.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.RecordArray(
     [
         ak.from_iter([1.1, 2.2, 3.3, 4.4, 5.5], highlevel=False),
@@ -630,23 +630,23 @@ layout = ak.contents.RecordArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(layout)
 ```
 
 Behavioral overloads are presented in more depth in {data}`ak.behavior`, but here are three examples:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.behavior[np.sqrt, "Special"] = lambda special: np.sqrt(special.x)
 
 np.sqrt(ak.Array(layout))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 class SpecialRecord(ak.Record):
     def len_y(self):
         return len(self.y)
@@ -657,7 +657,7 @@ ak.behavior["Special"] = SpecialRecord
 ak.Record(layout[2]).len_y()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 class SpecialArray(ak.Array):
     def len_y(self):
         return ak.num(self.y)
@@ -673,7 +673,7 @@ Content >: IndexedArray
 
 {class}`ak.contents.IndexedArray` is the only Content node that has exactly the same type as its `content`. An IndexedArray rearranges the elements of its `content`, as though it were a lazily applied array-slice.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.IndexedArray(
     ak.index.Index64(np.array([2, 0, 0, 1, 2])),
     ak.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3])),
@@ -681,7 +681,7 @@ layout = ak.contents.IndexedArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -691,7 +691,7 @@ IndexedArrays are used as an optimization when performing some operations on {cl
 
 For example, slicing the following `recordarray` by `[3, 2, 4, 4, 1, 0, 3]` does not affect any of the RecordArray's fields.
 
-```{code-cell} python3
+```{code-cell} ipython3
 recordarray = ak.contents.RecordArray(
     [
         ak.from_iter([1.1, 2.2, 3.3, 4.4, 5.5], highlevel=False),
@@ -702,7 +702,7 @@ recordarray = ak.contents.RecordArray(
 recordarray
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 recordarray[[3, 2, 4, 4, 1, 0, 3]]
 ```
 
@@ -711,7 +711,7 @@ Categorical data
 
 IndexedArrays, with the `"__array__": "categorical"` parameter, can represent categorical data (sometimes called dictionary-encoding).
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.IndexedArray(
     ak.index.Index64(np.array([2, 2, 1, 4, 0, 5, 3, 3, 0, 1])),
     ak.from_iter(["zero", "one", "two", "three", "four", "five"], highlevel=False),
@@ -735,7 +735,7 @@ Content >: IndexedOptionArray
 
 {class}`ak.contents.IndexedOptionArray` is an {class}`ak.contents.IndexedArray` in which negative values in the `index` are interpreted as missing. Since it has an `index`, the `content` does not need to have "dummy values" at each index of a missing value. It is therefore more compact for record-type data with many missing values, but {class}`ak.contents.ByteMaskedArray` and especially {class}`ak.contents.BitMaskedArray` are more compact for numerical data or data without many missing values.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.IndexedOptionArray(
     ak.index.Index64(np.array([2, -1, 0, -1, -1, 1, 2])),
     ak.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3])),
@@ -743,7 +743,7 @@ layout = ak.contents.IndexedOptionArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -758,7 +758,7 @@ Content >: ByteMaskedArray
 
 {class}`ak.contents.ByteMaskedArray` is most similar to NumPy's [masked arrays](https://numpy.org/doc/stable/reference/maskedarray.html), except that Awkward ByteMaskedArrays can contain any data type and variable-length structures. The `valid_when` parameter lets you choose whether `True` means an element is valid (not masked/not `None`) or `False` means an element is valid.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.ByteMaskedArray(
     ak.index.Index8(np.array([False, False, True, True, False, True, False], np.int8)),
     ak.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
@@ -767,7 +767,7 @@ layout = ak.contents.ByteMaskedArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
@@ -780,7 +780,7 @@ Content >: BitMaskedArray
 
 Since bits always come in groups of at least 8, an explicit `length` must be supplied to the constructor. Also, `lsb_order=True` or `False` determines whether the bytes are interpreted [least-significant bit](https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit) first or [most-significant bit](https://en.wikipedia.org/wiki/Bit_numbering#Most_significant_bit) first, respectively.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.BitMaskedArray(
     ak.index.IndexU8(
         np.packbits(np.array([False, False, True, True, False, True, False], np.uint8))
@@ -793,13 +793,13 @@ layout = ak.contents.BitMaskedArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
 Changing only the `lsb_order` changes the interpretation in important ways!
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     ak.contents.BitMaskedArray(
         layout.mask,
@@ -816,20 +816,20 @@ Content >: UnmaskedArray
 
 {class}`ak.contents.UnmaskedArray` describes formally missing data, but in a case in which no data are actually missing. It is a corner case of the four nodes that allow for missing data ({class}`ak.contents.IndexedOptionArray`, {class}`ak.contents.ByteMaskedArray`, {class}`ak.contents.BitMaskedArray`, and {class}`ak.contents.UnmaskedArray`). Missing data is also known as "[option type](https://en.wikipedia.org/wiki/Option_type)" (denoted by a question mark `?` or the word `option` in type strings).
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.UnmaskedArray(
     ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
 )
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(layout)
 ```
 
 The only distinguishing feature of an UnmaskedArray is the question mark `?` or `option` in its type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.type(layout)
 ```
 
@@ -850,7 +850,7 @@ Although the ability to make arrays with mixed data type is very expressive, not
 
 Awkward Array's UnionArray is equivalent to Apache Arrow's [dense union](https://arrow.apache.org/docs/format/Columnar.html#dense-union). Awkward Array has no counterpart for Apache Arrow's [sparse union](https://arrow.apache.org/docs/format/Columnar.html#sparse-union) (which has no `index`). {func}`ak.from_arrow` generates an `index` on demand when reading sparse union from Arrow.
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.UnionArray(
     ak.index.Index8(np.array([0, 1, 2, 0, 0, 1, 1, 2, 2, 0], np.int8)),
     ak.index.Index64(np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),
@@ -893,13 +893,13 @@ layout = ak.contents.UnionArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(layout)
 ```
 
 The `index` can be used to prevent the need to set up "dummy values" for all contents other than the one specified by a given tag. The above example could thus be more compact with the following (no unreachable data):
 
-```{code-cell} python3
+```{code-cell} ipython3
 layout = ak.contents.UnionArray(
     ak.index.Index8(np.array([0, 1, 2, 0, 0, 1, 1, 2, 2, 0], np.int8)),
     ak.index.Index64(np.array([0, 0, 0, 1, 2, 1, 2, 1, 2, 3])),
@@ -912,7 +912,7 @@ layout = ak.contents.UnionArray(
 layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_list(layout)
 ```
 
@@ -929,17 +929,17 @@ The {func}`ak.from_buffers` builds arrays using the above constructors, but the 
 
 Every {class}`ak.contents.Content` subclass has a corresponding {class}`ak.forms.Form`, and you can see a layout's Form through its `form` property.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])
 array.layout
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Abbreviated JSON representation
 array.layout.form
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 # Full JSON representation
 print(array.layout.form.to_json())
 ```

--- a/docs/user-guide/how-to-create-lists.md
+++ b/docs/user-guide/how-to-create-lists.md
@@ -14,7 +14,7 @@ kernelspec:
 How to create arrays of lists
 =============================
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -24,24 +24,24 @@ From Python lists
 
 If you have a collection of Python lists, the easiest way to turn them into an Awkward Array is to pass them to the {class}`ak.Array` constructor, which recognizes a non-dict, non-NumPy iterable and calls {func}`ak.from_iter`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 python_lists = [[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]]
 python_lists
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array = ak.Array(python_lists)
 awkward_array
 ```
 
 The lists of lists can be arbitrarily deep.
 
-```{code-cell} python3
+```{code-cell} ipython3
 python_lists = [[[[], [1, 2, 3]]], [[[4, 5]]], []]
 python_lists
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array = ak.Array(python_lists)
 awkward_array
 ```
@@ -52,20 +52,20 @@ The "`var *`" in the type string indicates nested levels of variable-length list
 
 The advantage of the Awkward Array is that the numerical data are now all in one array buffer and calculations are vectorized across the array, such as NumPy [universal functions](https://numpy.org/doc/stable/reference/ufuncs.html).
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.sqrt(awkward_array)
 ```
 
 Unlike Python lists, arrays consist of a homogeneous type. A Python list wouldn't notice if numerical data were given at two different levels of nesting, but that's a big difference to an Awkward Array.
 
-```{code-cell} python3
+```{code-cell} ipython3
 union_array = ak.Array([[[[], [1, 2, 3]]], [[4, 5]], []])
 union_array
 ```
 
 In this example, the data type is a "union" of two levels deep and three levels deep.
 
-```{code-cell} python3
+```{code-cell} ipython3
 union_array.type
 ```
 
@@ -78,12 +78,12 @@ From NumPy arrays
 
 The {class}`ak.Array` constructor loads NumPy arrays differently from Python lists. The inner dimensions of a NumPy array are guaranteed to have the same lengths, so they are interpreted as a fixed-length list type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_array = np.arange(2 * 3 * 5).reshape(2, 3, 5)
 numpy_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 regular_array = ak.Array(numpy_array)
 regular_array
 ```
@@ -94,7 +94,7 @@ The type in this case has no "`var *`" in it, only "`2 *`", "`3 *`", and "`5 *`"
 
 Furthermore, if NumPy arrays are _nested within_ Python lists (or other iterables), they'll be treated as variable-length ("`var *`") because there's no guarantee at the start of a sequence that all NumPy arrays in the sequence will have the same shape.
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_arrays = [
     np.arange(3 * 5).reshape(3, 5),
     np.arange(3 * 5, 2 * 3 * 5).reshape(3, 5),
@@ -102,20 +102,20 @@ numpy_arrays = [
 numpy_arrays
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 irregular_array = ak.Array(numpy_arrays)
 irregular_array
 ```
 
 Both `regular_array` and `irregular_array` have the same data values:
 
-```{code-cell} python3
+```{code-cell} ipython3
 regular_array.to_list() == irregular_array.to_list()
 ```
 
 but they have different types:
 
-```{code-cell} python3
+```{code-cell} ipython3
 regular_array.type, irregular_array.type
 ```
 
@@ -134,7 +134,7 @@ Another difference between {func}`ak.from_iter` and {func}`ak.from_numpy` is tha
 
 In some cases, list-making can be vectorized. If you have a flat NumPy array of data and an array of "counts" that add up to the length of the data, then you can {func}`ak.unflatten` it.
 
-```{code-cell} python3
+```{code-cell} ipython3
 data = np.array([1, 2, 3, 4, 5, 6, 7, 8])
 counts = np.array([3, 0, 1, 4])
 
@@ -148,11 +148,11 @@ The first list has length `3`, the second has length `0`, the third has length `
 
 This function is named {func}`ak.unflatten` because it has the opposite effect as {func}`ak.flatten` and {func}`ak.num`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(unflattened)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.num(unflattened)
 ```
 
@@ -163,7 +163,7 @@ With ArrayBuilder
 
 (This is what {func}`ak.from_iter` uses internally to accumulate lists.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 builder.begin_list()
@@ -184,7 +184,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.list():
@@ -210,11 +210,11 @@ Functions that Numba Just-In-Time (JIT) compiles can use {class}`ak.ArrayBuilder
 
 ([At this time](https://numba.pydata.org/numba-doc/dev/reference/pysupported.html#language), Numba can't use context managers, the `with` statement, in fully compiled code. {class}`ak.ArrayBuilder` can't be constructed or converted to an array using `snapshot` inside a JIT-compiled function, but can be outside the compiled context. Similarly, `ak.*` functions like {func}`ak.unflatten` can't be called inside a JIT-compiled function, but can be outside.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 import numba as nb
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def append_list(builder, start, stop):
     builder.begin_list()
@@ -237,7 +237,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def append_list(i, data, j, counts, start, stop):
     for x in range(start, stop):

--- a/docs/user-guide/how-to-create-missing.md
+++ b/docs/user-guide/how-to-create-missing.md
@@ -22,7 +22,7 @@ Pandas also handles missing data, but in several different ways. For floating po
 
 In Awkward Array, floating point `NaN` and a missing value are clearly distinct. Missing data, like all data in Awkward Arrays, are also not represented by any Python object; they are converted _to_ and _from_ `None` by {func}`ak.to_list` and {func}`ak.from_iter`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -32,31 +32,31 @@ From Python None
 
 The {class}`ak.Array` constructor and {func}`ak.from_iter` interpret `None` as a missing value, and {func}`ak.to_list` converts them back into `None`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([1, 2, 3, None, 4, 5])
 ```
 
 The missing values can be deeply nested (missing integers):
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[[[], [1, 2, None]]], [[[3]]], []])
 ```
 
 They can be shallow (missing lists):
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[[[], [1, 2]]], None, [[[3]]], []])
 ```
 
 Or both:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([[[[], [3]]], None, [[[None]]], []])
 ```
 
 Records can also be missing:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([{"x": 1, "y": 1}, None, {"x": 2, "y": 2}])
 ```
 
@@ -69,39 +69,39 @@ From NumPy arrays
 
 Normal NumPy arrays can't represent missing data, but masked arrays can. Here is how one is constructed in NumPy:
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_array = np.ma.MaskedArray([1, 2, 3, 4, 5], [False, False, True, True, False])
 numpy_array
 ```
 
 It returns `np.ma.masked` objects if you try to access missing values:
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_array[0], numpy_array[1], numpy_array[2], numpy_array[3], numpy_array[4]
 ```
 
 But it uses `None` for missing values in `tolist`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_array.tolist()
 ```
 
 The {func}`ak.from_numpy` function converts masked arrays into Awkward Arrays with missing values, as does the {class}`ak.Array` constructor.
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array = ak.Array(numpy_array)
 awkward_array
 ```
 
 The reverse, {func}`ak.to_numpy`, returns masked arrays if the Awkward Array has missing data.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(awkward_array)
 ```
 
 But [np.asarray](https://numpy.org/doc/stable/reference/generated/numpy.asarray.html), the usual way of casting data as NumPy arrays, does not. ([np.asarray](https://numpy.org/doc/stable/reference/generated/numpy.asarray.html) is supposed to return a plain [np.ndarray](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html), which [np.ma.masked_array](https://numpy.org/doc/stable/reference/generated/numpy.ma.masked_array.html) is not.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 np.asarray(awkward_array)
@@ -112,12 +112,12 @@ Missing rows vs missing numbers
 
 In Awkward Array, a missing list is a different thing from a list whose values are missing. However, {func}`ak.to_numpy` converts it for you.
 
-```{code-cell} python3
+```{code-cell} ipython3
 missing_row = ak.Array([[1, 2, 3], None, [4, 5, 6]])
 missing_row
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(missing_row)
 ```
 
@@ -126,12 +126,12 @@ NaN is not missing
 
 Floating point `NaN` values are simply unrelated to missing values, in both Awkward Array and NumPy.
 
-```{code-cell} python3
+```{code-cell} ipython3
 missing_with_nan = ak.Array([1.1, 2.2, np.nan, None, 3.3])
 missing_with_nan
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(missing_with_nan)
 ```
 
@@ -142,17 +142,17 @@ Sometimes, it's useful to think about a potentially missing value as a length-1 
 
 The Awkward functions {func}`ak.singletons` and {func}`ak.firsts` convert from "`None` form" to and from "lists form."
 
-```{code-cell} python3
+```{code-cell} ipython3
 none_form = ak.Array([1, 2, 3, None, None, 5])
 none_form
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 lists_form = ak.singletons(none_form)
 lists_form
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.firsts(lists_form)
 ```
 
@@ -161,23 +161,23 @@ Masking instead of slicing
 
 The most common way of filtering data is to slice it with an array of booleans (usually the result of a calculation).
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([1, 2, 3, 4, 5])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 booleans = ak.Array([True, True, False, False, True])
 booleans
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[booleans]
 ```
 
 The data can also be effectively filtered by replacing values with `None`. The following syntax does that:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.mask[booleans]
 ```
 
@@ -187,13 +187,13 @@ array.mask[booleans]
 
 An advantage of masking is that the length and nesting structure of the masked array is the same as the original array, so anything that broadcasts with one broadcasts with the other (so that unfiltered data can be used interchangeably with filtered data).
 
-```{code-cell} python3
+```{code-cell} ipython3
 array + array.mask[booleans]
 ```
 
 whereas
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 array + array[booleans]
@@ -206,7 +206,7 @@ With ArrayBuilder
 
 (This is what {func}`ak.from_iter` uses internally to accumulate data.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 builder.append(1)
@@ -226,11 +226,11 @@ Functions that Numba Just-In-Time (JIT) compiles can use {class}`ak.ArrayBuilder
 
 ({class}`ak.ArrayBuilder` can't be constructed or converted to an array using `snapshot` inside a JIT-compiled function, but can be outside the compiled context.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 import numba as nb
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def example(builder):
     builder.append(1)
@@ -247,7 +247,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def faster_example():
     data = np.empty(5, np.int64)

--- a/docs/user-guide/how-to-create-records.md
+++ b/docs/user-guide/how-to-create-records.md
@@ -18,7 +18,7 @@ In Awkward Array, a "record" is a structure containing a fixed-length set of typ
 
 All methods in Awkward Array are implemented as "[structs of arrays](https://en.wikipedia.org/wiki/AoS_and_SoA)," rather than arrays of structs, so making and breaking records are inexpensive operations that you can perform frequently in data analysis.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -28,7 +28,7 @@ From a list of Python dicts
 
 Records have a natural representation in JSON and Python as dicts, but only if all dicts in a series have the same set of field names. The {class}`ak.Array` invokes {func}`ak.from_iter` whenever presented with a list (or other non-string, non-dict iterable).
 
-```{code-cell} python3
+```{code-cell} ipython3
 python_dicts = [
     {"x": 1, "y": 1.1, "z": "one"},
     {"x": 2, "y": 2.2, "z": "two"},
@@ -41,7 +41,7 @@ python_dicts
 
 It is important that all of the dicts in the series have the same set of field names, since Awkward Array has to identify all of the records as having a single type:
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array = ak.Array(python_dicts)
 awkward_array
 ```
@@ -50,7 +50,7 @@ That is to say, an array of records is not a mapping from one type to another, s
 
 If you _try_ to mix field types in {func}`ak.from_iter` (ultimately from {class}`ak.ArrayBuilder`), the union of all sets of fields will be assumed, and any that aren't filled in every item will be presumed "missing."
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         {"a": 1, "b": 1, "c": 1},
@@ -67,7 +67,7 @@ From a single dict of columns
 
 If a _single dict_ is passed to {class}`ak.Array`, it will be interpreted as a set of columns, like [Pandas's DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) constructor. This is to provide a familiar interface to Pandas users.
 
-```{code-cell} python3
+```{code-cell} ipython3
 from_columns = ak.Array(
     {
         "x": [1, 2, 3, 4, 5],
@@ -80,7 +80,7 @@ from_columns
 
 This is _not_ the same as calling {func}`ak.from_iter` on the same input, which could not be a valid {class}`ak.Array` because a single dict would be an {class}`ak.Record`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 from_rows = ak.from_iter(
     {
         "x": [1, 2, 3, 4, 5],
@@ -96,7 +96,7 @@ Using ak.zip
 
 The {func}`ak.zip` function combines columns into an array of records, similar to the Pandas-style constructor described above.
 
-```{code-cell} python3
+```{code-cell} ipython3
 from_columns = ak.zip(
     {
         "x": [1, 2, 3, 4, 5],
@@ -111,7 +111,7 @@ The difference is that {func}`ak.zip` attempts to nested lists deeply, up to a `
 
 Given columns with nested lists:
 
-```{code-cell} python3
+```{code-cell} ipython3
 zipped = ak.zip(
     {
         "x": ak.Array([[1, 2, 3], [], [4, 5]]),
@@ -123,7 +123,7 @@ zipped
 
 By contrast, the same input to {class}`ak.Array`'s Pandas-style constructor keeps nested lists separate.
 
-```{code-cell} python3
+```{code-cell} ipython3
 not_zipped = ak.Array(
     {
         "x": ak.Array([[1, 2, 3], [], [4, 5]]),
@@ -135,14 +135,14 @@ not_zipped
 
 The difference can be seen in a comparison of their types:
 
-```{code-cell} python3
+```{code-cell} ipython3
 zipped.type.show()
 not_zipped.type.show()
 ```
 
 Also, {func}`ak.zip` can build records without field names, also known as "tuples."
 
-```{code-cell} python3
+```{code-cell} ipython3
 tuples = ak.zip(
     (ak.Array([[1, 2, 3], [], [4, 5]]), ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]))
 )
@@ -151,14 +151,14 @@ tuples
 
 Functions that return lists of pairs, such as {func}`ak.cartesian` and {func}`ak.combinations`, also use the tuple type.
 
-```{code-cell} python3
+```{code-cell} ipython3
 one = ak.Array([[1, 2, 3], [], [4, 5], [6]])
 two = ak.Array([["a", "b"], ["c"], ["d"], ["e", "f"]])
 
 ak.cartesian((one, two))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.combinations(one, 2)
 ```
 
@@ -167,7 +167,7 @@ Record names
 
 In addition to optional field names, record types can also have names.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(
     [
         {"x": 1, "y": 1.1},
@@ -180,14 +180,14 @@ ak.Array(
 )
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.zip(
     (ak.Array([[1, 2, 3], [], [4, 5]]), ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]])),
     with_name="AB",
 )
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.cartesian(
     {"L": ak.Array([1, 2, 3]), "R": ak.Array(["a", "b"])}, with_name="LeftRight", axis=0
 )
@@ -195,7 +195,7 @@ ak.cartesian(
 
 Names are for giving records [specialized behavior](how-to-specialize) through the {data}`ak.behavior` registry. These are like attaching methods to a class in the sense that all records with a particular name can be given Python properties and methods.
 
-```{code-cell} python3
+```{code-cell} ipython3
 class XYZRecord(ak.Record):
     def __repr__(self):
         return f"(X={self.x}:Y={self.y})"
@@ -224,15 +224,15 @@ array = ak.Array(
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.diff()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[0]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.sqrt(array)
 ```
 
@@ -243,7 +243,7 @@ With ArrayBuilder
 
 (This is what {func}`ak.from_iter` uses internally to accumulate records.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 builder.begin_record()
@@ -265,7 +265,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 with builder.record():
@@ -286,7 +286,7 @@ array
 
 The `begin_record` method and `record` context manager can take a name, which allows you to name your records on the spot.
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 for i in range(3):
@@ -305,7 +305,7 @@ Record names also let you decide between two ways of dealing with changing sets 
 
 Here is an illustration of that difference.
 
-```{code-cell} python3
+```{code-cell} ipython3
 def fill_A(builder, use_name):
     with builder.record("A" if use_name else None):
         builder.field("x").append(len(builder))
@@ -320,7 +320,7 @@ def fill_B(builder, use_name):
 
 Without names:
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 fill_A(builder, use_name=False)
@@ -337,7 +337,7 @@ without_names
 
 With names:
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 fill_A(builder, use_name=True)
@@ -354,11 +354,11 @@ with_names
 
 The difference can be seen in the type: `without_names` has only one record type, but the _x_ and _z_ fields are optional, and `with_names` has a union of two record types, neither of which have optional fields.
 
-```{code-cell} python3
+```{code-cell} ipython3
 without_names.type.show()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 with_names.type.show()
 ```
 
@@ -369,11 +369,11 @@ Functions that Numba Just-In-Time (JIT) compiles can use {class}`ak.ArrayBuilder
 
 ([At this time](https://numba.pydata.org/numba-doc/dev/reference/pysupported.html#language), Numba can't use context managers, the `with` statement, in fully compiled code. {class}`ak.ArrayBuilder` can't be constructed or converted to an array using `snapshot` inside a JIT-compiled function, but can be outside the compiled context. Similarly, `ak.*` functions like {func}`ak.zip` can't be called inside a JIT-compiled function, but can be outside.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 import numba as nb
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def append_record(builder, i):
     builder.begin_record()
@@ -396,7 +396,7 @@ array = builder.snapshot()
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 @nb.jit
 def faster_example():
     x = np.empty(3, np.int64)

--- a/docs/user-guide/how-to-create-strings.md
+++ b/docs/user-guide/how-to-create-strings.md
@@ -18,7 +18,7 @@ Awkward Arrays can contain strings, although these strings are just a special vi
 
 NumPy's strings are padded to have equal width, and Pandas's strings are Python objects. Awkward Array doesn't have nearly as many functions for manipulating arrays of strings as NumPy and Pandas, though.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -28,13 +28,13 @@ From Python strings
 
 The {class}`ak.Array` constructor and {func}`ak.from_iter` recognize strings, and strings are returned by {func}`ak.to_list`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(["one", "two", "three"])
 ```
 
 They may be nested within anything.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array([["one", "two"], [], ["three"]])
 ```
 
@@ -43,12 +43,12 @@ From NumPy arrays
 
 NumPy strings are also recognized by {func}`ak.from_numpy` and {func}`ak.to_numpy`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 numpy_array = np.array(["one", "two", "three", "four"])
 numpy_array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array = ak.Array(numpy_array)
 awkward_array
 ```
@@ -58,33 +58,33 @@ Operations with strings
 
 Since strings are really just lists, some of the list operations "just work" on strings.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.num(awkward_array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array[:, 1:]
 ```
 
 Others had to be specially overloaded for the string case, such as string-equality. The default meaning for `==` would be to descend to the lowest level and compare numbers (characters, in this case).
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array == "three"
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 awkward_array == ak.Array(["ONE", "TWO", "three", "four"])
 ```
 
 Similarly, {func}`ak.sort` and {func}`ak.argsort` sort strings lexicographically, not individual characters.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.sort(awkward_array)
 ```
 
 Still other operations had to be inhibited, since they wouldn't make sense for strings.
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 np.sqrt(awkward_array)
@@ -97,29 +97,29 @@ A large set of strings with few unique values are more efficiently manipulated a
 
 The {func}`ak.to_categorical` function makes Awkward Arrays categorical in this sense. {func}`ak.to_arrow` and {func}`ak.to_parquet` recognize categorical data and convert it to the corresponding Arrow and Parquet types.
 
-```{code-cell} python3
+```{code-cell} ipython3
 uncategorized = ak.Array(["three", "one", "two", "two", "three", "one", "one", "one"])
 uncategorized
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 categorized = ak.to_categorical(uncategorized)
 categorized
 ```
 
 Internally, the data now have an index that selects from a set of unique strings.
 
-```{code-cell} python3
+```{code-cell} ipython3
 categorized.layout.index
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.Array(categorized.layout.content)
 ```
 
 The main advantage to Awkward categorical data (other than proper conversions to Arrow and Parquet) is that equality is performed using the index integers.
 
-```{code-cell} python3
+```{code-cell} ipython3
 categorized == "one"
 ```
 
@@ -130,7 +130,7 @@ With ArrayBuilder
 
 (This is what {func}`ak.from_iter` uses internally to accumulate data.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 builder = ak.ArrayBuilder()
 
 builder.string("one")

--- a/docs/user-guide/how-to-restructure-flatten.md
+++ b/docs/user-guide/how-to-restructure-flatten.md
@@ -35,7 +35,7 @@ There are two functions that are responsible for flattening arrays: {func}`ak.fl
 
 After destructuring, you might _still_ need to call `np.asarray` on the output because the plotting library might not recognize an {class}`ak.Array` as an array. You'll probably also want to develop your destructuring on a commandline or a different Jupyter cell from the plotting library function call, to understand what structure the output has without the added complication of the plotting library's error messages.
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -47,7 +47,7 @@ ak.ravel
 
 First, let's create an array with some interesting structure.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [[{"x": 1.1, "y": [1]}, {"x": None, "y": [1, 2]}], [], [{"x": 3.3, "y": [1, 2, 3]}]]
 )
@@ -56,13 +56,13 @@ array
 
 As mentioned above, {func}`ak.ravel` is one of two functions that turns any array into a 1-dimensional array with no nested lists, no nested records.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.ravel(array)
 ```
 
 Calling this function on an already flat array does nothing, so you don't have to worry about what state your array had been in before you called it.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.ravel(ak.ravel(array))
 ```
 
@@ -80,26 +80,26 @@ ak.flatten with axis=None
 
 If {func}`ak.ravel` is a sledgehammer, then {func}`ak.flatten` with `axis=None` is a pile driver that turns any array into a 1-dimensional array with no nested lists, no nested records, and no missing data.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [[{"x": 1.1, "y": [1]}, {"x": None, "y": [1, 2]}], [], [{"x": 3.3, "y": [1, 2, 3]}]]
 )
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array, axis=None)
 ```
 
 Like {func}`ak.ravel`, Calling this function on an already flat array does nothing, so you don't have to worry about what state your array had been in before you called it.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.flatten(array, axis=None), axis=None)
 ```
 
 In addition to the concerns raised above, it is also important to consider whether the {data}`None` values in your array are meaningful. For example, consider an array of x-axis and y-axis values. If only the y-axis contains {data}`None` values, `ak.flatten(y_values, axis=None)` would produce an array that does not align with the flattened x-axis values.
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 x = ak.Array([[1, 2, 3], [4, 5, 6, 7]])
@@ -113,7 +113,7 @@ Selecting record fields
 
 A more controlled way to extract fields from a record is to [project](../reference/generated/ak.Array.html#projection) them by name.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         [{"x": 1.1, "y": [1], "z": "one"}, {"x": None, "y": [1, 2], "z": "two"}],
@@ -126,33 +126,33 @@ array
 
 If we want only the _x_ field, we can ask for it as an attribute (because it's a valid Python name) or with a string-valued slice:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.x
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array["x"]
 ```
 
 This controls the biggest deficiency of {func}`ak.flatten` with `axis=None`, the mixing of data with different meanings.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array.x, axis=None)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array.y, axis=None)
 ```
 
 If some of your fields can be safely flattened—together into one set—and others can't, you can use a list of strings to pick just the fields you want.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array[["x", "y"]], axis=None)
 ```
 
 (Careful! A tuple has a special meaning in slices, which doesn't apply here.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 array[("x", "y")]
@@ -160,7 +160,7 @@ array[("x", "y")]
 
 If you have records inside of records, you can extract them with [nested projection](../reference/generated/ak.Array.html#nested-projection) if they have common names.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         {"x": {"up": 1, "down": -1}, "y": {"up": 1.1, "down": -1.1}},
@@ -172,7 +172,7 @@ array = ak.Array(
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array[["x", "y"], "up"], axis=None)
 ```
 
@@ -181,29 +181,29 @@ ak.flatten for one axis
 
 Since `axis=None` is so dangerous, the default value of {func}`ak.flatten` is `axis=1`. This flattens only the first nested dimension.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]]))
 ```
 
 It also removes missing values _in the axis that is being flattened_ because flattening considers a missing list like an empty list.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[0, 1, 2], None, [3, 4], [5], [6, 7, 8, 9]]))
 ```
 
 It does not flatten or remove missing values from any other axis.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[[0, 1, 2, 3, 4]], [], [[5], [6, 7, 8, 9]]]))
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[[0, 1, 2, None]], [], [[5], [6, 7, 8, 9]]]))
 ```
 
 Moreover, you can't flatten already-flat data because a 1-dimensional array does not have an `axis=1`. (`axis` starts counting at `0`.)
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 ak.flatten(ak.Array([1, 2, 3, 4, 5]))
@@ -211,7 +211,7 @@ ak.flatten(ak.Array([1, 2, 3, 4, 5]))
 
 `axis=0` is a valid option for {func}`ak.flatten`, but since there can't be any lists at this level, it only removes missing values.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([1, 2, 3, None, None, 4, 5]), axis=0)
 ```
 
@@ -222,18 +222,18 @@ Flattening removes list structure without removing values. Often, you want to do
 
 This kind of operation is usually just a slice.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0, 1, 2], [3, 4], [5], [6, 7, 8, 9]])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[:, 0]
 ```
 
 The above syntax selects all lists from the array (`axis=0`) and the first element from each list (`axis=1`). We could have as easily selected the last:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[:, -1]
 ```
 
@@ -243,12 +243,12 @@ A plot made from `ak.flatten(array)` would be a plot of all numbers with no know
 
 What if you get this error?
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 array[:, 0]
@@ -258,41 +258,41 @@ It says that it can't get element `0` of one of the lists, and that's because th
 
 One way to deal with that is to take a range-slice, rather than ask for an individual element from each list.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[:, :1]
 ```
 
 But this array still has structure, so you can flatten it _as an additional step_.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array[:, :1])
 ```
 
 Alternatively, you may want to attack the problem head-on: the issue is that some lists have too few elements, so why not remove those lists with an explicit slice? The {func}`ak.num` function tells us the length of each nested list.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.num(array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.num(array) > 0
 ```
 
 Slicing the first dimension with this would ensure that the second dimension always has the element we seek.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[ak.num(array) > 0, 0]
 ```
 
 The same applies if we're taking the last element:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[ak.num(array) > 0, -1]
 ```
 
 You can also do fancy things, requesting both the first and last element of each list, as long as it doesn't run afoul of slicing rules (which were constrained to match NumPy's in cases that overlap).
 
-```{code-cell} python3
+```{code-cell} ipython3
 :tags: [raises-exception]
 
 array[
@@ -300,13 +300,13 @@ array[
 ]  # these two arrays have different lengths, can't be broadcasted as in NumPy advanced slicing
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[ak.num(array) > 0][:, [0, -1]]  # so just put them in different slices
 ```
 
 And then flatten the result (if necessary—the shape is regular; some plotting libraries would interpret it as a single set of numbers).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array[ak.num(array) > 0][:, [0, -1]])
 ```
 
@@ -319,30 +319,30 @@ The architypical aggregation function is "sum," which reduces a list by adding u
 
 Following NumPy, their default `axis` is `None`, but for this application, you'll need to specify an explicit axis.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.sum(array, axis=1)
 ```
 
 Some of these are not defined for empty lists, so you'll need to either replace the missing values with {func}`ak.fill_none` or flatten them.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.mean(array, axis=1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.fill_none(ak.mean(array, axis=1), 0)  # fill with zero
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.fill_none(ak.mean(array, axis=1), ak.mean(array))  # fill with the mean of all
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.mean(array, axis=1), axis=0)
 ```
 
@@ -357,16 +357,16 @@ Minimizing and maximizing are also reducers, {func}`ak.min` and {func}`ak.max` (
 
 They deserve their own section because they are an important case.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0, 2, 1], [], [4, 3], [5], [8, 6, 7, 9]])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.min(array, axis=1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.max(array, axis=1)
 ```
 
@@ -376,23 +376,23 @@ As before, they aren't defined for empty lists, so you'll have to _choose_ a met
 
 Sometimes, you want the "top N" elements from each list, rather than the "top 1." Awkward Array doesn't ([yet](https://github.com/scikit-hep/awkward-1.0/issues/554)) have a function for the "top N" elements, but it can be done with {func}`ak.sort` and a slice.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.sort(array, axis=1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.sort(array, axis=1)[:, -2:]
 ```
 
 We still have work to do: some of these lists are shorter than the 2 elements we asked for. What should be done with them? Eliminate all lists with fewer than two elements?
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.sort(array[ak.num(array) >= 2], axis=1)[:, -2:]
 ```
 
 Or just concatenate everything so that we don't lose the lists with only one value (`5` in this example)?
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.sort(array, axis=1)[:, -2:])
 ```
 
@@ -401,7 +401,7 @@ Minimizing/maximizing lists of records
 
 Unlike numbers, records do not have an ordering: you cannot call {func}`ak.min` on an array of records. But usually, what you want to do instead is to find the minimum or maximum of some quantity calculated from the records and pick records (or record fields) from that.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         [
@@ -424,34 +424,34 @@ array
 
 The {func}`ak.argmin` and {func}`ak.argmax` functions return the integer index where the minimum or maximum of some numeric formula can be found.
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.sqrt(array.x**2 + array.y**2)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.argmax(np.sqrt(array.x**2 + array.y**2), axis=1)
 ```
 
 These integer indexes can be used as slices if they don't eliminate a dimension, which can be requested via `keepdims=True`. This makes a length-1 list for each reduced output.
 
-```{code-cell} python3
+```{code-cell} ipython3
 maximize_by = ak.argmax(np.sqrt(array.x**2 + array.y**2), axis=1, keepdims=True)
 maximize_by
 ```
 
 Applying this to the original `array`, we get the "best" record in each list, according to `maximize_by`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[maximize_by]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array[maximize_by].to_list()
 ```
 
 This still has list structures and missing values, so it's ready for {func}`ak.flatten`, assuming that we extract the appropriate record field to plot.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array[maximize_by].z, axis=None)
 ```
 
@@ -460,7 +460,7 @@ Concatenating independently restructured arrays
 
 Sometimes, what you want to do can't be a single expression. Suppose we have this data:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}], [], [{"x": 3.3, "y": [1, 2, 3]}]]
 )
@@ -469,17 +469,17 @@ array
 
 and we want to combine all _x_ values and the maximum _y_ value in a plot. This requires a different expression on `array.x` from `array.y`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array.x)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.max(array.y, axis=2), axis=None)
 ```
 
 To get all of these into one array (because the plotting function only accepts one argument), you'll need to {func}`ak.concatenate` them.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate(
     [
         ak.flatten(array.x),
@@ -495,7 +495,7 @@ Dropping missing values with {func}`ak.flatten` doesn't keep track of where they
 
 Instead of {func}`ak.flatten`, you can use {func}`ak.is_none`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         {"x": 1, "y": 5.5},
@@ -508,20 +508,20 @@ array = ak.Array(
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.is_none(array.x)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.is_none(array.y)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 to_keep = ~(ak.is_none(array.x) | ak.is_none(array.y))
 to_keep
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.x[to_keep], array.y[to_keep]
 ```
 
@@ -530,7 +530,7 @@ Actually drawing structure
 
 If need be, you can change the plotter to match the data.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         [{"x": 1, "y": 3.3}, {"x": 2, "y": 1.1}, {"x": 3, "y": 2.2}],
@@ -547,7 +547,7 @@ array = ak.Array(
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import matplotlib.path
 import matplotlib.patches

--- a/docs/user-guide/how-to-restructure-pad.md
+++ b/docs/user-guide/how-to-restructure-pad.md
@@ -20,7 +20,7 @@ This tutorial presents several ways of doing that. Like [flattening for plots](h
 
 (In principle, graph neural networks should be able to learn about variable-length data without any losses, but I'm not familiar enough with how to set up these processes to explain it. If you're an expert, we'd like to hear tips and tricks in [GitHub Discussions](https://github.com/scikit-hep/awkward-1.0/discussions)!)
 
-```{code-cell} python3
+```{code-cell} ipython3
 import awkward as ak
 import numpy as np
 ```
@@ -30,26 +30,26 @@ Flattening an array
 
 Suppose you have an array like this:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
 array
 ```
 
 If the list boundaries are irrelevant to your machine learning application, you can simply {func}`ak.flatten` them.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array)
 ```
 
 The default `axis` for {func}`ak.flatten` is `1`, which is to say, the first level of nested list (`axis=1`) gets squashed to the outer level of array nesting (`axis=0`). If you have many levels to flatten at once, you can use `axis=None`:
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[[[[[1.1, 2.2, 3.3]]], [[[4.4, 5.5]]]]]]), axis=None)
 ```
 
 However, be aware that {func}`ak.flatten` with `axis=None` will also merge all fields of a record, which is usually undesirable, and the order might not be what you expect.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(
     ak.Array([{"x": 1.1, "y": 10}, {"x": 2.2, "y": 20}, {"x": 3.3, "y": 30}]), axis=None
 )
@@ -57,13 +57,13 @@ ak.flatten(
 
 Also be aware that flattening (for any `axis`) removes missing values (at that `axis`). That is, at the level where lists are concatenated, missing lists are treated the same way as empty lists.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[1.1, 2.2, 3.3], None, [4.4, 5.5]]))
 ```
 
 But only at that level.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.Array([[1.1, 2.2, None, 3.3], [], [4.4, 5.5]]))
 ```
 
@@ -74,33 +74,33 @@ Flattening is likely to be useful for training recurrent neural networks, which 
 
 Suppose we have a nested array of integers representing words in a corpus like this:
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[5512, 1364], [657], [4853, 6421, 3461, 7745], [5245, 654, 4216]])
 array
 ```
 
 Flattening it would turn them into a big run-on sentence, which may be a bad thing to learn.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(array)
 ```
 
 Suppose that we want to fix this by adding `0` as a marker meaning "end of sentence/stop." One way to do it is to make an array of `[0]` lists with the same length as `array` and {func}`ak.concatenate` them at `axis=1`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 periods = np.zeros((len(array), 1), np.int64)
 periods
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate([array, periods], axis=1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate([array, periods], axis=1).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.flatten(ak.concatenate([array, periods], axis=1))
 ```
 
@@ -109,34 +109,34 @@ Padding lists to a common length
 
 A general function for turning an array of lists into lists of the same length is {func}`ak.pad_none`. With the default `clip=False`, it ensures that a set of lists have _at least_ a given target length.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]])
 array
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.pad_none(array, 2).to_list()
 ```
 
 "At least length 2" means that the list is still a variable-length type, which we can see with the "`var *`" in its type string.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.pad_none(array, 2).type
 ```
 
 To produce lists of an exact length, set `clip=True`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.pad_none(array, 2, clip=True).to_list()
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.pad_none(array, 2, clip=True).type
 ```
 
 Now the type string says that the nested lists all have exactly two elements each. This can be directly converted into NumPy (allowing for missing data with {func}`ak.to_numpy`; casting as `np.asarray` doesn't allow the arrays to be [NumPy masked arrays](https://numpy.org/doc/stable/reference/maskedarray.html)).
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.to_numpy(ak.pad_none(array, 2, clip=True))
 ```
 
@@ -144,11 +144,11 @@ Perhaps your machine learning library knows how to deal with NumPy masked arrays
 
 {func}`ak.pad_none` and {func}`ak.fill_none` are frequently used together.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.fill_none(ak.pad_none(array, 2, clip=True), 999)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.asarray(ak.fill_none(ak.pad_none(array, 2, clip=True), 999))
 ```
 
@@ -157,7 +157,7 @@ Record fields into lists
 
 Sometimes, the data you need to put into one big array (tensor) for machine learning is scattered among several record fields. In Awkward Array, record fields are discontiguous (are stored in separate arrays) and nested lists are contiguous (same array). This will require a copy using {func}`ak.concatenate`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array = ak.Array(
     [
         {"a": 11, "b": 12, "c": 13, "d": 14, "e": 15, "f": 16, "g": 17, "h": 18},
@@ -172,30 +172,30 @@ array
 
 To concatenate, say, `array.a` and `array.b` as though `[a, b]` were a list, we have to put them into lists (of length 1). NumPy's `np.newaxis` slice will do that.
 
-```{code-cell} python3
+```{code-cell} ipython3
 array.a[:, np.newaxis], array.b[:, np.newaxis]
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate([array.a[:, np.newaxis], array.b[:, np.newaxis]], axis=1)
 ```
 
 If there are a lot of fields, doing this manually for each one would be a chore, so we use {func}`ak.fields` and {func}`ak.unzip`.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.fields(array)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.unzip(array)
 ```
 
 Now it's a one-liner.
 
-```{code-cell} python3
+```{code-cell} ipython3
 ak.concatenate(ak.unzip(array[:, np.newaxis]), axis=1)
 ```
 
-```{code-cell} python3
+```{code-cell} ipython3
 np.asarray(ak.concatenate(ak.unzip(array[:, np.newaxis]), axis=1))
 ```


### PR DESCRIPTION
This PR fixes the root cause that motivated #1964. In fact, the problem was exclusively on RTD, but when I checked my original fix, I checked the CI build result (which has not shown this highlighting problem). 

This PR adds IPython as a Sphinx extension, and reverts the changes to the `code-cell` language.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-docs-fix-syntax-highlighting/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->