### PR TITLE
fix: replace `axis_wrap_if_negative` with `maybe_posaxis`, simpler and more correct

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -305,8 +305,8 @@ def completely_flatten(
         return tuple(arrays)
 
 
-def flatten(layout: Content, axis: Integral = 1, depth: Integral = 0) -> Content:
-    offsets, flattened = layout._offsets_and_flattened(axis, depth)
+def flatten(layout: Content, axis: Integral = 1) -> Content:
+    offsets, flattened = layout._offsets_and_flattened(axis, 1)
     return flattened
 
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -122,6 +122,22 @@ def to_buffers(
     return form, len(content), container
 
 
+# FIXME: eventually, this should be in ak._util, but it's here to juxtapose axis_wrap_if_negative
+# This function must depend on 'depth'. I don't know how axis_wrap_if_negative was believed to work.
+def maybe_posaxis(
+    layout: Content, axis: AxisMaybeNone, depth: Integral
+) -> AxisMaybeNone:
+    if axis >= 0:
+        return axis
+    else:
+        is_branching, additional_depth = layout.branch_depth
+        if not is_branching:
+            return axis + depth + additional_depth - 1
+        else:
+            return None
+
+
+# FIXME: eventually phase out the use of axis_wrap_if_negative in favor of maybe_posaxis
 def axis_wrap_if_negative(
     layout: Content | Record, axis: AxisMaybeNone
 ) -> AxisMaybeNone:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -272,7 +272,7 @@ def unique(layout: Content, axis=None):
 def pad_none(
     layout: Content, length: Integral, axis: Integral, clip: bool = False
 ) -> Content:
-    return layout._pad_none(length, axis, 0, clip)
+    return layout._pad_none(length, axis, 1, clip)
 
 
 def completely_flatten(

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -7,7 +7,7 @@ from numbers import Integral
 
 import awkward as ak
 from awkward._backends import Backend
-from awkward.contents.content import ActionType, AxisMaybeNone, Content
+from awkward.contents.content import ActionType, Content
 from awkward.forms import form
 from awkward.record import Record
 from awkward.typing import Any
@@ -120,68 +120,6 @@ def to_buffers(
     content._to_buffers(form, getkey, container, backend)
 
     return form, len(content), container
-
-
-# FIXME: eventually, this should be in ak._util, but it's here to juxtapose axis_wrap_if_negative
-# This function must depend on 'depth'. I don't know how axis_wrap_if_negative was believed to work.
-def maybe_posaxis(
-    layout: Content | Record, axis: AxisMaybeNone, depth: Integral
-) -> AxisMaybeNone:
-    if isinstance(layout, Record):
-        if axis == 0:
-            raise ak._errors.wrap_error(
-                np.AxisError("Record type at axis=0 is a scalar, not an array")
-            )
-        return maybe_posaxis(layout._array, axis, depth)
-
-    if axis >= 0:
-        return axis
-
-    else:
-        is_branching, additional_depth = layout.branch_depth
-        if not is_branching:
-            return axis + depth + additional_depth - 1
-        else:
-            return None
-
-
-# FIXME: eventually phase out the use of axis_wrap_if_negative in favor of maybe_posaxis
-def axis_wrap_if_negative(
-    layout: Content | Record, axis: AxisMaybeNone
-) -> AxisMaybeNone:
-    if isinstance(layout, Record):
-        if axis == 0:
-            raise ak._errors.wrap_error(
-                np.AxisError("Record type at axis=0 is a scalar, not an array")
-            )
-        return axis_wrap_if_negative(layout._array, axis)
-
-    else:
-        if axis is None or axis >= 0:
-            return axis
-
-        mindepth, maxdepth = layout.minmax_depth
-        depth = layout.purelist_depth
-        if mindepth == depth and maxdepth == depth:
-            posaxis = depth + axis
-            if posaxis < 0:
-                raise ak._errors.wrap_error(
-                    np.AxisError(
-                        f"axis={axis} exceeds the depth ({depth}) of this array"
-                    )
-                )
-            return posaxis
-
-        elif mindepth + axis == 0:
-            raise ak._errors.wrap_error(
-                np.AxisError(
-                    "axis={} exceeds the depth ({}) of at least one record field (or union possibility) of this array".format(
-                        axis, depth
-                    )
-                )
-            )
-
-        return axis
 
 
 def local_index(layout: Content, axis: Integral):

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -319,7 +319,7 @@ def fill_none(layout: Content, value: Content) -> Content:
 
 
 def num(layout, axis):
-    return layout._num(axis)
+    return layout._num(axis, 0)
 
 
 def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -125,10 +125,18 @@ def to_buffers(
 # FIXME: eventually, this should be in ak._util, but it's here to juxtapose axis_wrap_if_negative
 # This function must depend on 'depth'. I don't know how axis_wrap_if_negative was believed to work.
 def maybe_posaxis(
-    layout: Content, axis: AxisMaybeNone, depth: Integral
+    layout: Content | Record, axis: AxisMaybeNone, depth: Integral
 ) -> AxisMaybeNone:
+    if isinstance(layout, Record):
+        if axis == 0:
+            raise ak._errors.wrap_error(
+                np.AxisError("Record type at axis=0 is a scalar, not an array")
+            )
+        return maybe_posaxis(layout._array, axis, depth)
+
     if axis >= 0:
         return axis
+
     else:
         is_branching, additional_depth = layout.branch_depth
         if not is_branching:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -208,7 +208,7 @@ def combinations(
             raise ak._errors.wrap_error(
                 ValueError("if provided, the length of 'fields' must be 'n'")
             )
-    return layout._combinations(n, replacement, recordlookup, parameters, axis, 0)
+    return layout._combinations(n, replacement, recordlookup, parameters, axis, 1)
 
 
 def is_unique(layout, axis: Integral | None = None) -> bool:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -185,7 +185,7 @@ def axis_wrap_if_negative(
 
 
 def local_index(layout: Content, axis: Integral):
-    return layout._local_index(axis, 0)
+    return layout._local_index(axis, 1)
 
 
 def combinations(

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -825,3 +825,22 @@ def to_arraylib(module, array, allow_missing):
         raise ak._errors.wrap_error(
             ValueError(f"{module.__name__} is not supported by to_arraylib")
         )
+
+
+def maybe_posaxis(layout, axis, depth):
+    if isinstance(layout, ak.record.Record):
+        if axis == 0:
+            raise ak._errors.wrap_error(
+                np.AxisError("Record type at axis=0 is a scalar, not an array")
+            )
+        return maybe_posaxis(layout._array, axis, depth)
+
+    if axis >= 0:
+        return axis
+
+    else:
+        is_branching, additional_depth = layout.branch_depth
+        if not is_branching:
+            return axis + depth + additional_depth - 1
+        else:
+            return None

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -434,8 +434,8 @@ class BitMaskedArray(Content):
     def project(self, mask=None):
         return self.to_ByteMaskedArray().project(mask)
 
-    def _num(self, axis, depth=0):
-        return self.to_ByteMaskedArray()._num(axis, depth)
+    def _num(self, axis, depth_m1):
+        return self.to_ByteMaskedArray()._num(axis, depth_m1)
 
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ByteMaskedArray._offsets_and_flattened(axis, depth)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -434,9 +434,6 @@ class BitMaskedArray(Content):
     def project(self, mask=None):
         return self.to_ByteMaskedArray().project(mask)
 
-    def _num(self, axis, depth_m1):
-        return self.to_ByteMaskedArray()._num(axis, depth_m1)
-
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ByteMaskedArray._offsets_and_flattened(axis, depth)
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -655,7 +655,7 @@ class ByteMaskedArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -556,24 +556,6 @@ class ByteMaskedArray(Content):
 
             return self._content._carry(nextcarry, False)
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        else:
-            _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
-
-            next = self._content._carry(nextcarry, False)
-            out = next._num(posaxis, depth_m1)
-
-            return ak.contents.IndexedOptionArray.simplified(
-                outindex, out, parameters=self._parameters
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -920,10 +920,10 @@ class ByteMaskedArray(Content):
         return self.mask._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(
                 mask.length, nplike=self._backend.index_nplike
@@ -943,14 +943,14 @@ class ByteMaskedArray(Content):
                     self._mask.length,
                 )
             )
-            next = self.project()._pad_none(target, posaxis, depth, clip)
+            next = self.project()._pad_none(target, axis, depth, clip)
             return ak.contents.IndexedOptionArray.simplified(
                 index, next, parameters=self._parameters
             )
         else:
             return ak.contents.ByteMaskedArray(
                 self._mask,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pad_none(target, axis, depth, clip),
                 self._valid_when,
                 parameters=self._parameters,
             )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -921,9 +921,9 @@ class ByteMaskedArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(
                 mask.length, nplike=self._backend.index_nplike

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -557,15 +557,15 @@ class ByteMaskedArray(Content):
             return self._content._carry(nextcarry, False)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, False)
 
-            offsets, flattened = next._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = next._offsets_and_flattened(axis, depth)
 
             if offsets.length == 0:
                 return (

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -557,7 +557,7 @@ class ByteMaskedArray(Content):
             return self._content._carry(nextcarry, False)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
@@ -654,7 +654,7 @@ class ByteMaskedArray(Content):
         return self.to_IndexedOptionArray64()._fill_none(value)
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -731,7 +731,7 @@ class ByteMaskedArray(Content):
             raise ak._errors.wrap_error(
                 ValueError("in combinations, 'n' must be at least 1")
             )
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -920,7 +920,7 @@ class ByteMaskedArray(Content):
         return self.mask._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -558,7 +558,7 @@ class ByteMaskedArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -556,9 +556,9 @@ class ByteMaskedArray(Content):
 
             return self._content._carry(nextcarry, False)
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
@@ -568,7 +568,7 @@ class ByteMaskedArray(Content):
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, False)
-            out = next._num(posaxis, depth)
+            out = next._num(posaxis, depth_m1)
 
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -731,15 +731,15 @@ class ByteMaskedArray(Content):
             raise ak._errors.wrap_error(
                 ValueError("in combinations, 'n' must be at least 1")
             )
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, True)
             out = next._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth
+                n, replacement, recordlookup, parameters, axis, depth
             )
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=parameters

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -654,14 +654,14 @@ class ByteMaskedArray(Content):
         return self.to_IndexedOptionArray64()._fill_none(value)
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, False)
-            out = next._local_index(posaxis, depth)
+            out = next._local_index(axis, depth)
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=self._parameters
             )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -732,7 +732,7 @@ class ByteMaskedArray(Content):
                 ValueError("in combinations, 'n' must be at least 1")
             )
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -159,7 +159,7 @@ class EmptyArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(
                 np.AxisError(self, "axis=0 not allowed for flatten")
@@ -189,7 +189,7 @@ class EmptyArray(Content):
         return EmptyArray(parameters=self._parameters, backend=self._backend)
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return ak.contents.NumpyArray(
                 self._backend.nplike.empty(0, np.int64),
@@ -279,7 +279,7 @@ class EmptyArray(Content):
         return 0
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -159,8 +159,8 @@ class EmptyArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(
                 np.AxisError(self, "axis=0 not allowed for flatten")
             )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -160,7 +160,7 @@ class EmptyArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(
                 np.AxisError(self, "axis=0 not allowed for flatten")
             )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -158,10 +158,10 @@ class EmptyArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
 
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -189,11 +189,17 @@ class EmptyArray(Content):
         return EmptyArray(parameters=self._parameters, backend=self._backend)
 
     def _local_index(self, axis, depth):
-        return ak.contents.NumpyArray(
-            self._backend.nplike.empty(0, np.int64),
-            parameters=None,
-            backend=self._backend,
-        )
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
+            return ak.contents.NumpyArray(
+                self._backend.nplike.empty(0, np.int64),
+                parameters=None,
+                backend=self._backend,
+            )
+        else:
+            raise ak._errors.wrap_error(
+                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            )
 
     def _numbers_to_type(self, name):
         return ak.contents.EmptyArray(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -158,20 +158,6 @@ class EmptyArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        else:
-            # TODO: This was changed to use `nplike` instead of `index_nplike`. Is this OK?
-            out = ak.index.Index64.empty(0, nplike=self._backend.nplike)
-            return ak.contents.NumpyArray(out, parameters=None, backend=self._backend)
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -279,8 +279,8 @@ class EmptyArray(Content):
         return 0
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 != depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -280,7 +280,7 @@ class EmptyArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis != depth:
+        if posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -388,17 +388,6 @@ class IndexedArray(Content):
                 )
             )
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        else:
-            return self.project()._num(posaxis, depth_m1)
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -916,15 +916,15 @@ class IndexedArray(Content):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis + 1 == depth + 1:
-            return self.project()._pad_none(target, posaxis, depth, clip)
+        elif posaxis is not None and posaxis + 1 == depth + 1:
+            return self.project()._pad_none(target, axis, depth, clip)
         else:
             return ak.contents.IndexedArray(
                 self._index,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pad_none(target, axis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -917,9 +917,9 @@ class IndexedArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             return self.project()._pad_none(target, posaxis, depth, clip)
         else:
             return ak.contents.IndexedArray(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -591,11 +591,11 @@ class IndexedArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
-            return self.project()._local_index(posaxis, depth)
+            return self.project()._local_index(axis, depth)
 
     def _unique_index(self, index, sorted=True):
         next = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -388,16 +388,16 @@ class IndexedArray(Content):
                 )
             )
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out
         else:
-            return self.project()._num(posaxis, depth)
+            return self.project()._num(posaxis, depth_m1)
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -389,7 +389,7 @@ class IndexedArray(Content):
             )
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
@@ -591,7 +591,7 @@ class IndexedArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -860,7 +860,7 @@ class IndexedArray(Content):
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis)
+        posaxis = ak._util.maybe_posaxis(self, axis)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -916,7 +916,7 @@ class IndexedArray(Content):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -390,7 +390,7 @@ class IndexedArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -389,12 +389,12 @@ class IndexedArray(Content):
             )
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:
-            return self.project()._offsets_and_flattened(posaxis, depth)
+            return self.project()._offsets_and_flattened(axis, depth)
 
     def _mergeable_next(self, other, mergebool):
         if isinstance(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -592,7 +592,7 @@ class IndexedArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             return self.project()._local_index(posaxis, depth)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -861,7 +861,7 @@ class IndexedArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return self.project()._combinations(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -860,12 +860,12 @@ class IndexedArray(Content):
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return self.project()._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth
+                n, replacement, recordlookup, parameters, axis, depth
             )
 
     def _reduce_next(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -476,7 +476,7 @@ class IndexedOptionArray(Content):
             return self._content._carry(nextcarry, False)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
@@ -740,7 +740,7 @@ class IndexedOptionArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -1361,7 +1361,7 @@ class IndexedOptionArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -1396,7 +1396,7 @@ class IndexedOptionArray(Content):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -476,14 +476,14 @@ class IndexedOptionArray(Content):
             return self._content._carry(nextcarry, False)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)
             next = self._content._carry(nextcarry, False)
 
-            offsets, flattened = next._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = next._offsets_and_flattened(axis, depth)
 
             if offsets.length == 0:
                 return (

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -740,14 +740,14 @@ class IndexedOptionArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
 
             next = self._content._carry(nextcarry, False)
-            out = next._local_index(posaxis, depth)
+            out = next._local_index(axis, depth)
             out2 = ak.contents.IndexedOptionArray(
                 outindex, out, parameters=self._parameters
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -477,7 +477,7 @@ class IndexedOptionArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -475,21 +475,6 @@ class IndexedOptionArray(Content):
 
             return self._content._carry(nextcarry, False)
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
-        next = self._content._carry(nextcarry, False)
-        out = next._num(posaxis, depth_m1)
-        return ak.contents.IndexedOptionArray.simplified(
-            outindex, out, parameters=self._parameters
-        )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -741,7 +741,7 @@ class IndexedOptionArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1397,9 +1397,9 @@ class IndexedOptionArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(mask.length, self._backend.index_nplike)
             assert (

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -475,9 +475,9 @@ class IndexedOptionArray(Content):
 
             return self._content._carry(nextcarry, False)
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
@@ -485,7 +485,7 @@ class IndexedOptionArray(Content):
                 return out
         _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
         next = self._content._carry(nextcarry, False)
-        out = next._num(posaxis, depth)
+        out = next._num(posaxis, depth_m1)
         return ak.contents.IndexedOptionArray.simplified(
             outindex, out, parameters=self._parameters
         )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1396,10 +1396,10 @@ class IndexedOptionArray(Content):
         return self.index._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
             index = ak.index.Index64.empty(mask.length, self._backend.index_nplike)
             assert (
@@ -1413,14 +1413,14 @@ class IndexedOptionArray(Content):
                     mask.dtype.type,
                 ](index.data, mask.data, mask.length)
             )
-            next = self.project()._pad_none(target, posaxis, depth, clip)
+            next = self.project()._pad_none(target, axis, depth, clip)
             return ak.contents.IndexedOptionArray.simplified(
                 index, next, parameters=self._parameters
             )
         else:
             return ak.contents.IndexedOptionArray(
                 self._index,
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pad_none(target, axis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1361,14 +1361,14 @@ class IndexedOptionArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)
             next = self._content._carry(nextcarry, True)
             out = next._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth
+                n, replacement, recordlookup, parameters, axis, depth
             )
             return IndexedOptionArray.simplified(outindex, out, parameters=parameters)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1362,7 +1362,7 @@ class IndexedOptionArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             _, nextcarry, outindex = self._nextcarry_outindex(self._backend)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1234,9 +1234,9 @@ class ListArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         if not clip:
             posaxis = ak._do.axis_wrap_if_negative(self, axis)
-            if posaxis == depth:
+            if posaxis + 1 == depth:
                 return self._pad_none_axis0(target, clip)
-            elif posaxis == depth + 1:
+            elif posaxis + 1 == depth + 1:
                 min_ = ak.index.Index64.empty(1, self._backend.index_nplike)
                 assert (
                     min_.nplike is self._backend.index_nplike

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1068,7 +1068,7 @@ class ListArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
@@ -1233,7 +1233,7 @@ class ListArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         if not clip:
-            posaxis = ak._do.maybe_posaxis(self, axis, depth)
+            posaxis = ak._util.maybe_posaxis(self, axis, depth)
             if posaxis is not None and posaxis + 1 == depth:
                 return self._pad_none_axis0(target, clip)
             elif posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -894,15 +894,15 @@ class ListArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out
-        elif posaxis == depth + 1:
+        elif posaxis == depth_m1 + 1:
             tonum = ak.index.Index64.empty(self.length, self._backend.index_nplike)
             assert (
                 tonum.nplike is self._backend.index_nplike
@@ -924,7 +924,7 @@ class ListArray(Content):
             )
             return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
         else:
-            return self.to_ListOffsetArray64(True)._num(posaxis, depth)
+            return self.to_ListOffsetArray64(True)._num(posaxis, depth_m1)
 
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -894,38 +894,6 @@ class ListArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        elif posaxis == depth_m1 + 1:
-            tonum = ak.index.Index64.empty(self.length, self._backend.index_nplike)
-            assert (
-                tonum.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
-            )
-            self._handle_error(
-                self._backend[
-                    "awkward_ListArray_num",
-                    tonum.dtype.type,
-                    self._starts.dtype.type,
-                    self._stops.dtype.type,
-                ](
-                    tonum.data,
-                    self._starts.data,
-                    self._stops.data,
-                    self.length,
-                )
-            )
-            return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
-        else:
-            return self.to_ListOffsetArray64(True)._num(posaxis, depth_m1)
-
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1069,9 +1069,9 @@ class ListArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._backend.nplike.known_data:
                 innerlength = offsets[offsets.length - 1]

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1233,10 +1233,10 @@ class ListArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         if not clip:
-            posaxis = ak._do.axis_wrap_if_negative(self, axis)
-            if posaxis + 1 == depth:
+            posaxis = ak._do.maybe_posaxis(self, axis, depth)
+            if posaxis is not None and posaxis + 1 == depth:
                 return self._pad_none_axis0(target, clip)
-            elif posaxis + 1 == depth + 1:
+            elif posaxis is not None and posaxis + 1 == depth + 1:
                 min_ = ak.index.Index64.empty(1, self._backend.index_nplike)
                 assert (
                     min_.nplike is self._backend.index_nplike
@@ -1329,7 +1329,7 @@ class ListArray(Content):
                 return ak.contents.ListArray(
                     self._starts,
                     self._stops,
-                    self._content._pad_none(target, posaxis, depth + 1, clip),
+                    self._content._pad_none(target, axis, depth + 1, clip),
                     parameters=self._parameters,
                 )
         else:

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1068,10 +1068,10 @@ class ListArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._backend.nplike.known_data:
                 innerlength = offsets[offsets.length - 1]
@@ -1100,7 +1100,7 @@ class ListArray(Content):
             return ak.contents.ListArray(
                 self._starts,
                 self._stops,
-                self._content._local_index(posaxis, depth + 1),
+                self._content._local_index(axis, depth + 1),
             )
 
     def _numbers_to_type(self, name):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -602,11 +602,11 @@ class ListOffsetArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             listoffsetarray = self.to_ListOffsetArray64(True)
             stop = listoffsetarray.offsets[-1]
             content = listoffsetarray.content._getitem_range(slice(0, stop))
@@ -614,7 +614,7 @@ class ListOffsetArray(Content):
 
         else:
             inneroffsets, flattened = self._content._offsets_and_flattened(
-                posaxis, depth + 1
+                axis, depth + 1
             )
             offsets = ak.index.Index64.zeros(
                 0,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -715,10 +715,10 @@ class ListOffsetArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._backend.nplike.known_data:
                 innerlength = offsets[offsets.length - 1]
@@ -745,7 +745,7 @@ class ListOffsetArray(Content):
             )
         else:
             return ak.contents.ListOffsetArray(
-                self._offsets, self._content._local_index(posaxis, depth + 1)
+                self._offsets, self._content._local_index(axis, depth + 1)
             )
 
     def _numbers_to_type(self, name):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -601,42 +601,6 @@ class ListOffsetArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        elif posaxis == depth_m1 + 1:
-            tonum = ak.index.Index64.empty(self.length, self._backend.index_nplike)
-            assert (
-                tonum.nplike is self._backend.index_nplike
-                and self.starts.nplike is self._backend.index_nplike
-                and self.stops.nplike is self._backend.index_nplike
-            )
-            self._handle_error(
-                self._backend[
-                    "awkward_ListArray_num",
-                    tonum.dtype.type,
-                    self.starts.dtype.type,
-                    self.stops.dtype.type,
-                ](
-                    tonum.data,
-                    self.starts.data,
-                    self.stops.data,
-                    self.length,
-                )
-            )
-            return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
-        else:
-            next = self._content._num(posaxis, depth_m1 + 1)
-            offsets = self._compact_offsets64(True)
-            return ak.contents.ListOffsetArray(
-                offsets, next, parameters=self._parameters
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -716,9 +716,9 @@ class ListOffsetArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
             if self._backend.nplike.known_data:
                 innerlength = offsets[offsets.length - 1]

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -602,7 +602,7 @@ class ListOffsetArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
@@ -715,7 +715,7 @@ class ListOffsetArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
@@ -1269,7 +1269,7 @@ class ListOffsetArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif posaxis is not None and posaxis + 1 == depth + 1:
@@ -1712,7 +1712,7 @@ class ListOffsetArray(Content):
         return self.offsets._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         if posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1712,10 +1712,10 @@ class ListOffsetArray(Content):
         return self.offsets._nbytes_part() + self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        if posaxis + 1 == depth + 1:
+        if posaxis is not None and posaxis + 1 == depth + 1:
             if not clip:
                 tolength = ak.index.Index64.empty(1, self._backend.index_nplike)
                 offsets_ = ak.index.Index64.empty(
@@ -1821,7 +1821,7 @@ class ListOffsetArray(Content):
         else:
             return ak.contents.ListOffsetArray(
                 self._offsets,
-                self._content._pad_none(target, posaxis, depth + 1, clip),
+                self._content._pad_none(target, axis, depth + 1, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1270,9 +1270,9 @@ class ListOffsetArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             if (
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1713,9 +1713,9 @@ class ListOffsetArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        if posaxis == depth + 1:
+        if posaxis + 1 == depth + 1:
             if not clip:
                 tolength = ak.index.Index64.empty(1, self._backend.index_nplike)
                 offsets_ = ak.index.Index64.empty(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -603,10 +603,10 @@ class ListOffsetArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             listoffsetarray = self.to_ListOffsetArray64(True)
             stop = listoffsetarray.offsets[-1]
             content = listoffsetarray.content._getitem_range(slice(0, stop))

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1269,10 +1269,10 @@ class ListOffsetArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             if (
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
@@ -1381,7 +1381,7 @@ class ListOffsetArray(Content):
         else:
             compact = self.to_ListOffsetArray64(True)
             next = compact._content._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth + 1
+                n, replacement, recordlookup, parameters, axis, depth + 1
             )
             return ak.contents.ListOffsetArray(
                 compact.offsets, next, parameters=self._parameters

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -601,15 +601,15 @@ class ListOffsetArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out
-        elif posaxis == depth + 1:
+        elif posaxis == depth_m1 + 1:
             tonum = ak.index.Index64.empty(self.length, self._backend.index_nplike)
             assert (
                 tonum.nplike is self._backend.index_nplike
@@ -631,7 +631,7 @@ class ListOffsetArray(Content):
             )
             return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
         else:
-            next = self._content._num(posaxis, depth + 1)
+            next = self._content._num(posaxis, depth_m1 + 1)
             offsets = self._compact_offsets64(True)
             return ak.contents.ListOffsetArray(
                 offsets, next, parameters=self._parameters

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1166,8 +1166,8 @@ class NumpyArray(Content):
             )
         elif len(self.shape) > 1 or not self.is_contiguous:
             return self.to_RegularArray()._pad_none(target, axis, depth, clip)
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 != depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )
@@ -1175,7 +1175,7 @@ class NumpyArray(Content):
             if target < self.length:
                 return self
             else:
-                return self._pad_none(target, posaxis, depth, clip=True)
+                return self._pad_none(target, axis, depth, clip=True)
         else:
             return self._pad_none_axis0(target, clip=True)
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1020,8 +1020,8 @@ class NumpyArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif len(self.shape) <= 1:
             raise ak._errors.wrap_error(
@@ -1029,7 +1029,7 @@ class NumpyArray(Content):
             )
         else:
             return self.to_RegularArray()._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth
+                n, replacement, recordlookup, parameters, axis, depth
             )
 
     def _reduce_next(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -316,7 +316,7 @@ class NumpyArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
@@ -434,7 +434,7 @@ class NumpyArray(Content):
         return self
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif len(self.shape) <= 1:
@@ -1020,7 +1020,7 @@ class NumpyArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif len(self.shape) <= 1:
@@ -1166,7 +1166,7 @@ class NumpyArray(Content):
             )
         elif len(self.shape) > 1 or not self.is_contiguous:
             return self.to_RegularArray()._pad_none(target, axis, depth, clip)
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -435,7 +435,7 @@ class NumpyArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         elif len(self.shape) <= 1:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -317,7 +317,7 @@ class NumpyArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         elif len(self.shape) != 1:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1021,7 +1021,7 @@ class NumpyArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif len(self.shape) <= 1:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -315,42 +315,6 @@ class NumpyArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        shape = []
-        reps = 1
-        size = self.length
-        i = 0
-        while i < self._data.ndim - 1 and depth_m1 < posaxis:
-            shape.append(self.shape[i])
-            reps *= self.shape[i]
-            size = self.shape[i + 1]
-            i += 1
-            depth_m1 += 1
-        if posaxis > depth_m1:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth_m1 + 1})")
-            )
-
-        tonum = ak.index.Index64.empty(reps, self._backend.index_nplike)
-        assert tonum.nplike is self._backend.index_nplike
-        self._handle_error(
-            self._backend["awkward_RegularArray_num", tonum.dtype.type](
-                tonum.data, size, reps
-            )
-        )
-        return ak.contents.NumpyArray(
-            tonum.data.reshape(shape),
-            parameters=self._parameters,
-            backend=self._backend,
-        )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1167,7 +1167,7 @@ class NumpyArray(Content):
         elif len(self.shape) > 1 or not self.is_contiguous:
             return self.to_RegularArray()._pad_none(target, axis, depth, clip)
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis != depth:
+        if posaxis + 1 != depth:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -316,12 +316,12 @@ class NumpyArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         elif len(self.shape) != 1:
-            return self.to_RegularArray()._offsets_and_flattened(posaxis, depth)
+            return self.to_RegularArray()._offsets_and_flattened(axis, depth)
 
         else:
             raise ak._errors.wrap_error(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -434,15 +434,15 @@ class NumpyArray(Content):
         return self
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif len(self.shape) <= 1:
             raise ak._errors.wrap_error(
                 np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
             )
         else:
-            return self.to_RegularArray()._local_index(posaxis, depth)
+            return self.to_RegularArray()._local_index(axis, depth)
 
     def to_contiguous(self) -> Self:
         if self.is_contiguous:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -315,9 +315,9 @@ class NumpyArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
@@ -327,15 +327,15 @@ class NumpyArray(Content):
         reps = 1
         size = self.length
         i = 0
-        while i < self._data.ndim - 1 and depth < posaxis:
+        while i < self._data.ndim - 1 and depth_m1 < posaxis:
             shape.append(self.shape[i])
             reps *= self.shape[i]
             size = self.shape[i + 1]
             i += 1
-            depth += 1
-        if posaxis > depth:
+            depth_m1 += 1
+        if posaxis > depth_m1:
             raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth_m1 + 1})")
             )
 
         tonum = ak.index.Index64.empty(reps, self._backend.index_nplike)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -443,35 +443,6 @@ class RecordArray(Content):
             )
             return next._getitem_next(nexthead, nexttail, advanced)
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            npsingle = self._backend.index_nplike.full((1,), self.length, np.int64)
-            single = ak.index.Index64(npsingle, nplike=self._backend.index_nplike)
-            singleton = ak.contents.NumpyArray(
-                single, parameters=None, backend=self._backend
-            )
-            contents = [singleton] * len(self._contents)
-            record = ak.contents.RecordArray(
-                contents,
-                self._fields,
-                1,
-                parameters=self._parameters,
-                backend=self._backend,
-            )
-            return record[0]
-        else:
-            contents = []
-            for content in self._contents:
-                contents.append(content._num(posaxis, depth_m1))
-            return ak.contents.RecordArray(
-                contents,
-                self._fields,
-                self._length,
-                parameters=self._parameters,
-                backend=self._backend,
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -445,10 +445,10 @@ class RecordArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             raise ak._errors.wrap_error(
                 ValueError(
                     "arrays of records cannot be flattened (but their contents can be; try a different 'axis')"

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -659,7 +659,7 @@ class RecordArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             contents = []

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -805,13 +805,13 @@ class RecordArray(Content):
         return result
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._pad_none(target, posaxis, depth, clip))
+                contents.append(content._pad_none(target, axis, depth, clip))
             if len(contents) == 0:
                 return ak.contents.RecordArray(
                     contents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -443,9 +443,9 @@ class RecordArray(Content):
             )
             return next._getitem_next(nexthead, nexttail, advanced)
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             npsingle = self._backend.index_nplike.full((1,), self.length, np.int64)
             single = ak.index.Index64(npsingle, nplike=self._backend.index_nplike)
             singleton = ak.contents.NumpyArray(
@@ -463,7 +463,7 @@ class RecordArray(Content):
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._num(posaxis, depth))
+                contents.append(content._num(posaxis, depth_m1))
             return ak.contents.RecordArray(
                 contents,
                 self._fields,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -444,7 +444,7 @@ class RecordArray(Content):
             return next._getitem_next(nexthead, nexttail, advanced)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
@@ -658,7 +658,7 @@ class RecordArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -741,7 +741,7 @@ class RecordArray(Content):
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -805,7 +805,7 @@ class RecordArray(Content):
         return result
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -742,7 +742,7 @@ class RecordArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             contents = []

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -658,13 +658,13 @@ class RecordArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._local_index(posaxis, depth))
+                contents.append(content._local_index(axis, depth))
             return RecordArray(
                 contents,
                 self._fields,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -741,15 +741,15 @@ class RecordArray(Content):
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             contents = []
             for content in self._contents:
                 contents.append(
                     content._combinations(
-                        n, replacement, recordlookup, parameters, posaxis, depth
+                        n, replacement, recordlookup, parameters, axis, depth
                     )
                 )
             return ak.contents.RecordArray(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -444,11 +444,11 @@ class RecordArray(Content):
             return next._getitem_next(nexthead, nexttail, advanced)
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             raise ak._errors.wrap_error(
                 ValueError(
                     "arrays of records cannot be flattened (but their contents can be; try a different 'axis')"
@@ -459,7 +459,7 @@ class RecordArray(Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(slice(0, self.length))
-                offsets, flattened = trimmed._offsets_and_flattened(posaxis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
                 if self._backend.nplike.known_shape and offsets.length != 0:
                     raise ak._errors.wrap_error(
                         AssertionError(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -806,7 +806,7 @@ class RecordArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:
             contents = []

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -612,29 +612,6 @@ class RegularArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self._length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        elif posaxis == depth_m1 + 1:
-            tonum = ak.index.Index64.empty(self._length, self._backend.index_nplike)
-            assert tonum.nplike is self._backend.index_nplike
-            self._handle_error(
-                self._backend["awkward_RegularArray_num", tonum.dtype.type](
-                    tonum.data, self._size, self._length
-                )
-            )
-            return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
-        else:
-            next = self._content._num(posaxis, depth_m1 + 1)
-            return ak.contents.RegularArray(
-                next, self._size, self._length, parameters=self._parameters
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1120,10 +1120,10 @@ class RegularArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
 
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             if not clip:
                 if target < self._size:
                     return self

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -612,15 +612,15 @@ class RegularArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self._length
             if ak._util.is_integer(out):
                 return np.int64(out)
             else:
                 return out
-        elif posaxis == depth + 1:
+        elif posaxis == depth_m1 + 1:
             tonum = ak.index.Index64.empty(self._length, self._backend.index_nplike)
             assert tonum.nplike is self._backend.index_nplike
             self._handle_error(
@@ -630,7 +630,7 @@ class RegularArray(Content):
             )
             return ak.contents.NumpyArray(tonum, parameters=None, backend=self._backend)
         else:
-            next = self._content._num(posaxis, depth + 1)
+            next = self._content._num(posaxis, depth_m1 + 1)
             return ak.contents.RegularArray(
                 next, self._size, self._length, parameters=self._parameters
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1119,16 +1119,16 @@ class RegularArray(Content):
         return self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
 
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             if not clip:
                 if target < self._size:
                     return self
                 else:
-                    return self._pad_none(target, posaxis, depth, True)
+                    return self._pad_none(target, axis, depth, True)
 
             else:
                 index = ak.index.Index64.empty(
@@ -1152,7 +1152,7 @@ class RegularArray(Content):
 
         else:
             return ak.contents.RegularArray(
-                self._content._pad_none(target, posaxis, depth + 1, clip),
+                self._content._pad_none(target, axis, depth + 1, clip),
                 self._size,
                 self._length,
                 parameters=self._parameters,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -815,9 +815,9 @@ class RegularArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             if (
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -688,9 +688,9 @@ class RegularArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             localindex = ak.index.Index64.empty(
                 self._length * self._size, nplike=self._backend.index_nplike
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -687,10 +687,10 @@ class RegularArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             localindex = ak.index.Index64.empty(
                 self._length * self._size, nplike=self._backend.index_nplike
             )
@@ -706,7 +706,7 @@ class RegularArray(Content):
             )
         else:
             return ak.contents.RegularArray(
-                self._content._local_index(posaxis, depth + 1), self._size, self._length
+                self._content._local_index(axis, depth + 1), self._size, self._length
             )
 
     def _numbers_to_type(self, name):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -814,10 +814,10 @@ class RegularArray(Content):
         return out
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
-        elif posaxis + 1 == depth + 1:
+        elif posaxis is not None and posaxis + 1 == depth + 1:
             if (
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
@@ -905,9 +905,7 @@ class RegularArray(Content):
         else:
             next = self._content._getitem_range(
                 slice(0, self._length * self._size)
-            )._combinations(
-                n, replacement, recordlookup, parameters, posaxis, depth + 1
-            )
+            )._combinations(n, replacement, recordlookup, parameters, axis, depth + 1)
             return ak.contents.RegularArray(
                 next, self._size, self._length, parameters=self._parameters
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -687,7 +687,7 @@ class RegularArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
@@ -814,7 +814,7 @@ class RegularArray(Content):
         return out
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif posaxis is not None and posaxis + 1 == depth + 1:
@@ -1117,7 +1117,7 @@ class RegularArray(Content):
         return self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -759,9 +759,9 @@ class UnionArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
@@ -770,7 +770,7 @@ class UnionArray(Content):
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._num(posaxis, depth))
+                contents.append(content._num(posaxis, depth_m1))
             return UnionArray.simplified(
                 self._tags,
                 self._index,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1346,7 +1346,7 @@ class UnionArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:
             contents = []

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -760,7 +760,7 @@ class UnionArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
@@ -1113,7 +1113,7 @@ class UnionArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -1128,7 +1128,7 @@ class UnionArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -1345,7 +1345,7 @@ class UnionArray(Content):
         return result
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1345,13 +1345,13 @@ class UnionArray(Content):
         return result
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._pad_none(target, posaxis, depth, clip))
+                contents.append(content._pad_none(target, axis, depth, clip))
             return ak.contents.UnionArray.simplified(
                 self.tags,
                 self.index,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1129,7 +1129,7 @@ class UnionArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             contents = []

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -759,25 +759,6 @@ class UnionArray(Content):
         else:
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        else:
-            contents = []
-            for content in self._contents:
-                contents.append(content._num(posaxis, depth_m1))
-            return UnionArray.simplified(
-                self._tags,
-                self._index,
-                contents,
-                parameters=self._parameters,
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -760,9 +760,9 @@ class UnionArray(Content):
             raise ak._errors.wrap_error(AssertionError(repr(head)))
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
 
-        if posaxis + 1 == depth:
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:
@@ -774,7 +774,7 @@ class UnionArray(Content):
 
             for i in range(len(self._contents)):
                 offsets, flattened = self._contents[i]._offsets_and_flattened(
-                    posaxis, depth
+                    axis, depth
                 )
                 offsetsraws[i] = offsets.ptr
                 contents.append(flattened)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -762,7 +762,7 @@ class UnionArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
 
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
 
         else:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1128,15 +1128,15 @@ class UnionArray(Content):
             )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             contents = []
             for content in self._contents:
                 contents.append(
                     content._combinations(
-                        n, replacement, recordlookup, parameters, posaxis, depth
+                        n, replacement, recordlookup, parameters, axis, depth
                     )
                 )
             return ak.unionarray.UnionArray(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1113,13 +1113,13 @@ class UnionArray(Content):
         )
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             contents = []
             for content in self._contents:
-                contents.append(content._local_index(posaxis, depth))
+                contents.append(content._local_index(axis, depth))
             return UnionArray(
                 self._tags,
                 self._index,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1114,7 +1114,7 @@ class UnionArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             contents = []

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -233,9 +233,9 @@ class UnmaskedArray(Content):
         else:
             return self._content
 
-    def _num(self, axis, depth=0):
+    def _num(self, axis, depth_m1):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis == depth_m1:
             out = self.length
             if ak._util.is_integer(out):
                 return np.int64(out)
@@ -243,7 +243,7 @@ class UnmaskedArray(Content):
                 return out
         else:
             return ak.contents.UnmaskedArray(
-                self._content._num(posaxis, depth), parameters=self._parameters
+                self._content._num(posaxis, depth_m1), parameters=self._parameters
             )
 
     def _offsets_and_flattened(self, axis, depth):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -414,14 +414,14 @@ class UnmaskedArray(Content):
         return self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis + 1 == depth + 1:
-            return self._content._pad_none(target, posaxis, depth, clip)
+        elif posaxis is not None and posaxis + 1 == depth + 1:
+            return self._content._pad_none(target, axis, depth, clip)
         else:
             return ak.contents.UnmaskedArray(
-                self._content._pad_none(target, posaxis, depth, clip),
+                self._content._pad_none(target, axis, depth, clip),
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -235,7 +235,7 @@ class UnmaskedArray(Content):
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
             offsets, flattened = self._content._offsets_and_flattened(posaxis, depth)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -233,19 +233,6 @@ class UnmaskedArray(Content):
         else:
             return self._content
 
-    def _num(self, axis, depth_m1):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth_m1:
-            out = self.length
-            if ak._util.is_integer(out):
-                return np.int64(out)
-            else:
-                return out
-        else:
-            return ak.contents.UnmaskedArray(
-                self._content._num(posaxis, depth_m1), parameters=self._parameters
-            )
-
     def _offsets_and_flattened(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
         if posaxis == depth:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -415,9 +415,9 @@ class UnmaskedArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
-        elif posaxis == depth + 1:
+        elif posaxis + 1 == depth + 1:
             return self._content._pad_none(target, posaxis, depth, clip)
         else:
             return ak.contents.UnmaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -234,7 +234,7 @@ class UnmaskedArray(Content):
             return self._content
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
@@ -289,7 +289,7 @@ class UnmaskedArray(Content):
         return self._content._fill_none(value)
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
@@ -372,7 +372,7 @@ class UnmaskedArray(Content):
             return out
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
@@ -414,7 +414,7 @@ class UnmaskedArray(Content):
         return self.content._nbytes_part()
 
     def _pad_none(self, target, axis, depth, clip):
-        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -289,12 +289,12 @@ class UnmaskedArray(Content):
         return self._content._fill_none(value)
 
     def _local_index(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             return UnmaskedArray(
-                self._content._local_index(posaxis, depth), parameters=self._parameters
+                self._content._local_index(axis, depth), parameters=self._parameters
             )
 
     def _numbers_to_type(self, name):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -290,7 +290,7 @@ class UnmaskedArray(Content):
 
     def _local_index(self, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._local_index_axis0()
         else:
             return UnmaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -373,7 +373,7 @@ class UnmaskedArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis == depth:
+        if posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return ak.contents.UnmaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -234,11 +234,11 @@ class UnmaskedArray(Content):
             return self._content
 
     def _offsets_and_flattened(self, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
         else:
-            offsets, flattened = self._content._offsets_and_flattened(posaxis, depth)
+            offsets, flattened = self._content._offsets_and_flattened(axis, depth)
             if offsets.length == 0:
                 return (
                     offsets,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -372,13 +372,13 @@ class UnmaskedArray(Content):
             return out
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._do.axis_wrap_if_negative(self, axis)
-        if posaxis + 1 == depth:
+        posaxis = ak._do.maybe_posaxis(self, axis, depth)
+        if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return ak.contents.UnmaskedArray(
                 self._content._combinations(
-                    n, replacement, recordlookup, parameters, posaxis, depth
+                    n, replacement, recordlookup, parameters, axis, depth
                 ),
                 parameters=self._parameters,
             )

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -235,11 +235,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         new_arrays_values = new_arrays
 
-    posaxis = ak._do.maybe_posaxis(new_arrays_values[0], axis, 1)
+    posaxis = ak._util.maybe_posaxis(new_arrays_values[0], axis, 1)
     if posaxis is None or posaxis < 0:
         raise ak._errors.wrap_error(ValueError("negative axis depth is ambiguous"))
     for x in new_arrays_values[1:]:
-        if ak._do.maybe_posaxis(x, axis, 1) != posaxis:
+        if ak._util.maybe_posaxis(x, axis, 1) != posaxis:
             raise ak._errors.wrap_error(
                 ValueError(
                     "arrays to cartesian-product do not have the same depth for negative axis"

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -235,11 +235,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         new_arrays_values = new_arrays
 
-    posaxis = ak._do.axis_wrap_if_negative(new_arrays_values[0], axis)
-    if posaxis < 0:
+    posaxis = ak._do.maybe_posaxis(new_arrays_values[0], axis, 1)
+    if posaxis is None or posaxis < 0:
         raise ak._errors.wrap_error(ValueError("negative axis depth is ambiguous"))
     for x in new_arrays_values[1:]:
-        if ak._do.axis_wrap_if_negative(x, axis) != posaxis:
+        if ak._do.maybe_posaxis(x, axis, 1) != posaxis:
             raise ak._errors.wrap_error(
                 ValueError(
                     "arrays to cartesian-product do not have the same depth for negative axis"

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -226,7 +226,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                 all_flatten = []
 
                 for x in nextinputs:
-                    o, f = x._offsets_and_flattened(1, 0)
+                    o, f = x._offsets_and_flattened(1, 1)
                     o = backend.index_nplike.asarray(o)
                     c = o[1:] - o[:-1]
                     backend.index_nplike.add(counts, c, out=counts)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -56,7 +56,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
         content = ak.operations.to_layout(arrays, allow_record=False, allow_other=False)
         # Only handle concatenation along `axis=0`
         # Let ambiguous depth arrays fall through
-        if ak._do.maybe_posaxis(content, axis, 1) == 0:
+        if ak._util.maybe_posaxis(content, axis, 1) == 0:
             return ak.operations.ak_flatten._impl(content, 1, highlevel, behavior)
 
     content_or_others = [
@@ -72,7 +72,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
             ValueError("need at least one array to concatenate")
         )
 
-    posaxis = ak._do.maybe_posaxis(contents[0], axis, 1)
+    posaxis = ak._util.maybe_posaxis(contents[0], axis, 1)
     maxdepth = max(
         x.minmax_depth[1]
         for x in content_or_others
@@ -87,7 +87,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
         )
     for x in content_or_others:
         if isinstance(x, ak.contents.Content):
-            if ak._do.maybe_posaxis(x, axis, 1) != posaxis:
+            if ak._util.maybe_posaxis(x, axis, 1) != posaxis:
                 raise ak._errors.wrap_error(
                     ValueError(
                         "arrays to concatenate do not have the same depth for negative "

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -120,7 +120,7 @@ def _impl(array, value, axis, highlevel, behavior):
     else:
 
         def action(layout, depth, **kwargs):
-            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            posaxis = ak._util.maybe_posaxis(layout, axis, depth)
             if posaxis is not None and posaxis + 1 < depth:
                 return layout
             elif posaxis is not None and posaxis + 1 == depth:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -119,17 +119,19 @@ def _impl(array, value, axis, highlevel, behavior):
 
     else:
 
-        def action(layout, depth, depth_context, **kwargs):
-            posaxis = ak._do.axis_wrap_if_negative(layout, depth_context["posaxis"])
-            depth_context["posaxis"] = posaxis
-            if posaxis + 1 < depth:
+        def action(layout, depth, **kwargs):
+            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            if posaxis is not None and posaxis + 1 < depth:
                 return layout
-            elif posaxis + 1 == depth:
+            elif posaxis is not None and posaxis + 1 == depth:
                 return maybe_fillna(layout)
+            elif layout.is_leaf:
+                raise ak._errors.wrap_error(
+                    np.AxisError(
+                        f"axis={axis} exceeds the depth of this array ({depth})"
+                    )
+                )
 
-    depth_context = {"posaxis": axis}
-    out = ak._do.recursively_apply(
-        arraylayout, action, behavior, depth_context=depth_context
-    )
+    out = ak._do.recursively_apply(arraylayout, action, behavior)
 
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -46,14 +46,13 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
-    posaxis = ak._do.axis_wrap_if_negative(layout, axis)
 
     if not ak._util.is_integer(axis):
         raise ak._errors.wrap_error(
             TypeError(f"'axis' must be an integer, not {axis!r}")
         )
 
-    if posaxis == 0:
+    if ak._do.maybe_posaxis(layout, axis, 1) == 0:
         # specialized logic; it's tested in test_0582-propagate-context-in-broadcast_and_apply.py
         # Build an integer-typed slice array, so that we can
         # ensure we have advanced indexing for both length==0
@@ -67,7 +66,8 @@ def _impl(array, axis, highlevel, behavior):
     else:
 
         def action(layout, depth, depth_context, **kwargs):
-            posaxis = ak._do.axis_wrap_if_negative(layout, depth_context["posaxis"])
+            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+
             if posaxis == depth and layout.is_list:
                 nplike = layout._backend.index_nplike
 
@@ -91,11 +91,6 @@ def _impl(array, axis, highlevel, behavior):
                     )
                 )
 
-            depth_context["posaxis"] = posaxis
-
-        depth_context = {"posaxis": posaxis}
-        out = ak._do.recursively_apply(
-            layout, action, behavior, depth_context, numpy_to_regular=True
-        )
+        out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -52,7 +52,7 @@ def _impl(array, axis, highlevel, behavior):
             TypeError(f"'axis' must be an integer, not {axis!r}")
         )
 
-    if ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    if ak._util.maybe_posaxis(layout, axis, 1) == 0:
         # specialized logic; it's tested in test_0582-propagate-context-in-broadcast_and_apply.py
         # Build an integer-typed slice array, so that we can
         # ensure we have advanced indexing for both length==0
@@ -66,7 +66,7 @@ def _impl(array, axis, highlevel, behavior):
     else:
 
         def action(layout, depth, depth_context, **kwargs):
-            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
             if posaxis == depth and layout.is_list:
                 nplike = layout._backend.index_nplike

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -174,7 +174,7 @@ def _impl(array, axis, highlevel, behavior):
 
         return ak._util.wrap(result, behavior, highlevel)
 
-    elif axis == 0 or ak._do.axis_wrap_if_negative(layout, axis) == 0:
+    elif axis == 0 or ak._do.maybe_posaxis(layout, axis, 1) == 0:
 
         def apply(layout):
             backend = layout.backend

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -174,7 +174,7 @@ def _impl(array, axis, highlevel, behavior):
 
         return ak._util.wrap(result, behavior, highlevel)
 
-    elif axis == 0 or ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    elif axis == 0 or ak._util.maybe_posaxis(layout, axis, 1) == 0:
 
         def apply(layout):
             backend = layout.backend

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -52,13 +52,13 @@ def _impl(array, axis, highlevel, behavior):
 
         out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 
-    elif ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    elif ak._util.maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level is already regular (ArrayType)
 
     else:
 
         def action(layout, depth, **kwargs):
-            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            posaxis = ak._util.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_regular:
                 return layout.to_ListOffsetArray64(False)
             elif posaxis == depth and layout.is_list:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -38,7 +38,7 @@ def _impl(array, axis, highlevel, behavior):
         )
 
     def action(layout, depth, **kwargs):
-        posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+        posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
             if layout.is_union:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -37,20 +37,12 @@ def _impl(array, axis, highlevel, behavior):
             TypeError(f"'axis' must be an integer, not {axis!r}")
         )
 
-    def action(layout, depth, **kwargs):
+    def action(layout, depth, lateral_context, **kwargs):
         posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
-            if layout.is_union:
-                contents = [
-                    ak._do.recursively_apply(x, action, behavior, numpy_to_regular=True)
-                    for x in layout.contents
-                ]
-                return ak.contents.UnionArray.simplified(
-                    layout.tags,
-                    layout.index,
-                    contents,
-                )
+            if layout.is_union or layout.is_record:
+                return None
 
             elif layout.is_option:
                 return ak.contents.NumpyArray(layout.mask_as_bool(valid_when=False))

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -29,59 +29,43 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-
-    # Determine the (potentially nested) bytemask
-    def getfunction_inner(layout, depth, **kwargs):
-        if not isinstance(layout, ak.contents.Content):
-            return
-
-        backend = layout.backend
-
-        if layout.is_option:
-            layout = layout.to_IndexedOptionArray64()
-
-            # Convert the option type into a union, using the mask
-            # as a tag.
-            tag = backend.index_nplike.asarray(layout.mask_as_bool(valid_when=False))
-            index = backend.index_nplike.where(
-                tag, 0, backend.nplike.asarray(layout.index)
-            )
-
-            return ak.contents.UnionArray.simplified(
-                ak.index.Index8(tag),
-                ak.index.Index64(index),
-                [
-                    ak._do.recursively_apply(
-                        layout.content, getfunction_inner, behavior
-                    ),
-                    ak.contents.NumpyArray(
-                        backend.nplike.array([True], dtype=np.bool_)
-                    ),
-                ],
-            )
-
-        elif layout.is_numpy or layout.is_unknown or layout.is_list or layout.is_record:
-            return ak.contents.NumpyArray(
-                backend.nplike.zeros(len(layout), dtype=np.bool_)
-            )
-
-    # Locate the axis
-    def getfunction_outer(layout, depth, depth_context, **kwargs):
-        depth_context["posaxis"] = ak._do.axis_wrap_if_negative(
-            layout, depth_context["posaxis"]
-        )
-        if depth_context["posaxis"] == depth - 1:
-            return ak._do.recursively_apply(layout, getfunction_inner, behavior)
-
     layout = ak.operations.to_layout(array)
-    max_axis = layout.branch_depth[1] - 1
-    if axis > max_axis:
-        raise ak._errors.wrap_error(
-            np.AxisError(f"axis={axis} exceeds the depth of this array ({max_axis})")
-        )
     behavior = ak._util.behavior_of(array, behavior=behavior)
-    depth_context = {"posaxis": axis}
-    out = ak._do.recursively_apply(
-        layout, getfunction_outer, behavior, depth_context=depth_context
-    )
+
+    if not ak._util.is_integer(axis):
+        raise ak._errors.wrap_error(
+            TypeError(f"'axis' must be an integer, not {axis!r}")
+        )
+
+    def action(layout, depth, **kwargs):
+        posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+
+        if posaxis is not None and posaxis + 1 == depth:
+            if layout.is_union:
+                contents = [
+                    ak._do.recursively_apply(x, action, behavior, numpy_to_regular=True)
+                    for x in layout.contents
+                ]
+                return ak.contents.UnionArray.simplified(
+                    layout.tags,
+                    layout.index,
+                    contents,
+                )
+
+            elif layout.is_option:
+                return ak.contents.NumpyArray(layout.mask_as_bool(valid_when=False))
+
+            else:
+                nplike = layout._backend.nplike
+                return ak.contents.NumpyArray(
+                    nplike.zeros(layout.length, dtype=np.bool_)
+                )
+
+        elif layout.is_leaf:
+            raise ak._errors.wrap_error(
+                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            )
+
+    out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -80,14 +80,14 @@ def _impl(array, axis, highlevel, behavior):
             TypeError(f"'axis' must be an integer, not {axis!r}")
         )
 
-    if ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    if ak._util.maybe_posaxis(layout, axis, 1) == 0:
         if isinstance(layout, ak.record.Record):
             return 1
         else:
             return layout.length
 
     def action(layout, depth, **kwargs):
-        posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+        posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
         if posaxis == depth and layout.is_list:
             return ak.contents.NumpyArray(layout.stops.data - layout.starts.data)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -131,7 +131,7 @@ def _impl(array, axis, keepdims, mask_identity, flatten_records):
                     out = ak.highlevel.Array(ak.operations.fill_none(out, 0, axis=-1))
 
                 if not keepdims:
-                    posaxis = ak._do.maybe_posaxis(out.layout, axis, 1)
+                    posaxis = ak._util.maybe_posaxis(out.layout, axis, 1)
                     out = out[(slice(None, None),) * posaxis + (0,)]
 
         return out

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -131,7 +131,7 @@ def _impl(array, axis, keepdims, mask_identity, flatten_records):
                     out = ak.highlevel.Array(ak.operations.fill_none(out, 0, axis=-1))
 
                 if not keepdims:
-                    posaxis = ak._do.axis_wrap_if_negative(out.layout, axis)
+                    posaxis = ak._do.maybe_posaxis(out.layout, axis, 1)
                     out = out[(slice(None, None),) * posaxis + (0,)]
 
         return out

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -53,7 +53,7 @@ def _impl(array, axis, highlevel, behavior):
         )
 
     def action(layout, depth, **kwargs):
-        posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+        posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
             if layout.is_union:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -56,7 +56,18 @@ def _impl(array, axis, highlevel, behavior):
         posaxis = ak._do.maybe_posaxis(layout, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
-            if layout.is_option:
+            if layout.is_union:
+                contents = [
+                    ak._do.recursively_apply(x, action, behavior, numpy_to_regular=True)
+                    for x in layout.contents
+                ]
+                return ak.contents.UnionArray.simplified(
+                    layout.tags,
+                    layout.index,
+                    contents,
+                )
+
+            elif layout.is_option:
                 nplike = layout._backend.index_nplike
 
                 offsets = nplike.empty(layout.length + 1, dtype=np.int64)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -56,16 +56,8 @@ def _impl(array, axis, highlevel, behavior):
         posaxis = ak._util.maybe_posaxis(layout, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
-            if layout.is_union:
-                contents = [
-                    ak._do.recursively_apply(x, action, behavior, numpy_to_regular=True)
-                    for x in layout.contents
-                ]
-                return ak.contents.UnionArray.simplified(
-                    layout.tags,
-                    layout.index,
-                    contents,
-                )
+            if layout.is_union or layout.is_record:
+                return None
 
             elif layout.is_option:
                 nplike = layout._backend.index_nplike

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -167,7 +167,7 @@ or
             return [(ak.operations.to_numpy(layout), row_arrays, col_names)]
 
         elif layout.purelist_depth > 1:
-            offsets, flattened = layout._offsets_and_flattened(axis=1, depth=0)
+            offsets, flattened = layout._offsets_and_flattened(axis=1, depth=1)
             offsets = numpy.asarray(offsets)
             starts, stops = offsets[:-1], offsets[1:]
             counts = stops - starts

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -65,13 +65,13 @@ def _impl(array, axis, highlevel, behavior):
 
         out = ak._do.recursively_apply(layout, action, behavior)
 
-    elif ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    elif ak._util.maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level can only be regular (ArrayType)
 
     else:
 
         def action(layout, depth, **kwargs):
-            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            posaxis = ak._util.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_list:
                 return layout.to_RegularArray()
 

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -56,7 +56,6 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
 def _impl(array, axis, highlevel, behavior):
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
-    posaxis = ak._do.axis_wrap_if_negative(layout, axis)
 
     if axis is None:
 
@@ -66,13 +65,13 @@ def _impl(array, axis, highlevel, behavior):
 
         out = ak._do.recursively_apply(layout, action, behavior)
 
-    elif posaxis == 0:
+    elif ak._do.maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level can only be regular (ArrayType)
 
     else:
 
-        def action(layout, depth, depth_context, **kwargs):
-            posaxis = ak._do.axis_wrap_if_negative(layout, depth_context["posaxis"])
+        def action(layout, depth, **kwargs):
+            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_list:
                 return layout.to_RegularArray()
             elif posaxis == 0:
@@ -82,9 +81,6 @@ def _impl(array, axis, highlevel, behavior):
                     )
                 )
 
-            depth_context["posaxis"] = posaxis
-
-        depth_context = {"posaxis": posaxis}
-        out = ak._do.recursively_apply(layout, action, behavior, depth_context)
+        out = ak._do.recursively_apply(layout, action, behavior)
 
     return ak._util.wrap(out, behavior, highlevel)

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -74,7 +74,8 @@ def _impl(array, axis, highlevel, behavior):
             posaxis = ak._do.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_list:
                 return layout.to_RegularArray()
-            elif posaxis == 0:
+
+            elif layout.is_leaf:
                 raise ak._errors.wrap_error(
                     np.AxisError(
                         f"axis={axis} exceeds the depth of this array ({depth})"

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -156,7 +156,7 @@ def _impl(array, counts, axis, highlevel, behavior):
 
         return out
 
-    if axis == 0 or ak._do.maybe_posaxis(layout, axis, 1) == 0:
+    if axis == 0 or ak._util.maybe_posaxis(layout, axis, 1) == 0:
         out = doit(layout)
 
     else:
@@ -167,7 +167,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             # internal layout to be unflattened (#910)
             layout = layout.to_packed()
 
-            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
+            posaxis = ak._util.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_list:
                 # We are one *above* the level where we want to apply this.
                 listoffsetarray = layout.to_ListOffsetArray64(True)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -156,18 +156,18 @@ def _impl(array, counts, axis, highlevel, behavior):
 
         return out
 
-    if axis == 0 or ak._do.axis_wrap_if_negative(layout, axis) == 0:
+    if axis == 0 or ak._do.maybe_posaxis(layout, axis, 1) == 0:
         out = doit(layout)
 
     else:
 
-        def transform(layout, depth, posaxis):
+        def transform(layout, depth, axis):
             # Pack the current layout. This ensures that the `counts` array,
             # which is computed with these layouts applied, aligns with the
             # internal layout to be unflattened (#910)
             layout = layout.to_packed()
 
-            posaxis = ak._do.axis_wrap_if_negative(layout, posaxis)
+            posaxis = ak._do.maybe_posaxis(layout, axis, depth)
             if posaxis == depth and layout.is_list:
                 # We are one *above* the level where we want to apply this.
                 listoffsetarray = layout.to_ListOffsetArray64(True)
@@ -205,7 +205,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             else:
                 return layout
 
-        out = transform(layout, depth=1, posaxis=axis)
+        out = transform(layout, depth=1, axis=axis)
 
     if current_offsets is not None and not (
         len(current_offsets[0]) == 1 and current_offsets[0][0] == 0

--- a/tests/test_0163-negative-axis-wrap.py
+++ b/tests/test_0163-negative-axis-wrap.py
@@ -36,7 +36,7 @@ def test_array_3d():
 
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=-4)
-    assert "axis=-4 exceeds the depth (3) of this array" in str(err.value)
+    assert "axis=-4 exceeds the depth" in str(err.value)
 
 
 def test_list_array():
@@ -74,7 +74,7 @@ def test_record_array():
         ]
     )
 
-    assert ak.operations.num(array, axis=0).to_list() == {"x": 3, "y": 3}
+    assert ak.operations.num(array, axis=0) == 3
     assert ak.operations.num(array, axis=1).to_list() == [
         {"x": 1, "y": 2},
         {"x": 2, "y": 3},

--- a/tests/test_0163-negative-axis-wrap.py
+++ b/tests/test_0163-negative-axis-wrap.py
@@ -24,7 +24,7 @@ def test_array_3d():
     ]
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=3)
-    assert "axis=3 exceeds the depth of this array (2)" in str(err.value)
+    assert "axis=3 exceeds the depth of this array" in str(err.value)
 
     assert to_list(ak.operations.num(array, axis=-1)) == [
         [2, 2, 2, 2, 2],
@@ -51,7 +51,7 @@ def test_list_array():
 
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=3)
-        assert "axis=3 exceeds the depth of this array (2)" in str(err.value)
+        assert "axis=3 exceeds the depth of this array" in str(err.value)
 
     assert ak.operations.num(array, axis=-1).to_list() == [
         [2, 2, 2, 2, 2],
@@ -62,7 +62,7 @@ def test_list_array():
     assert ak.operations.num(array, axis=-3) == 3
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=-4)
-        assert "axis=-4 exceeds the depth of this array (3)" in str(err.value)
+        assert "axis=-4 exceeds the depth of this array" in str(err.value)
 
 
 def test_record_array():
@@ -82,7 +82,7 @@ def test_record_array():
     ]
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=2)
-        assert "axis=2 exceeds the depth of this array (1)" in str(err.value)
+        assert "axis=2 exceeds the depth of this array" in str(err.value)
 
     assert ak.operations.num(array, axis=-1).to_list() == [
         {"x": 1, "y": [0, 1]},
@@ -102,8 +102,8 @@ def test_record_array_axis_out_of_range():
 
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=-2)
-        assert "axis=-2 exceeds the depth of this array (2)" in str(err.value)
+        assert "axis=-2 exceeds the depth of this array" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         assert ak.operations.num(array, axis=-3)
-        assert "axis=-3 exceeds the depth (2) of this array" in str(err.value)
+        assert "axis=-3 exceeds the depth" in str(err.value)

--- a/tests/test_1137-num.py
+++ b/tests/test_1137-num.py
@@ -56,7 +56,7 @@ def test_numpyarray():
     ]
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
 
 def test_regulararray():
@@ -73,7 +73,7 @@ def test_regulararray():
     ]
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
     empty = ak.contents.RegularArray(
         ak.highlevel.Array([[1, 2, 3], [], [4, 5]]).layout, 0, zeros_length=0
@@ -110,7 +110,7 @@ def test_listarray():
     ]
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
 
 def test_listoffsetarray():
@@ -138,7 +138,7 @@ def test_listoffsetarray():
     ]
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
 
 def test_indexedarray():
@@ -171,7 +171,7 @@ def test_indexedarray():
 
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
 
 def test_indexedoptionarray():
@@ -208,7 +208,7 @@ def test_indexedoptionarray():
 
     with pytest.raises(ValueError) as err:
         ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array (3)")
+    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
 
 
 def test_recordarray():
@@ -311,7 +311,7 @@ def test_array_3d():
     ]
     with pytest.raises(ValueError) as err:
         assert ak._do.num(array, axis=3)
-        assert str(err.value).startswith("axis=3 exceeds the depth of this array (2)")
+        assert str(err.value).startswith("axis=3 exceeds the depth of this array")
 
     assert to_list(ak._do.num(array, axis=-1)) == [
         [2, 2, 2, 2, 2],
@@ -323,4 +323,4 @@ def test_array_3d():
 
     with pytest.raises(ValueError) as err:
         assert ak._do.num(array, axis=-4)
-        assert str(err.value).startswith("axis=-4 exceeds the depth of this array (3)")
+        assert str(err.value).startswith("axis=-4 exceeds the depth of this array")

--- a/tests/test_1137-num.py
+++ b/tests/test_1137-num.py
@@ -29,34 +29,35 @@ def test_bytemaskedarray_num():
         None,
         [[], [10.0, 11.1, 12.2]],
     ]
-    assert ak._do.num(array, axis=0) == 5
-    assert ak._do.num(array, axis=-3) == 5
-    assert to_list(ak._do.num(array, axis=1)) == [3, 0, None, None, 2]
-    assert to_list(ak._do.num(array, axis=-2)) == [3, 0, None, None, 2]
-    assert to_list(ak._do.num(array, axis=2)) == [[3, 0, 2], [], None, None, [0, 3]]
-    assert to_list(ak._do.num(array, axis=-1)) == [[3, 0, 2], [], None, None, [0, 3]]
+    assert ak.num(array, axis=0) == 5
+    assert ak.num(array, axis=-3) == 5
+    assert to_list(ak.num(array, axis=1)) == [3, 0, None, None, 2]
+    assert to_list(ak.num(array, axis=-2)) == [3, 0, None, None, 2]
+    assert to_list(ak.num(array, axis=2)) == [[3, 0, 2], [], None, None, [0, 3]]
+    assert to_list(ak.num(array, axis=-1)) == [[3, 0, 2], [], None, None, [0, 3]]
 
 
 def test_emptyarray():
     array = ak.contents.EmptyArray()
-    assert to_list(ak._do.num(array, 0)) == 0
-    assert to_list(ak._do.num(array, 1)) == []
-    assert to_list(ak._do.num(array, 2)) == []
+    assert to_list(ak.num(array, 0)) == 0
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 1)
+    assert "axis=1 exceeds the depth" in str(err.value)
 
 
 def test_numpyarray():
     array = ak.contents.NumpyArray(np.arange(2 * 3 * 5 * 7).reshape(2, 3, 5, 7))
 
-    assert ak._do.num(array, 0) == 2
-    assert to_list(ak._do.num(array, 1)) == [3, 3]
-    assert to_list(ak._do.num(array, axis=2)) == [[5, 5, 5], [5, 5, 5]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert ak.num(array, 0) == 2
+    assert to_list(ak.num(array, 1)) == [3, 3]
+    assert to_list(ak.num(array, axis=2)) == [[5, 5, 5], [5, 5, 5]]
+    assert to_list(ak.num(array, 3)) == [
         [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]],
         [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]],
     ]
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
 
 def test_regulararray():
@@ -64,24 +65,24 @@ def test_regulararray():
         np.arange(2 * 3 * 5 * 7).reshape(2, 3, 5, 7)
     ).to_RegularArray()
 
-    assert ak._do.num(array, 0) == 2
-    assert to_list(ak._do.num(array, 1)) == [3, 3]
-    assert to_list(ak._do.num(array, 2)) == [[5, 5, 5], [5, 5, 5]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert ak.num(array, 0) == 2
+    assert to_list(ak.num(array, 1)) == [3, 3]
+    assert to_list(ak.num(array, 2)) == [[5, 5, 5], [5, 5, 5]]
+    assert to_list(ak.num(array, 3)) == [
         [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]],
         [[7, 7, 7, 7, 7], [7, 7, 7, 7, 7], [7, 7, 7, 7, 7]],
     ]
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
     empty = ak.contents.RegularArray(
         ak.highlevel.Array([[1, 2, 3], [], [4, 5]]).layout, 0, zeros_length=0
     )
 
-    assert ak._do.num(empty, axis=0) == 0
-    assert to_list(ak._do.num(empty, axis=1)) == []
-    assert to_list(ak._do.num(empty, axis=2)) == []
+    assert ak.num(empty, axis=0) == 0
+    assert to_list(ak.num(empty, axis=1)) == []
+    assert to_list(ak.num(empty, axis=2)) == []
 
 
 def test_listarray():
@@ -100,17 +101,17 @@ def test_listarray():
         [[[18, 19], [20, 21], [22, 23]], [[24, 25], [26, 27], [28, 29]]],
     ]
 
-    assert to_list(ak._do.num(array, 0)) == 3
-    assert to_list(ak._do.num(array, 1)) == [3, 0, 2]
-    assert to_list(ak._do.num(array, 2)) == [[3, 3, 3], [], [3, 3]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert to_list(ak.num(array, 0)) == 3
+    assert to_list(ak.num(array, 1)) == [3, 0, 2]
+    assert to_list(ak.num(array, 2)) == [[3, 3, 3], [], [3, 3]]
+    assert to_list(ak.num(array, 3)) == [
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
         [],
         [[2, 2, 2], [2, 2, 2]],
     ]
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
 
 def test_listoffsetarray():
@@ -128,17 +129,17 @@ def test_listoffsetarray():
         [[[18, 19], [20, 21], [22, 23]], [[24, 25], [26, 27], [28, 29]]],
     ]
 
-    assert to_list(ak._do.num(array, 0)) == 3
-    assert to_list(ak._do.num(array, 1)) == [3, 0, 2]
-    assert to_list(ak._do.num(array, 2)) == [[3, 3, 3], [], [3, 3]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert to_list(ak.num(array, 0)) == 3
+    assert to_list(ak.num(array, 1)) == [3, 0, 2]
+    assert to_list(ak.num(array, 2)) == [[3, 3, 3], [], [3, 3]]
+    assert to_list(ak.num(array, 3)) == [
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
         [],
         [[2, 2, 2], [2, 2, 2]],
     ]
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
 
 def test_indexedarray():
@@ -159,19 +160,19 @@ def test_indexedarray():
         ],
     ]
 
-    assert to_list(ak._do.num(array, 0)) == 4
-    assert to_list(ak._do.num(array, 1)) == [2, 2, 0, 3]
-    assert to_list(ak._do.num(array, 2)) == [[3, 3], [3, 3], [], [3, 3, 3]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert to_list(ak.num(array, 0)) == 4
+    assert to_list(ak.num(array, 1)) == [2, 2, 0, 3]
+    assert to_list(ak.num(array, 2)) == [[3, 3], [3, 3], [], [3, 3, 3]]
+    assert to_list(ak.num(array, 3)) == [
         [[2, 2, 2], [2, 2, 2]],
         [[2, 2, 2], [2, 2, 2]],
         [],
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
     ]
 
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
 
 def test_indexedoptionarray():
@@ -194,10 +195,10 @@ def test_indexedoptionarray():
         ],
     ]
 
-    assert to_list(ak._do.num(array, 0)) == 6
-    assert to_list(ak._do.num(array, 1)) == [2, None, 2, 0, None, 3]
-    assert to_list(ak._do.num(array, 2)) == [[3, 3], None, [3, 3], [], None, [3, 3, 3]]
-    assert to_list(ak._do.num(array, 3)) == [
+    assert to_list(ak.num(array, 0)) == 6
+    assert to_list(ak.num(array, 1)) == [2, None, 2, 0, None, 3]
+    assert to_list(ak.num(array, 2)) == [[3, 3], None, [3, 3], [], None, [3, 3, 3]]
+    assert to_list(ak.num(array, 3)) == [
         [[2, 2, 2], [2, 2, 2]],
         None,
         [[2, 2, 2], [2, 2, 2]],
@@ -206,9 +207,9 @@ def test_indexedoptionarray():
         [[2, 2, 2], [2, 2, 2], [2, 2, 2]],
     ]
 
-    with pytest.raises(ValueError) as err:
-        ak._do.num(array, 4)
-    assert str(err.value).startswith("axis=4 exceeds the depth of this array")
+    with pytest.raises(np.AxisError) as err:
+        ak.num(array, 4)
+    assert "axis=4 exceeds the depth" in str(err.value)
 
 
 def test_recordarray():
@@ -222,7 +223,7 @@ def test_recordarray():
         highlevel=False,
     )
 
-    assert to_list(ak._do.num(array, 0)) == {"x": 4, "y": 4}
+    assert ak.num(array, 0) == 4
 
     array = ak.operations.from_iter(
         [
@@ -234,14 +235,14 @@ def test_recordarray():
         highlevel=False,
     )
 
-    assert to_list(ak._do.num(array, 0)) == {"x": 4, "y": 4}
-    assert to_list(ak._do.num(array, 1)) == [
+    assert ak.num(array, 0) == 4
+    assert to_list(ak.num(array, 1)) == [
         {"x": 3, "y": 0},
         {"x": 2, "y": 1},
         {"x": 1, "y": 2},
         {"x": 0, "y": 3},
     ]
-    assert to_list(ak._do.num(array, 1)[2]) == {"x": 1, "y": 2}
+    assert to_list(ak.num(array, 1)[2]) == {"x": 1, "y": 2}
 
     array = ak.operations.from_iter(
         [
@@ -253,14 +254,14 @@ def test_recordarray():
         highlevel=False,
     )
 
-    assert to_list(ak._do.num(array, 0)) == {"x": 4, "y": 4}
-    assert to_list(ak._do.num(array, 1)) == [
+    assert ak.num(array, 0) == 4
+    assert to_list(ak.num(array, 1)) == [
         {"x": 1, "y": 0},
         {"x": 1, "y": 1},
         {"x": 1, "y": 2},
         {"x": 1, "y": 3},
     ]
-    assert to_list(ak._do.num(array, 1)[2]) == {"x": 1, "y": 2}
+    assert to_list(ak.num(array, 1)[2]) == {"x": 1, "y": 2}
 
 
 def test_unionarray():
@@ -284,9 +285,9 @@ def test_unionarray():
         [],
     ]
 
-    assert ak._do.num(array, 0) == 8
-    assert isinstance(ak._do.num(array, 1), ak.contents.NumpyArray)
-    assert to_list(ak._do.num(array, 1)) == [0, 3, 1, 2, 2, 1, 3, 0]
+    assert ak.num(array, 0) == 8
+    assert isinstance(ak.num(array, 1, highlevel=False), ak.contents.NumpyArray)
+    assert to_list(ak.num(array, 1)) == [0, 3, 1, 2, 2, 1, 3, 0]
 
 
 def test_highlevel():
@@ -302,25 +303,25 @@ def test_array_3d():
         [[10, 11], [12, 13], [14, 15], [16, 17], [18, 19]],
         [[20, 21], [22, 23], [24, 25], [26, 27], [28, 29]],
     ]
-    assert ak._do.num(array, axis=0) == 3
-    assert to_list(ak._do.num(array, axis=1)) == [5, 5, 5]
-    assert to_list(ak._do.num(array, axis=2)) == [
+    assert ak.num(array, axis=0) == 3
+    assert to_list(ak.num(array, axis=1)) == [5, 5, 5]
+    assert to_list(ak.num(array, axis=2)) == [
         [2, 2, 2, 2, 2],
         [2, 2, 2, 2, 2],
         [2, 2, 2, 2, 2],
     ]
     with pytest.raises(ValueError) as err:
-        assert ak._do.num(array, axis=3)
+        assert ak.num(array, axis=3)
         assert str(err.value).startswith("axis=3 exceeds the depth of this array")
 
-    assert to_list(ak._do.num(array, axis=-1)) == [
+    assert to_list(ak.num(array, axis=-1)) == [
         [2, 2, 2, 2, 2],
         [2, 2, 2, 2, 2],
         [2, 2, 2, 2, 2],
     ]
-    assert to_list(ak._do.num(array, axis=-2)) == [5, 5, 5]
-    assert ak._do.num(array, axis=-3) == 3
+    assert to_list(ak.num(array, axis=-2)) == [5, 5, 5]
+    assert ak.num(array, axis=-3) == 3
 
     with pytest.raises(ValueError) as err:
-        assert ak._do.num(array, axis=-4)
+        assert ak.num(array, axis=-4)
         assert str(err.value).startswith("axis=-4 exceeds the depth of this array")

--- a/tests/test_1137-num.py
+++ b/tests/test_1137-num.py
@@ -40,6 +40,7 @@ def test_bytemaskedarray_num():
 def test_emptyarray():
     array = ak.contents.EmptyArray()
     assert to_list(ak.num(array, 0)) == 0
+    assert to_list(ak.num(array, -1)) == 0
     with pytest.raises(np.AxisError) as err:
         ak.num(array, 1)
     assert "axis=1 exceeds the depth" in str(err.value)

--- a/tests/test_1565-axis_wrap_if_negative_record.py
+++ b/tests/test_1565-axis_wrap_if_negative_record.py
@@ -26,7 +26,6 @@ def test_axis_wrap_if_negative_record_v2():
 
     with pytest.raises(np.AxisError):
         r = ak.operations.to_regular(r, 0)
-    r = ak.operations.to_regular(r, 2)
 
     list_cell_chain_field = [
         [["TRA", "TRAV1", 15], ["TRB", "TRBV1", 12]],

--- a/tests/test_1914-improved-axis-to-posaxis.py
+++ b/tests/test_1914-improved-axis-to-posaxis.py
@@ -65,3 +65,67 @@ def test_is_none():
 
     with pytest.raises(np.AxisError):
         ak.is_none(array, axis=-3)
+
+
+def test_singletons():
+    array = ak.Array(
+        [
+            None,
+            [None],
+            [{"x": None, "y": None}],
+            [{"x": [None], "y": [None]}],
+            [{"x": [1], "y": [[None]]}],
+            [{"x": [2], "y": [[1, 2, 3]]}],
+        ]
+    )
+
+    assert ak.singletons(array, axis=0).tolist() == [
+        [],
+        [[None]],
+        [[{"x": None, "y": None}]],
+        [[{"x": [None], "y": [None]}]],
+        [[{"x": [1], "y": [[None]]}]],
+        [[{"x": [2], "y": [[1, 2, 3]]}]],
+    ]
+
+    assert ak.singletons(array, axis=1).tolist() == [
+        None,
+        [[]],
+        [[{"x": None, "y": None}]],
+        [[{"x": [None], "y": [None]}]],
+        [[{"x": [1], "y": [[None]]}]],
+        [[{"x": [2], "y": [[1, 2, 3]]}]],
+    ]
+
+    assert ak.singletons(array, axis=2).tolist() == [
+        None,
+        [None],
+        [{"x": None, "y": None}],
+        [{"x": [[]], "y": [[]]}],
+        [{"x": [[1]], "y": [[[None]]]}],
+        [{"x": [[2]], "y": [[[1, 2, 3]]]}],
+    ]
+
+    with pytest.raises(np.AxisError):
+        ak.singletons(array, axis=3)
+
+    assert ak.singletons(array, axis=-1).tolist() == [
+        None,
+        [None],
+        [{"x": None, "y": None}],
+        [{"x": [[]], "y": [None]}],
+        [{"x": [[1]], "y": [[[]]]}],
+        [{"x": [[2]], "y": [[[1], [2], [3]]]}],
+    ]
+
+    assert ak.singletons(array, axis=-2).tolist() == [
+        None,
+        [None],
+        [{"x": [], "y": None}],
+        [{"x": [[None]], "y": [[]]}],
+        [{"x": [[1]], "y": [[[None]]]}],
+        [{"x": [[2]], "y": [[[1, 2, 3]]]}],
+    ]
+
+    with pytest.raises(np.AxisError):
+        ak.singletons(array, axis=-3)

--- a/tests/test_1914-improved-axis-to-posaxis.py
+++ b/tests/test_1914-improved-axis-to-posaxis.py
@@ -129,3 +129,14 @@ def test_singletons():
 
     with pytest.raises(np.AxisError):
         ak.singletons(array, axis=-3)
+
+
+def test_is_none_union():
+    left = ak.Array([[[{"x": 1, "y": None}]]])
+    right = ak.Array([[[{"a": 1, "b": None}]]])
+
+    array = ak.concatenate([left, right], axis=2)
+
+    assert ak.is_none(array, axis=-1).tolist() == [
+        [[{"x": False, "y": True}, {"a": False, "b": True}]]
+    ]

--- a/tests/test_1914-improved-axis-to-posaxis.py
+++ b/tests/test_1914-improved-axis-to-posaxis.py
@@ -1,0 +1,67 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_is_none():
+    array = ak.Array(
+        [
+            None,
+            [None],
+            [{"x": None, "y": None}],
+            [{"x": [None], "y": [None]}],
+            [{"x": [1], "y": [[None]]}],
+            [{"x": [2], "y": [[1, 2, 3]]}],
+        ]
+    )
+
+    assert ak.is_none(array, axis=0).tolist() == [
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
+    assert ak.is_none(array, axis=1).tolist() == [
+        None,
+        [True],
+        [False],
+        [False],
+        [False],
+        [False],
+    ]
+    assert ak.is_none(array, axis=2).tolist() == [
+        None,
+        [None],
+        [{"x": None, "y": None}],
+        [{"x": [True], "y": [True]}],
+        [{"x": [False], "y": [False]}],
+        [{"x": [False], "y": [False]}],
+    ]
+
+    with pytest.raises(np.AxisError):
+        ak.is_none(array, axis=3)
+
+    assert ak.is_none(array, axis=-1).tolist() == [
+        None,
+        [None],
+        [{"x": None, "y": None}],
+        [{"x": [True], "y": [None]}],
+        [{"x": [False], "y": [[True]]}],
+        [{"x": [False], "y": [[False, False, False]]}],
+    ]
+    assert ak.is_none(array, axis=-2).tolist() == [
+        None,
+        [None],
+        [{"x": True, "y": None}],
+        [{"x": False, "y": [True]}],
+        [{"x": False, "y": [False]}],
+        [{"x": False, "y": [False]}],
+    ]
+
+    with pytest.raises(np.AxisError):
+        ak.is_none(array, axis=-3)


### PR DESCRIPTION
I can't believe it: `axis_wrap_if_negative` has always been wrong. This function dates back to the early days of Awkward 1.x. We've been using it for so long, in so many things, that I would have thought that it's been through every possible test.

To convert a negative `axis` into its non-negative equivalent, you have to know the absolute depth of the array. With `depth == 1` for a 1-dimensional array and increasing for each nested list, the non-negative axis is `axis + depth` where `axis` is negative. For instance, if `axis == -1` (deepest) and `depth == 2` (array of lists of primitives), `axis + depth == 1`: the equivalent non-negative `axis == 1`.

If there's branching (a union or a record), then there isn't a single depth; we can't evaluate `axis + depth`. However, as we recurse down, we'll eventually recurse through the branching structure. Inside of a record of `{x: var * float64, y: var * var * int32}`, for instance, we can evaluate one `depth` inside the `x` branch and a different `depth` inside the `y` branch. We want to do that so that `axis=-1` means "deepest for all branches," i.e. the `float64` for `x` and the `int32` for `y`.

That's why `axis_wrap_if_negative` passes `axis` through unchanged if (a) it's already non-negative or (b) the `layout` it's looking at is branched. The idea is that we'll repeatedly call `axis_wrap_if_negative` while the value we get back is negative. As soon as it's non-negative, we keep that value.

However, if we're recursing, the `layout` that we have at some level is not the whole layout. If we only have the `x` branch of a record, for instance, we'll see its `var * float64` as "`layout`", and if `x`'s record were embedded within other lists, we wouldn't see them. The depth we compute form _that_ "`layout`" is therefore relative to the depth of last branching (the record with `x` and `y`, in this example).

Since `axis_wrap_if_negative` takes this partial "`layout`" and the negative `axis` as arguments, it can _never_ determine the absolute depth, and therefore cannot correctly convert the `axis` into a non-negative `axis`... in general.

There's only one case that works anyway: if the branching happens to be at the top level, the relative depth is equal to the absolute depth and we get the right answer. I've looked around, and I've only ever seen tests of negative `axis` with non-branching arrays (no records or unions) or the branching is a RecordArray at top level (this special case). There are tests in which different fields have different depths, like

```
# * {x: var * float64, y: var * var * int32}
```

but never within another list, like

```
# * var * {x: var * float64, y: var * var * int32}
```

The examples in #1914 were apparently the first general test of negative to non-negative `axis` conversion.

So I started this PR by introducing a new function (which will eventually live in `ak._util`, but right now it's in `ak._do` to be next to `axis_wrap_if_negative` for juxtaposition), which does the conversion correctly. It needs the same arguments as `axis_wrap_if_negative` _and also_ the current `depth`, to correct for the fact that the `layout` it's seeing is not the whole array.

I've implemented `ak.is_none` with it. Now I'm going to look for other functions that were using `axis_wrap_if_negative` incorrectly. I don't think we'll fix all of these bugs before the 2.0.0 release tomorrow, but we'll get the pattern established.

They're bugs and we can change them without a deprecation cycle.

<!-- docs-preview-start -->
----
:books: The documentation for this PR will be available at <https://awkward-array.readthedocs.io/en/jpivarski-improved-axis-to-posaxis/> once Read the Docs has finished building :hammer:
<!-- docs-preview-end -->