### PR TITLE
fix: ak.Record dict constructor should retain type.

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -38,24 +38,28 @@ def numpy_at_least(version):
     return parse_version(numpy.__version__) >= parse_version(version)
 
 
-def in_module(obj, modulename):
+def in_module(obj, modulename: str) -> bool:
     m = type(obj).__module__
     return m == modulename or m.startswith(modulename + ".")
 
 
-def is_file_path(x):
+def is_file_path(x) -> bool:
     try:
         return os.path.isfile(x)
     except ValueError:
         return False
 
 
-def is_sized_iterable(obj):
+def is_sized_iterable(obj) -> bool:
     return isinstance(obj, Iterable) and isinstance(obj, Sized)
 
 
-def is_integer(x):
+def is_integer(x) -> bool:
     return isinstance(x, numbers.Integral) and not isinstance(x, bool)
+
+
+def is_non_string_iterable(obj) -> bool:
+    return not isinstance(obj, str) and isinstance(obj, Iterable)
 
 
 def tobytes(array):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1528,7 +1528,7 @@ class Record(NDArrayOperatorsMixin):
             contents = []
             for k, v in data.items():
                 fields.append(k)
-                if not isinstance(v, str) and isinstance(v, Iterable):
+                if ak._util.is_non_string_iterable(v):
                     contents.append(Array(v).layout[np.newaxis])
                 else:
                     contents.append(Array([v]).layout)

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1524,7 +1524,16 @@ class Record(NDArrayOperatorsMixin):
             layout = ak.operations.from_json(data, highlevel=False)
 
         elif isinstance(data, dict):
-            layout = ak.operations.from_iter([data], highlevel=False)[0]
+            fields = []
+            contents = []
+            for k, v in data.items():
+                fields.append(k)
+                if not isinstance(v, str) and isinstance(v, Iterable):
+                    contents.append(Array(v).layout[np.newaxis])
+                else:
+                    contents.append(Array([v]).layout)
+
+            layout = ak.record.Record(ak.contents.RecordArray(contents, fields), at=0)
 
         elif isinstance(data, Iterable):
             raise ak._errors.wrap_error(

--- a/tests/test_1978-akRecord-constructor-should-retain-type.py
+++ b/tests/test_1978-akRecord-constructor-should-retain-type.py
@@ -1,0 +1,11 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    j1 = ak.from_numpy(np.empty(0, np.int32))
+    assert str(ak.Record({"d": j1}).type) == "{d: 0 * int32}"


### PR DESCRIPTION
This correction has no effect on the value semantics, just the type semantics:

```python
>>> j1 = ak.from_numpy(np.empty(0, np.int32))
>>> ak.Record({"d": j1})
<Record {d: []} type='{d: var * unknown}'>
```

becomes

```python
>>> j1 = ak.from_numpy(np.empty(0, np.int32))
>>> ak.Record({"d": j1})
<Record {d: []} type='{d: 0 * int32}'>
```

In a sense, it also provides symmetry between ak.Array and ak.Record, in that they both have this "Pandas-style" constructor now, but since it's a distinction in values for ak.Array but only types for ak.Record, the _effect_ is a little different.

Anyway, it's nice to get this in before the API freeze because this does change the API.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-ak.record-constructor-should-retain-type/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->