### PR TITLE
fix: repr of unknown-length arrays

### DIFF
--- a/tests/test_2042-pretty-print-typetracer.py
+++ b/tests/test_2042-pretty-print-typetracer.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+
+def test():
+    form = ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float32", inner_shape=(2,))
+    )
+    layout = form.length_zero_array().layout.to_typetracer(forget_length=True)
+    array = ak.Array(layout)
+    assert str(array) == "<Array-typetracer type='?? * var * 2 * float32'>"


### PR DESCRIPTION
```python
import awkward as ak


def test():
    form = ak.forms.ListOffsetForm(
        "i64", ak.forms.NumpyForm("float32", inner_shape=(2,))
    )
    layout = form.length_zero_array().layout.to_typetracer(forget_length=True)
    array = ak.Array(layout)
    assert str(array) == "<Array-typetracer type='?? * var * 2 * float32'>"
```

This test does not succeed for `2.0.4`, because the pretty-print logic tries to determine `len(array)`. 

Although the fix for this is simple enough, down the road we might want to expose this in our public typetracer API.