### PR TITLE
feat: expose typetracer in public backend API

### DIFF
--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -936,11 +936,7 @@ def nplike_of(*arrays, default: D = _UNSET) -> NumpyLike | D:
 
         raise ak._errors.wrap_error(
             ValueError(
-                """attempting to use both a 'cpu' array and a 'cuda' array in the same operation; use one of
-
-    ak.to_backend(array, 'cpu')
-    ak.to_backend(array, 'cuda')
-
-to move one or the other to main memory or the GPU(s)."""
+                """attempting to use arrays with more than one backend in the same operation; use
+#ak.to_backend to coerce the arrays to the same backend."""
             )
         )

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -13,7 +13,8 @@ def backend(*arrays) -> str:
     * `"cpu"` for arrays backed by NumPy;
     * `"cuda"` for arrays backed by CuPy;
     * `"jax"` for arrays backed by JAX;
-    * None if the objects are not Awkward, NumPy, JAX, or CuPy arrays (e.g.
+    * `"typetracer"` for arrays without any data;
+    * None if the objects are not Awkward, NumPy, JAX, CuPy, or typetracer arrays (e.g.
       Python numbers, booleans, strings).
 
     See #ak.to_backend.
@@ -27,12 +28,4 @@ def backend(*arrays) -> str:
 
 def _impl(arrays) -> str:
     backend_impl = ak._backends.backend_of(*arrays, default=None)
-    if isinstance(backend_impl, ak._backends.TypeTracerBackend):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "at least one of the given arrays was a typetracer array. "
-                "This is an internal backend that you should not have encountered. "
-                "Please file a bug report at https://github.com/scikit-hep/awkward/issues/"
-            )
-        )
     return backend_impl.name

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -19,8 +19,8 @@ def to_backend(array, backend, *, highlevel=True, behavior=None):
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
 
-    Converts an array from `"cpu"`, `"cuda"`, or `"jax"` kernels to `"cpu"`,
-    `"cuda"`, or `"jax"`.
+    Converts an array from `"cpu"`, `"cuda"`, `"jax"` kernels to `"cpu"`,
+    `"cuda"`, `"jax"`, or `"typetracer"` .
 
     Any components that are already in the desired backend are viewed,
     rather than copied, so this operation can be an inexpensive way to ensure

--- a/tests/test_1940_ak_backend.py
+++ b/tests/test_1940_ak_backend.py
@@ -10,13 +10,11 @@ def test_typetracer():
     array = ak.Array([[0, 1, 2, 3], [8, 9, 10, 11]])
     typetracer = ak.Array(array.layout.to_typetracer())
 
-    with pytest.raises(ValueError, match="internal backend"):
-        ak.backend(typetracer)
+    assert ak.backend(typetracer) == "typetracer"
 
 
-def test_typetracer_mixed():
+def test_to_typetracer():
     array = ak.Array([[0, 1, 2, 3], [8, 9, 10, 11]])
-    typetracer = ak.Array(array.layout.to_typetracer())
 
-    with pytest.raises(ValueError, match="internal backend"):
-        ak.backend(typetracer, array)
+    assert ak.backend(array) == "cpu"
+    assert ak.backend(ak.to_backend(array, "typetracer")) == "typetracer"


### PR DESCRIPTION
This PR exposes typetracer in `ak.backend` and `ak.to_backend`. It does not yet expose any callable typetracer APIs.