### PR TITLE
ci: drop pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -197,9 +197,13 @@ jobs:
     - name: Copy C++ documentation
       run: cp -r awkward-cpp/docs/html/ docs/_static/doxygen
 
+    - name: Enable analytics & version selector
+      if: github.event_name == 'push' || github.event_name == 'release'
+      run: |
+        echo "DOCS_REPORT_ANALYTICS=1" >> $GITHUB_ENV
+        echo "DOCS_SHOW_VERSION=1" >> $GITHUB_ENV
+
     - name: Generate Python documentation
-      env:
-        DOCS_SHOW_VERSION: 1
       run: sphinx-build -M html . _build/
       working-directory: docs
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -237,25 +237,6 @@ jobs:
         name: docs
         path: docs/_build/html
 
-      # TODO HACK!
-    - name: Layout documentation
-      run: |
-        # Setup docs with `/doc/main` path
-        mkdir -p "/tmp/awkward-docs/doc"
-        cp -r docs/_build/html \
-                 "/tmp/awkward-docs/doc/main"
-        cp -r docs/_build/html \
-                 "/tmp/awkward-docs/doc/stable"
-        cp -r docs/_build/html \
-                 "/tmp/awkward-docs/doc/2.0"
-        python3 dev/generate-redirects.py docs/redirects-user-guide.json /tmp/awkward-docs/
-
-    - name: Upload Pages artefact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        # Upload entire repository
-        path: /tmp/awkward-docs
-
     - name: Upload Jupyter Book cache
       uses: actions/upload-artifact@v3
       with:
@@ -346,22 +327,3 @@ jobs:
           aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/$version/"
           aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" \
             --paths "/doc/$version/" "/doc/switcher.json"
-
-  deploy-docs:
-    runs-on: ubuntu-22.04
-    needs: [build-docs]
-    # We can only deploy for PRs on host repo, or pushes to main
-    if: ${{ github.event_name == 'push' }}
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup Pages
-      uses: actions/configure-pages@v2
-
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,11 +91,12 @@ html_theme_options = {
             "url": "https://github.com/scikit-hep/awkward/releases",
         },
     ],
-    "analytics": {
+}
+if "DOCS_REPORT_ANALYTICS" in os.environ:
+    html_theme_options["analytics"] = {
         "plausible_analytics_domain": "awkward-array.org",
         "plausible_analytics_url": "https://views.scientific-python.org/js/plausible.js",
-    },
-}
+    }
 # Don't show version for offline builds by default
 if "DOCS_SHOW_VERSION" in os.environ:
     html_theme_options["switcher"] = {
@@ -158,10 +159,12 @@ linkcheck_ignore = [
 ]
 # Eventually we need to revisit these
 if (datetime.date.today() - datetime.date(2022, 12, 13)) < datetime.timedelta(days=30):
-    linkcheck_ignore.extend([
-        r"^https:\/\/doi.org\/10\.1051\/epjconf\/202024505023$",
-        r"^https:\/\/doi.org\/10\.1051\/epjconf\/202125103002$",
-    ])
+    linkcheck_ignore.extend(
+        [
+            r"^https:\/\/doi.org\/10\.1051\/epjconf\/202024505023$",
+            r"^https:\/\/doi.org\/10\.1051\/epjconf\/202125103002$",
+        ]
+    )
 
 HERE = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
This PR should remove the GitHub Pages documentation deployment from the CI, and disable version selectors for previews.