### PR TITLE
fix: broken links due to cpp split

### DIFF
--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB_RECURSE LIBAWKWARD_SOURCES CONFIGURE_DEPENDS "src/libawkward/*.cpp")
 
 # Shared properties
 add_library(awkward-parent INTERFACE)
-target_compile_definitions(awkward-parent INTERFACE VERSION_INFO="${VERSION_INFO}")
+target_compile_definitions(awkward-parent INTERFACE VERSION_INFO="${SKBUILD_PROJECT_VERSION}")
 target_include_directories(awkward-parent INTERFACE include)
 target_compile_features(awkward-parent INTERFACE cxx_std_11)
 

--- a/awkward-cpp/include/awkward/common.h
+++ b/awkward-cpp/include/awkward/common.h
@@ -30,7 +30,7 @@
 
 #define QUOTE(x) #x
 
-#define FILENAME_FOR_EXCEPTIONS_C(filename, line) "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/awkward-cpp-" VERSION_INFO "/awkward-cpp/" filename "#L" #line ")"
+#define FILENAME_FOR_EXCEPTIONS_C(filename, line) "\n\n(https://github.com/scikit-hep/awkward/blob/awkward-cpp-" VERSION_INFO "/awkward-cpp/" filename "#L" #line ")"
 #define FILENAME_FOR_EXCEPTIONS(filename, line) std::string(FILENAME_FOR_EXCEPTIONS_C(filename, line))
 
 #ifdef __GNUC__

--- a/awkward-cpp/include/awkward/common.h
+++ b/awkward-cpp/include/awkward/common.h
@@ -30,9 +30,8 @@
 
 #define QUOTE(x) #x
 
-#define FILENAME_FOR_EXCEPTIONS(filename, line) std::string("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" VERSION_INFO "/" filename "#L" #line ")")
-#define FILENAME_FOR_EXCEPTIONS_C(filename, line) ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" VERSION_INFO "/" filename "#L" #line ")")
-#define FILENAME_FOR_EXCEPTIONS_CUDA(filename, line) ("\n\n(https://github.com/scikit-hep/awkward-1.0/blob/" QUOTE(VERSION_INFO) "/" filename "#L" #line ")")
+#define FILENAME_FOR_EXCEPTIONS_C(filename, line) "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/awkward-cpp-" VERSION_INFO "/awkward-cpp/" filename "#L" #line ")"
+#define FILENAME_FOR_EXCEPTIONS(...) std::string ( FILENAME_FOR_EXCEPTIONS_C(__VA_ARGS__) )
 
 #ifdef __GNUC__
 // Silence a gcc warning: type attributes ignored after type is already defined

--- a/awkward-cpp/include/awkward/common.h
+++ b/awkward-cpp/include/awkward/common.h
@@ -31,7 +31,7 @@
 #define QUOTE(x) #x
 
 #define FILENAME_FOR_EXCEPTIONS_C(filename, line) "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/awkward-cpp-" VERSION_INFO "/awkward-cpp/" filename "#L" #line ")"
-#define FILENAME_FOR_EXCEPTIONS(...) std::string ( FILENAME_FOR_EXCEPTIONS_C(__VA_ARGS__) )
+#define FILENAME_FOR_EXCEPTIONS(...) std::string(FILENAME_FOR_EXCEPTIONS_C(__VA_ARGS__))
 
 #ifdef __GNUC__
 // Silence a gcc warning: type attributes ignored after type is already defined

--- a/awkward-cpp/include/awkward/common.h
+++ b/awkward-cpp/include/awkward/common.h
@@ -31,7 +31,7 @@
 #define QUOTE(x) #x
 
 #define FILENAME_FOR_EXCEPTIONS_C(filename, line) "\n\n(https://github.com/scikit-hep/awkward-1.0/blob/awkward-cpp-" VERSION_INFO "/awkward-cpp/" filename "#L" #line ")"
-#define FILENAME_FOR_EXCEPTIONS(...) std::string(FILENAME_FOR_EXCEPTIONS_C(__VA_ARGS__))
+#define FILENAME_FOR_EXCEPTIONS(filename, line) std::string(FILENAME_FOR_EXCEPTIONS_C(filename, line))
 
 #ifdef __GNUC__
 // Silence a gcc warning: type attributes ignored after type is already defined


### PR DESCRIPTION
Fixes #2081 

We will also need to update our Git workflow such that C++ releases are assigned tags.