### PR TITLE
fix: support empty record arrays in `ak.to_numpy`

### DIFF
--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -868,7 +868,7 @@ class RecordArray(Content):
                 ValueError(f"cannot convert {self} into np.ndarray")
             )
         out = self._backend.nplike.empty(
-            contents[0].shape[0],
+            self.length,
             dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],
         )
         mask = None

--- a/tests/test_1944-to-numpy-empty-record-array.py
+++ b/tests/test_1944-to-numpy-empty-record-array.py
@@ -1,0 +1,7 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+
+def test():
+    assert ak.to_numpy(ak.Array([{}, {}])).tolist() == [(), ()]


### PR DESCRIPTION
Fixes #1944