### PR TITLE
fix: correct NumPy zero-size broadcasting

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -670,18 +670,34 @@ def apply_step(
                 isinstance(x, RegularArray) or not isinstance(x, listtypes)
                 for x in inputs
             ):
-                maxsize = max(x.size for x in inputs if isinstance(x, RegularArray))
+                # Ensure all layouts have same length
+                length = None
+                for x in inputs:
+                    if isinstance(x, Content):
+                        if length is None:
+                            length = x.length
+                        elif backend.nplike.known_shape:
+                            assert length == x.length
+                assert length is not None
 
                 if backend.nplike.known_data:
+                    if any(x.size == 0 for x in inputs if isinstance(x, RegularArray)):
+                        dimsize = 0
+                    else:
+                        dimsize = max(
+                            x.size for x in inputs if isinstance(x, RegularArray)
+                        )
+
                     for x in inputs:
                         if isinstance(x, RegularArray):
-                            if maxsize > 1 and x.size == 1:
+                            if dimsize > 1 and x.size == 1:
+                                # For any (N, 1) array, we know we'll broadcast to (N, M) where M is maxsize
                                 tmpindex = Index64(
                                     backend.index_nplike.repeat(
                                         backend.index_nplike.arange(
                                             x.length, dtype=np.int64
                                         ),
-                                        maxsize,
+                                        dimsize,
                                     ),
                                     nplike=backend.index_nplike,
                                 )
@@ -689,20 +705,22 @@ def apply_step(
                     nextinputs = []
                     for x in inputs:
                         if isinstance(x, RegularArray):
-                            if maxsize > 1 and x.size == 1:
+                            if dimsize > 1 and x.size == 1:
                                 nextinputs.append(
                                     x.content[: x.length * x.size]._carry(
                                         tmpindex, allow_lazy=False
                                     )
                                 )
-                            elif x.size == maxsize:
+                            elif x.size == dimsize:
                                 nextinputs.append(x.content[: x.length * x.size])
+                            elif dimsize == 0:
+                                nextinputs.append(x.content[:0])
                             else:
                                 raise ak._errors.wrap_error(
                                     ValueError(
                                         "cannot broadcast RegularArray of size "
                                         "{} with RegularArray of size {} {}".format(
-                                            x.size, maxsize, in_function(options)
+                                            x.size, dimsize, in_function(options)
                                         )
                                     )
                                 )
@@ -718,15 +736,6 @@ def apply_step(
                         else:
                             nextinputs.append(x)
 
-                length = None
-                for x in inputs:
-                    if isinstance(x, Content):
-                        if length is None:
-                            length = x.length
-                        elif backend.nplike.known_shape:
-                            assert length == x.length
-                assert length is not None
-
                 outcontent = apply_step(
                     backend,
                     nextinputs,
@@ -740,7 +749,7 @@ def apply_step(
                 assert isinstance(outcontent, tuple)
                 parameters = parameters_factory(len(outcontent))
                 return tuple(
-                    RegularArray(x, maxsize, length, parameters=p)
+                    RegularArray(x, dimsize, length, parameters=p)
                     for x, p in zip(outcontent, parameters)
                 )
 

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -680,14 +680,12 @@ def apply_step(
                             assert length == x.length
                 assert length is not None
 
-                if backend.nplike.known_data:
-                    if any(x.size == 0 for x in inputs if isinstance(x, RegularArray)):
-                        dimsize = 0
-                    else:
-                        dimsize = max(
-                            x.size for x in inputs if isinstance(x, RegularArray)
-                        )
+                if any(x.size == 0 for x in inputs if isinstance(x, RegularArray)):
+                    dimsize = 0
+                else:
+                    dimsize = max(x.size for x in inputs if isinstance(x, RegularArray))
 
+                if backend.nplike.known_data:
                     for x in inputs:
                         if isinstance(x, RegularArray):
                             if dimsize > 1 and x.size == 1:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -931,7 +931,10 @@ def arrays_approx_equal(
                 and (left.is_tuple == right.is_tuple)
                 and all([visitor(x, y) for x, y in zip(left.contents, right.contents)])
             )
-        elif left.is_empty:
+        elif left.is_unknown:
             return True
+
+        else:
+            raise ak._errors.wrap_error(AssertionError)
 
     return visitor(left, right)

--- a/tests/test_2082_broadcast_zero_size.py
+++ b/tests/test_2082_broadcast_zero_size.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_axis(axis):
+    this_slice = (slice(None),) * axis + (slice(0, 0),) + (...,)
+    that_slice = (slice(None),) * axis + (slice(0, 1),) + (...,)
+    x = np.arange(3 * 5 * 7).reshape(3, 5, 7)
+    result = np.broadcast_arrays(x[this_slice], x[that_slice])
+
+    y = ak.from_numpy(x)
+    result_ak = ak.broadcast_arrays(y[this_slice], y[that_slice])
+
+    assert ak._util.arrays_approx_equal(result, result_ak)


### PR DESCRIPTION
Fixes #2082, i.e. zero-size broadcasting:
```python
import numpy as np
import awkward as ak


x = np.arange(4 * 5 * 9).reshape(4, 5, 9)
result = np.broadcast_arrays(x[:, :0, ...], x[:, :1, ...])

y = ak.from_numpy(x)
result_ak = ak.broadcast_arrays(y[:, :0, ...], y[:, :1, ...])

assert ak._util.arrays_approx_equal(
    result, result_ak
)
```