### PR TITLE
fix: remove unused keyword arg

### DIFF
--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -19,7 +19,6 @@ def transform(
     right_broadcast=True,
     numpy_to_regular=False,
     regular_to_jagged=False,
-    return_simplified=True,
     return_value="simplified",
     highlevel=True,
     behavior=None,


### PR DESCRIPTION
#1968 added the redundant `return_simplified` argument to `ak.transform`. I missed it in my initial review, but it doesn't do anything and should be removed. I think we can do this immediately; the option isn't documented, and doesn't do anything.