### PR TITLE
fix: widen input support for `ak.type()`

### DIFF
--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -141,4 +141,5 @@ def _impl(array):
         return array.form.type
 
     else:
-        raise ak._errors.wrap_error(TypeError(f"unrecognized array type: {array!r}"))
+        layout = ak.to_layout(array, allow_other=False)
+        return _impl(ak._util.wrap(layout))

--- a/tests/test_2008-ak-type-layout.py
+++ b/tests/test_2008-ak-type-layout.py
@@ -1,0 +1,16 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import re
+
+import awkward as ak
+
+
+def test_simple():
+    assert re.match(r"3 \* u?int\d+", str(ak.type([1, 2, 3])))
+
+
+def test_complex():
+    assert re.match(
+        r"2 \* \{x: union\[var \* \?u?int\d+, float\d+\]\}",
+        str(ak.type([{"x": [None, 10]}, {"x": 40.0}])),
+    )


### PR DESCRIPTION
Fixes #2008