### PR TITLE
fix: add `Record.copy`

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1223,3 +1223,6 @@ class Content:
 
     def _fill_none(self, value: Content) -> Content:
         raise ak._errors.wrap_error(NotImplementedError)
+
+    def copy(self) -> Self:
+        raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -5,6 +5,7 @@ import copy
 from collections.abc import Iterable
 
 import awkward as ak
+from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.typing import Self
 
@@ -227,5 +228,7 @@ class Record:
     def __deepcopy__(self, memo):
         return Record(copy.deepcopy(self._array, memo), self._at)
 
-    def copy(self) -> Self:
-        return Record(self._array, self._at)
+    def copy(self, array=unset, at=unset) -> Self:
+        return Record(
+            self._array if array is unset else array, self._at if at is unset else at
+        )

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -221,8 +221,11 @@ class Record:
         else:
             return dict(zip(self._array.fields, contents))
 
-    def __copy__(self):
-        return Record(self._array, self._at)
+    def __copy__(self) -> Self:
+        return self.copy()
 
     def __deepcopy__(self, memo):
         return Record(copy.deepcopy(self._array, memo), self._at)
+
+    def copy(self) -> Self:
+        return Record(self._array, self._at)


### PR DESCRIPTION
I haven't added any tests, because we probably need to revisit our `copy` tests anyway (this code has been touched a reasonable amount)