### PR TITLE
fix: support merging of `RegularArray` and `NumpyArray`

### DIFF
--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -64,7 +64,10 @@ class NumpyMetadata(Singleton):
 
     nat = numpy.datetime64("NaT")
     datetime_data = numpy.datetime_data
-    issubdtype = numpy.issubdtype
+
+    @property
+    def issubdtype(self):
+        return numpy.issubdtype
 
     AxisError = numpy.AxisError
 
@@ -365,6 +368,9 @@ class NumpyLike(Singleton):
 
     def datetime_as_string(self, *args, **kwargs):
         return self._module.datetime_as_string(*args, **kwargs)
+
+    def can_cast(self, *args, **kwargs):
+        return self._module.can_cast(*args, **kwargs)
 
     @classmethod
     def is_own_array(cls, obj) -> bool:

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -989,7 +989,7 @@ class TypeTracer(ak._nplikes.NumpyLike):
             try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def concatenate(self, arrays):
+    def concatenate(self, arrays, casting="same_kind"):
         for x in arrays:
             try_touch_data(x)
 

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -1236,6 +1236,9 @@ class TypeTracer(ak._nplikes.NumpyLike):
         # array, max_line_width, precision=None, suppress_small=None
         return "[?? ... ??]"
 
+    def can_cast(self, *args, **kwargs):
+        return numpy.can_cast(*args, **kwargs)
+
     def datetime_as_string(self, *args, **kwargs):
         for x in args:
             try_touch_data(x)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -931,7 +931,7 @@ class ListArray(Content):
         ):
             return self._mergeable(other.content, mergebool)
 
-        if isinstance(
+        elif isinstance(
             other,
             (
                 ak.contents.RegularArray,
@@ -940,6 +940,9 @@ class ListArray(Content):
             ),
         ):
             return self._content._mergeable(other.content, mergebool)
+
+        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
+            return self._mergeable(other._to_regular_primitive(), mergebool)
 
         else:
             return False

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -701,7 +701,7 @@ class ListOffsetArray(Content):
         ):
             return self._mergeable(other.content, mergebool)
 
-        if isinstance(
+        elif isinstance(
             other,
             (
                 ak.contents.RegularArray,
@@ -710,6 +710,9 @@ class ListOffsetArray(Content):
             ),
         ):
             return self._content._mergeable(other.content, mergebool)
+
+        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
+            return self._mergeable(other._to_regular_primitive(), mergebool)
 
         else:
             return False

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -348,10 +348,11 @@ class NumpyArray(Content):
             if self._data.ndim != other._data.ndim:
                 return False
 
+            # Obvious fast-path
             if self.dtype == other.dtype:
                 return True
 
-            # Merge booleans i.e. {bool, number}
+            # Special-case booleans i.e. {bool, number}
             elif mergebool and (
                 np.issubdtype(self.dtype, np.bool_)
                 and np.issubdtype(other.dtype, np.number)
@@ -360,13 +361,7 @@ class NumpyArray(Content):
             ):
                 return True
 
-            # Merge number e.g. {complex, float} etc.
-            elif np.issubdtype(self.dtype, np.number) and np.issubdtype(
-                other._data.dtype, np.number
-            ):
-                return True
-            # We should only be here with datetime dtypes, failed boolean
-            # merges, or obscure datetime
+            # Default merging (can we cast one to the other)
             else:
                 return self.backend.nplike.can_cast(
                     self.dtype, other.dtype, casting="same_kind"

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1332,9 +1332,12 @@ class NumpyArray(Content):
         else:
             return True
 
-    def _to_regular_primitive(self):
+    def _to_regular_primitive(self) -> ak.contents.RegularArray:
+        # A length-1 slice in each dimension
         index = tuple([slice(None, 1)] * len(self.shape))
+        # Broadcast this trivial slice to the true dimensions (zero-copy)
         new_data = self.backend.nplike.broadcast_to(self._data[index], self.shape)
+        # Convert contiguous array to `RegularArray`
         return NumpyArray(
             new_data, backend=self.backend, parameters=self.parameters
         ).to_RegularArray()

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -361,6 +361,15 @@ class NumpyArray(Content):
             ):
                 return True
 
+            # Currently we're less permissive than NumPy on merging datetimes / timedeltas
+            elif (
+                np.issubdtype(self.dtype, np.datetime64)
+                or np.issubdtype(self.dtype, np.timedelta64)
+                or np.issubdtype(other.dtype, np.datetime64)
+                or np.issubdtype(other.dtype, np.timedelta64)
+            ):
+                return False
+
             # Default merging (can we cast one to the other)
             else:
                 return self.backend.nplike.can_cast(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -353,13 +353,13 @@ class NumpyArray(Content):
                 return True
 
             # Special-case booleans i.e. {bool, number}
-            elif mergebool and (
+            elif (
                 np.issubdtype(self.dtype, np.bool_)
                 and np.issubdtype(other.dtype, np.number)
                 or np.issubdtype(self.dtype, np.number)
                 and np.issubdtype(other.dtype, np.bool_)
             ):
-                return True
+                return mergebool
 
             # Currently we're less permissive than NumPy on merging datetimes / timedeltas
             elif (

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -648,11 +648,9 @@ class RegularArray(Content):
         ):
             return self._content._mergeable(other.content, mergebool)
 
-        # For n-dimensional NumpyArrays, let's now convert them to RegularArray
-        # We could add a special case that tries to first convert self to NumpyArray
-        # and merge conventionally, but it's not worth it at this stage.
-        elif isinstance(other, ak.contents.NumpyArray) and other.purelist_depth > 1:
-            return self._content._mergeable(other.to_RegularArray().content, mergebool)
+        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
+            return self._mergeable(other._to_regular_primitive(), mergebool)
+
         else:
             return False
 

--- a/tests/test_2058_merge_numpy_array.py
+++ b/tests/test_2058_merge_numpy_array.py
@@ -26,3 +26,27 @@ def test_regular():
     assert ak.concatenate((x, y)).type == ak.types.ArrayType(
         ak.types.ListType(ak.types.NumpyType("int64")), 8
     )
+
+
+def test_regular_mergebool_false():
+    x = ak.from_numpy(np.zeros((4, 3), dtype=np.bool_), regulararray=True)
+    y = ak.from_numpy(np.ones((4, 2), dtype=np.int64), regulararray=True)
+
+    assert ak.concatenate((x, y), mergebool=False).type == ak.types.ArrayType(
+        ak.types.UnionType(
+            [
+                ak.types.RegularType(ak.types.NumpyType("bool"), 3),
+                ak.types.RegularType(ak.types.NumpyType("int64"), 2),
+            ]
+        ),
+        8,
+    )
+
+
+def test_regular_mergebool_true():
+    x = ak.from_numpy(np.zeros((4, 3), dtype=np.bool_), regulararray=True)
+    y = ak.from_numpy(np.ones((4, 2), dtype=np.int64), regulararray=True)
+
+    assert ak.concatenate((x, y), mergebool=True).type == ak.types.ArrayType(
+        ak.types.ListType(ak.types.NumpyType("int64")), 8
+    )

--- a/tests/test_2058_merge_numpy_array.py
+++ b/tests/test_2058_merge_numpy_array.py
@@ -1,0 +1,28 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_numpy():
+    x = ak.from_numpy(
+        np.arange(4 * 3, dtype=np.int64).reshape(4, 3), regulararray=False
+    )
+    y = ak.from_numpy(
+        np.arange(4 * 2, dtype=np.int64).reshape(4, 2), regulararray=False
+    )
+
+    assert ak.concatenate((x, y)).type == ak.types.ArrayType(
+        ak.types.ListType(ak.types.NumpyType("int64")), 8
+    )
+
+
+def test_regular():
+    x = ak.from_numpy(np.arange(4 * 3, dtype=np.int64).reshape(4, 3), regulararray=True)
+    y = ak.from_numpy(np.arange(4 * 2, dtype=np.int64).reshape(4, 2), regulararray=True)
+
+    assert ak.concatenate((x, y)).type == ak.types.ArrayType(
+        ak.types.ListType(ak.types.NumpyType("int64")), 8
+    )


### PR DESCRIPTION
This is a PoC to fix #2058. Jim and I also discussed doing this properly at the form level, which I might even explore in another draft PR.

- [ ] Restore `main` casting semantics