### PR TITLE
fix: missed a NumpyArray.raw call without an underscore.

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1746,9 +1746,9 @@ class Record(NDArrayOperatorsMixin):
             if isinstance(out, ak.contents.NumpyArray):
                 array_param = out.parameter("__array__")
                 if array_param == "byte":
-                    return ak._util.tobytes(out.raw(numpy))
+                    return ak._util.tobytes(out._raw(numpy))
                 elif array_param == "char":
-                    return ak._util.tobytes(out.raw(numpy)).decode(
+                    return ak._util.tobytes(out._raw(numpy)).decode(
                         errors="surrogateescape"
                     )
             if isinstance(out, (ak.contents.Content, ak.record.Record)):

--- a/tests/test_1991-missed-a-NumpyArray-raw-call-without-underscore.py
+++ b/tests/test_1991-missed-a-NumpyArray-raw-call-without-underscore.py
@@ -1,10 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import json
-
-import numpy as np
-import pytest
-
 import awkward as ak
 
 

--- a/tests/test_1991-missed-a-NumpyArray-raw-call-without-underscore.py
+++ b/tests/test_1991-missed-a-NumpyArray-raw-call-without-underscore.py
@@ -1,0 +1,16 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import json
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test():
+    assert ak.Record({"x": "hello"})["x"] == "hello"
+    assert ak.Record({"x": b"hello"})["x"] == b"hello"
+
+    assert ak.Array([{"x": "hello"}])[0, "x"] == "hello"
+    assert ak.Array([{"x": b"hello"}])[0, "x"] == b"hello"


### PR DESCRIPTION
I ran the Uproot tests "just before" the final Awkward release, but "just before" was a day or two ago. Uproot caught this tiny refactoring error, which now has a test. I scanned through the codebase and there is not another error of this type.

Awkward 2.0.1 will be sooner than we'd thought.