### PR TITLE
docs: correct canonical URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -136,6 +136,8 @@ jobs:
       run:
         # Ensure conda env is activated
         shell: "bash -l {0}"
+    env:
+        DOCS_CANONICAL_VERSION: main
     steps:
     - uses: actions/checkout@v3
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,11 +49,17 @@ if "DOCS_VERSION" in os.environ:
 else:
     version_match = version
 
-# Build sitemap on main
-if version_match == "main":
-    extensions.append("sphinx_sitemap")
-    # Sitemap URLs are relative to `html_baseurl`
-    sitemap_url_scheme = "{link}"
+
+# Specify a canonical version
+if "DOCS_CANONICAL_VERSION" in os.environ:
+    canonical_version = os.environ["DOCS_CANONICAL_VERSION"]
+    html_baseurl = f"https://awkward-array.org/doc/{canonical_version}/"
+
+    # Build sitemap on main
+    if version_match == canonical_version:
+        extensions.append("sphinx_sitemap")
+        # Sitemap URLs are relative to `html_baseurl`
+        sitemap_url_scheme = "{link}"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -68,7 +74,6 @@ exclude_patterns = ["_build", "_templates", "Thumbs.db", "jupyter_execute", ".*"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_baseurl = f"https://awkward-array.org/doc/main/"
 html_context = {
     "github_user": "scikit-hep",
     "github_repo": "awkward",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,13 +36,24 @@ extensions = [
     "sphinx_design",
     "sphinx_external_toc",
     "sphinx.ext.intersphinx",
-    "sphinx_sitemap",
     "myst_nb",
     # Preserve old links
     "jupyterlite_sphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
 ]
+
+# Allow the CI to set version_match="main"
+if "DOCS_VERSION" in os.environ:
+    version_match = os.environ["DOCS_VERSION"]
+else:
+    version_match = version
+
+# Build sitemap on main
+if version_match == "main":
+    extensions.append("sphinx_sitemap")
+    # Sitemap URLs are relative to `html_baseurl`
+    sitemap_url_scheme = "{link}"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -56,8 +67,8 @@ exclude_patterns = ["_build", "_templates", "Thumbs.db", "jupyter_execute", ".*"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-html_baseurl = 'https://awkward-array.org/doc/'
+
+html_baseurl = f"https://awkward-array.org/doc/main/"
 html_context = {
     "github_user": "scikit-hep",
     "github_repo": "awkward",
@@ -101,12 +112,6 @@ if "DOCS_REPORT_ANALYTICS" in os.environ:
         "plausible_analytics_domain": "awkward-array.org",
         "plausible_analytics_url": "https://views.scientific-python.org/js/plausible.js",
     }
-
-# Allow the CI to set version_match="main"
-if "DOCS_VERSION" in os.environ:
-    version_match = os.environ["DOCS_VERSION"]
-else:
-    version_match = version
 
 # Don't show version for offline builds by default
 if "DOCS_SHOW_VERSION" in os.environ:
@@ -178,9 +183,8 @@ if (datetime.date.today() - datetime.date(2022, 12, 13)) < datetime.timedelta(da
         ]
     )
 
-HERE = pathlib.Path(__file__).parent
-
 # Generate Python docstrings
+HERE = pathlib.Path(__file__).parent
 runpy.run_path(HERE / "prepare_docstrings.py", run_name="__main__")
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.5.0
+sphinx>=4.5.0,<5.0.0
 PyYAML
 black
 pycparser


### PR DESCRIPTION
This PR ensures that we only build the sitemap for the `main` version, and that the `link rel="canonical"` links point to `main`. This ensures that Google does not index versioned links.