### PR TITLE
fix: don't try to re-wrap `array_function` overload results

### DIFF
--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -50,15 +50,16 @@ def array_function(func, types, args, kwargs, behavior):
         rectilinear_args = tuple(_to_rectilinear(x) for x in args)
         rectilinear_kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
         result = func(*rectilinear_args, **rectilinear_kwargs)
+        # We want the result to be a layout (this will fail for functions returning non-array convertibles)
+        out = ak.operations.ak_to_layout._impl(
+            result, allow_record=True, allow_other=True
+        )
+        if isinstance(out, (ak.contents.Content, ak.record.Record)):
+            return ak._util.wrap(out, behavior=behavior)
+        else:
+            return out
     else:
-        result = function(*args, **kwargs)
-
-    # We want the result to be a layout
-    out = ak.operations.ak_to_layout._impl(result, allow_record=True, allow_other=True)
-    if isinstance(out, (ak.contents.Content, ak.record.Record)):
-        return ak._util.wrap(out, behavior=behavior)
-    else:
-        return out
+        return function(*args, **kwargs)
 
 
 def implements(numpy_function):

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -54,10 +54,7 @@ def array_function(func, types, args, kwargs, behavior):
         out = ak.operations.ak_to_layout._impl(
             result, allow_record=True, allow_other=True
         )
-        if isinstance(out, (ak.contents.Content, ak.record.Record)):
-            return ak._util.wrap(out, behavior=behavior)
-        else:
-            return out
+        return ak._util.wrap(out, behavior=behavior, allow_other=True)
     else:
         return function(*args, **kwargs)
 

--- a/tests/test_2078_array_function_wrap.py
+++ b/tests/test_2078_array_function_wrap.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    left = ak.Array([1, 2, 3])
+    right = ak.Array([[1, 2], [4, 5, 6], [None]])
+    result = np.broadcast_arrays(left, right)
+    assert isinstance(result, list)
+    assert isinstance(result[0], ak.Array)
+    assert isinstance(result[1], ak.Array)
+    assert result[0].to_list() == [[1, 1], [2, 2, 2], [None]]
+    assert result[1].to_list() == [[1, 2], [4, 5, 6], [None]]


### PR DESCRIPTION
Our integration with NumPy's array function mechanism means that users can in some cases invoke NumPy-only functions on Awkward Arrays (if they're rectilinear). However, our existing support for this mechanism is breaking Awkward overloads such as `ak.broadcast_arrays`, because it assumes that the result should be a layout.

In the long run, we could apply an inverse `_to_rectilinear` transform to recover high-level `ak.Array`/`ak.Record`s, but in this instance, I think the solution is even more clear cut.

If Awkward has an overload for an array function, then it should already be returning high-level objects. Therefore, we don't need to re-wrap the result. This PR applies such a fix, which means that any NumPy-only overloads that return non-arrays will still need a fix. However, this is a simple first step.

Fixes #2078 