### PR TITLE
wip: L2 access scope implementation

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -71,12 +71,12 @@ def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
 def broadcast_unpack(x, isscalar: list[bool], backend: ak._backends.Backend):
     if all(isscalar):
         if not backend.nplike.known_shape or x.length == 0:
-            return x._getitem_nothing()._getitem_nothing()
+            return x._pub_getitem_nothing()._pub_getitem_nothing()
         else:
             return x[0][0]
     else:
         if not backend.nplike.known_shape or x.length == 0:
-            return x._getitem_nothing()
+            return x._pub_getitem_nothing()
         else:
             return x[0]
 

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -685,7 +685,7 @@ def apply_step(
                         if isinstance(x, RegularArray):
                             if maxsize > 1 and x.size == 1:
                                 nextinputs.append(
-                                    x.content[: x.length * x.size]._carry(
+                                    x.content[: x.length * x.size]._pub_carry(
                                         tmpindex, allow_lazy=False
                                     )
                                 )

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -131,7 +131,7 @@ class ArrayView:
 
     def toarray(self):
         layout = self.type.tolayout(self.lookup, self.pos, self.fields)
-        sliced = layout._getitem_range(slice(self.start, self.stop))
+        sliced = layout._pub_getitem_range(slice(self.start, self.stop))
         return ak._util.wrap(sliced, self.behavior)
 
 

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -1004,7 +1004,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
             )
 
             if record_is_scalar:
-                return out._getitem_at(0)
+                return out._pub_getitem_at(0)
 
             if record_is_optiontype and record_mask is None and generate_bitmasks:
                 record_mask = numpy.zeros(len(out), dtype=np.bool_)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -179,7 +179,7 @@ if pyarrow is not None:
         pyarrow.large_binary(),
     )
 
-    _pyarrow_to_numpy_dtype = {
+    _pyarrow_pub_to_numpy_dtype = {
         pyarrow.date32(): (True, np.dtype("M8[D]")),
         pyarrow.date64(): (False, np.dtype("M8[ms]")),
         pyarrow.time32("s"): (True, np.dtype("M8[s]")),
@@ -675,7 +675,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         validbits = buffers.pop(0)
         data = buffers.pop(0)
 
-        to64, dt = _pyarrow_to_numpy_dtype.get(str(storage_type), (False, None))
+        to64, dt = _pyarrow_pub_to_numpy_dtype.get(str(storage_type), (False, None))
         if to64:
             data = numpy.frombuffer(data, dtype=np.int32).astype(np.int64)
         if dt is None:
@@ -882,7 +882,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         )
 
     elif isinstance(storage_type, pyarrow.lib.DataType):
-        _, dt = _pyarrow_to_numpy_dtype.get(str(storage_type), (False, None))
+        _, dt = _pyarrow_pub_to_numpy_dtype.get(str(storage_type), (False, None))
         if dt is None:
             dt = np.dtype(storage_type.to_pandas_dtype())
 

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -39,7 +39,7 @@ is_identifier = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
 
 
 def get_at(data, index):
-    out = data._layout._getitem_at(index)
+    out = data._layout._pub_getitem_at(index)
     if isinstance(out, ak.contents.NumpyArray):
         array_param = out.parameter("__array__")
         if array_param == "byte":
@@ -53,7 +53,7 @@ def get_at(data, index):
 
 
 def get_field(data, field):
-    out = data._layout._getitem_field(field)
+    out = data._layout._pub_getitem_field(field)
     if isinstance(out, ak.contents.NumpyArray):
         array_param = out.parameter("__array__")
         if array_param == "byte":

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -300,7 +300,7 @@ def normalise_item_nested(item):
         nextindex = item.index.data.astype(np.int64)  # this ALWAYS copies
         nonnull = nextindex >= 0
 
-        projected = item.content._carry(ak.index.Index64(nextindex[nonnull]), False)
+        projected = item.content._pub_carry(ak.index.Index64(nextindex[nonnull]), False)
 
         # content has been projected; index must agree
         nextindex[nonnull] = item.backend.index_nplike.arange(
@@ -325,7 +325,7 @@ def normalise_item_nested(item):
         positions_where_valid = item.backend.index_nplike.nonzero(is_valid)[0]
 
         nextcontent = normalise_item_nested(
-            item.content._carry(ak.index.Index64(positions_where_valid), False)
+            item.content._pub_carry(ak.index.Index64(positions_where_valid), False)
         )
 
         nextindex = item.backend.index_nplike.full(is_valid.shape[0], -1, np.int64)

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -491,7 +491,7 @@ def union_to_record(unionarray, anonymous):
                 if isinstance(layout, ak.contents.RecordArray):
                     for field in layout.fields:
                         if name == field:
-                            union_contents.append(layout._getitem_field(field))
+                            union_contents.append(layout._pub_getitem_field(field))
                             break
                     else:
                         union_contents.append(missingarray)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -604,8 +604,8 @@ class BitMaskedArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         return self.to_ByteMaskedArray()._pad_none(target, axis, depth, clip)
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        return self.to_ByteMaskedArray()._to_arrow(
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+        return self.to_ByteMaskedArray()._pub_to_arrow(
             pyarrow, mask_node, validbytes, length, options
         )
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -712,13 +712,13 @@ class BitMaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
         mask = self.mask_as_bool(valid_when=True)[: self._length]
-        out = self._content._pub_getitem_range(slice(0, self._length))._to_list(
+        out = self._content._pub_getitem_range(slice(0, self._length))._pub_to_list(
             behavior, json_conversions
         )
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -561,8 +561,8 @@ class BitMaskedArray(Content):
             order,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        return self.to_ByteMaskedArray()._combinations(
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+        return self.to_ByteMaskedArray()._pub_combinations(
             n, replacement, recordlookup, parameters, axis, depth
         )
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -566,7 +566,7 @@ class BitMaskedArray(Content):
             n, replacement, recordlookup, parameters, axis, depth
         )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -578,7 +578,7 @@ class BitMaskedArray(Content):
         keepdims,
         behavior,
     ):
-        return self.to_ByteMaskedArray()._reduce_next(
+        return self.to_ByteMaskedArray()._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -612,10 +612,10 @@ class BitMaskedArray(Content):
     def _pub_to_numpy(self, allow_missing):
         return self.to_ByteMaskedArray()._pub_to_numpy(allow_missing)
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._completely_flatten(backend, options)
+            return self.project()._pub_completely_flatten(backend, options)
         else:
             return [self]
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -609,8 +609,8 @@ class BitMaskedArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_ByteMaskedArray()._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        return self.to_ByteMaskedArray()._pub_to_numpy(allow_missing)
 
     def _completely_flatten(self, backend, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -512,10 +512,10 @@ class BitMaskedArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._mask.length == 0:
             return self
-        out = self.to_IndexedOptionArray64()._unique(
+        out = self.to_IndexedOptionArray64()._pub_unique(
             negaxis, starts, parents, outlength
         )
         if negaxis is None:

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -547,10 +547,10 @@ class BitMaskedArray(Content):
             order,
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        return self.to_IndexedOptionArray64()._sort_next(
+        return self.to_IndexedOptionArray64()._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -619,7 +619,7 @@ class BitMaskedArray(Content):
         else:
             return [self]
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._backend.nplike.known_shape:
@@ -636,7 +636,7 @@ class BitMaskedArray(Content):
             def continuation():
                 return make(
                     self._mask,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,
@@ -653,7 +653,7 @@ class BitMaskedArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth,

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -523,7 +523,7 @@ class BitMaskedArray(Content):
         else:
             return out._content
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -535,7 +535,7 @@ class BitMaskedArray(Content):
         kind,
         order,
     ):
-        return self.to_IndexedOptionArray64()._argsort_next(
+        return self.to_IndexedOptionArray64()._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -505,10 +505,10 @@ class BitMaskedArray(Content):
     def numbers_to_type(self, name):
         return self.to_ByteMaskedArray().numbers_to_type(name)
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._mask.length == 0:
             return True
-        return self.to_IndexedOptionArray64()._is_unique(
+        return self.to_IndexedOptionArray64()._pub_is_unique(
             negaxis, starts, parents, outlength
         )
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -373,12 +373,12 @@ class BitMaskedArray(Content):
         )
         return bytemask.data[: self._length].view(np.bool_)
 
-    def _getitem_nothing(self):
-        return self._content._getitem_range(slice(0, 0))
+    def _pub_getitem_nothing(self):
+        return self._content._pub_getitem_range(slice(0, 0))
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if not self._backend.nplike.known_data:
-            return ak._typetracer.MaybeNone(self._content._getitem_at(where))
+            return ak._typetracer.MaybeNone(self._content._pub_getitem_at(where))
 
         if where < 0:
             where += self.length
@@ -389,27 +389,27 @@ class BitMaskedArray(Content):
         else:
             bit = bool(self._mask[where // 8] & (128 >> (where % 8)))
         if bit == self._valid_when:
-            return self._content._getitem_at(where)
+            return self._content._pub_getitem_at(where)
         else:
             return None
 
-    def _getitem_range(self, where):
-        return self.to_ByteMaskedArray()._getitem_range(where)
+    def _pub_getitem_range(self, where):
+        return self.to_ByteMaskedArray()._pub_getitem_range(where)
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         return BitMaskedArray.simplified(
             self._mask,
-            self._content._getitem_field(where, only_fields),
+            self._content._pub_getitem_field(where, only_fields),
             self._valid_when,
             self._length,
             self._lsb_order,
             parameters=None,
         )
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         return BitMaskedArray.simplified(
             self._mask,
-            self._content._getitem_fields(where, only_fields),
+            self._content._pub_getitem_fields(where, only_fields),
             self._valid_when,
             self._length,
             self._lsb_order,
@@ -420,34 +420,34 @@ class BitMaskedArray(Content):
         assert isinstance(carry, ak.index.Index)
         return self.to_ByteMaskedArray()._carry(carry, allow_lazy)
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
-        return self.to_ByteMaskedArray()._getitem_next_jagged(
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+        return self.to_ByteMaskedArray()._pub_getitem_next_jagged(
             slicestarts, slicestops, slicecontent, tail
         )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
         elif isinstance(
             head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
-            return self.to_ByteMaskedArray()._getitem_next(head, tail, advanced)
+            return self.to_ByteMaskedArray()._pub_getitem_next(head, tail, advanced)
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            return self._getitem_next_missing(head, tail, advanced)
+            return self._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
@@ -718,7 +718,7 @@ class BitMaskedArray(Content):
             return out
 
         mask = self.mask_as_bool(valid_when=True)[: self._length]
-        out = self._content._getitem_range(slice(0, self._length))._to_list(
+        out = self._content._pub_getitem_range(slice(0, self._length))._to_list(
             behavior, json_conversions
         )
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -598,8 +598,8 @@ class BitMaskedArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.mask._nbytes_part() + self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.mask._pub_nbytes_part() + self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         return self.to_ByteMaskedArray()._pub_pad_none(target, axis, depth, clip)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -601,8 +601,8 @@ class BitMaskedArray(Content):
     def _nbytes_part(self):
         return self.mask._nbytes_part() + self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
-        return self.to_ByteMaskedArray()._pad_none(target, axis, depth, clip)
+    def _pub_pad_none(self, target, axis, depth, clip):
+        return self.to_ByteMaskedArray()._pub_pad_none(target, axis, depth, clip)
 
     def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self.to_ByteMaskedArray()._pub_to_arrow(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -458,7 +458,7 @@ class BitMaskedArray(Content):
     def num(self, axis, depth=0):
         return self.to_ByteMaskedArray().num(axis, depth)
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         return self.to_ByteMaskedArray._offsets_and_flattened(axis, depth)
 
     def _mergeable(self, other, mergebool):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -416,9 +416,9 @@ class BitMaskedArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
-        return self.to_ByteMaskedArray()._carry(carry, allow_lazy)
+        return self.to_ByteMaskedArray()._pub_carry(carry, allow_lazy)
 
     def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         return self.to_ByteMaskedArray()._pub_getitem_next_jagged(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -325,7 +325,7 @@ class ByteMaskedArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -335,7 +335,7 @@ class ByteMaskedArray(Content):
 
         return ByteMaskedArray.simplified(
             nextmask,
-            self._content._carry(carry, allow_lazy),
+            self._content._pub_carry(carry, allow_lazy),
             self._valid_when,
             parameters=self._parameters,
         )
@@ -439,7 +439,7 @@ class ByteMaskedArray(Content):
             slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
         )
 
-        next = self._content._carry(nextcarry, True)
+        next = self._content._pub_carry(nextcarry, True)
         out = next._pub_getitem_next_jagged(
             reducedstarts, reducedstops, slicecontent, tail
         )
@@ -463,7 +463,7 @@ class ByteMaskedArray(Content):
             nexthead, nexttail = ak._slicing.headtail(tail)
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, True)
+            next = self._content._pub_carry(nextcarry, True)
             out = next._pub_getitem_next(head, tail, advanced)
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters
@@ -566,7 +566,7 @@ class ByteMaskedArray(Content):
                 )
             )
 
-            return self._content._carry(nextcarry, False)
+            return self._content._pub_carry(nextcarry, False)
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -579,7 +579,7 @@ class ByteMaskedArray(Content):
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
             out = next.num(posaxis, depth)
 
             return ak.contents.IndexedOptionArray.simplified(
@@ -593,7 +593,7 @@ class ByteMaskedArray(Content):
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
 
             offsets, flattened = next._offsets_and_flattened(posaxis, depth)
 
@@ -690,7 +690,7 @@ class ByteMaskedArray(Content):
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
             out = next._local_index(posaxis, depth)
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters
@@ -767,7 +767,7 @@ class ByteMaskedArray(Content):
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, True)
+            next = self._content._pub_carry(nextcarry, True)
             out = next._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
@@ -888,7 +888,7 @@ class ByteMaskedArray(Content):
         else:
             nextshifts = None
 
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
 
         out = next._reduce_next(
             reducer,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -951,7 +951,7 @@ class ByteMaskedArray(Content):
     def _nbytes_part(self):
         return self.mask._nbytes_part() + self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
@@ -975,14 +975,14 @@ class ByteMaskedArray(Content):
                     self._mask.length,
                 )
             )
-            next = self.project()._pad_none(target, posaxis, depth, clip)
+            next = self.project()._pub_pad_none(target, posaxis, depth, clip)
             return ak.contents.IndexedOptionArray.simplified(
                 index, next, parameters=self._parameters
             )
         else:
             return ak.contents.ByteMaskedArray(
                 self._mask,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pub_pad_none(target, posaxis, depth, clip),
                 self._valid_when,
                 parameters=self._parameters,
             )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -756,19 +756,21 @@ class ByteMaskedArray(Content):
             order,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         if n < 1:
             raise ak._errors.wrap_error(
                 ValueError("in combinations, 'n' must be at least 1")
             )
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._pub_carry(nextcarry, True)
-            out = next._combinations(
+            out = next._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
             return ak.contents.IndexedOptionArray.simplified(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -711,10 +711,10 @@ class ByteMaskedArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._mask.length == 0:
             return self
-        return self.to_IndexedOptionArray64()._unique(
+        return self.to_IndexedOptionArray64()._pub_unique(
             negaxis, starts, parents, outlength
         )
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1087,13 +1087,13 @@ class ByteMaskedArray(Content):
                 self._mask, content, self._valid_when, parameters=self._parameters
             )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
         mask = self.mask_as_bool(valid_when=True)
-        out = self._content._pub_getitem_range(slice(0, len(mask)))._to_list(
+        out = self._content._pub_getitem_range(slice(0, len(mask)))._pub_to_list(
             behavior, json_conversions
         )
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -742,10 +742,10 @@ class ByteMaskedArray(Content):
             order,
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        return self.to_IndexedOptionArray64()._sort_next(
+        return self.to_IndexedOptionArray64()._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -948,8 +948,8 @@ class ByteMaskedArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.mask._nbytes_part() + self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.mask._pub_nbytes_part() + self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -987,10 +987,10 @@ class ByteMaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         this_validbytes = self.mask_as_bool(valid_when=True)
 
-        return self._content._to_arrow(
+        return self._content._pub_to_arrow(
             pyarrow,
             self,
             ak._connect.pyarrow.and_validbytes(validbytes, this_validbytes),

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -998,8 +998,8 @@ class ByteMaskedArray(Content):
             options,
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_IndexedOptionArray64()._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        return self.to_IndexedOptionArray64()._pub_to_numpy(allow_missing)
 
     def _completely_flatten(self, backend, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -775,7 +775,7 @@ class ByteMaskedArray(Content):
                 outindex, out, parameters=parameters
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -890,7 +890,7 @@ class ByteMaskedArray(Content):
 
         next = self._content._pub_carry(nextcarry, False)
 
-        out = next._reduce_next(
+        out = next._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -718,7 +718,7 @@ class ByteMaskedArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -730,7 +730,7 @@ class ByteMaskedArray(Content):
         kind,
         order,
     ):
-        return self.to_IndexedOptionArray64()._argsort_next(
+        return self.to_IndexedOptionArray64()._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1001,10 +1001,10 @@ class ByteMaskedArray(Content):
     def _pub_to_numpy(self, allow_missing):
         return self.to_IndexedOptionArray64()._pub_to_numpy(allow_missing)
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._completely_flatten(backend, options)
+            return self.project()._pub_completely_flatten(backend, options)
         else:
             return [self]
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -586,7 +586,7 @@ class ByteMaskedArray(Content):
                 outindex, out, parameters=self.parameters
             )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
@@ -595,7 +595,7 @@ class ByteMaskedArray(Content):
 
             next = self._content._pub_carry(nextcarry, False)
 
-            offsets, flattened = next._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = next._pub_offsets_and_flattened(posaxis, depth)
 
             if offsets.length == 0:
                 return (

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1008,7 +1008,7 @@ class ByteMaskedArray(Content):
         else:
             return [self]
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._backend.nplike.known_shape:
@@ -1025,7 +1025,7 @@ class ByteMaskedArray(Content):
             def continuation():
                 return make(
                     self._mask,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,
@@ -1040,7 +1040,7 @@ class ByteMaskedArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -704,10 +704,10 @@ class ByteMaskedArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._mask.length == 0:
             return True
-        return self.to_IndexedOptionArray64()._is_unique(
+        return self.to_IndexedOptionArray64()._pub_is_unique(
             negaxis, starts, parents, outlength
         )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1172,7 +1172,7 @@ class Content:
 
         starts = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
         parents = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)
-        return self._sort_next(
+        return self._pub_sort_next(
             negaxis,
             starts,
             parents,
@@ -1183,7 +1183,7 @@ class Content:
             order,
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self,
         negaxis: Integral,
         starts: ak.index.Index,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1105,7 +1105,7 @@ class Content:
 
         starts = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
         parents = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)
-        return self._argsort_next(
+        return self._pub_argsort_next(
             negaxis,
             starts,
             None,
@@ -1117,7 +1117,7 @@ class Content:
             order,
         )
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis: Integral,
         starts: ak.index.Index,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1321,7 +1321,10 @@ class Content:
 
     @property
     def nbytes(self) -> int:
-        return self._nbytes_part()
+        return self._pub_nbytes_part()
+
+    def _pub_nbytes_part(self) -> int:
+        raise ak._errors.wrap_error(NotImplementedError)
 
     def purelist_parameter(self, key: str):
         return self.Form.purelist_parameter(self, key)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1518,7 +1518,7 @@ class Content:
     ):
         if backend is None:
             backend = self._backend
-        arrays = self._completely_flatten(
+        arrays = self._pub_completely_flatten(
             backend,
             {
                 "flatten_records": flatten_records,
@@ -1528,7 +1528,7 @@ class Content:
         )
         return tuple(arrays)
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def recursively_apply(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1455,9 +1455,9 @@ class Content:
         )
 
     def pad_none(self, length: Integral, axis: Integral, clip: bool = False) -> Content:
-        return self._pad_none(length, axis, 0, clip)
+        return self._pub_pad_none(length, axis, 0, clip)
 
-    def _pad_none(
+    def _pub_pad_none(
         self, target: Integral, axis: Integral, depth: Integral, clip: bool
     ) -> Content:
         raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1330,9 +1330,9 @@ class Content:
         negaxis = axis if axis is None else -axis
         starts = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
         parents = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)
-        return self._is_unique(negaxis, starts, parents, 1)
+        return self._pub_is_unique(negaxis, starts, parents, 1)
 
-    def _is_unique(
+    def _pub_is_unique(
         self,
         negaxis: Integral | None,
         starts: ak.index.Index,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1594,7 +1594,7 @@ class Content:
         else:
             complex_real_string, complex_imag_string = None, None
 
-        return self.packed()._to_list(
+        return self.packed()._pub_to_list(
             behavior,
             {
                 "nan_string": nan_string,
@@ -1613,9 +1613,9 @@ class Content:
         return self.to_list(behavior)
 
     def to_list(self, behavior: dict | None = None) -> list:
-        return self.packed()._to_list(behavior, None)
+        return self.packed()._pub_to_list(behavior, None)
 
-    def _to_list(
+    def _pub_to_list(
         self, behavior: dict | None, json_conversions: dict[str, Any] | None
     ) -> list:
         raise ak._errors.wrap_error(NotImplementedError)
@@ -1626,12 +1626,12 @@ class Content:
         if self.is_record:
             getitem = ak._util.recordclass(self, behavior).__getitem__
             overloaded = getitem is not ak.highlevel.Record.__getitem__ and not getattr(
-                getitem, "ignore_in_to_list", False
+                getitem, "ignore_in_pub_to_list", False
             )
         else:
             getitem = ak._util.arrayclass(self, behavior).__getitem__
             overloaded = getitem is not ak.highlevel.Array.__getitem__ and not getattr(
-                getitem, "ignore_in_to_list", False
+                getitem, "ignore_in_pub_to_list", False
             )
 
         if overloaded:
@@ -1640,7 +1640,7 @@ class Content:
             for i in range(self.length):
                 out[i] = array[i]
                 if isinstance(out[i], (ak.highlevel.Array, ak.highlevel.Record)):
-                    out[i] = out[i]._layout._to_list(behavior, json_conversions)
+                    out[i] = out[i]._layout._pub_to_list(behavior, json_conversions)
                 elif hasattr(out[i], "tolist"):
                     out[i] = out[i].tolist()
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1381,7 +1381,7 @@ class Content:
                 self.length, nplike=self._backend.index_nplike
             )
 
-            return self._unique(negaxis, starts, parents, 1)
+            return self._pub_unique(negaxis, starts, parents, 1)
 
         raise ak._errors.wrap_error(
             np.AxisError(
@@ -1391,7 +1391,7 @@ class Content:
             )
         )
 
-    def _unique(
+    def _pub_unique(
         self,
         negaxis: Integral | None,
         starts: ak.index.Index,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1544,7 +1544,7 @@ class Content:
         return_array: bool = True,
         function_name: str | None = None,
     ) -> Content | None:
-        return self._recursively_apply(
+        return self._pub_recursively_apply(
             action,
             behavior,
             1,
@@ -1560,7 +1560,7 @@ class Content:
             },
         )
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self,
         action: ActionType,
         behavior: dict | None,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1721,10 +1721,10 @@ class Content:
             return out
 
     def flatten(self, axis: Integral = 1, depth: Integral = 0) -> Content:
-        offsets, flattened = self._offsets_and_flattened(axis, depth)
+        offsets, flattened = self._pub_offsets_and_flattened(axis, depth)
         return flattened
 
-    def _offsets_and_flattened(
+    def _pub_offsets_and_flattened(
         self, axis: Integral, depth: Integral
     ) -> tuple[ak.index.Index, Content]:
         raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1476,7 +1476,7 @@ class Content:
         import awkward._connect.pyarrow
 
         pyarrow = awkward._connect.pyarrow.import_pyarrow("to_arrow")
-        return self._to_arrow(
+        return self._pub_to_arrow(
             pyarrow,
             None,
             None,
@@ -1493,7 +1493,7 @@ class Content:
             },
         )
 
-    def _to_arrow(
+    def _pub_to_arrow(
         self,
         pyarrow: Any,
         mask_node: Any,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1504,9 +1504,9 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def to_numpy(self, allow_missing: bool = True):
-        return self._to_numpy(allow_missing)
+        return self._pub_to_numpy(allow_missing)
 
-    def _to_numpy(self, allow_missing: bool):
+    def _pub_to_numpy(self, allow_missing: bool):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def completely_flatten(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -184,7 +184,7 @@ class Content:
     def _forget_length(self) -> Self:
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def to_buffers(
+    def _pub_to_buffers(
         self,
         container: MutableMapping[str, Any] | None = None,
         buffer_key="{form_key}-{attribute}",
@@ -198,7 +198,9 @@ class Content:
             backend = self._backend
         if not backend.nplike.known_data:
             raise ak._errors.wrap_error(
-                TypeError("cannot call 'to_buffers' on an array without concrete data")
+                TypeError(
+                    "cannot call '_pub_to_buffers' on an array without concrete data"
+                )
             )
 
         if isinstance(buffer_key, str):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1196,7 +1196,7 @@ class Content:
     ):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _combinations_axis0(
+    def _pub_combinations_axis0(
         self,
         n: Integral,
         replacement: bool,
@@ -1289,9 +1289,9 @@ class Content:
                 raise ak._errors.wrap_error(
                     ValueError("if provided, the length of 'fields' must be 'n'")
                 )
-        return self._combinations(n, replacement, recordlookup, parameters, axis, 0)
+        return self._pub_combinations(n, replacement, recordlookup, parameters, axis, 0)
 
-    def _combinations(
+    def _pub_combinations(
         self,
         n: Integral,
         replacement: bool,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -887,7 +887,7 @@ class Content:
     def _local_index(self, axis: Integral, depth: Integral):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _reduce(
+    def _pub_reduce(
         self,
         reducer: type[ak._reducers.Reducer],
         axis: Integral = -1,
@@ -932,7 +932,7 @@ class Content:
         starts = ak.index.Index64.zeros(1, self._backend.index_nplike)
         parents = ak.index.Index64.zeros(self.length, self._backend.index_nplike)
         shifts = None
-        next = self._reduce_next(
+        next = self._pub_reduce_next(
             reducer,
             negaxis,
             starts,
@@ -946,7 +946,7 @@ class Content:
 
         return next[0]
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer: type[ak._reducers.Reducer],
         negaxis: Integral,
@@ -967,7 +967,9 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.ArgMin, axis, mask, keepdims, behavior)
+        return self._pub_reduce(
+            awkward._reducers.ArgMin, axis, mask, keepdims, behavior
+        )
 
     def argmax(
         self,
@@ -976,7 +978,9 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.ArgMax, axis, mask, keepdims, behavior)
+        return self._pub_reduce(
+            awkward._reducers.ArgMax, axis, mask, keepdims, behavior
+        )
 
     def count(
         self,
@@ -985,7 +989,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.Count, axis, mask, keepdims, behavior)
+        return self._pub_reduce(awkward._reducers.Count, axis, mask, keepdims, behavior)
 
     def count_nonzero(
         self,
@@ -994,7 +998,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(
+        return self._pub_reduce(
             awkward._reducers.CountNonzero, axis, mask, keepdims, behavior
         )
 
@@ -1005,7 +1009,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.Sum, axis, mask, keepdims, behavior)
+        return self._pub_reduce(awkward._reducers.Sum, axis, mask, keepdims, behavior)
 
     def prod(
         self,
@@ -1014,7 +1018,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.Prod, axis, mask, keepdims, behavior)
+        return self._pub_reduce(awkward._reducers.Prod, axis, mask, keepdims, behavior)
 
     def any(
         self,
@@ -1023,7 +1027,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.Any, axis, mask, keepdims, behavior)
+        return self._pub_reduce(awkward._reducers.Any, axis, mask, keepdims, behavior)
 
     def all(
         self,
@@ -1032,7 +1036,7 @@ class Content:
         keepdims: bool = False,
         behavior: dict | None = None,
     ):
-        return self._reduce(awkward._reducers.All, axis, mask, keepdims, behavior)
+        return self._pub_reduce(awkward._reducers.All, axis, mask, keepdims, behavior)
 
     def min(
         self,
@@ -1042,7 +1046,7 @@ class Content:
         initial: dict | None = None,
         behavior=None,
     ):
-        return self._reduce(
+        return self._pub_reduce(
             awkward._reducers.Min(initial), axis, mask, keepdims, behavior
         )
 
@@ -1054,7 +1058,7 @@ class Content:
         initial: dict | None = None,
         behavior: dict = None,
     ):
-        return self._reduce(
+        return self._pub_reduce(
             awkward._reducers.Max(initial), axis, mask, keepdims, behavior
         )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -639,7 +639,7 @@ class Content:
                 )
 
             out = ak._slicing.getitem_next_array_wrap(
-                self._carry(carry, allow_lazy), where.shape
+                self._pub_carry(carry, allow_lazy), where.shape
             )
             if out.length == 0:
                 return out._pub_getitem_nothing()
@@ -650,7 +650,7 @@ class Content:
             return self._pub_getitem((where,))
 
         elif ak._util.is_sized_iterable(where) and len(where) == 0:
-            return self._carry(
+            return self._pub_carry(
                 ak.index.Index64.empty(0, self._backend.index_nplike),
                 allow_lazy=True,
             )
@@ -698,10 +698,10 @@ class Content:
     def _pub_getitem_next(self, head, tail, advanced: ak.index.Index | None):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _carry(self, carry: ak.index.Index, allow_lazy: bool):
+    def _pub_carry(self, carry: ak.index.Index, allow_lazy: bool):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _carry_asrange(self, carry: ak.index.Index):
+    def _pub_carry_asrange(self, carry: ak.index.Index):
         assert isinstance(carry, ak.index.Index)
 
         result = self._backend.index_nplike.empty(1, dtype=np.bool_)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -335,7 +335,7 @@ class EmptyArray(Content):
     def _pub_completely_flatten(self, backend, options):
         return []
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if options["return_array"]:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -182,7 +182,7 @@ class EmptyArray(Content):
             out = ak.index.Index64.empty(0, nplike=self._backend.nplike)
             return ak.contents.NumpyArray(out, parameters=None, backend=self._backend)
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -305,7 +305,7 @@ class EmptyArray(Content):
         else:
             return self.pad_none_axis0(target, True)
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         if options["emptyarray_to"] is None:
             return pyarrow.Array.from_buffers(
                 ak._connect.pyarrow.to_awkwardarrow_type(
@@ -327,7 +327,7 @@ class EmptyArray(Content):
             next = ak.contents.NumpyArray(
                 numpy.empty(length, dtype), self._parameters, backend=self._backend
             )
-            return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
+            return next._pub_to_arrow(pyarrow, mask_node, validbytes, length, options)
 
     def _pub_to_numpy(self, allow_missing):
         return self._backend.nplike.empty(0, dtype=np.float64)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -230,7 +230,7 @@ class EmptyArray(Content):
     def _unique(self, negaxis, starts, parents, outlength):
         return self
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -243,7 +243,7 @@ class EmptyArray(Content):
         order,
     ):
         as_numpy = self.to_NumpyArray(np.float64)
-        return as_numpy._argsort_next(
+        return as_numpy._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -114,7 +114,7 @@ class EmptyArray(Content):
             return self._pub_getitem_range(slice(0, 0))
         raise ak._errors.index_error(self, where, "not an array of records")
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         if not carry.nplike.known_shape or carry.length == 0:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -265,7 +265,7 @@ class EmptyArray(Content):
             parameters=self._parameters, backend=self._backend
         )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -278,7 +278,7 @@ class EmptyArray(Content):
         behavior,
     ):
         as_numpy = self.to_NumpyArray(reducer.preferred_dtype)
-        return as_numpy._reduce_next(
+        return as_numpy._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -293,7 +293,7 @@ class EmptyArray(Content):
     def _validity_error(self, path):
         return ""
 
-    def _nbytes_part(self):
+    def _pub_nbytes_part(self):
         return 0
 
     def _pub_pad_none(self, target, axis, depth, clip):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -296,7 +296,7 @@ class EmptyArray(Content):
     def _nbytes_part(self):
         return 0
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis != depth:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -224,7 +224,7 @@ class EmptyArray(Content):
             parameters=self._parameters, backend=self._backend
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         return True
 
     def _pub_unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -255,7 +255,7 @@ class EmptyArray(Content):
             order,
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         return self

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -332,7 +332,7 @@ class EmptyArray(Content):
     def _pub_to_numpy(self, allow_missing):
         return self._backend.nplike.empty(0, dtype=np.float64)
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         return []
 
     def _recursively_apply(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -227,7 +227,7 @@ class EmptyArray(Content):
     def _is_unique(self, negaxis, starts, parents, outlength):
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         return self
 
     def _pub_argsort_next(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -97,21 +97,21 @@ class EmptyArray(Content):
     def __iter__(self):
         return iter([])
 
-    def _getitem_nothing(self):
+    def _pub_getitem_nothing(self):
         return self
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         raise ak._errors.index_error(self, where, "array is empty")
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         return self
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         raise ak._errors.index_error(self, where, "not an array of records")
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         if len(where) == 0:
-            return self._getitem_range(slice(0, 0))
+            return self._pub_getitem_range(slice(0, 0))
         raise ak._errors.index_error(self, where, "not an array of records")
 
     def _carry(self, carry, allow_lazy):
@@ -122,7 +122,7 @@ class EmptyArray(Content):
         else:
             raise ak._errors.index_error(self, carry.data, "array is empty")
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         raise ak._errors.index_error(
             self,
             ak.contents.ListArray(
@@ -131,7 +131,7 @@ class EmptyArray(Content):
             "too many jagged slice dimensions for array",
         )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -142,16 +142,16 @@ class EmptyArray(Content):
             raise ak._errors.index_error(self, head, "array is empty")
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
             if not head.nplike.known_shape or head.length == 0:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -372,7 +372,7 @@ class EmptyArray(Content):
     def packed(self):
         return self
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         return []
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -329,7 +329,7 @@ class EmptyArray(Content):
             )
             return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         return self._backend.nplike.empty(0, dtype=np.float64)
 
     def _completely_flatten(self, backend, options):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -260,7 +260,7 @@ class EmptyArray(Content):
     ):
         return self
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         return ak.contents.EmptyArray(
             parameters=self._parameters, backend=self._backend
         )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1015,8 +1015,8 @@ class IndexedArray(Content):
     def _pub_to_numpy(self, allow_missing):
         return self.project()._pub_to_numpy(allow_missing)
 
-    def _completely_flatten(self, backend, options):
-        return self.project()._completely_flatten(backend, options)
+    def _pub_completely_flatten(self, backend, options):
+        return self.project()._pub_completely_flatten(backend, options)
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -948,8 +948,8 @@ class IndexedArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.index._nbytes_part() + self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.index._pub_nbytes_part() + self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -893,12 +893,14 @@ class IndexedArray(Content):
             order,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
-            return self.project()._combinations(
+            return self.project()._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1018,7 +1018,7 @@ class IndexedArray(Content):
     def _pub_completely_flatten(self, backend, options):
         return self.project()._pub_completely_flatten(backend, options)
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
@@ -1044,7 +1044,7 @@ class IndexedArray(Content):
             def continuation():
                 return make(
                     index,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,
@@ -1058,7 +1058,7 @@ class IndexedArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -845,7 +845,7 @@ class IndexedArray(Content):
 
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -858,7 +858,7 @@ class IndexedArray(Content):
         order,
     ):
         next = self._content._pub_carry(self._index, False)
-        return next._argsort_next(
+        return next._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -951,16 +951,16 @@ class IndexedArray(Content):
     def _nbytes_part(self):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
-            return self.project()._pad_none(target, posaxis, depth, clip)
+            return self.project()._pub_pad_none(target, posaxis, depth, clip)
         else:
             return ak.contents.IndexedArray(
                 self._index,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pub_pad_none(target, posaxis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -201,20 +201,20 @@ class IndexedArray(Content):
         else:
             return self._index.data < 0
 
-    def _getitem_nothing(self):
-        return self._content._getitem_range(slice(0, 0))
+    def _pub_getitem_nothing(self):
+        return self._content._pub_getitem_range(slice(0, 0))
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if not self._backend.nplike.known_data:
-            return self._content._getitem_at(where)
+            return self._content._pub_getitem_at(where)
 
         if where < 0:
             where += self.length
         if self._backend.nplike.known_shape and not 0 <= where < self.length:
             raise ak._errors.index_error(self, where)
-        return self._content._getitem_at(self._index[where])
+        return self._content._pub_getitem_at(self._index[where])
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         if not self._backend.nplike.known_shape:
             return self
 
@@ -224,17 +224,17 @@ class IndexedArray(Content):
             self._index[start:stop], self._content, parameters=self._parameters
         )
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         return IndexedArray.simplified(
             self._index,
-            self._content._getitem_field(where, only_fields),
+            self._content._pub_getitem_field(where, only_fields),
             parameters=None,
         )
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         return IndexedArray.simplified(
             self._index,
-            self._content._getitem_fields(where, only_fields),
+            self._content._pub_getitem_fields(where, only_fields),
             parameters=None,
         )
 
@@ -248,7 +248,9 @@ class IndexedArray(Content):
 
         return IndexedArray(nextindex, self._content, parameters=self._parameters)
 
-    def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged_generic(
+        self, slicestarts, slicestops, slicecontent, tail
+    ):
         if self._backend.nplike.known_shape and slicestarts.length != self.length:
             raise ak._errors.index_error(
                 self,
@@ -280,14 +282,16 @@ class IndexedArray(Content):
         )
         # an eager carry (allow_lazy = false) to avoid infinite loop (unproven)
         next = self._content._carry(nextcarry, False)
-        return next._getitem_next_jagged(slicestarts, slicestops, slicecontent, tail)
-
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
-        return self._getitem_next_jagged_generic(
+        return next._pub_getitem_next_jagged(
             slicestarts, slicestops, slicecontent, tail
         )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+        return self._pub_getitem_next_jagged_generic(
+            slicestarts, slicestops, slicecontent, tail
+        )
+
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -318,22 +322,22 @@ class IndexedArray(Content):
             )
 
             next = self._content._carry(nextcarry, False)
-            return next._getitem_next(head, tail, advanced)
+            return next._pub_getitem_next(head, tail, advanced)
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            return self._getitem_next_missing(head, tail, advanced)
+            return self._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -703,7 +703,7 @@ class IndexedArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._index.length == 0:
             return True
 
@@ -713,7 +713,7 @@ class IndexedArray(Content):
             return False
 
         next = self._content._pub_carry(nextindex, False)
-        return next._is_unique(negaxis, starts, parents, outlength)
+        return next._pub_is_unique(negaxis, starts, parents, outlength)
 
     def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._index.length == 0:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -89,7 +89,7 @@ class IndexedArray(Content):
         is_cat = parameters is not None and parameters.get("__array__") == "categorical"
 
         if content.is_union and not is_cat:
-            return content._carry(index, allow_lazy=False).copy(
+            return content._pub_carry(index, allow_lazy=False).copy(
                 parameters=ak._util.merge_parameters(content._parameters, parameters)
             )
 
@@ -238,7 +238,7 @@ class IndexedArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -281,7 +281,7 @@ class IndexedArray(Content):
             slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
         )
         # an eager carry (allow_lazy = false) to avoid infinite loop (unproven)
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
         return next._pub_getitem_next_jagged(
             slicestarts, slicestops, slicecontent, tail
         )
@@ -321,7 +321,7 @@ class IndexedArray(Content):
                 slicer=head,
             )
 
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
             return next._pub_getitem_next(head, tail, advanced)
 
         elif isinstance(head, str):
@@ -396,7 +396,7 @@ class IndexedArray(Content):
                     self._content.length,
                 )
             )
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
             return next.copy(
                 parameters=ak._util.merge_parameters(
                     next._parameters,
@@ -712,7 +712,7 @@ class IndexedArray(Content):
         if len(nextindex) != len(self._index):
             return False
 
-        next = self._content._carry(nextindex, False)
+        next = self._content._pub_carry(nextindex, False)
         return next._is_unique(negaxis, starts, parents, outlength)
 
     def _unique(self, negaxis, starts, parents, outlength):
@@ -752,7 +752,7 @@ class IndexedArray(Content):
                 index_length,
             )
         )
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
         unique = next._unique(
             negaxis,
             starts,
@@ -857,7 +857,7 @@ class IndexedArray(Content):
         kind,
         order,
     ):
-        next = self._content._carry(self._index, False)
+        next = self._content._pub_carry(self._index, False)
         return next._argsort_next(
             negaxis,
             starts,
@@ -881,7 +881,7 @@ class IndexedArray(Content):
         kind,
         order,
     ):
-        next = self._content._carry(self._index, False)
+        next = self._content._pub_carry(self._index, False)
         return next._sort_next(
             negaxis,
             starts,
@@ -914,7 +914,7 @@ class IndexedArray(Content):
         keepdims,
         behavior,
     ):
-        next = self._content._carry(self._index, False)
+        next = self._content._pub_carry(self._index, False)
         return next._reduce_next(
             reducer,
             negaxis,
@@ -1004,7 +1004,7 @@ class IndexedArray(Content):
                 # In that case, don't call self._content[index]; it's empty anyway.
                 next = self._content
             else:
-                next = self._content._carry(ak.index.Index(index), False)
+                next = self._content._pub_carry(ak.index.Index(index), False)
 
             return next.merge_parameters(self._parameters)._to_arrow(
                 pyarrow, mask_node, validbytes, length, options
@@ -1097,7 +1097,7 @@ class IndexedArray(Content):
             return out
 
         index = self._index.raw(numpy)
-        nextcontent = self._content._carry(ak.index.Index(index), False)
+        nextcontent = self._content._pub_carry(ak.index.Index(index), False)
         return nextcontent._to_list(behavior, json_conversions)
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -870,7 +870,7 @@ class IndexedArray(Content):
             order,
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self,
         negaxis,
         starts,
@@ -882,7 +882,7 @@ class IndexedArray(Content):
         order,
     ):
         next = self._content._pub_carry(self._index, False)
-        return next._sort_next(
+        return next._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -964,7 +964,7 @@ class IndexedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         if (
             not options["categorical_as_dictionary"]
             and self.parameter("__array__") == "categorical"
@@ -972,12 +972,12 @@ class IndexedArray(Content):
             next_parameters = dict(self._parameters)
             del next_parameters["__array__"]
             next = IndexedArray(self._index, self._content, parameters=next_parameters)
-            return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
+            return next._pub_to_arrow(pyarrow, mask_node, validbytes, length, options)
 
         index = self._index.raw(numpy)
 
         if self.parameter("__array__") == "categorical":
-            dictionary = self._content._to_arrow(
+            dictionary = self._content._pub_to_arrow(
                 pyarrow, None, None, self._content.length, options
             )
             out = pyarrow.DictionaryArray.from_arrays(
@@ -1001,14 +1001,14 @@ class IndexedArray(Content):
 
         else:
             if self._content.length == 0:
-                # IndexedOptionArray._to_arrow replaces -1 in the index with 0. So behind
+                # IndexedOptionArray._pub_to_arrow replaces -1 in the index with 0. So behind
                 # every masked value is self._content[0], unless self._content.length == 0.
                 # In that case, don't call self._content[index]; it's empty anyway.
                 next = self._content
             else:
                 next = self._content._pub_carry(ak.index.Index(index), False)
 
-            return next.merge_parameters(self._parameters)._to_arrow(
+            return next.merge_parameters(self._parameters)._pub_to_arrow(
                 pyarrow, mask_node, validbytes, length, options
             )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -416,13 +416,13 @@ class IndexedArray(Content):
         else:
             return self.project().num(posaxis, depth)
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:
-            return self.project()._offsets_and_flattened(posaxis, depth)
+            return self.project()._pub_offsets_and_flattened(posaxis, depth)
 
     def _mergeable(self, other, mergebool):
         if isinstance(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1093,14 +1093,14 @@ class IndexedArray(Content):
         else:
             return self.project().packed()
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
         index = self._index.raw(numpy)
         nextcontent = self._content._pub_carry(ak.index.Index(index), False)
-        return nextcontent._to_list(behavior, json_conversions)
+        return nextcontent._pub_to_list(behavior, json_conversions)
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1012,8 +1012,8 @@ class IndexedArray(Content):
                 pyarrow, mask_node, validbytes, length, options
             )
 
-    def _to_numpy(self, allow_missing):
-        return self.project()._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        return self.project()._pub_to_numpy(allow_missing)
 
     def _completely_flatten(self, backend, options):
         return self.project()._completely_flatten(backend, options)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -631,7 +631,7 @@ class IndexedArray(Content):
         else:
             return self.project()._local_index(posaxis, depth)
 
-    def _unique_index(self, index, sorted=True):
+    def _pub_unique_index(self, index, sorted=True):
         next = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)
         length = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
 
@@ -707,7 +707,7 @@ class IndexedArray(Content):
         if self._index.length == 0:
             return True
 
-        nextindex = self._unique_index(self._index)
+        nextindex = self._pub_unique_index(self._index)
 
         if len(nextindex) != len(self._index):
             return False
@@ -715,7 +715,7 @@ class IndexedArray(Content):
         next = self._content._pub_carry(nextindex, False)
         return next._is_unique(negaxis, starts, parents, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._index.length == 0:
             return self
 
@@ -753,7 +753,7 @@ class IndexedArray(Content):
             )
         )
         next = self._content._pub_carry(nextcarry, False)
-        unique = next._unique(
+        unique = next._pub_unique(
             negaxis,
             starts,
             nextparents,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -902,7 +902,7 @@ class IndexedArray(Content):
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -915,7 +915,7 @@ class IndexedArray(Content):
         behavior,
     ):
         next = self._content._pub_carry(self._index, False)
-        return next._reduce_next(
+        return next._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1236,7 +1236,7 @@ class IndexedOptionArray(Content):
         else:
             return out
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         assert (
@@ -1247,7 +1247,7 @@ class IndexedOptionArray(Content):
 
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
 
-        out = next._sort_next(
+        out = next._pub_sort_next(
             negaxis,
             starts,
             nextparents,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1464,7 +1464,7 @@ class IndexedOptionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         index = numpy.array(self._index, copy=True)
         this_validbytes = self.mask_as_bool(valid_when=True)
         index[~this_validbytes] = 0
@@ -1479,7 +1479,7 @@ class IndexedOptionArray(Content):
         next = ak.contents.IndexedArray(
             ak.index.Index(index), self._content, parameters=next_parameters
         )
-        return next._to_arrow(
+        return next._pub_to_arrow(
             pyarrow,
             self,
             ak._connect.pyarrow.and_validbytes(validbytes, this_validbytes),

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1435,7 +1435,7 @@ class IndexedOptionArray(Content):
     def _nbytes_part(self):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
@@ -1453,14 +1453,14 @@ class IndexedOptionArray(Content):
                     mask.dtype.type,
                 ](index.data, mask.data, mask.length)
             )
-            next = self.project()._pad_none(target, posaxis, depth, clip)
+            next = self.project()._pub_pad_none(target, posaxis, depth, clip)
             return ak.contents.IndexedOptionArray.simplified(
                 index, next, parameters=self._parameters
             )
         else:
             return ak.contents.IndexedOptionArray(
                 self._index,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pub_pad_none(target, posaxis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1545,7 +1545,7 @@ class IndexedOptionArray(Content):
         else:
             return [self]
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
@@ -1575,7 +1575,7 @@ class IndexedOptionArray(Content):
             def continuation():
                 return make(
                     index,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,
@@ -1589,7 +1589,7 @@ class IndexedOptionArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1398,14 +1398,16 @@ class IndexedOptionArray(Content):
                 outoffsets, inner, parameters=self._parameters
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
             next = self._content._pub_carry(nextcarry, True)
-            out = next._combinations(
+            out = next._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
             return IndexedOptionArray.simplified(outindex, out, parameters=parameters)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -871,7 +871,7 @@ class IndexedOptionArray(Content):
         projected = self.project()
         return projected._is_unique(negaxis, starts, parents, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         branch, depth = self.branch_depth
 
         inject_nones = (
@@ -882,7 +882,7 @@ class IndexedOptionArray(Content):
 
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
 
-        out = next._unique(
+        out = next._pub_unique(
             negaxis,
             starts,
             nextparents,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1538,10 +1538,10 @@ class IndexedOptionArray(Content):
             else:
                 return content
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._completely_flatten(backend, options)
+            return self.project()._pub_completely_flatten(backend, options)
         else:
             return [self]
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1642,7 +1642,7 @@ class IndexedOptionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
@@ -1653,7 +1653,7 @@ class IndexedOptionArray(Content):
         nextcontent = self._content._pub_carry(
             ak.index.Index(index[not_missing]), False
         )
-        out = nextcontent._to_list(behavior, json_conversions)
+        out = nextcontent._pub_to_list(behavior, json_conversions)
 
         for i, isvalid in enumerate(not_missing):
             if not isvalid:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -507,7 +507,7 @@ class IndexedOptionArray(Content):
             outindex, out, parameters=self.parameters
         )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
@@ -515,7 +515,7 @@ class IndexedOptionArray(Content):
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
             next = self._content._pub_carry(nextcarry, False)
 
-            offsets, flattened = next._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = next._pub_offsets_and_flattened(posaxis, depth)
 
             if offsets.length == 0:
                 return (

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1299,7 +1299,7 @@ class IndexedOptionArray(Content):
         else:
             return out
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1320,7 +1320,7 @@ class IndexedOptionArray(Content):
         else:
             nextshifts = None
 
-        out = next._reduce_next(
+        out = next._pub_reduce_next(
             reducer,
             negaxis,
             starts,
@@ -1361,11 +1361,11 @@ class IndexedOptionArray(Content):
                     )
                 )
             # In this branch, we're above the axis at which the reduction takes place.
-            # `next._reduce_next` is therefore expected to return a list/regular layout
-            # node. As detailed in `RegularArray._reduce_next`, `_reduce_next` wraps the
+            # `next._pub_reduce_next` is therefore expected to return a list/regular layout
+            # node. As detailed in `RegularArray._pub_reduce_next`, `_pub_reduce_next` wraps the
             # reduction in a list-type of length `outlength` before returning to the caller,
             # which effectively means that the reduction of *this* layout corresponds to the
-            # child of the returned `next._reduce_next(...)`, i.e. `out.content`. So, we unpack
+            # child of the returned `next._pub_reduce_next(...)`, i.e. `out.content`. So, we unpack
             # the returned list type and wrap its child by a new `IndexedOptionArray`, before
             # re-wrapping the result to have the length and starts requested by the caller.
             outoffsets = ak.index.Index64.empty(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -864,12 +864,12 @@ class IndexedOptionArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._index.length == 0:
             return True
 
         projected = self.project()
-        return projected._is_unique(negaxis, starts, parents, outlength)
+        return projected._pub_is_unique(negaxis, starts, parents, outlength)
 
     def _pub_unique(self, negaxis, starts, parents, outlength):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1432,8 +1432,8 @@ class IndexedOptionArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.index._nbytes_part() + self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.index._pub_nbytes_part() + self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -198,9 +198,9 @@ class IndexedOptionArray(Content):
         if self._content.length == 0:
             content = self._content.form.length_one_array(
                 backend=self._backend, highlevel=False
-            )._carry(carry, False)
+            )._pub_carry(carry, False)
         else:
-            content = self._content._carry(carry, False)
+            content = self._content._pub_carry(carry, False)
 
         return ak.contents.ByteMaskedArray(
             mask, content, valid_when, parameters=self._parameters
@@ -257,7 +257,7 @@ class IndexedOptionArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -366,7 +366,7 @@ class IndexedOptionArray(Content):
             ),
             slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
         )
-        next = self._content._carry(nextcarry, True)
+        next = self._content._pub_carry(nextcarry, True)
         out = next._pub_getitem_next_jagged(
             reducedstarts, reducedstops, slicecontent, tail
         )
@@ -391,7 +391,7 @@ class IndexedOptionArray(Content):
 
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, True)
+            next = self._content._pub_carry(nextcarry, True)
             out = next._pub_getitem_next(head, tail, advanced)
             return IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters
@@ -490,7 +490,7 @@ class IndexedOptionArray(Content):
                 )
             )
 
-            return self._content._carry(nextcarry, False)
+            return self._content._pub_carry(nextcarry, False)
 
     def num(self, axis, depth=0):
         posaxis = self.axis_wrap_if_negative(axis)
@@ -501,7 +501,7 @@ class IndexedOptionArray(Content):
             else:
                 return out
         _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
         out = next.num(posaxis, depth)
         return ak.contents.IndexedOptionArray.simplified(
             outindex, out, parameters=self.parameters
@@ -513,7 +513,7 @@ class IndexedOptionArray(Content):
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
 
             offsets, flattened = next._offsets_and_flattened(posaxis, depth)
 
@@ -784,7 +784,7 @@ class IndexedOptionArray(Content):
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
-            next = self._content._carry(nextcarry, False)
+            next = self._content._pub_carry(nextcarry, False)
             out = next._local_index(posaxis, depth)
             out2 = ak.contents.IndexedOptionArray(
                 outindex, out, parameters=self._parameters
@@ -849,7 +849,7 @@ class IndexedOptionArray(Content):
             )
         )
 
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
         if nextstarts.length > 1:
             return next._is_subrange_equal(nextstarts, nextstops, nextstarts.length)
         else:
@@ -1098,7 +1098,7 @@ class IndexedOptionArray(Content):
                 index_length,
             )
         )
-        next = self._content._carry(nextcarry, False)
+        next = self._content._pub_carry(nextcarry, False)
         return next, nextparents, numnull, outindex
 
     def _argsort_next(
@@ -1404,7 +1404,7 @@ class IndexedOptionArray(Content):
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
-            next = self._content._carry(nextcarry, True)
+            next = self._content._pub_carry(nextcarry, True)
             out = next._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
@@ -1648,7 +1648,9 @@ class IndexedOptionArray(Content):
         index = self._index.raw(numpy)
         not_missing = index >= 0
 
-        nextcontent = self._content._carry(ak.index.Index(index[not_missing]), False)
+        nextcontent = self._content._pub_carry(
+            ak.index.Index(index[not_missing]), False
+        )
         out = nextcontent._to_list(behavior, json_conversions)
 
         for i, isvalid in enumerate(not_missing):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -217,12 +217,12 @@ class IndexedOptionArray(Content):
         else:
             return self._index.raw(self._backend.index_nplike) < 0
 
-    def _getitem_nothing(self):
-        return self._content._getitem_range(slice(0, 0))
+    def _pub_getitem_nothing(self):
+        return self._content._pub_getitem_range(slice(0, 0))
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if not self._backend.nplike.known_data:
-            return ak._typetracer.MaybeNone(self._content._getitem_at(where))
+            return ak._typetracer.MaybeNone(self._content._pub_getitem_at(where))
 
         if where < 0:
             where += self.length
@@ -231,9 +231,9 @@ class IndexedOptionArray(Content):
         if self._index[where] < 0:
             return None
         else:
-            return self._content._getitem_at(self._index[where])
+            return self._content._pub_getitem_at(self._index[where])
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         if not self._backend.nplike.known_shape:
             return self
 
@@ -243,17 +243,17 @@ class IndexedOptionArray(Content):
             self._index[start:stop], self._content, parameters=self._parameters
         )
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         return IndexedOptionArray.simplified(
             self._index,
-            self._content._getitem_field(where, only_fields),
+            self._content._pub_getitem_field(where, only_fields),
             parameters=None,
         )
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         return IndexedOptionArray.simplified(
             self._index,
-            self._content._getitem_fields(where, only_fields),
+            self._content._pub_getitem_fields(where, only_fields),
             parameters=None,
         )
 
@@ -316,7 +316,9 @@ class IndexedOptionArray(Content):
 
         return numnull[0], nextcarry, outindex
 
-    def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged_generic(
+        self, slicestarts, slicestops, slicecontent, tail
+    ):
         slicestarts = slicestarts.to_nplike(self._backend.index_nplike)
         slicestops = slicestops.to_nplike(self._backend.index_nplike)
 
@@ -365,18 +367,20 @@ class IndexedOptionArray(Content):
             slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
         )
         next = self._content._carry(nextcarry, True)
-        out = next._getitem_next_jagged(reducedstarts, reducedstops, slicecontent, tail)
+        out = next._pub_getitem_next_jagged(
+            reducedstarts, reducedstops, slicecontent, tail
+        )
 
         return ak.contents.IndexedOptionArray.simplified(
             outindex, out, parameters=self._parameters
         )
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
-        return self._getitem_next_jagged_generic(
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+        return self._pub_getitem_next_jagged_generic(
             slicestarts, slicestops, slicecontent, tail
         )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -388,25 +392,25 @@ class IndexedOptionArray(Content):
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, True)
-            out = next._getitem_next(head, tail, advanced)
+            out = next._pub_getitem_next(head, tail, advanced)
             return IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters
             )
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list) and isinstance(head[0], str):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            return self._getitem_next_missing(head, tail, advanced)
+            return self._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1487,8 +1487,8 @@ class IndexedOptionArray(Content):
             options,
         )
 
-    def _to_numpy(self, allow_missing):
-        content = self.project()._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        content = self.project()._pub_to_numpy(allow_missing)
 
         shape = list(content.shape)
         shape[0] = self.length

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1101,7 +1101,7 @@ class IndexedOptionArray(Content):
         next = self._content._pub_carry(nextcarry, False)
         return next, nextparents, numnull, outindex
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -1128,7 +1128,7 @@ class IndexedOptionArray(Content):
         else:
             nextshifts = None
 
-        out = next._argsort_next(
+        out = next._pub_argsort_next(
             negaxis,
             starts,
             nextshifts,
@@ -1140,7 +1140,7 @@ class IndexedOptionArray(Content):
             order,
         )
 
-        # `next._argsort_next` is given the non-None values. We choose to
+        # `next._pub_argsort_next` is given the non-None values. We choose to
         # sort None values to the end of the list, meaning we need to grow `out`
         # to account for these None values. First, we locate these nones within
         # their sublists
@@ -1165,7 +1165,7 @@ class IndexedOptionArray(Content):
         # If we wrap a NumpyArray (i.e., axis=-1), then we want `argmax` to return
         # the indices of each `None` value, rather than `None` itself.
         # We can test for this condition by seeing whether the NumpyArray of indices
-        # is mergeable with our content (`out = next._argsort_next result`).
+        # is mergeable with our content (`out = next._pub_argsort_next result`).
         # If so, try to concatenate them at the end of `out`.`
         nulls_index_content = ak.contents.NumpyArray(
             nulls_index, parameters=None, backend=self._backend

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1473,8 +1473,8 @@ class ListArray(Content):
     def packed(self):
         return self.to_ListOffsetArray64(True).packed()
 
-    def _to_list(self, behavior, json_conversions):
-        return ListOffsetArray._to_list(self, behavior, json_conversions)
+    def _pub_to_list(self, behavior, json_conversions):
+        return ListOffsetArray._pub_to_list(self, behavior, json_conversions)
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1167,10 +1167,10 @@ class ListArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._starts.length == 0:
             return self
-        return self.to_ListOffsetArray64(True)._unique(
+        return self.to_ListOffsetArray64(True)._pub_unique(
             negaxis, starts, parents, outlength
         )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1219,7 +1219,7 @@ class ListArray(Content):
             self, n, replacement, recordlookup, parameters, axis, depth
         )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1231,7 +1231,7 @@ class ListArray(Content):
         keepdims,
         behavior,
     ):
-        return self.to_ListOffsetArray64(True)._reduce_next(
+        return self.to_ListOffsetArray64(True)._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1385,8 +1385,8 @@ class ListArray(Content):
                 target, axis, depth, clip=True
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        return self.to_ListOffsetArray64(False)._to_arrow(
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+        return self.to_ListOffsetArray64(False)._pub_to_arrow(
             pyarrow, mask_node, validbytes, length, options
         )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1393,7 +1393,7 @@ class ListArray(Content):
     def _pub_to_numpy(self, allow_missing):
         return self.to_RegularArray()._pub_to_numpy(allow_missing)
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
@@ -1402,7 +1402,7 @@ class ListArray(Content):
         else:
             next = self.to_ListOffsetArray64(False)
             flat = next.content[next.offsets[0] : next.offsets[-1]]
-            return flat._completely_flatten(backend, options)
+            return flat._pub_completely_flatten(backend, options)
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -942,8 +942,8 @@ class ListArray(Content):
         else:
             return self.to_ListOffsetArray64(True).num(posaxis, depth)
 
-    def _offsets_and_flattened(self, axis, depth):
-        return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
+    def _pub_offsets_and_flattened(self, axis, depth):
+        return self.to_ListOffsetArray64(True)._pub_offsets_and_flattened(axis, depth)
 
     def _mergeable(self, other, mergebool):
         if isinstance(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -267,7 +267,7 @@ class ListArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -425,7 +425,7 @@ class ListArray(Content):
                 ),
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
             nexthead, nexttail = ak._slicing.headtail(tail)
             outcontent = nextcontent._pub_getitem_next(nexthead, nexttail, None)
 
@@ -515,7 +515,7 @@ class ListArray(Content):
 
                 # Generate ranges between starts and stops
                 as_list_offset_array = self.to_ListOffsetArray64(True)
-                nextcontent = as_list_offset_array._content._carry(nextcarry, True)
+                nextcontent = as_list_offset_array._content._pub_carry(nextcarry, True)
                 next = ak.contents.ListOffsetArray(
                     smalloffsets, nextcontent, parameters=self._parameters
                 )
@@ -594,7 +594,7 @@ class ListArray(Content):
                 ),
                 slicer=head,
             )
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
             return nextcontent._pub_getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
@@ -679,7 +679,7 @@ class ListArray(Content):
                 slicer=head,
             )
 
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
 
             if advanced is None or advanced.length == 0:
                 return ak.contents.ListOffsetArray(
@@ -793,7 +793,7 @@ class ListArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
 
                 out = nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
@@ -841,7 +841,7 @@ class ListArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
 
                 return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
@@ -895,7 +895,7 @@ class ListArray(Content):
                 ),
                 slicer=head,
             )
-            carried = self._content._carry(nextcarry, True)
+            carried = self._content._pub_carry(nextcarry, True)
             down = carried._pub_getitem_next_jagged(
                 multistarts, multistops, head._content, tail
             )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1390,8 +1390,8 @@ class ListArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_RegularArray()._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        return self.to_RegularArray()._pub_to_numpy(allow_missing)
 
     def _completely_flatten(self, backend, options):
         if (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1279,7 +1279,7 @@ class ListArray(Content):
             + self.content._nbytes_part()
         )
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         if not clip:
             posaxis = self.axis_wrap_if_negative(axis)
             if posaxis == depth:
@@ -1377,11 +1377,11 @@ class ListArray(Content):
                 return ak.contents.ListArray(
                     self._starts,
                     self._stops,
-                    self._content._pad_none(target, posaxis, depth + 1, clip),
+                    self._content._pub_pad_none(target, posaxis, depth + 1, clip),
                     parameters=self._parameters,
                 )
         else:
-            return self.to_ListOffsetArray64(True)._pad_none(
+            return self.to_ListOffsetArray64(True)._pub_pad_none(
                 target, axis, depth, clip=True
             )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1404,7 +1404,7 @@ class ListArray(Content):
             flat = next.content[next.offsets[0] : next.offsets[-1]]
             return flat._pub_completely_flatten(backend, options)
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
@@ -1429,7 +1429,7 @@ class ListArray(Content):
                 return ListArray(
                     starts,
                     stops,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth + 1,
@@ -1443,7 +1443,7 @@ class ListArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth + 1,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1174,7 +1174,7 @@ class ListArray(Content):
             negaxis, starts, parents, outlength
         )
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -1187,7 +1187,7 @@ class ListArray(Content):
         order,
     ):
         next = self.to_ListOffsetArray64(True)
-        out = next._argsort_next(
+        out = next._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1159,11 +1159,11 @@ class ListArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._starts.length == 0:
             return True
 
-        return self.to_ListOffsetArray64(True)._is_unique(
+        return self.to_ListOffsetArray64(True)._pub_is_unique(
             negaxis, starts, parents, outlength
         )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1200,10 +1200,10 @@ class ListArray(Content):
         )
         return out
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        return self.to_ListOffsetArray64(True)._sort_next(
+        return self.to_ListOffsetArray64(True)._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1272,11 +1272,11 @@ class ListArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
+    def _pub_nbytes_part(self):
         return (
-            self.starts._nbytes_part()
-            + self.stops._nbytes_part()
-            + self.content._nbytes_part()
+            self.starts._pub_nbytes_part()
+            + self.stops._pub_nbytes_part()
+            + self.content._pub_nbytes_part()
         )
 
     def _pub_pad_none(self, target, axis, depth, clip):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1214,8 +1214,8 @@ class ListArray(Content):
             order,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        return ListOffsetArray._combinations(
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+        return ListOffsetArray._pub_combinations(
             self, n, replacement, recordlookup, parameters, axis, depth
         )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -973,7 +973,7 @@ class ListOffsetArray(Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -1098,7 +1098,7 @@ class ListOffsetArray(Content):
             )
 
             nextcontent = self._content._pub_carry(nextcarry, False)
-            outcontent = nextcontent._argsort_next(
+            outcontent = nextcontent._pub_argsort_next(
                 negaxis - 1,
                 nextstarts,
                 nextshifts,
@@ -1156,7 +1156,7 @@ class ListOffsetArray(Content):
             )
 
             trimmed = self._content[self._offsets[0] : self._offsets[-1]]
-            outcontent = trimmed._argsort_next(
+            outcontent = trimmed._pub_argsort_next(
                 negaxis,
                 self._offsets[:-1],
                 shifts,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1759,8 +1759,8 @@ class ListOffsetArray(Content):
         else:
             return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.offsets._nbytes_part() + self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.offsets._pub_nbytes_part() + self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2069,7 +2069,7 @@ class ListOffsetArray(Content):
             content = content[: next._offsets[-1]]
         return ListOffsetArray(next._offsets, content, parameters=next._parameters)
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         starts, stops = self.starts, self.stops
         starts_data = starts.raw(numpy)
         stops_data = stops.raw(numpy)[: len(starts_data)]
@@ -2122,7 +2122,7 @@ class ListOffsetArray(Content):
             if out is not None:
                 return out
 
-            content = nextcontent._to_list(behavior, json_conversions)
+            content = nextcontent._pub_to_list(behavior, json_conversions)
             out = [None] * starts.length
 
             for i in range(starts.length):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1985,7 +1985,7 @@ class ListOffsetArray(Content):
                 ),
             )
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
             return self._backend.nplike.array(self.to_list())

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1762,7 +1762,7 @@ class ListOffsetArray(Content):
     def _nbytes_part(self):
         return self.offsets._nbytes_part() + self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
@@ -1872,7 +1872,7 @@ class ListOffsetArray(Content):
         else:
             return ak.contents.ListOffsetArray(
                 self._offsets,
-                self._content._pad_none(target, posaxis, depth + 1, clip),
+                self._content._pub_pad_none(target, posaxis, depth + 1, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -254,7 +254,7 @@ class ListOffsetArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -328,7 +328,7 @@ class ListOffsetArray(Content):
             )
         )
 
-        nextcontent = self._content._carry(nextcarry, True)
+        nextcontent = self._content._pub_carry(nextcarry, True)
 
         return ListOffsetArray(offsets, nextcontent, parameters=self._parameters)
 
@@ -370,7 +370,7 @@ class ListOffsetArray(Content):
                 ),
                 slicer=head,
             )
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
             return nextcontent._pub_getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
@@ -448,7 +448,7 @@ class ListOffsetArray(Content):
                 slicer=head,
             )
 
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
 
             if advanced is None or advanced.length == 0:
                 return ak.contents.ListOffsetArray(
@@ -552,7 +552,7 @@ class ListOffsetArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
 
                 out = nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
@@ -599,7 +599,7 @@ class ListOffsetArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
                 return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
         elif isinstance(head, ak.contents.ListOffsetArray):
@@ -903,7 +903,7 @@ class ListOffsetArray(Content):
                 nextstarts,
             ) = self._rearrange_prepare_next(outlength, parents)
 
-            nextcontent = self._content._carry(nextcarry, False)
+            nextcontent = self._content._pub_carry(nextcarry, False)
             outcontent = nextcontent._unique(
                 negaxis - 1,
                 nextstarts,
@@ -932,7 +932,7 @@ class ListOffsetArray(Content):
 
             return ak.contents.ListOffsetArray(
                 outcontent._compact_offsets64(True),
-                outcontent._content._carry(outcarry, False),
+                outcontent._content._pub_carry(outcarry, False),
                 parameters=self._parameters,
             )
 
@@ -1097,7 +1097,7 @@ class ListOffsetArray(Content):
                 )
             )
 
-            nextcontent = self._content._carry(nextcarry, False)
+            nextcontent = self._content._pub_carry(nextcarry, False)
             outcontent = nextcontent._argsort_next(
                 negaxis - 1,
                 nextstarts,
@@ -1130,7 +1130,7 @@ class ListOffsetArray(Content):
             )
 
             out_offsets = self._compact_offsets64(True)
-            out = outcontent._carry(outcarry, False)
+            out = outcontent._pub_carry(outcarry, False)
             return ak.contents.ListOffsetArray(
                 out_offsets, out, parameters=self._parameters
             )
@@ -1221,7 +1221,7 @@ class ListOffsetArray(Content):
                         False,
                     )
                 )
-                return self._carry(nextcarry, False)
+                return self._pub_carry(nextcarry, False)
 
         if not branch and (negaxis == depth):
             if (
@@ -1244,7 +1244,7 @@ class ListOffsetArray(Content):
                 nextstarts,
             ) = self._rearrange_prepare_next(outlength, parents)
 
-            nextcontent = self._content._carry(nextcarry, False)
+            nextcontent = self._content._pub_carry(nextcarry, False)
             outcontent = nextcontent._sort_next(
                 negaxis - 1,
                 nextstarts,
@@ -1277,7 +1277,7 @@ class ListOffsetArray(Content):
 
             return ak.contents.ListOffsetArray(
                 self._compact_offsets64(True),
-                outcontent._carry(outcarry, False),
+                outcontent._pub_carry(outcarry, False),
                 parameters=self._parameters,
             )
         else:
@@ -1415,7 +1415,7 @@ class ListOffsetArray(Content):
             contents = []
 
             for ptr in tocarry:
-                contents.append(self._content._carry(ptr, True))
+                contents.append(self._content._pub_carry(ptr, True))
 
             recordarray = ak.contents.RecordArray(
                 contents,
@@ -1545,7 +1545,7 @@ class ListOffsetArray(Content):
             else:
                 nextshifts = None
 
-            nextcontent = self._content._carry(nextcarry, False)
+            nextcontent = self._content._pub_carry(nextcarry, False)
             outcontent = nextcontent._reduce_next(
                 reducer,
                 negaxis - 1,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -650,7 +650,7 @@ class ListOffsetArray(Content):
                 offsets, next, parameters=self.parameters
             )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
@@ -662,7 +662,7 @@ class ListOffsetArray(Content):
             return (listoffsetarray.offsets, content)
 
         else:
-            inneroffsets, flattened = self._content._offsets_and_flattened(
+            inneroffsets, flattened = self._content._pub_offsets_and_flattened(
                 posaxis, depth + 1
             )
             offsets = ak.index.Index64.zeros(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1876,7 +1876,7 @@ class ListOffsetArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         is_string = self.parameter("__array__") == "string"
         is_bytestring = self.parameter("__array__") == "bytestring"
         if is_string:
@@ -1908,7 +1908,7 @@ class ListOffsetArray(Content):
                     self._content,
                     parameters=self._parameters,
                 )
-                return next.to_ListOffsetArray64(True)._to_arrow(
+                return next.to_ListOffsetArray64(True)._pub_to_arrow(
                     pyarrow, mask_node, validbytes, length, options
                 )
 
@@ -1953,7 +1953,7 @@ class ListOffsetArray(Content):
             )
 
         else:
-            paarray = akcontent._to_arrow(
+            paarray = akcontent._pub_to_arrow(
                 pyarrow, None, None, akcontent.length, options
             )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1172,7 +1172,7 @@ class ListOffsetArray(Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         branch, depth = self.branch_depth
@@ -1245,7 +1245,7 @@ class ListOffsetArray(Content):
             ) = self._rearrange_prepare_next(outlength, parents)
 
             nextcontent = self._content._pub_carry(nextcarry, False)
-            outcontent = nextcontent._sort_next(
+            outcontent = nextcontent._pub_sort_next(
                 negaxis - 1,
                 nextstarts,
                 nextparents,
@@ -1302,7 +1302,7 @@ class ListOffsetArray(Content):
             )
 
             trimmed = self._content[self._offsets[0] : self._offsets[-1]]
-            outcontent = trimmed._sort_next(
+            outcontent = trimmed._pub_sort_next(
                 negaxis,
                 self._offsets[:-1],
                 nextparents,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2004,7 +2004,7 @@ class ListOffsetArray(Content):
             flat = self._content[self._offsets[0] : self._offsets[-1]]
             return flat._pub_completely_flatten(backend, options)
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._backend.nplike.known_shape and self._backend.nplike.known_data:
@@ -2021,7 +2021,7 @@ class ListOffsetArray(Content):
             def continuation():
                 return ListOffsetArray(
                     offsets,
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth + 1,
@@ -2035,7 +2035,7 @@ class ListOffsetArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth + 1,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -804,7 +804,7 @@ class ListOffsetArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._offsets.length - 1 == 0:
             return True
 
@@ -831,10 +831,10 @@ class ListOffsetArray(Content):
                 return out2.length == self.length
 
         if negaxis is None:
-            return self._content._is_unique(negaxis, starts, parents, outlength)
+            return self._content._pub_is_unique(negaxis, starts, parents, outlength)
 
         if not branch and (negaxis == depth):
-            return self._content._is_unique(negaxis - 1, starts, parents, outlength)
+            return self._content._pub_is_unique(negaxis - 1, starts, parents, outlength)
         else:
             nextparents = ak.index.Index64.empty(
                 self._offsets[-1] - self._offsets[0], self._backend.index_nplike
@@ -857,7 +857,7 @@ class ListOffsetArray(Content):
             )
             starts = self._offsets[:-1]
 
-            return self._content._is_unique(negaxis, starts, nextparents, outlength)
+            return self._content._pub_is_unique(negaxis, starts, nextparents, outlength)
 
     def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._offsets.length - 1 == 0:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1317,10 +1317,12 @@ class ListOffsetArray(Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         elif posaxis == depth + 1:
             if (
                 self.parameter("__array__") == "string"
@@ -1429,7 +1431,7 @@ class ListOffsetArray(Content):
             )
         else:
             compact = self.to_ListOffsetArray64(True)
-            next = compact._content._combinations(
+            next = compact._content._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth + 1
             )
             return ak.contents.ListOffsetArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1994,7 +1994,7 @@ class ListOffsetArray(Content):
             self.to_RegularArray(), allow_missing=allow_missing
         )
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
@@ -2002,7 +2002,7 @@ class ListOffsetArray(Content):
             return [self]
         else:
             flat = self._content[self._offsets[0] : self._offsets[-1]]
-            return flat._completely_flatten(backend, options)
+            return flat._pub_completely_flatten(backend, options)
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -824,7 +824,7 @@ class ListOffsetArray(Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_pub_unique_strings(self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -859,7 +859,7 @@ class ListOffsetArray(Content):
 
             return self._content._is_unique(negaxis, starts, nextparents, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._offsets.length - 1 == 0:
             return self
 
@@ -877,7 +877,7 @@ class ListOffsetArray(Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_pub_unique_strings(self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -904,7 +904,7 @@ class ListOffsetArray(Content):
             ) = self._rearrange_prepare_next(outlength, parents)
 
             nextcontent = self._content._pub_carry(nextcarry, False)
-            outcontent = nextcontent._unique(
+            outcontent = nextcontent._pub_unique(
                 negaxis - 1,
                 nextstarts,
                 nextparents,
@@ -958,7 +958,7 @@ class ListOffsetArray(Content):
             )
 
             trimmed = self._content[self._offsets[0] : self._offsets[-1]]
-            outcontent = trimmed._unique(
+            outcontent = trimmed._pub_unique(
                 negaxis,
                 self._offsets[:-1],
                 nextparents,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1436,7 +1436,7 @@ class ListOffsetArray(Content):
                 compact.offsets, next, parameters=self._parameters
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1452,7 +1452,7 @@ class ListOffsetArray(Content):
             self._offsets.nplike.known_data and self._offsets[0] != 0
         ):
             next = self.to_ListOffsetArray64(True)
-            return next._reduce_next(
+            return next._pub_reduce_next(
                 reducer,
                 negaxis,
                 starts,
@@ -1546,7 +1546,7 @@ class ListOffsetArray(Content):
                 nextshifts = None
 
             nextcontent = self._content._pub_carry(nextcarry, False)
-            outcontent = nextcontent._reduce_next(
+            outcontent = nextcontent._pub_reduce_next(
                 reducer,
                 negaxis - 1,
                 nextstarts,
@@ -1590,7 +1590,7 @@ class ListOffsetArray(Content):
             trimmed = self._content[self.offsets[0] : self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
-            outcontent = trimmed._reduce_next(
+            outcontent = trimmed._pub_reduce_next(
                 reducer,
                 negaxis,
                 nextstarts,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -376,13 +376,13 @@ class NumpyArray(Content):
             tonum.data.reshape(shape), parameters=self.parameters, backend=self._backend
         )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         elif len(self.shape) != 1:
-            return self.to_RegularArray()._offsets_and_flattened(posaxis, depth)
+            return self.to_RegularArray()._pub_offsets_and_flattened(posaxis, depth)
 
         else:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1093,7 +1093,7 @@ class NumpyArray(Content):
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1106,7 +1106,7 @@ class NumpyArray(Content):
         behavior,
     ):
         if self._data.ndim > 1:
-            return self.to_RegularArray()._reduce_next(
+            return self.to_RegularArray()._pub_reduce_next(
                 reducer,
                 negaxis,
                 starts,
@@ -1118,7 +1118,7 @@ class NumpyArray(Content):
                 behavior,
             )
         elif not self.is_contiguous:
-            return self.contiguous()._reduce_next(
+            return self.contiguous()._pub_reduce_next(
                 reducer,
                 negaxis,
                 starts,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1275,7 +1275,7 @@ class NumpyArray(Content):
             ),
         )
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         out = numpy.asarray(self._data)
         if type(out).__module__.startswith("cupy."):
             return out.get()

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -255,7 +255,7 @@ class NumpyArray(Content):
             return self._pub_getitem_range(slice(0, 0))
         raise ak._errors.index_error(self, where, "not an array of records")
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
         try:
             nextdata = self._data[carry.data]

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1222,13 +1222,13 @@ class NumpyArray(Content):
                 return f'at {path} ("{type(self)}"): shape[{i}] % itemsize != 0'
         return ""
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         if len(self.shape) == 0:
             raise ak._errors.wrap_error(
                 ValueError("cannot apply ak.pad_none to a scalar")
             )
         elif len(self.shape) > 1 or not self.is_contiguous:
-            return self.to_RegularArray()._pad_none(target, axis, depth, clip)
+            return self.to_RegularArray()._pub_pad_none(target, axis, depth, clip)
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis != depth:
             raise ak._errors.wrap_error(
@@ -1238,7 +1238,7 @@ class NumpyArray(Content):
             if target < self.length:
                 return self
             else:
-                return self._pad_none(target, posaxis, depth, clip=True)
+                return self._pub_pad_none(target, posaxis, depth, clip=True)
         else:
             return self.pad_none_axis0(target, clip=True)
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -662,13 +662,13 @@ class NumpyArray(Content):
                 backend=self._backend,
             )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self.length == 0:
             return True
 
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self if self.is_contiguous else self.contiguous()
-            return contiguous_self.to_RegularArray()._is_unique(
+            return contiguous_self.to_RegularArray()._pub_is_unique(
                 negaxis,
                 starts,
                 parents,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -861,7 +861,7 @@ class NumpyArray(Content):
                 outoffsets, ak.contents.NumpyArray(out), parameters=self._parameters
             )
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -879,7 +879,7 @@ class NumpyArray(Content):
             )
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self if self.is_contiguous else self.contiguous()
-            return contiguous_self.to_RegularArray()._argsort_next(
+            return contiguous_self.to_RegularArray()._pub_argsort_next(
                 negaxis,
                 starts,
                 shifts,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1333,7 +1333,7 @@ class NumpyArray(Content):
     def packed(self):
         return self.contiguous().to_RegularArray()
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         if self.parameter("__array__") == "byte":
             convert_bytes = (
                 None if json_conversions is None else json_conversions["convert_bytes"]
@@ -1369,7 +1369,7 @@ class NumpyArray(Content):
                             self.length,
                             parameters=self._parameters,
                             backend=self._backend,
-                        )._to_list(behavior, json_conversions)
+                        )._pub_to_list(behavior, json_conversions)
 
             out = self._data.tolist()
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1282,7 +1282,7 @@ class NumpyArray(Content):
         else:
             return out
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         return [
             ak.contents.NumpyArray(
                 self.raw(backend.nplike).reshape(-1), backend=backend

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -989,7 +989,7 @@ class NumpyArray(Content):
             out = NumpyArray(nextcarry, parameters=None, backend=self._backend)
             return out
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         if len(self.shape) == 0:
@@ -999,7 +999,7 @@ class NumpyArray(Content):
 
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self if self.is_contiguous else self.contiguous()
-            return contiguous_self.to_RegularArray()._sort_next(
+            return contiguous_self.to_RegularArray()._pub_sort_next(
                 negaxis,
                 starts,
                 parents,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1245,9 +1245,9 @@ class NumpyArray(Content):
     def _nbytes_part(self):
         return self.data.nbytes
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         if self._data.ndim != 1:
-            return self.to_RegularArray()._to_arrow(
+            return self.to_RegularArray()._pub_to_arrow(
                 pyarrow, mask_node, validbytes, length, options
             )
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -213,13 +213,13 @@ class NumpyArray(Content):
     def __iter__(self):
         return iter(self._data)
 
-    def _getitem_nothing(self):
+    def _pub_getitem_nothing(self):
         tmp = self._data[0:0]
         return NumpyArray(
             tmp.reshape((0,) + tmp.shape[2:]), parameters=None, backend=self._backend
         )
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if not self._backend.nplike.known_data and len(self._data.shape) == 1:
             return ak._typetracer.UnknownScalar(self._data.dtype)
 
@@ -233,7 +233,7 @@ class NumpyArray(Content):
         else:
             return out
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         if not self._backend.nplike.known_shape:
             return self
 
@@ -247,12 +247,12 @@ class NumpyArray(Content):
 
         return NumpyArray(out, parameters=self._parameters, backend=self._backend)
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         raise ak._errors.index_error(self, where, "not an array of records")
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         if len(where) == 0:
-            return self._getitem_range(slice(0, 0))
+            return self._pub_getitem_range(slice(0, 0))
         raise ak._errors.index_error(self, where, "not an array of records")
 
     def _carry(self, carry, allow_lazy):
@@ -263,7 +263,7 @@ class NumpyArray(Content):
             raise ak._errors.index_error(self, carry.data, str(err)) from err
         return NumpyArray(nextdata, parameters=self._parameters, backend=self._backend)
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         if self._data.ndim == 1:
             raise ak._errors.index_error(
                 self,
@@ -274,11 +274,11 @@ class NumpyArray(Content):
             )
         else:
             next = self.to_RegularArray()
-            return next._getitem_next_jagged(
+            return next._pub_getitem_next_jagged(
                 slicestarts, slicestops, slicecontent, tail
             )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -305,10 +305,10 @@ class NumpyArray(Content):
             return out2
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
             if advanced is None:
@@ -337,7 +337,7 @@ class NumpyArray(Content):
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
             next = self.to_RegularArray()
-            return next._getitem_next_missing(head, tail, advanced)
+            return next._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1289,11 +1289,11 @@ class NumpyArray(Content):
             )
         ]
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._data.ndim != 1 and options["numpy_to_regular"]:
-            return self.to_RegularArray()._recursively_apply(
+            return self.to_RegularArray()._pub_recursively_apply(
                 action, behavior, depth, depth_context, lateral_context, options
             )
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1242,7 +1242,7 @@ class NumpyArray(Content):
         else:
             return self.pad_none_axis0(target, clip=True)
 
-    def _nbytes_part(self):
+    def _pub_nbytes_part(self):
         return self.data.nbytes
 
     def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1080,16 +1080,18 @@ class NumpyArray(Content):
                 backend=self._backend,
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         elif len(self.shape) <= 1:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )
         else:
-            return self.to_RegularArray()._combinations(
+            return self.to_RegularArray()._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth
             )
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -591,7 +591,7 @@ class NumpyArray(Content):
 
         return True if is_equal[0] == 1 else False
 
-    def _as_unique_strings(self, offsets):
+    def _as_pub_unique_strings(self, offsets):
         offsets = ak.index.Index64(offsets.data, nplike=offsets.nplike)
         outoffsets = ak.index.Index64.empty(
             offsets.length, nplike=self._backend.index_nplike
@@ -675,13 +675,13 @@ class NumpyArray(Content):
                 outlength,
             )
         else:
-            out = self._unique(negaxis, starts, parents, outlength)
+            out = self._pub_unique(negaxis, starts, parents, outlength)
             if isinstance(out, ak.contents.ListOffsetArray):
                 return out.content.length == self.length
 
             return out.length == self.length
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self.shape[0] == 0:
             return self
 
@@ -745,7 +745,7 @@ class NumpyArray(Content):
         # axis is not None
         if len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self if self.is_contiguous else self.contiguous()
-            return contiguous_self.to_RegularArray()._unique(
+            return contiguous_self.to_RegularArray()._pub_unique(
                 negaxis,
                 starts,
                 parents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -750,7 +750,7 @@ class RecordArray(Content):
     def _unique(self, negaxis, starts, parents, outlength):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -796,15 +796,17 @@ class RecordArray(Content):
             backend=self._backend,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
             contents = []
             for content in self._contents:
                 contents.append(
-                    content._combinations(
+                    content._pub_combinations(
                         n, replacement, recordlookup, parameters, posaxis, depth
                     )
                 )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -945,12 +945,12 @@ class RecordArray(Content):
 
         return out
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
                 out.extend(
-                    content[: self._length]._completely_flatten(backend, options)
+                    content[: self._length]._pub_completely_flatten(backend, options)
                 )
             return out
         else:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -816,7 +816,7 @@ class RecordArray(Content):
                 backend=self._backend,
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -741,9 +741,9 @@ class RecordArray(Content):
             backend=self._backend,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         for content in self._contents:
-            if not content._is_unique(negaxis, starts, parents, outlength):
+            if not content._pub_is_unique(negaxis, starts, parents, outlength):
                 return False
         return True
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -917,10 +917,10 @@ class RecordArray(Content):
             children=values,
         )
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         if self.fields is None:
             return self._backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_numpy(allow_missing) for x in self._contents]
+        contents = [x._pub_to_numpy(allow_missing) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ak._errors.wrap_error(
                 ValueError(f"cannot convert {self} into np.ndarray")

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -493,7 +493,7 @@ class RecordArray(Content):
                 backend=self._backend,
             )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
@@ -509,7 +509,7 @@ class RecordArray(Content):
             contents = []
             for content in self._contents:
                 trimmed = content._pub_getitem_range(slice(0, self.length))
-                offsets, flattened = trimmed._offsets_and_flattened(posaxis, depth)
+                offsets, flattened = trimmed._pub_offsets_and_flattened(posaxis, depth)
                 if self._backend.nplike.known_shape and offsets.length != 0:
                     raise ak._errors.wrap_error(
                         AssertionError(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -747,7 +747,7 @@ class RecordArray(Content):
                 return False
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _pub_argsort_next(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -856,10 +856,10 @@ class RecordArray(Content):
                 return sub
         return ""
 
-    def _nbytes_part(self):
+    def _pub_nbytes_part(self):
         result = 0
         for content in self.contents:
-            result = result + content._nbytes_part()
+            result = result + content._pub_nbytes_part()
         return result
 
     def _pub_pad_none(self, target, axis, depth, clip):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -887,9 +887,9 @@ class RecordArray(Content):
                     backend=self._backend,
                 )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         values = [
-            (x if x.length == length else x[:length])._to_arrow(
+            (x if x.length == length else x[:length])._pub_to_arrow(
                 pyarrow, mask_node, validbytes, length, options
             )
             for x in self._contents

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -764,7 +764,7 @@ class RecordArray(Content):
     ):
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         if self._fields is None or len(self._fields) == 0:
@@ -777,7 +777,7 @@ class RecordArray(Content):
         contents = []
         for content in self._contents:
             contents.append(
-                content._sort_next(
+                content._pub_sort_next(
                     negaxis,
                     starts,
                     parents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -965,7 +965,7 @@ class RecordArray(Content):
                 )
             )
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._backend.nplike.known_shape:
@@ -984,7 +984,7 @@ class RecordArray(Content):
                     )
                 return RecordArray(
                     [
-                        content._recursively_apply(
+                        content._pub_recursively_apply(
                             action,
                             behavior,
                             depth,
@@ -1004,7 +1004,7 @@ class RecordArray(Content):
 
             def continuation():
                 for content in contents:
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -862,14 +862,14 @@ class RecordArray(Content):
             result = result + content._nbytes_part()
         return result
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._pad_none(target, posaxis, depth, clip))
+                contents.append(content._pub_pad_none(target, posaxis, depth, clip))
             if len(contents) == 0:
                 return ak.contents.RecordArray(
                     contents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1043,13 +1043,15 @@ class RecordArray(Content):
             backend=self._backend,
         )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [
+                x._pub_to_list(behavior, json_conversions) for x in self._contents
+            ]
             length = self._length
             out = [None] * length
             for i in range(length):
@@ -1060,7 +1062,9 @@ class RecordArray(Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [
+                x._pub_to_list(behavior, json_conversions) for x in self._contents
+            ]
             length = self._length
             out = [None] * length
             for i in range(length):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -369,7 +369,7 @@ class RecordArray(Content):
             contents, fields, self._length, parameters=None, backend=self._backend
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         if allow_lazy:
@@ -390,7 +390,7 @@ class RecordArray(Content):
 
         else:
             contents = [
-                self.content(i)._carry(carry, allow_lazy)
+                self.content(i)._pub_carry(carry, allow_lazy)
                 for i in range(len(self._contents))
             ]
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1169,7 +1169,7 @@ class RegularArray(Content):
     def _nbytes_part(self):
         return self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
@@ -1179,7 +1179,7 @@ class RegularArray(Content):
                 if target < self._size:
                     return self
                 else:
-                    return self._pad_none(target, posaxis, depth, True)
+                    return self._pub_pad_none(target, posaxis, depth, True)
 
             else:
                 index = ak.index.Index64.empty(
@@ -1203,7 +1203,7 @@ class RegularArray(Content):
 
         else:
             return ak.contents.RegularArray(
-                self._content._pad_none(target, posaxis, depth + 1, clip),
+                self._content._pub_pad_none(target, posaxis, depth + 1, clip),
                 self._size,
                 self._length,
                 parameters=self._parameters,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1349,7 +1349,7 @@ class RegularArray(Content):
             content, self._size, self._length, parameters=self._parameters
         )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         if self.parameter("__array__") == "bytestring":
             convert_bytes = (
                 None if json_conversions is None else json_conversions["convert_bytes"]
@@ -1388,7 +1388,7 @@ class RegularArray(Content):
             if out is not None:
                 return out
 
-            content = self._content._to_list(behavior, json_conversions)
+            content = self._content._pub_to_list(behavior, json_conversions)
             length, size = self._length, self._size
             out = [None] * length
             for i in range(length):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -798,7 +798,7 @@ class RegularArray(Content):
 
         return out
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -811,7 +811,7 @@ class RegularArray(Content):
         order,
     ):
         next = self.to_ListOffsetArray64(True)
-        out = next._argsort_next(
+        out = next._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -834,10 +834,10 @@ class RegularArray(Content):
 
         return out
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        out = self.to_ListOffsetArray64(True)._sort_next(
+        out = self.to_ListOffsetArray64(True)._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1273,7 +1273,7 @@ class RegularArray(Content):
                 ),
             )
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
@@ -1281,7 +1281,7 @@ class RegularArray(Content):
             return [self]
         else:
             flat = self._content[: self._length * self._size]
-            return flat._completely_flatten(backend, options)
+            return flat._pub_completely_flatten(backend, options)
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -199,19 +199,19 @@ class RegularArray(Content):
                 backend=self._backend,
             )
 
-    def _getitem_nothing(self):
-        return self._content._getitem_range(slice(0, 0))
+    def _pub_getitem_nothing(self):
+        return self._content._pub_getitem_range(slice(0, 0))
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if self._backend.nplike.known_data and where < 0:
             where += self._length
 
         if where < 0 or where >= self._length:
             raise ak._errors.index_error(self, where)
         start, stop = (where) * self._size, (where + 1) * self._size
-        return self._content._getitem_range(slice(start, stop))
+        return self._content._pub_getitem_range(slice(start, stop))
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         if not self._backend.nplike.known_shape:
             return self
 
@@ -220,23 +220,23 @@ class RegularArray(Content):
         zeros_length = stop - start
         substart, substop = start * self._size, stop * self._size
         return RegularArray(
-            self._content._getitem_range(slice(substart, substop)),
+            self._content._pub_getitem_range(slice(substart, substop)),
             self._size,
             zeros_length,
             parameters=self._parameters,
         )
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         return RegularArray(
-            self._content._getitem_field(where, only_fields),
+            self._content._pub_getitem_field(where, only_fields),
             self._size,
             self._length,
             parameters=None,
         )
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         return RegularArray(
-            self._content._getitem_fields(where, only_fields),
+            self._content._pub_getitem_fields(where, only_fields),
             self._size,
             self._length,
             parameters=None,
@@ -357,9 +357,9 @@ class RegularArray(Content):
                 offsets, self._content, parameters=self._parameters
             )
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         out = self.to_ListOffsetArray64(True)
-        return out._getitem_next_jagged(slicestarts, slicestops, slicecontent, tail)
+        return out._pub_getitem_next_jagged(slicestarts, slicestops, slicecontent, tail)
 
     def maybe_to_array(self):
         out = self._content.maybe_to_array()
@@ -368,7 +368,7 @@ class RegularArray(Content):
         else:
             return out.reshape((self._length, -1) + out.shape[1:])
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -388,7 +388,7 @@ class RegularArray(Content):
                 slicer=head,
             )
             nextcontent = self._content._carry(nextcarry, True)
-            return nextcontent._getitem_next(nexthead, nexttail, advanced)
+            return nextcontent._pub_getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
             nexthead, nexttail = ak._slicing.headtail(tail)
@@ -429,7 +429,7 @@ class RegularArray(Content):
 
             if advanced is None or advanced.length == 0:
                 return RegularArray(
-                    nextcontent._getitem_next(nexthead, nexttail, advanced),
+                    nextcontent._pub_getitem_next(nexthead, nexttail, advanced),
                     nextsize,
                     self._length,
                     parameters=self._parameters,
@@ -457,23 +457,23 @@ class RegularArray(Content):
                     slicer=head,
                 )
                 return RegularArray(
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced),
                     nextsize,
                     self._length,
                     parameters=self._parameters,
                 )
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
             head = head.to_nplike(self._backend.index_nplike)
@@ -528,7 +528,7 @@ class RegularArray(Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
                         out, head.metadata.get("shape", (head.length,)), self._length
@@ -542,7 +542,7 @@ class RegularArray(Content):
                     0, nplike=self._backend.index_nplike
                 )
                 nextcontent = self._content._carry(nextcarry, True)
-                return nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
             else:
                 nextcarry = ak.index.Index64.empty(
@@ -577,7 +577,7 @@ class RegularArray(Content):
                     slicer=head,
                 )
                 nextcontent = self._content._carry(nextcarry, True)
-                return nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
         elif isinstance(head, ak.contents.ListOffsetArray):
             headlength = head.length
@@ -624,7 +624,7 @@ class RegularArray(Content):
                 ),
                 slicer=head,
             )
-            down = self._content._getitem_next_jagged(
+            down = self._content._pub_getitem_next_jagged(
                 multistarts, multistops, head._content, tail
             )
 
@@ -633,7 +633,7 @@ class RegularArray(Content):
             )
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            return self._getitem_next_missing(head, tail, advanced)
+            return self._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
@@ -952,7 +952,7 @@ class RegularArray(Content):
                 recordarray, combinationslen, self._length, parameters=self._parameters
             )
         else:
-            next = self._content._getitem_range(
+            next = self._content._pub_getitem_range(
                 slice(0, self._length * self._size)
             )._combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth + 1
@@ -1125,7 +1125,7 @@ class RegularArray(Content):
                         outcontent.offsets[outcontent.offsets.length - 1],
                     )
 
-                    trimmed = outcontent.content._getitem_range(slice(start, stop))
+                    trimmed = outcontent.content._pub_getitem_range(slice(start, stop))
                     assert len(trimmed) == self._size * len(outcontent)
 
                     outcontent = ak.contents.RegularArray(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -777,10 +777,10 @@ class RegularArray(Content):
             outlength,
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._length == 0:
             return self
-        out = self.to_ListOffsetArray64(True)._unique(
+        out = self.to_ListOffsetArray64(True)._pub_unique(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -242,7 +242,7 @@ class RegularArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         where = carry.data
@@ -282,7 +282,7 @@ class RegularArray(Content):
         )
 
         return RegularArray(
-            self._content._carry(nextcarry, allow_lazy),
+            self._content._pub_carry(nextcarry, allow_lazy),
             self._size,
             where.shape[0],
             parameters=self._parameters,
@@ -337,7 +337,7 @@ class RegularArray(Content):
                     offsets.length,
                 )
             )
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
             return ak.contents.ListOffsetArray(
                 offsets, nextcontent, parameters=self._parameters
             )
@@ -387,7 +387,7 @@ class RegularArray(Content):
                 ),
                 slicer=head,
             )
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
             return nextcontent._pub_getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
@@ -425,7 +425,7 @@ class RegularArray(Content):
                 slicer=head,
             )
 
-            nextcontent = self._content._carry(nextcarry, True)
+            nextcontent = self._content._pub_carry(nextcarry, True)
 
             if advanced is None or advanced.length == 0:
                 return RegularArray(
@@ -526,7 +526,7 @@ class RegularArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
 
                 out = nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
@@ -541,7 +541,7 @@ class RegularArray(Content):
                 nextadvanced = ak.index.Index64.empty(
                     0, nplike=self._backend.index_nplike
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
                 return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
             else:
@@ -576,7 +576,7 @@ class RegularArray(Content):
                     ),
                     slicer=head,
                 )
-                nextcontent = self._content._carry(nextcarry, True)
+                nextcontent = self._content._pub_carry(nextcarry, True)
                 return nextcontent._pub_getitem_next(nexthead, nexttail, nextadvanced)
 
         elif isinstance(head, ak.contents.ListOffsetArray):
@@ -938,7 +938,7 @@ class RegularArray(Content):
             contents = []
             length = None
             for ptr in tocarry:
-                contents.append(self._content._carry(ptr, True))
+                contents.append(self._content._pub_carry(ptr, True))
                 length = contents[-1].length
             assert length is not None
             recordarray = ak.contents.RecordArray(
@@ -1024,7 +1024,7 @@ class RegularArray(Content):
             else:
                 nextshifts = None
 
-            nextcontent = self._content._carry(nextcarry, False)
+            nextcontent = self._content._pub_carry(nextcarry, False)
             outcontent = nextcontent._reduce_next(
                 reducer,
                 negaxis - 1,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1283,7 +1283,7 @@ class RegularArray(Content):
             flat = self._content[: self._length * self._size]
             return flat._pub_completely_flatten(backend, options)
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if self._backend.nplike.known_shape:
@@ -1295,7 +1295,7 @@ class RegularArray(Content):
 
             def continuation():
                 return RegularArray(
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth + 1,
@@ -1311,7 +1311,7 @@ class RegularArray(Content):
         else:
 
             def continuation():
-                content._recursively_apply(
+                content._pub_recursively_apply(
                     action,
                     behavior,
                     depth + 1,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1218,9 +1218,9 @@ class RegularArray(Content):
         shape = (self._length, self._size) + out.shape[1:]
         return out[: self._length * self._size].reshape(shape)
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         if self.parameter("__array__") == "string":
-            return self.to_ListOffsetArray64(False)._to_arrow(
+            return self.to_ListOffsetArray64(False)._pub_to_arrow(
                 pyarrow, mask_node, validbytes, length, options
             )
 
@@ -1247,7 +1247,7 @@ class RegularArray(Content):
             )
 
         else:
-            paarray = akcontent._to_arrow(
+            paarray = akcontent._pub_to_arrow(
                 pyarrow, None, None, self._length * self._size, options
             )
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -961,7 +961,7 @@ class RegularArray(Content):
                 next, self._size, self._length, parameters=self._parameters
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1025,7 +1025,7 @@ class RegularArray(Content):
                 nextshifts = None
 
             nextcontent = self._content._pub_carry(nextcarry, False)
-            outcontent = nextcontent._reduce_next(
+            outcontent = nextcontent._pub_reduce_next(
                 reducer,
                 negaxis - 1,
                 nextstarts,
@@ -1072,7 +1072,7 @@ class RegularArray(Content):
                     nplike=self._backend.index_nplike,
                 )
 
-            outcontent = self._content._reduce_next(
+            outcontent = self._content._pub_reduce_next(
                 reducer,
                 negaxis,
                 nextstarts,
@@ -1094,9 +1094,9 @@ class RegularArray(Content):
             # *disappears*, and is replaced by the bare reduction `NumpyArray`. Therefore, if
             # this layout is _directly_ above the reduction, it won't survive the reduction.
             #
-            # The `_reduce_next` mechanism returns its first result (by recursion) from the
+            # The `_pub_reduce_next` mechanism returns its first result (by recursion) from the
             # leaf `NumpyArray`. The parent `RegularArray` takes the `negaxis != depth` branch,
-            # and asks the `NumpyArray` to perform the reduction. The `_reduce_next` is such that the
+            # and asks the `NumpyArray` to perform the reduction. The `_pub_reduce_next` is such that the
             # callee must wrap the reduction result into a list whose length is given by the *caller*,
             # i.e. the parent. Therefore, the `RegularArray(..., size=3)` layout reduces its content with
             # `outlength=len(self)=5*4`. The parent of this `RegularArray` (with `size=4`)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -661,8 +661,8 @@ class RegularArray(Content):
                 next, self._size, self._length, parameters=self._parameters
             )
 
-    def _offsets_and_flattened(self, axis, depth):
-        return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
+    def _pub_offsets_and_flattened(self, axis, depth):
+        return self.to_ListOffsetArray64(True)._pub_offsets_and_flattened(axis, depth)
 
     def _mergeable(self, other, mergebool):
         if isinstance(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -862,10 +862,12 @@ class RegularArray(Content):
 
         return out
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         elif posaxis == depth + 1:
             if (
                 self.parameter("__array__") == "string"
@@ -954,7 +956,7 @@ class RegularArray(Content):
         else:
             next = self._content._pub_getitem_range(
                 slice(0, self._length * self._size)
-            )._combinations(
+            )._pub_combinations(
                 n, replacement, recordlookup, parameters, posaxis, depth + 1
             )
             return ak.contents.RegularArray(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1209,7 +1209,7 @@ class RegularArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
             return self._backend.nplike.array(self.to_list())

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -766,11 +766,11 @@ class RegularArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._length == 0:
             return True
 
-        return self.to_ListOffsetArray64(True)._is_unique(
+        return self.to_ListOffsetArray64(True)._pub_is_unique(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1166,8 +1166,8 @@ class RegularArray(Content):
 
         return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1381,10 +1381,10 @@ class UnionArray(Content):
 
             return ""
 
-    def _nbytes_part(self):
-        result = self.tags._nbytes_part() + self.index._nbytes_part()
+    def _pub_nbytes_part(self):
+        result = self.tags._pub_nbytes_part() + self.index._pub_nbytes_part()
         for content in self.contents:
-            result = result + content._nbytes_part()
+            result = result + content._pub_nbytes_part()
         return result
 
     def _pub_pad_none(self, target, axis, depth, clip):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1168,15 +1168,17 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
             contents = []
             for content in self._contents:
                 contents.append(
-                    content._combinations(
+                    content._pub_combinations(
                         n, replacement, recordlookup, parameters, posaxis, depth
                     )
                 )

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1507,14 +1507,14 @@ class UnionArray(Content):
             out[mask] = content
         return out
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         out = []
         for i in range(len(self._contents)):
             index = self._index[self._tags.data == i]
             out.extend(
                 self._contents[i]
                 ._pub_carry(index, False)
-                ._completely_flatten(backend, options)
+                ._pub_completely_flatten(backend, options)
             )
         return out
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1603,14 +1603,14 @@ class UnionArray(Content):
             parameters=self._parameters,
         )
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
         tags = self._tags.raw(numpy)
         index = self._index.raw(numpy)
-        contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+        contents = [x._pub_to_list(behavior, json_conversions) for x in self._contents]
 
         out = [None] * tags.shape[0]
         for i, tag in enumerate(tags):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1290,7 +1290,7 @@ class UnionArray(Content):
             negaxis, starts, parents, outlength, ascending, stable, kind, order
         )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -1316,7 +1316,7 @@ class UnionArray(Content):
                 )
             )
 
-        return simplified._reduce_next(
+        return simplified._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1387,14 +1387,14 @@ class UnionArray(Content):
             result = result + content._nbytes_part()
         return result
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._pad_none(target, posaxis, depth, clip))
+                contents.append(content._pub_pad_none(target, posaxis, depth, clip))
             return ak.contents.UnionArray.simplified(
                 self.tags,
                 self.index,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1480,9 +1480,10 @@ class UnionArray(Content):
             children=values,
         )
 
-    def _to_numpy(self, allow_missing):
+    def _pub_to_numpy(self, allow_missing):
         contents = [
-            self.project(i)._to_numpy(allow_missing) for i in range(len(self.contents))
+            self.project(i)._pub_to_numpy(allow_missing)
+            for i in range(len(self.contents))
         ]
 
         if any(isinstance(x, self._backend.nplike.ma.MaskedArray) for x in contents):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1518,7 +1518,7 @@ class UnionArray(Content):
             )
         return out
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if options["return_array"]:
@@ -1532,7 +1532,7 @@ class UnionArray(Content):
                     self._tags,
                     self._index,
                     [
-                        content._recursively_apply(
+                        content._pub_recursively_apply(
                             action,
                             behavior,
                             depth,
@@ -1549,7 +1549,7 @@ class UnionArray(Content):
 
             def continuation():
                 for content in self._contents:
-                    content._recursively_apply(
+                    content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1265,7 +1265,7 @@ class UnionArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, kind, order
         )
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
         if self.length == 0:
@@ -1286,7 +1286,7 @@ class UnionArray(Content):
                 ValueError("cannot sort an irreducible UnionArray")
             )
 
-        return simplified._sort_next(
+        return simplified._pub_sort_next(
             negaxis, starts, parents, outlength, ascending, stable, kind, order
         )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -800,7 +800,7 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
 
         if posaxis == depth:
@@ -814,7 +814,7 @@ class UnionArray(Content):
             contents = []
 
             for i in range(len(self._contents)):
-                offsets, flattened = self._contents[i]._offsets_and_flattened(
+                offsets, flattened = self._contents[i]._pub_offsets_and_flattened(
                     posaxis, depth
                 )
                 offsetsraws[i] = offsets.ptr

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -364,7 +364,7 @@ class UnionArray(Content):
             )
 
         if len(contents) == 1:
-            next = contents[0]._carry(index, True)
+            next = contents[0]._pub_carry(index, True)
             return next.copy(
                 parameters=ak._util.merge_parameters(next._parameters, parameters)
             )
@@ -495,7 +495,7 @@ class UnionArray(Content):
             parameters=None,
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         assert isinstance(carry, ak.index.Index)
 
         try:
@@ -536,7 +536,7 @@ class UnionArray(Content):
                     contents.append(ak.contents.UnmaskedArray.simplified(content))
 
         else:
-            # like _carry, above
+            # like _pub_carry, above
             carry_data = index.raw(self._backend.nplike).copy()
             is_missing = carry_data < 0
 
@@ -616,7 +616,7 @@ class UnionArray(Content):
         nextcarry = ak.index.Index64(
             tmpcarry.data[: lenout[0]], nplike=self._backend.index_nplike
         )
-        return self._contents[index]._carry(nextcarry, False)
+        return self._contents[index]._pub_carry(nextcarry, False)
 
     @staticmethod
     def regular_index(
@@ -1510,7 +1510,7 @@ class UnionArray(Content):
             index = self._index[self._tags.data == i]
             out.extend(
                 self._contents[i]
-                ._carry(index, False)
+                ._pub_carry(index, False)
                 ._completely_flatten(backend, options)
             )
         return out

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1402,7 +1402,7 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         nptags = self._tags.raw(numpy)
         npindex = self._index.raw(numpy)
         copied_index = False
@@ -1444,7 +1444,7 @@ class UnionArray(Content):
                 this_length = this_index.max() + 1
 
             values.append(
-                content._to_arrow(
+                content._pub_to_arrow(
                     pyarrow, mask_node, this_validbytes, this_length, options
                 )
             )

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1230,7 +1230,7 @@ class UnionArray(Content):
 
         return simplified._unique(negaxis, starts, parents, outlength)
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -1261,7 +1261,7 @@ class UnionArray(Content):
                 ValueError("cannot argsort an irreducible UnionArray")
             )
 
-        return simplified._argsort_next(
+        return simplified._pub_argsort_next(
             negaxis, starts, shifts, parents, outlength, ascending, stable, kind, order
         )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1200,7 +1200,7 @@ class UnionArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1214,7 +1214,7 @@ class UnionArray(Content):
                 ValueError("cannot check if an irreducible UnionArray is unique")
             )
 
-        return simplified._is_unique(negaxis, starts, parents, outlength)
+        return simplified._pub_is_unique(negaxis, starts, parents, outlength)
 
     def _pub_unique(self, negaxis, starts, parents, outlength):
         simplified = type(self).simplified(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1216,7 +1216,7 @@ class UnionArray(Content):
 
         return simplified._is_unique(negaxis, starts, parents, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1230,7 +1230,7 @@ class UnionArray(Content):
                 ValueError("cannot make a unique irreducible UnionArray")
             )
 
-        return simplified._unique(negaxis, starts, parents, outlength)
+        return simplified._pub_unique(negaxis, starts, parents, outlength)
 
     def _pub_argsort_next(
         self,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -393,13 +393,15 @@ class UnmaskedArray(Content):
         else:
             return out
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _pub_combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
-            return self._combinations_axis0(n, replacement, recordlookup, parameters)
+            return self._pub_combinations_axis0(
+                n, replacement, recordlookup, parameters
+            )
         else:
             return ak.contents.UnmaskedArray(
-                self._content._combinations(
+                self._content._pub_combinations(
                     n, replacement, recordlookup, parameters, posaxis, depth
                 ),
                 parameters=self._parameters,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -452,8 +452,8 @@ class UnmaskedArray(Content):
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self._content._to_arrow(pyarrow, self, None, length, options)
 
-    def _to_numpy(self, allow_missing):
-        content = self.content._to_numpy(allow_missing)
+    def _pub_to_numpy(self, allow_missing):
+        content = self.content._pub_to_numpy(allow_missing)
         if allow_missing:
             return self._backend.nplike.ma.MaskedArray(content)
         else:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -436,8 +436,8 @@ class UnmaskedArray(Content):
     def _validity_error(self, path):
         return self._content.validity_error(path + ".content")
 
-    def _nbytes_part(self):
-        return self.content._nbytes_part()
+    def _pub_nbytes_part(self):
+        return self.content._pub_nbytes_part()
 
     def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -329,10 +329,10 @@ class UnmaskedArray(Content):
             return True
         return self._content._is_unique(negaxis, starts, parents, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._content.length == 0:
             return self
-        return self._content._unique(negaxis, starts, parents, outlength)
+        return self._content._pub_unique(negaxis, starts, parents, outlength)
 
     def _pub_argsort_next(
         self,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -439,15 +439,15 @@ class UnmaskedArray(Content):
     def _nbytes_part(self):
         return self.content._nbytes_part()
 
-    def _pad_none(self, target, axis, depth, clip):
+    def _pub_pad_none(self, target, axis, depth, clip):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             return self.pad_none_axis0(target, clip)
         elif posaxis == depth + 1:
-            return self._content._pad_none(target, posaxis, depth, clip)
+            return self._content._pub_pad_none(target, posaxis, depth, clip)
         else:
             return ak.contents.UnmaskedArray(
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pub_pad_none(target, posaxis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -405,7 +405,7 @@ class UnmaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _reduce_next(
+    def _pub_reduce_next(
         self,
         reducer,
         negaxis,
@@ -417,7 +417,7 @@ class UnmaskedArray(Content):
         keepdims,
         behavior,
     ):
-        return self._content._reduce_next(
+        return self._content._pub_reduce_next(
             reducer,
             negaxis,
             starts,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -466,7 +466,7 @@ class UnmaskedArray(Content):
         else:
             return [self]
 
-    def _recursively_apply(
+    def _pub_recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if options["return_array"]:
@@ -477,7 +477,7 @@ class UnmaskedArray(Content):
 
             def continuation():
                 return make(
-                    self._content._recursively_apply(
+                    self._content._pub_recursively_apply(
                         action,
                         behavior,
                         depth,
@@ -491,7 +491,7 @@ class UnmaskedArray(Content):
         else:
 
             def continuation():
-                self._content._recursively_apply(
+                self._content._pub_recursively_apply(
                     action,
                     behavior,
                     depth,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -521,12 +521,12 @@ class UnmaskedArray(Content):
     def packed(self):
         return UnmaskedArray(self._content.packed(), parameters=self._parameters)
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out
 
-        return self._content._to_list(behavior, json_conversions)
+        return self._content._pub_to_list(behavior, json_conversions)
 
     def to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -324,10 +324,10 @@ class UnmaskedArray(Content):
             self._content.numbers_to_type(name), parameters=self._parameters
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _pub_is_unique(self, negaxis, starts, parents, outlength):
         if self._content.length == 0:
             return True
-        return self._content._is_unique(negaxis, starts, parents, outlength)
+        return self._content._pub_is_unique(negaxis, starts, parents, outlength)
 
     def _pub_unique(self, negaxis, starts, parents, outlength):
         if self._content.length == 0:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -255,12 +255,14 @@ class UnmaskedArray(Content):
                 self._content.num(posaxis, depth), parameters=self._parameters
             )
 
-    def _offsets_and_flattened(self, axis, depth):
+    def _pub_offsets_and_flattened(self, axis, depth):
         posaxis = self.axis_wrap_if_negative(axis)
         if posaxis == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
-            offsets, flattened = self._content._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = self._content._pub_offsets_and_flattened(
+                posaxis, depth
+            )
             if offsets.length == 0:
                 return (
                     offsets,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -334,7 +334,7 @@ class UnmaskedArray(Content):
             return self
         return self._content._unique(negaxis, starts, parents, outlength)
 
-    def _argsort_next(
+    def _pub_argsort_next(
         self,
         negaxis,
         starts,
@@ -346,7 +346,7 @@ class UnmaskedArray(Content):
         kind,
         order,
     ):
-        out = self._content._argsort_next(
+        out = self._content._pub_argsort_next(
             negaxis,
             starts,
             shifts,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -451,8 +451,8 @@ class UnmaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        return self._content._to_arrow(pyarrow, self, None, length, options)
+    def _pub_to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+        return self._content._pub_to_arrow(pyarrow, self, None, length, options)
 
     def _pub_to_numpy(self, allow_missing):
         content = self.content._pub_to_numpy(allow_missing)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -161,34 +161,34 @@ class UnmaskedArray(Content):
                 self._content.length, dtype=np.bool_
             )
 
-    def _getitem_nothing(self):
-        return self._content._getitem_range(slice(0, 0))
+    def _pub_getitem_nothing(self):
+        return self._content._pub_getitem_range(slice(0, 0))
 
-    def _getitem_at(self, where):
+    def _pub_getitem_at(self, where):
         if not self._backend.nplike.known_data:
-            return ak._typetracer.MaybeNone(self._content._getitem_at(where))
+            return ak._typetracer.MaybeNone(self._content._pub_getitem_at(where))
 
-        return self._content._getitem_at(where)
+        return self._content._pub_getitem_at(where)
 
-    def _getitem_range(self, where):
+    def _pub_getitem_range(self, where):
         if not self._backend.nplike.known_shape:
             return self
 
         start, stop, step = where.indices(self.length)
         assert step == 1
         return UnmaskedArray(
-            self._content._getitem_range(slice(start, stop)),
+            self._content._pub_getitem_range(slice(start, stop)),
             parameters=self._parameters,
         )
 
-    def _getitem_field(self, where, only_fields=()):
+    def _pub_getitem_field(self, where, only_fields=()):
         return UnmaskedArray.simplified(
-            self._content._getitem_field(where, only_fields), parameters=None
+            self._content._pub_getitem_field(where, only_fields), parameters=None
         )
 
-    def _getitem_fields(self, where, only_fields=()):
+    def _pub_getitem_fields(self, where, only_fields=()):
         return UnmaskedArray.simplified(
-            self._content._getitem_fields(where, only_fields), parameters=None
+            self._content._pub_getitem_fields(where, only_fields), parameters=None
         )
 
     def _carry(self, carry, allow_lazy):
@@ -196,15 +196,15 @@ class UnmaskedArray(Content):
             self._content._carry(carry, allow_lazy), parameters=self._parameters
         )
 
-    def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
+    def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         return UnmaskedArray(
-            self._content._getitem_next_jagged(
+            self._content._pub_getitem_next_jagged(
                 slicestarts, slicestops, slicecontent, tail
             ),
             parameters=self._parameters,
         )
 
-    def _getitem_next(self, head, tail, advanced):
+    def _pub_getitem_next(self, head, tail, advanced):
         if head == ():
             return self
 
@@ -212,24 +212,24 @@ class UnmaskedArray(Content):
             head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             return UnmaskedArray.simplified(
-                self._content._getitem_next(head, tail, advanced),
+                self._content._pub_getitem_next(head, tail, advanced),
                 parameters=self._parameters,
             )
 
         elif isinstance(head, str):
-            return self._getitem_next_field(head, tail, advanced)
+            return self._pub_getitem_next_field(head, tail, advanced)
 
         elif isinstance(head, list):
-            return self._getitem_next_fields(head, tail, advanced)
+            return self._pub_getitem_next_fields(head, tail, advanced)
 
         elif head is np.newaxis:
-            return self._getitem_next_newaxis(tail, advanced)
+            return self._pub_getitem_next_newaxis(tail, advanced)
 
         elif head is Ellipsis:
-            return self._getitem_next_ellipsis(tail, advanced)
+            return self._pub_getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.contents.IndexedOptionArray):
-            return self._getitem_next_missing(head, tail, advanced)
+            return self._pub_getitem_next_missing(head, tail, advanced)
 
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -191,9 +191,9 @@ class UnmaskedArray(Content):
             self._content._pub_getitem_fields(where, only_fields), parameters=None
         )
 
-    def _carry(self, carry, allow_lazy):
+    def _pub_carry(self, carry, allow_lazy):
         return UnmaskedArray.simplified(
-            self._content._carry(carry, allow_lazy), parameters=self._parameters
+            self._content._pub_carry(carry, allow_lazy), parameters=self._parameters
         )
 
     def _pub_getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -367,10 +367,10 @@ class UnmaskedArray(Content):
         else:
             return out
 
-    def _sort_next(
+    def _pub_sort_next(
         self, negaxis, starts, parents, outlength, ascending, stable, kind, order
     ):
-        out = self._content._sort_next(
+        out = self._content._pub_sort_next(
             negaxis,
             starts,
             parents,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -459,10 +459,10 @@ class UnmaskedArray(Content):
         else:
             return content
 
-    def _completely_flatten(self, backend, options):
+    def _pub_completely_flatten(self, backend, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._completely_flatten(backend, options)
+            return self.project()._pub_completely_flatten(backend, options)
         else:
             return [self]
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2781,6 +2781,6 @@ class ArrayBuilder(Sized):
         return self.Record(self, name)
 
 
-def ignore_in_to_list(getitem_function):
-    getitem_function.ignore_in_to_list = True
+def ignore_in_pub_to_list(getitem_function):
+    getitem_function.ignore_in_pub_to_list = True
     return getitem_function

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -209,7 +209,7 @@ class Index:
             nplike=self._nplike,
         )
 
-    def _nbytes_part(self):
+    def _pub_nbytes_part(self):
         return self.data.nbytes
 
     def to_nplike(self, nplike: ak._nplikes.NumpyLike) -> Self:

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -226,7 +226,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                 all_flatten = []
 
                 for x in nextinputs:
-                    o, f = x._offsets_and_flattened(1, 0)
+                    o, f = x._pub_offsets_and_flattened(1, 0)
                     o = backend.index_nplike.asarray(o)
                     c = o[1:] - o[:-1]
                     backend.index_nplike.add(counts, c, out=counts)

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -65,7 +65,7 @@ def _impl(array, generate_bitmasks, highlevel, behavior):
                 out = awkward._connect.pyarrow.remove_optiontype(out)
 
             if awkwardarrow_type.record_is_scalar:
-                out = out._getitem_at(0)
+                out = out._pub_getitem_at(0)
 
     def remove_revertable(layout, **kwargs):
         if hasattr(layout, "__pyarrow_original"):

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -431,8 +431,8 @@ def _record_to_complex(layout, complex_record_fields):
         def action(node, **kwargs):
             if isinstance(node, ak.contents.RecordArray):
                 if set(complex_record_fields).issubset(node.fields):
-                    real = node._getitem_field(complex_record_fields[0])
-                    imag = node._getitem_field(complex_record_fields[1])
+                    real = node._pub_getitem_field(complex_record_fields[0])
+                    imag = node._pub_getitem_field(complex_record_fields[1])
                     if (
                         isinstance(real, ak.contents.NumpyArray)
                         and len(real.shape) == 1

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -132,7 +132,7 @@ def _impl(array, container, buffer_key, form_key, id_start, backend):
     if backend is not None:
         backend = ak._backends.regularize_backend(backend)
 
-    return layout.to_buffers(
+    return layout._pub_to_buffers(
         container=container,
         buffer_key=buffer_key,
         form_key=form_key,

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -192,7 +192,9 @@ or
             else:
                 return sum(
                     (
-                        recurse(layout._getitem_field(n), row_arrays, col_names + (n,))
+                        recurse(
+                            layout._pub_getitem_field(n), row_arrays, col_names + (n,)
+                        )
                         for n in layout.fields
                     ),
                     [],
@@ -201,7 +203,7 @@ or
         elif isinstance(layout, ak.contents.RecordArray):
             return sum(
                 (
-                    recurse(layout._getitem_field(n), row_arrays, col_names + (n,))
+                    recurse(layout._pub_getitem_field(n), row_arrays, col_names + (n,))
                     for n in layout.fields
                 ),
                 [],

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -167,7 +167,7 @@ or
             return [(ak.operations.to_numpy(layout), row_arrays, col_names)]
 
         elif layout.purelist_depth > 1:
-            offsets, flattened = layout._offsets_and_flattened(axis=1, depth=0)
+            offsets, flattened = layout._pub_offsets_and_flattened(axis=1, depth=0)
             offsets = numpy.asarray(offsets)
             starts, stops = offsets[:-1], offsets[1:]
             counts = stops - starts

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -168,7 +168,7 @@ def _impl(
         out = array.array[array.at : array.at + 1]
 
     elif isinstance(array, _ext.ArrayBuilder):
-        formstr, length, buffers = array.to_buffers()
+        formstr, length, buffers = array._pub_to_buffers()
         form = ak.forms.from_json(formstr)
 
         out = ak.operations.from_buffers(form, length, buffers, highlevel=False)

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -58,7 +58,7 @@ def _impl(array):
         return array.to_list(None)
 
     elif isinstance(array, _ext.ArrayBuilder):
-        formstr, length, container = array.to_buffers()
+        formstr, length, container = array._pub_to_buffers()
         form = ak.forms.from_json(formstr)
         layout = ak.operations.from_buffers(form, length, container)
         return layout.to_list(None)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -501,7 +501,7 @@ def _impl(
                     )
                 )
 
-        out = layout._recursively_apply(
+        out = layout._pub_recursively_apply(
             action,
             behavior,
             1,

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -123,9 +123,9 @@ class Record:
 
     def __getitem__(self, where):
         with ak._errors.SlicingErrorContext(self, where):
-            return self._getitem(where)
+            return self._pub_getitem(where)
 
-    def _getitem(self, where):
+    def _pub_getitem(self, where):
         if ak._util.is_integer(where):
             raise ak._errors.wrap_error(
                 IndexError("scalar Record cannot be sliced by an integer")
@@ -137,7 +137,7 @@ class Record:
             )
 
         elif isinstance(where, str):
-            return self._getitem_field(where)
+            return self._pub_getitem_field(where)
 
         elif where is np.newaxis:
             raise ak._errors.wrap_error(
@@ -153,10 +153,10 @@ class Record:
             return self
 
         elif isinstance(where, tuple) and len(where) == 1:
-            return self._getitem(where[0])
+            return self._pub_getitem(where[0])
 
         elif isinstance(where, tuple) and isinstance(where[0], str):
-            return self._getitem_field(where[0])._getitem(where[1:])
+            return self._pub_getitem_field(where[0])._pub_getitem(where[1:])
 
         elif isinstance(where, ak.highlevel.Array):
             raise ak._errors.wrap_error(
@@ -174,7 +174,7 @@ class Record:
             )
 
         elif isinstance(where, Iterable) and all(isinstance(x, str) for x in where):
-            return self._getitem_fields(where)
+            return self._pub_getitem_fields(where)
 
         elif isinstance(where, Iterable):
             raise ak._errors.wrap_error(
@@ -190,11 +190,11 @@ class Record:
                 )
             )
 
-    def _getitem_field(self, where):
-        return self._array._getitem_field(where)._getitem_at(self._at)
+    def _pub_getitem_field(self, where):
+        return self._array._pub_getitem_field(where)._pub_getitem_at(self._at)
 
-    def _getitem_fields(self, where):
-        return self._array._getitem_fields(where)._getitem_at(self._at)
+    def _pub_getitem_fields(self, where):
+        return self._array._pub_getitem_fields(where)._pub_getitem_at(self._at)
 
     def packed(self):
         if self._array.length == 1:

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -203,9 +203,9 @@ class Record:
             return Record(self._array[self._at : self._at + 1].packed(), 0)
 
     def to_list(self, behavior=None):
-        return self._to_list(behavior, None)
+        return self._pub_to_list(behavior, None)
 
-    def _to_list(self, behavior, json_conversions):
+    def _pub_to_list(self, behavior, json_conversions):
         overloaded = (
             ak._util.recordclass(self._array, behavior).__getitem__
             is not ak.highlevel.Record.__getitem__
@@ -217,7 +217,7 @@ class Record:
             for field in self._array.fields:
                 contents.append(record[field])
                 if isinstance(contents[-1], (ak.highlevel.Array, ak.highlevel.Record)):
-                    contents[-1] = contents[-1]._layout._to_list(
+                    contents[-1] = contents[-1]._layout._pub_to_list(
                         behavior, json_conversions
                     )
                 elif hasattr(contents[-1], "tolist"):
@@ -225,7 +225,9 @@ class Record:
 
         else:
             contents = [
-                content[self._at : self._at + 1]._to_list(behavior, json_conversions)[0]
+                content[self._at : self._at + 1]._pub_to_list(
+                    behavior, json_conversions
+                )[0]
                 for content in self._array.contents
             ]
 

--- a/tests/test_0959-_getitem_array-implementation.py
+++ b/tests/test_0959-_getitem_array-implementation.py
@@ -339,10 +339,10 @@ def test_RegularArray_RecordArray_NumpyArray():
         ),
         3,
     )
-    resultv2 = v2a._carry(ak.index.Index(np.array([0], np.int64)), False)
+    resultv2 = v2a._pub_carry(ak.index.Index(np.array([0], np.int64)), False)
     assert to_list(resultv2) == [[{"nest": 0.0}, {"nest": 1.1}, {"nest": 2.2}]]
     assert (
-        v2a.typetracer._carry(ak.index.Index(np.array([0], np.int64)), False).form
+        v2a.typetracer._pub_carry(ak.index.Index(np.array([0], np.int64)), False).form
         == resultv2.form
     )
 
@@ -353,10 +353,10 @@ def test_RegularArray_RecordArray_NumpyArray():
         0,
         zeros_length=10,
     )
-    resultv2 = v2b._carry(ak.index.Index(np.array([0], np.int64)), False)
+    resultv2 = v2b._pub_carry(ak.index.Index(np.array([0], np.int64)), False)
     assert to_list(resultv2) == [[]]
     assert (
-        v2b.typetracer._carry(ak.index.Index(np.array([0], np.int64)), False).form
+        v2b.typetracer._pub_carry(ak.index.Index(np.array([0], np.int64)), False).form
         == resultv2.form
     )
 
@@ -439,10 +439,12 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
         ),
         valid_when=True,
     )
-    resultv2 = v2a._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
+    resultv2 = v2a._pub_carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
     assert to_list(resultv2) == [{"nest": 1.1}, None, {"nest": 5.5}]
     assert (
-        v2a.typetracer._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False).form
+        v2a.typetracer._pub_carry(
+            ak.index.Index(np.array([0, 1, 4], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -458,10 +460,12 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
         ),
         valid_when=False,
     )
-    resultv2 = v2b._carry(ak.index.Index(np.array([3, 1, 4], np.int64)), False)
+    resultv2 = v2b._pub_carry(ak.index.Index(np.array([3, 1, 4], np.int64)), False)
     assert to_list(resultv2) == [None, None, {"nest": 5.5}]
     assert (
-        v2b.typetracer._carry(ak.index.Index(np.array([3, 1, 4], np.int64)), False).form
+        v2b.typetracer._pub_carry(
+            ak.index.Index(np.array([3, 1, 4], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -518,10 +522,12 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    resultv2 = v2a._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
+    resultv2 = v2a._pub_carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
     assert to_list(resultv2) == [{"nest": 0.0}, {"nest": 1.0}, None]
     assert (
-        v2a.typetracer._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False).form
+        v2a.typetracer._pub_carry(
+            ak.index.Index(np.array([0, 1, 4], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -577,10 +583,12 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    resultv2 = v2b._carry(ak.index.Index(np.array([1, 1, 4], np.int64)), False)
+    resultv2 = v2b._pub_carry(ak.index.Index(np.array([1, 1, 4], np.int64)), False)
     assert to_list(resultv2) == [{"nest": 1.0}, {"nest": 1.0}, None]
     assert (
-        v2b.typetracer._carry(ak.index.Index(np.array([1, 1, 4], np.int64)), False).form
+        v2b.typetracer._pub_carry(
+            ak.index.Index(np.array([1, 1, 4], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -639,10 +647,12 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    resultv2 = v2c._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
+    resultv2 = v2c._pub_carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False)
     assert to_list(resultv2) == [{"nest": 0.0}, {"nest": 1.0}, None]
     assert (
-        v2c.typetracer._carry(ak.index.Index(np.array([0, 1, 4], np.int64)), False).form
+        v2c.typetracer._pub_carry(
+            ak.index.Index(np.array([0, 1, 4], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -701,10 +711,12 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    resultv2 = v2d._carry(ak.index.Index(np.array([0, 0, 0], np.int64)), False)
+    resultv2 = v2d._pub_carry(ak.index.Index(np.array([0, 0, 0], np.int64)), False)
     assert to_list(resultv2) == [{"nest": 0.0}, {"nest": 0.0}, {"nest": 0.0}]
     assert (
-        v2d.typetracer._carry(ak.index.Index(np.array([0, 0, 0], np.int64)), False).form
+        v2d.typetracer._pub_carry(
+            ak.index.Index(np.array([0, 0, 0], np.int64)), False
+        ).form
         == resultv2.form
     )
 
@@ -716,7 +728,9 @@ def test_UnmaskedArray_RecordArray_NumpyArray():
             ["nest"],
         )
     )
-    resultv2 = v2a._carry(ak.index.Index(np.array([0, 1, 1, 1, 1], np.int64)), False)
+    resultv2 = v2a._pub_carry(
+        ak.index.Index(np.array([0, 1, 1, 1, 1], np.int64)), False
+    )
     assert to_list(resultv2) == [
         {"nest": 0.0},
         {"nest": 1.1},
@@ -725,7 +739,7 @@ def test_UnmaskedArray_RecordArray_NumpyArray():
         {"nest": 1.1},
     ]
     assert (
-        v2a.typetracer._carry(
+        v2a.typetracer._pub_carry(
             ak.index.Index(np.array([0, 1, 1, 1, 1], np.int64)), False
         ).form
         == resultv2.form
@@ -764,10 +778,10 @@ def test_RecordArray_NumpyArray_lazy():
         ],
         ["x", "y"],
     )
-    resultv2 = v2a._carry(ak.index.Index(np.array([1, 2], np.int64)), True)
+    resultv2 = v2a._pub_carry(ak.index.Index(np.array([1, 2], np.int64)), True)
     assert to_list(resultv2) == [{"x": 1, "y": 1.1}, {"x": 2, "y": 2.2}]
     assert (
-        v2a.typetracer._carry(ak.index.Index(np.array([1, 2], np.int64)), True).form
+        v2a.typetracer._pub_carry(ak.index.Index(np.array([1, 2], np.int64)), True).form
         == resultv2.form
     )
 
@@ -778,10 +792,10 @@ def test_RecordArray_NumpyArray_lazy():
         ],
         None,
     )
-    resultv2 = v2b._carry(ak.index.Index(np.array([0, 1, 2, 3, 4], np.int64)), True)
+    resultv2 = v2b._pub_carry(ak.index.Index(np.array([0, 1, 2, 3, 4], np.int64)), True)
     assert to_list(resultv2) == [(0, 0.0), (1, 1.1), (2, 2.2), (3, 3.3), (4, 4.4)]
     assert (
-        v2b.typetracer._carry(
+        v2b.typetracer._pub_carry(
             ak.index.Index(np.array([0, 1, 2, 3, 4], np.int64)), True
         ).form
         == resultv2.form


### PR DESCRIPTION
This PR demonstrates one potential solution to the discussion in #1969

There, @jpivarski outlines four levels of access scope for Awkward Array's API

Here's a table outlining these, and demonstrating the naming convention in this PR

| Level | Permitted Visibility | Syntax / Feature (in #1975) |
|-------|----------------------|-------------------|
| 1     | Users                | `ak.XXX`          |
| 2     | 3rd Party Developers | `layout.XXX`      |
| 3     | Any Awkward class    | `layout._pub_XXX` |
| 4     | Same Awkward Class   | `layout._XXX`     |

There are other ways to introduce a level-2←→level-3 split, such as L-3 attributes being Python-public, i.e. `layout.private_XXX` instead of `layout._public_XXX`, where `private_` indicate to L2 and L1 users that they should not use these attributes.


<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-wip-private-impl/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->