### PR TITLE
fix: support unzipping `ak.Record`

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -427,9 +427,11 @@ def behavior_of(*arrays, **kwargs):
     return behavior
 
 
-def wrap(content, behavior=None, highlevel=True, like=None):
-    assert content is None or isinstance(
-        content, (ak.contents.Content, ak.record.Record)
+def wrap(content, behavior=None, highlevel=True, like=None, allow_other=False):
+    assert (
+        content is None
+        or isinstance(content, (ak.contents.Content, ak.record.Record))
+        or allow_other
     )
     assert behavior is None or isinstance(behavior, Mapping)
     assert isinstance(highlevel, bool)

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -60,6 +60,9 @@ def _impl(array, highlevel, behavior):
     ak._do.recursively_apply(layout, check_for_union, behavior, return_array=False)
 
     if len(fields) == 0:
-        return (ak._util.wrap(layout, behavior, highlevel),)
+        return (ak._util.wrap(layout, behavior, highlevel, allow_other=True),)
     else:
-        return tuple(ak._util.wrap(layout[n], behavior, highlevel) for n in fields)
+        return tuple(
+            ak._util.wrap(layout[n], behavior, highlevel, allow_other=True)
+            for n in fields
+        )

--- a/tests/test_2076_ak_unzip_record.py
+++ b/tests/test_2076_ak_unzip_record.py
@@ -1,0 +1,11 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    record = ak.Record({"x": 1, "y": 2, "z": 3})
+    assert ak.fields(record) == ["x", "y", "z"]
+    assert ak.unzip(record) == (1, 2, 3)


### PR DESCRIPTION
Fixes #2076 by adding an `allow_other=False` argument to `ak._util.unzip`. Most of the time we want to only be wrapping layouts, but it might occasionally be the case that an operation can legitimately produce a scalar. 

`allow_other=True` is set only for `ak.unzip` with this PR.