### PR TITLE
ci: fix flake8 warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,14 +1,13 @@
-
 [flake8]
 extend-select = C,B,B9,T,AK1
-extend-ignore = E203,E501,B950,E266
+# B905 should be removed once python>=3.10
+extend-ignore = E203,E501,B950,E266,B905
 max-complexity = 100
-exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generated_parser.py, awkward/_typeparser/generated_parser.py
+exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generated_parser.py
 per-file-ignores =
     tests/*: T, AK1
     dev/*: T, T201, AK1
-    src/awkward/__init__.py: E402, F401, F403, AK1
-    src/awkward/__init__.py: F401, F403
+    src/awkward/__init__.py: E402, F401, F403, AK1, F401, F403
     src/awkward/operations/__init__.py: F401
     src/awkward/_connect/numba/*: AK1
     src/awkward/_errors.py: AK1


### PR DESCRIPTION
I'm not sure why this is needed; I can't reproduce locally, and it should be disabled by default. pre-commit.ci seems to complain, though.

As this is breaking PR workflows, and touches .flake8 only, I'm going to merge when it's successful.