### PR TITLE
fix: rebuild invalid `check` pointers in `ArrayBuilder`

### DIFF
--- a/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
+++ b/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
@@ -399,15 +399,18 @@ namespace awkward {
     }
 
     if (!begun_  &&
-        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name) || (!check && nameptr_ == nullptr && name_ == name))) {
+        ((check  &&  name_ == name)  ||  (!check  &&  nameptr_ == name))) {
+      begun_ = true;
+      nextindex_ = -1;
+      nexttotry_ = 0;
+    } else if (!begun_  &&
+        ((!check && nameptr_ == nullptr && name_ == name))) {
       begun_ = true;
       nextindex_ = -1;
       nexttotry_ = 0;
 
       // Rebuild pointer for this name
-      if (!check && nameptr_ == nullptr) {
-          nameptr_ = name;
-      }
+      nameptr_ = name;
     }
     else if (!begun_) {
       BuilderPtr out = UnionBuilder::fromsingle(options_, shared_from_this());

--- a/tests/test_2055_array_builder_check.py
+++ b/tests/test_2055_array_builder_check.py
@@ -1,0 +1,55 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+from numba import njit
+
+import awkward as ak
+
+
+def test_field_name():
+    builder = ak.ArrayBuilder()
+    builder.begin_record("x")
+    builder.field("time").real(0.0)
+    builder.end_record()
+
+    @njit
+    def func(builder):
+        builder.begin_record("x")
+        builder.field("time").real(2.0)
+        builder.end_record()
+        return builder
+
+    func(builder)
+
+    assert builder.type == ak.types.ArrayType(
+        ak.types.RecordType(
+            [ak.types.NumpyType("float64")], ["time"], parameters={"__record__": "x"}
+        ),
+        2,
+    )
+
+
+def test_no_field_name():
+    builder = ak.ArrayBuilder()
+    builder.begin_record()
+    builder.field("time").real(0.0)
+    builder.end_record()
+
+    @njit
+    def func(builder):
+        builder.begin_record()
+        builder.field("time").real(2.0)
+        builder.end_record()
+        return builder
+
+    func(builder)
+
+    result = builder.snapshot()
+    assert ak._util.arrays_approx_equal(
+        result,
+        ak.contents.RecordArray(
+            fields=["time"],
+            contents=[ak.contents.NumpyArray(np.array([0, 2], dtype=np.float64))],
+        ),
+    )

--- a/tests/test_2055_array_builder_check.py
+++ b/tests/test_2055_array_builder_check.py
@@ -1,10 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
-from numba import njit
+import pytest
 
 import awkward as ak
+
+numba = pytest.importorskip("numba")
 
 
 def test_field_name():
@@ -13,7 +14,7 @@ def test_field_name():
     builder.field("time").real(0.0)
     builder.end_record()
 
-    @njit
+    @numba.njit
     def func(builder):
         builder.begin_record("x")
         builder.field("time").real(2.0)
@@ -36,7 +37,7 @@ def test_no_field_name():
     builder.field("time").real(0.0)
     builder.end_record()
 
-    @njit
+    @numba.njit
     def func(builder):
         builder.begin_record()
         builder.field("time").real(2.0)


### PR DESCRIPTION
This PR fixes #2054, fixes #2053, which occur when a user mixes "fast" and "slow" modes of the record / field builders. The string pointers that are used to implement the fast mechanism are assumed to come from an intern pool, i.e. the same string has the same pointer. This fails when Python strings are used, as they come from different pools, and aren't guaranteed to be stable.

To correct this, we can ensure that the slow-mode invalidates any pointers, and that the fast-mode treats `nullptr` as a cue to rebuild the pointer.