### PR TITLE
chore: add ABI version number to AwkwardForth

### DIFF
--- a/awkward-cpp/include/awkward/forth/ForthMachine.h
+++ b/awkward-cpp/include/awkward/forth/ForthMachine.h
@@ -34,6 +34,10 @@ namespace awkward {
     ~ForthMachineOf();
 
     /// @brief HERE
+    int64_t
+      abi_version() const noexcept;
+
+    /// @brief HERE
     const std::string
       source() const noexcept;
 

--- a/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
+++ b/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
@@ -9,6 +9,9 @@
 #include "awkward/forth/ForthMachine.h"
 
 namespace awkward {
+  // ABI version must be increased whenever any interpretation of the bytecode changes.
+  #define ABI_VERSION 1
+
   // Instruction values are preprocessor macros to be equally usable in 32-bit and
   // 64-bit instruction sets.
 
@@ -275,6 +278,12 @@ namespace awkward {
     delete [] do_recursion_depth_;
     delete [] do_stop_;
     delete [] do_i_;
+  }
+
+  template <typename T, typename I>
+  int64_t
+  ForthMachineOf<T, I>::abi_version() const noexcept {
+    return ABI_VERSION;
   }
 
   template <typename T, typename I>

--- a/awkward-cpp/src/python/forth.cpp
+++ b/awkward-cpp/src/python/forth.cpp
@@ -213,6 +213,8 @@ make_ForthMachineOf(const py::handle& m, const std::string& name) {
                     + key + FILENAME(__LINE__));
             }
           })
+          .def_property_readonly("abi_version",
+              &ak::ForthMachineOf<T, I>::abi_version)
           .def_property_readonly("source",
               &ak::ForthMachineOf<T, I>::source)
           .def_property_readonly("bytecodes",


### PR DESCRIPTION
This is so that @aryan26roy's project of Numba-compiling AwkwardForth code will be notified of any changes in the Forth byte code (changes on the C++ side that can invalidate code on the Python side; at least there needs to be an assertion).