### PR TITLE
docs: add note in README.md about pip installing through git.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Awkward Array is even faster when used in [Numba](https://numba.pydata.org/)'s J
 
 See the [Getting started](https://awkward-array.org/doc/main/getting-started/index.html) documentation on [awkward-array.org](https://awkward-array.org) for an introduction, including a [no-install demo](https://awkward-array.org/doc/main/getting-started/try-awkward-array.html) you can try in your web browser.
 
+# Getting help
+
+   * View the documentation on [awkward-array.org](https://awkward-array.org/).
+   * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/awkward/issues).
+   * If you have a "How do I...?" question, start a [GitHub Discussion](https://github.com/scikit-hep/awkward/discussions) with category "Q&A".
+   * Alternatively, ask about it on [StackOverflow with the [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
+   * To ask questions in real time, try the Gitter [Scikit-HEP/awkward-array](https://gitter.im/Scikit-HEP/awkward-array) chat room.
+
 # Installation
 
 Awkward Array can be installed from [PyPI](https://pypi.org/project/awkward) using pip:
@@ -85,17 +93,9 @@ Awkward Array is also available on [conda-forge](https://conda-forge.org/docs/us
 conda install -c conda-forge awkward
 ```
 
-Because of the two packages (`awkward-cpp` may be updated in GitHub but not on PyPI), pip install through git (`pip install git+https://...`) will not work. Instead, use the [Installation for developers](#installation-for-developers) section below.
-
-# Getting help
-
-   * View the documentation on [awkward-array.org](https://awkward-array.org/).
-   * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/awkward/issues).
-   * If you have a "How do I...?" question, start a [GitHub Discussion](https://github.com/scikit-hep/awkward/discussions) with category "Q&A".
-   * Alternatively, ask about it on [StackOverflow with the [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
-   * To ask questions in real time, try the Gitter [Scikit-HEP/awkward-array](https://gitter.im/Scikit-HEP/awkward-array) chat room.
-
 <!-- readme-pypi-ignore-after -->
+
+Because of the two packages (`awkward-cpp` may be updated in GitHub but not on PyPI), pip install through git (`pip install git+https://...`) will not work. Instead, use the [Installation for developers](#installation-for-developers) section below.
 
 # Installation for developers
 
@@ -116,7 +116,7 @@ Tests can be run in parallel with [pytest](https://docs.pytest.org/):
 python -m pytest -n auto tests
 ```
 
-For more details, see [CONTRIBUTING.md](CONTRIBUTING.md), or one of the links below.
+For more details, see [CONTRIBUTING.md](https://github.com/scikit-hep/awkward/blob/main/CONTRIBUTING.md), or one of the links below.
 
    * [Continuous integration](https://github.com/scikit-hep/awkward/actions/workflows/build-test.yml) and [continuous deployment](https://github.com/scikit-hep/awkward/actions/workflows/wheels.yml) are hosted by [GitHub Actions](https://github.com/features/actions/).
    * [Code of conduct](https://scikit-hep.org/code-of-conduct) for how we work together.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Awkward Array is also available on [conda-forge](https://conda-forge.org/docs/us
 conda install -c conda-forge awkward
 ```
 
+Because of the two packages (`awkward-cpp` may be updated in GitHub but not on PyPI), pip install through git (`pip install git+https://...`) will not work. Instead, use the [Installation for developers](#installation-for-developers) section below.
+
 # Getting help
 
    * View the documentation on [awkward-array.org](https://awkward-array.org/).


### PR DESCRIPTION
I think that the only place where installation is described in enough detail to include a note about not using pip with git is on the README.

This note links to the Installation for developers section, which isn't on PyPI. The note is too detailed for PyPI, anyway.

To make that work with a single cut, I also moved the Getting started section earlier. It makes more sense for the two Installation sections to be next to each other, anyway. The Getting started is short enough that it's clear that there's an installation section immediately after it.