### PR TITLE
fix: ak_from_parquet

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -244,7 +244,7 @@ def _load(
     else:
         # TODO: if each array is a record?
         return ak.operations.ak_concatenate._impl(
-            arrays, 0, True, True, highlevel, behavior
+            arrays, axis=0, mergebool=True, highlevel=highlevel, behavior=behavior
         )
 
 


### PR DESCRIPTION
This PR fixes #1973

The issue came from parameters miss-match. 

The use-case from the issue was tested locally: 

```
>>> import awkward as ak
>>> import dask_awkward as dak
>>> ds = dak.from_parquet("s3://ddavistemp/higgs_pq/*.parquet", storage_options={"anon": True})
>>> dak.to_parquet(ds, "outputs")
>>> ak.from_parquet("outputs")
<Array [{run: 1, ...}, ..., {run: 1, ...}] type='299683 * {run: int64, lumi...'>
```

cc @jpivarski 


<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/ioanaif-fix-ak-from-parquet/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->