### PR TITLE
fix: EmptyArray.is_numpy should be False.

### DIFF
--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -14,7 +14,6 @@ numpy = ak._nplikes.Numpy.instance()
 
 
 class EmptyArray(Content):
-    is_numpy = True
     is_unknown = True
 
     def __init__(self, *, parameters=None, backend=None):

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -58,7 +58,7 @@ def _impl(array, axis, highlevel, behavior):
                 ],
             )
 
-        elif layout.is_unknown or layout.is_list or layout.is_record or layout.is_numpy:
+        elif layout.is_numpy or layout.is_unknown or layout.is_list or layout.is_record:
             return ak.contents.NumpyArray(
                 backend.nplike.zeros(len(layout), dtype=np.bool_)
             )


### PR DESCRIPTION
`EmptyArray.is_numpy` is now `False` because it's surprising. (`EmptyArrays` are sometimes coerced to being `NumpyArrays` with `dtype=np.float64` to match the NumPy behavior, but in general, `EmptyArray` represents an unknown type, not a NumPy-like type.)

There's already `EmptyArray.is_unknown` to identify them, and everywhere that we actually cared about it, we were already checking for it:

```
% fgrep -r '.is_numpy' --include \*.py src/awkward
src/awkward/contents/listarray.py:            if not content.is_numpy or not content.parameter("__array__") == "char":
src/awkward/contents/listarray.py:            if not content.is_numpy or not content.parameter("__array__") == "byte":
src/awkward/contents/listoffsetarray.py:            if not content.is_numpy or not content.parameter("__array__") == "char":
src/awkward/contents/listoffsetarray.py:            if not content.is_numpy or not content.parameter("__array__") == "byte":
src/awkward/contents/regulararray.py:            if not content.is_numpy or not content.parameter("__array__") == "char":
src/awkward/contents/regulararray.py:            if not content.is_numpy or not content.parameter("__array__") == "byte":
src/awkward/operations/ak_unflatten.py:        elif counts.is_numpy or counts.is_unknown:
src/awkward/operations/ak_is_none.py:        elif layout.is_numpy or layout.is_unknown or layout.is_list or layout.is_record:
src/awkward/operations/ak_transform.py:        ...     if layout.is_numpy:
src/awkward/operations/ak_transform.py:        ...     if layouts[0].is_numpy and layouts[1].is_numpy:
```

The first section really wants only `NumpyArray` because it's checking for arrays of `char` or `byte`, which `EmptyArray` is not. The last two, in `ak_transform.py`, are examples in docstrings. Everything else already checks for `is_numpy or is_unknown`.

Demonstrably, it does not affect any tests.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-emptyarray.is_numpy-should-be-false/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->