### PR TITLE
refactor: add `@final` to contents, types, and forms

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   rev: "v5.11.3"
   hooks:
     - id: isort
-      exclude: ^src/(awkward|awkward/_v2)/__init__\.py$
+      exclude: ^src/awkward/__init__\.py$
 
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ exclude = ["^src/awkward/[^/]+\\.py$"]
 plugins = [
     "numpy.typing.mypy_plugin"
 ]
+python_version = "3.11"
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -11,12 +11,13 @@ from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class BitMaskedArray(Content):
     is_option = True
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -10,12 +10,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class ByteMaskedArray(Content):
     is_option = True
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -7,12 +7,13 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class EmptyArray(Content):
     is_unknown = True
     is_leaf = True

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,12 +8,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class IndexedArray(Content):
     is_indexed = True
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -8,12 +8,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class IndexedOptionArray(Content):
     is_option = True
     is_indexed = True

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -9,11 +9,12 @@ from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
 from awkward.forms.listform import ListForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
+@final
 class ListArray(Content):
     is_list = True
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -8,12 +8,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class ListOffsetArray(Content):
     is_list = True
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -8,12 +8,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.numpyform import NumpyForm
 from awkward.types.numpytype import primitive_to_dtype
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class NumpyArray(Content):
     is_numpy = True
     is_leaf = True

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,12 +10,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.recordform import RecordForm
 from awkward.record import Record
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class RecordArray(Content):
     is_record = True
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -7,12 +7,13 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.regularform import RegularForm
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class RegularArray(Content):
     is_list = True
     is_regular = True

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -12,12 +12,13 @@ from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class UnionArray(Content):
     is_union = True
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -7,12 +7,13 @@ import awkward as ak
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.unmaskedform import UnmaskedForm
-from awkward.typing import Final, Self
+from awkward.typing import Final, Self, final
 
 np = ak._nplikes.NumpyMetadata.instance()
 numpy = ak._nplikes.Numpy.instance()
 
 
+@final
 class UnmaskedArray(Content):
     is_option = True
 

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class BitMaskedForm(Form):
     is_option = True
 

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class ByteMaskedForm(Form):
     is_option = True
 

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form
+from awkward.typing import final
 
 
+@final
 class EmptyForm(Form):
     is_numpy = True
     is_unknown = True

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal, _parameters_update
+from awkward.typing import final
 
 
+@final
 class IndexedForm(Form):
     is_indexed = True
 

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class IndexedOptionForm(Form):
     is_option = True
     is_indexed = True

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class ListForm(Form):
     is_list = True
 

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class ListOffsetForm(Form):
     is_list = True
 

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 np = ak._nplikes.NumpyMetadata.instance()
 
@@ -34,6 +35,7 @@ def from_dtype(dtype, parameters=None):
     )
 
 
+@final
 class NumpyForm(Form):
     is_numpy = True
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -6,8 +6,10 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class RecordForm(Form):
     is_record = True
 

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class RegularForm(Form):
     is_list = True
     is_regular = True

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -5,8 +5,10 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class UnionForm(Form):
     is_union = True
 

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward._util import unset
 from awkward.forms.form import Form, _parameters_equal
+from awkward.typing import final
 
 
+@final
 class UnmaskedForm(Form):
     is_option = True
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 
+@final
 class ListType(Type):
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -6,6 +6,7 @@ import re
 import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 np = ak._nplikes.NumpyMetadata.instance()
 
@@ -92,6 +93,7 @@ for primitive, dtype in _primitive_to_dtype_dict.items():
     _dtype_to_primitive_dict[dtype] = primitive
 
 
+@final
 class NumpyType(Type):
     def __init__(self, primitive, *, parameters=None, typestr=None):
         primitive = dtype_to_primitive(primitive_to_dtype(primitive))

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -6,8 +6,10 @@ from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
 from awkward.types.type import Type
 from awkward.types.uniontype import UnionType
+from awkward.typing import final
 
 
+@final
 class OptionType(Type):
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,8 +7,10 @@ import awkward as ak
 import awkward._prettyprint
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 
+@final
 class RecordType(Type):
     def __init__(self, contents, fields, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 
+@final
 class RegularType(Type):
     def __init__(self, content, size, *, parameters=None, typestr=None):
         if not isinstance(content, Type):

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -5,8 +5,10 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 
+@final
 class UnionType(Type):
     def __init__(self, contents, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -3,8 +3,10 @@
 import awkward as ak
 from awkward.forms.form import _parameters_equal
 from awkward.types.type import Type
+from awkward.typing import final
 
 
+@final
 class UnknownType(Type):
     def __init__(self, *, parameters=None, typestr=None):
         if parameters is not None and not isinstance(parameters, dict):

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -3,20 +3,40 @@ from __future__ import annotations
 
 import sys
 import typing
-from typing import *  # noqa: F401, F403
+from typing import *  # noqa: F403
 
-__all__ = [*typing.__all__, "AxisMaybeNone"]
+__all__ = [
+    "Final",
+    "Self",
+    "final",
+    "Protocol",
+    "Unpack",
+    "TypeAlias",
+    "runtime_checkable",
+    "AxisMaybeNone",
+] + typing.__all__
 
 
 AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)
 
 
 if sys.version_info < (3, 11):
-    import typing_extensions
-    from typing_extensions import *  # noqa: F401, F403
-
-    __all__ += typing_extensions.__all__
-
-
-def __dir__() -> tuple[str, ...]:
-    return __all__
+    from typing_extensions import (  # noqa: F401, F403
+        Final,
+        Protocol,
+        Self,
+        TypeAlias,
+        Unpack,
+        final,
+        runtime_checkable,
+    )
+else:
+    from typing import (  # noqa: F401, F403
+        Final,
+        Protocol,
+        Self,
+        TypeAlias,
+        Unpack,
+        final,
+        runtime_checkable,
+    )

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -5,16 +5,20 @@ import sys
 import typing
 from typing import *  # noqa: F403
 
-__all__ = [
-    "Final",
-    "Self",
-    "final",
-    "Protocol",
-    "Unpack",
-    "TypeAlias",
-    "runtime_checkable",
-    "AxisMaybeNone",
-] + typing.__all__
+__all__ = list(
+    {
+        "Final",
+        "Self",
+        "final",
+        "Protocol",
+        "Unpack",
+        "TypeAlias",
+        "runtime_checkable",
+        "AxisMaybeNone",
+        "TypedDict",
+        *typing.__all__,
+    }
+)
 
 
 AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)
@@ -26,6 +30,7 @@ if sys.version_info < (3, 11):
         Protocol,
         Self,
         TypeAlias,
+        TypedDict,
         Unpack,
         final,
         runtime_checkable,
@@ -36,6 +41,7 @@ else:
         Protocol,
         Self,
         TypeAlias,
+        TypedDict,
         Unpack,
         final,
         runtime_checkable,


### PR DESCRIPTION
This type hint makes it clear (and, in future, enforces) that contents, types, and forms are all final non-inheritable types.