### PR TITLE
refactor: rename `Form` to `form_cls`

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -11,7 +11,7 @@ from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -114,7 +114,7 @@ class BitMaskedArray(Content):
     def lsb_order(self):
         return self._lsb_order
 
-    Form = BitMaskedForm
+    form_cls: Final = BitMaskedForm
 
     def copy(
         self,
@@ -190,7 +190,7 @@ class BitMaskedArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._mask.form,
             self._content._form_with_key(getkey),
             self._valid_when,
@@ -200,7 +200,7 @@ class BitMaskedArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "mask")
         container[key] = ak._util.little_endian(self._mask.raw(backend.index_nplike))
         self._content._to_buffers(form.content, getkey, container, backend)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -10,7 +10,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -84,7 +84,7 @@ class ByteMaskedArray(Content):
     def valid_when(self):
         return self._valid_when
 
-    Form = ByteMaskedForm
+    form_cls: Final = ByteMaskedForm
 
     def copy(self, mask=unset, content=unset, valid_when=unset, *, parameters=unset):
         return ByteMaskedArray(
@@ -139,7 +139,7 @@ class ByteMaskedArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._mask.form,
             self._content._form_with_key(getkey),
             self._valid_when,
@@ -148,7 +148,7 @@ class ByteMaskedArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "mask")
         container[key] = ak._util.little_endian(self._mask.raw(backend.index_nplike))
         self._content._to_buffers(form.content, getkey, container, backend)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -9,7 +9,7 @@ from numbers import Complex, Integral, Real
 import awkward as ak
 import awkward._reducers
 from awkward._backends import Backend, TypeTracerBackend
-from awkward.forms import form
+from awkward.forms.form import Form, _parameters_equal
 from awkward.typing import Any, Self, TypeAlias, TypeVar
 
 np = ak._nplikes.NumpyMetadata.instance()
@@ -121,7 +121,7 @@ class Content:
         return self._backend
 
     @property
-    def form(self) -> form.Form:
+    def form(self) -> Form:
         return self.form_with_key(None)
 
     def form_with_key(self, form_key="node{id}", id_start=0):
@@ -159,12 +159,12 @@ class Content:
 
     def _form_with_key(
         self,
-        getkey: Callable[[Content], form.Form],
-    ) -> form.Form:
+        getkey: Callable[[Content], Form],
+    ) -> Form:
         raise ak._errors.wrap_error(NotImplementedError)
 
     @property
-    def Form(self) -> type[form.Form]:
+    def form_cls(self) -> type[Form]:
         raise ak._errors.wrap_error(NotImplementedError)
 
     @property
@@ -191,7 +191,7 @@ class Content:
         form_key: str | None = "node{id}",
         id_start: Integral = 0,
         backend: Backend = None,
-    ) -> tuple[form.Form, int, Mapping[str, Any]]:
+    ) -> tuple[Form, int, Mapping[str, Any]]:
         if container is None:
             container = {}
         if backend is None:
@@ -240,11 +240,11 @@ class Content:
 
     def _to_buffers(
         self,
-        form: form.Form,
-        getkey: Callable[[Content, form.Form, str], str],
+        form: Form,
+        getkey: Callable[[Content, Form, str], str],
         container: MutableMapping[str, Any] | None,
         backend: Backend,
-    ) -> tuple[form.Form, int, Mapping[str, Any]]:
+    ) -> tuple[Form, int, Mapping[str, Any]]:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def __len__(self) -> int:
@@ -775,7 +775,7 @@ class Content:
             return True
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
-            form._parameters_equal(
+            _parameters_equal(
                 self._parameters, other._parameters, only_array_record=True
             )
         ):
@@ -1316,7 +1316,7 @@ class Content:
         return self._nbytes_part()
 
     def purelist_parameter(self, key: str):
-        return self.Form.purelist_parameter(self, key)
+        return self.form_cls.purelist_parameter(self, key)
 
     def is_unique(self, axis: Integral | None = None) -> bool:
         negaxis = axis if axis is None else -axis
@@ -1394,35 +1394,35 @@ class Content:
 
     @property
     def is_identity_like(self) -> bool:
-        return self.Form.is_identity_like.__get__(self)
+        return self.form_cls.is_identity_like.__get__(self)
 
     @property
     def purelist_isregular(self) -> bool:
-        return self.Form.purelist_isregular.__get__(self)
+        return self.form_cls.purelist_isregular.__get__(self)
 
     @property
     def purelist_depth(self) -> int:
-        return self.Form.purelist_depth.__get__(self)
+        return self.form_cls.purelist_depth.__get__(self)
 
     @property
     def minmax_depth(self) -> tuple[int, int]:
-        return self.Form.minmax_depth.__get__(self)
+        return self.form_cls.minmax_depth.__get__(self)
 
     @property
     def branch_depth(self) -> tuple[bool, int]:
-        return self.Form.branch_depth.__get__(self)
+        return self.form_cls.branch_depth.__get__(self)
 
     @property
     def fields(self) -> list[str]:
-        return self.Form.fields.__get__(self)
+        return self.form_cls.fields.__get__(self)
 
     @property
     def is_tuple(self) -> bool:
-        return self.Form.is_tuple.__get__(self)
+        return self.form_cls.is_tuple.__get__(self)
 
     @property
     def dimension_optiontype(self) -> bool:
-        return self.Form.dimension_optiontype.__get__(self)
+        return self.form_cls.dimension_optiontype.__get__(self)
 
     def pad_none_axis0(self, target: Integral, clip: bool) -> Content:
         if not clip and target < self.length:
@@ -1748,7 +1748,7 @@ class Content:
         return (
             self.__class__ is other.__class__
             and len(self) == len(other)
-            and ak.forms.form._parameters_equal(
+            and _parameters_equal(
                 self.parameters, other.parameters, only_array_record=False
             )
             and self._layout_equal(other, index_dtype, numpyarray)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -22,7 +22,7 @@ class EmptyArray(Content):
             backend = ak._backends.NumpyBackend.instance()
         self._init(parameters, backend)
 
-    Form = EmptyForm
+    form_cls: Final = EmptyForm
 
     def copy(
         self,
@@ -46,10 +46,10 @@ class EmptyArray(Content):
         return cls(parameters=parameters, backend=backend)
 
     def _form_with_key(self, getkey):
-        return self.Form(parameters=self._parameters, form_key=getkey(self))
+        return self.form_cls(parameters=self._parameters, form_key=getkey(self))
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
 
     @property
     def typetracer(self):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,7 +8,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -65,7 +65,7 @@ class IndexedArray(Content):
     def content(self):
         return self._content
 
-    Form = IndexedForm
+    form_cls: Final = IndexedForm
 
     def copy(self, index=unset, content=unset, *, parameters=unset):
         return IndexedArray(
@@ -137,7 +137,7 @@ class IndexedArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._index.form,
             self._content._form_with_key(getkey),
             parameters=self._parameters,
@@ -145,7 +145,7 @@ class IndexedArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "index")
         container[key] = ak._util.little_endian(self._index.raw(backend.index_nplike))
         self._content._to_buffers(form.content, getkey, container, backend)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -8,7 +8,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -65,7 +65,7 @@ class IndexedOptionArray(Content):
     def content(self):
         return self._content
 
-    Form = IndexedOptionForm
+    form_cls: Final = IndexedOptionForm
 
     def copy(self, index=unset, content=unset, *, parameters=unset):
         return IndexedOptionArray(
@@ -124,7 +124,7 @@ class IndexedOptionArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._index.form,
             self._content._form_with_key(getkey),
             parameters=self._parameters,
@@ -132,7 +132,7 @@ class IndexedOptionArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "index")
         container[key] = ak._util.little_endian(self._index.raw(backend.index_nplike))
         self._content._to_buffers(form.content, getkey, container, backend)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -9,7 +9,7 @@ from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
 from awkward.forms.listform import ListForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 
@@ -98,7 +98,7 @@ class ListArray(Content):
     def content(self):
         return self._content
 
-    Form = ListForm
+    form_cls: Final = ListForm
 
     def copy(self, starts=unset, stops=unset, content=unset, *, parameters=unset):
         return ListArray(
@@ -125,7 +125,7 @@ class ListArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._starts.form,
             self._stops.form,
             self._content._form_with_key(getkey),
@@ -134,7 +134,7 @@ class ListArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key1 = getkey(self, form, "starts")
         key2 = getkey(self, form, "stops")
         container[key1] = ak._util.little_endian(self._starts.raw(backend.index_nplike))

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -8,7 +8,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -79,7 +79,7 @@ class ListOffsetArray(Content):
     def content(self):
         return self._content
 
-    Form = ListOffsetForm
+    form_cls: Final = ListOffsetForm
 
     def copy(self, offsets=unset, content=unset, *, parameters=unset):
         return ListOffsetArray(
@@ -112,7 +112,7 @@ class ListOffsetArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._offsets.form,
             self._content._form_with_key(getkey),
             parameters=self._parameters,
@@ -120,7 +120,7 @@ class ListOffsetArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "offsets")
         container[key] = ak._util.little_endian(self._offsets.raw(backend.index_nplike))
         self._content._to_buffers(form.content, getkey, container, backend)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -8,7 +8,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.numpyform import NumpyForm
 from awkward.types.numpytype import primitive_to_dtype
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -55,7 +55,7 @@ class NumpyArray(Content):
     def data(self):
         return self._data
 
-    Form = NumpyForm
+    form_cls: Final = NumpyForm
 
     def copy(
         self,
@@ -118,7 +118,7 @@ class NumpyArray(Content):
         return self._backend.nplike.raw(self.data, nplike)
 
     def _form_with_key(self, getkey):
-        return self.Form(
+        return self.form_cls(
             ak.types.numpytype.dtype_to_primitive(self._data.dtype),
             self._data.shape[1:],
             parameters=self._parameters,
@@ -126,7 +126,7 @@ class NumpyArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key = getkey(self, form, "data")
         container[key] = ak._util.little_endian(self.raw(backend.nplike))
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,7 +10,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.recordform import RecordForm
 from awkward.record import Record
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -144,7 +144,7 @@ class RecordArray(Content):
         else:
             return self._fields
 
-    Form = RecordForm
+    form_cls: Final = RecordForm
 
     def copy(
         self,
@@ -197,7 +197,7 @@ class RecordArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             [x._form_with_key(getkey) for x in self._contents],
             self._fields,
             parameters=self._parameters,
@@ -205,7 +205,7 @@ class RecordArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         if self._fields is None:
             for i, content in enumerate(self._contents):
                 content._to_buffers(form.content(i), getkey, container, backend)
@@ -278,16 +278,16 @@ class RecordArray(Content):
         )
 
     def index_to_field(self, index):
-        return self.Form.index_to_field(self, index)
+        return self.form_cls.index_to_field(self, index)
 
     def field_to_index(self, field):
-        return self.Form.field_to_index(self, field)
+        return self.form_cls.field_to_index(self, field)
 
     def has_field(self, field):
-        return self.Form.has_field(self, field)
+        return self.form_cls.has_field(self, field)
 
     def content(self, index_or_field):
-        out = self.Form.content(self, index_or_field)
+        out = self.form_cls.content(self, index_or_field)
         if out.length == self._length:
             return out
         else:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.regularform import RegularForm
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -82,7 +82,7 @@ class RegularArray(Content):
     def size(self):
         return self._size
 
-    Form = RegularForm
+    form_cls: Final = RegularForm
 
     def copy(self, content=unset, size=unset, zeros_length=unset, *, parameters=unset):
         return RegularArray(
@@ -119,7 +119,7 @@ class RegularArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._content._form_with_key(getkey),
             self._size,
             parameters=self._parameters,
@@ -127,7 +127,7 @@ class RegularArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         self._content._to_buffers(form.content, getkey, container, backend)
 
     @property

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -12,7 +12,7 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -138,7 +138,7 @@ class UnionArray(Content):
     def contents(self):
         return self._contents
 
-    Form = UnionForm
+    form_cls: Final = UnionForm
 
     def copy(
         self,
@@ -382,7 +382,7 @@ class UnionArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._tags.form,
             self._index.form,
             [x._form_with_key(getkey) for x in self._contents],
@@ -391,7 +391,7 @@ class UnionArray(Content):
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         key1 = getkey(self, form, "tags")
         key2 = getkey(self, form, "index")
         container[key1] = ak._util.little_endian(self._tags.raw(backend.index_nplike))

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.unmaskedform import UnmaskedForm
-from awkward.typing import Self
+from awkward.typing import Final, Self
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
@@ -40,7 +40,7 @@ class UnmaskedArray(Content):
     def content(self):
         return self._content
 
-    Form = UnmaskedForm
+    form_cls: Final = UnmaskedForm
 
     def copy(self, content=unset, *, parameters=unset):
         return UnmaskedArray(
@@ -73,14 +73,14 @@ class UnmaskedArray(Content):
 
     def _form_with_key(self, getkey):
         form_key = getkey(self)
-        return self.Form(
+        return self.form_cls(
             self._content._form_with_key(getkey),
             parameters=self._parameters,
             form_key=form_key,
         )
 
     def _to_buffers(self, form, getkey, container, backend):
-        assert isinstance(form, self.Form)
+        assert isinstance(form, self.form_cls)
         self._content._to_buffers(form.content, getkey, container, backend)
 
     @property


### PR DESCRIPTION
This renames `Content.Form` to `Content.form_cls`, which is better in line with the PEP8 naming conventions

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/agoose77-refactor-rename-form/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->