### PR TITLE
fix: implement explicit translation for NEP-18

### DIFF
--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -1,4 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import functools
+import inspect
 
 import numpy
 
@@ -53,24 +55,45 @@ def _to_rectilinear(arg):
         return arg
 
 
+def _array_function_no_impl(func, types, args, kwargs, behavior):
+    rectilinear_args = tuple(_to_rectilinear(x) for x in args)
+    rectilinear_kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
+    result = func(*rectilinear_args, **rectilinear_kwargs)
+    # We want the result to be a layout (this will fail for functions returning non-array convertibles)
+    out = ak.operations.ak_to_layout._impl(result, allow_record=True, allow_other=True)
+    return ak._util.wrap(out, behavior=behavior, allow_other=True)
+
+
 def array_function(func, types, args, kwargs, behavior):
     function = implemented.get(func)
+    # Use NumPy's implementation
     if function is None:
-        rectilinear_args = tuple(_to_rectilinear(x) for x in args)
-        rectilinear_kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
-        result = func(*rectilinear_args, **rectilinear_kwargs)
-        # We want the result to be a layout (this will fail for functions returning non-array convertibles)
-        out = ak.operations.ak_to_layout._impl(
-            result, allow_record=True, allow_other=True
-        )
-        return ak._util.wrap(out, behavior=behavior, allow_other=True)
+        return _array_function_no_impl(func, types, args, kwargs, behavior)
     else:
         return function(*args, **kwargs)
 
 
 def implements(numpy_function):
     def decorator(function):
-        implemented[getattr(numpy, numpy_function)] = function
+        signature = inspect.signature(function)
+        unsupported_names = {
+            p.name for p in signature.parameters.values() if p.default is unsupported
+        }
+
+        @functools.wraps(function)
+        def ensure_valid_args(*args, **kwargs):
+            parameters = signature.bind(*args, **kwargs)
+            provided_invalid_names = parameters.arguments.keys() & unsupported_names
+            if provided_invalid_names:
+                names = ", ".join(provided_invalid_names)
+                raise ak._errors.wrap_error(
+                    TypeError(
+                        f"Awkward NEP-18 overload was provided with unsupported argument(s): {names}"
+                    )
+                )
+            return function(*args, **kwargs)
+
+        implemented[getattr(numpy, numpy_function)] = ensure_valid_args
         return function
 
     return decorator

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -13,6 +13,15 @@ if not numpy_at_least("1.13.1"):
     raise ImportError("NumPy 1.13.1 or later required")
 
 
+# FIXME: introduce sentinel type for this
+class _Unsupported:
+    def __repr__(self):
+        return f"{__name__}.unsupported"
+
+
+unsupported = _Unsupported()
+
+
 def convert_to_array(layout, args, kwargs):
     out = ak.operations.to_numpy(layout, allow_missing=False)
     if args == () and kwargs == {}:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -875,7 +875,7 @@ class IndexedArray(Content):
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        posaxis = ak._util.maybe_posaxis(self, axis)
+        posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("all")
 def all(
     array,
     axis=None,
@@ -90,3 +90,8 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("all")
+def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False, *, where=unsupported):
+    return all(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("any")
 def any(
     array,
     axis=None,
@@ -90,3 +90,8 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("any")
+def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False, *, where=unsupported):
+    return any(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("argmax")
 def argmax(
     array,
     axis=None,
@@ -80,7 +80,6 @@ def argmax(
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@ak._connect.numpy.implements("nanargmax")
 def nanargmax(
     array,
     axis=None,
@@ -164,3 +163,13 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("argmax")
+def _nep_18_impl_argmax(a, axis=None, out=unsupported, *, keepdims=False):
+    return argmax(a, axis=axis, keepdims=keepdims)
+
+
+@ak._connect.numpy.implements("nanargmax")
+def _nep_18_impl_nanargmax(a, axis=None, out=unsupported, *, keepdims=False):
+    return nanargmax(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("argmin")
 def argmin(
     array,
     axis=None,
@@ -80,7 +80,6 @@ def argmin(
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@ak._connect.numpy.implements("nanargmin")
 def nanargmin(
     array,
     axis=None,
@@ -163,3 +162,13 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("argmin")
+def _nep_18_impl_argmin(a, axis=None, out=unsupported, *, keepdims=False):
+    return argmin(a, axis=axis, keepdims=keepdims)
+
+
+@ak._connect.numpy.implements("nanargmin")
+def _nep_18_impl_nanargmin(a, axis=None, out=unsupported, *, keepdims=False):
+    return nanargmin(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -76,6 +76,8 @@ def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
         stable = False
     else:
         raise ak._errors.wrap_error(
-            ValueError("unsupported argument passed to overloaded NumPy function")
+            ValueError(
+                f"unsupported value for 'kind' passed to overloaded NumPy function 'argsort': {kind!r}"
+            )
         )
     return argsort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("argsort")
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):
@@ -64,3 +64,18 @@ def _impl(array, axis, ascending, stable, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.argsort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)
+
+
+@ak._connect.numpy.implements("argsort")
+def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
+    if kind is None:
+        stable = False
+    elif kind == "stable":
+        stable = True
+    elif kind == "heapsort":
+        stable = False
+    else:
+        raise ak._errors.wrap_error(
+            ValueError("unsupported argument passed to overloaded NumPy function")
+        )
+    return argsort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("broadcast_arrays")
 def broadcast_arrays(
     *arrays,
     depth_limit=None,
@@ -230,3 +230,8 @@ def _impl(
     )
     assert isinstance(out, tuple)
     return [ak._util.wrap(x, behavior, highlevel) for x in out]
+
+
+@ak._connect.numpy.implements("broadcast_arrays")
+def _nep_18_impl(*args, subok=unsupported):
+    return broadcast_arrays(*args)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -3,11 +3,11 @@
 import copy as _copy
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("copy")
 def copy(array):
     """
     Args:
@@ -65,3 +65,8 @@ def copy(array):
 
 def _impl(array):
     return _copy.deepcopy(array)
+
+
+@ak._connect.numpy.implements("copy")
+def _nep_18_impl(a, order=unsupported, subok=unsupported):
+    return copy(a)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -6,7 +6,6 @@ from awkward._util import unset
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("count_nonzero")
 def count_nonzero(
     array,
     axis=None,
@@ -92,3 +91,8 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("count_nonzero")
+def _nep_18_impl(a, axis=None, *, keepdims=False):
+    return count_nonzero(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward.operations.ak_zeros_like import _ZEROS
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("full_like")
 def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
@@ -183,3 +183,10 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         return out
     else:
         return ak._util.wrap(out, behavior, highlevel)
+
+
+@ak._connect.numpy.implements("full_like")
+def _nep_18_impl(
+    a, fill_value, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+):
+    return full_like(a, fill_value=fill_value, dtype=dtype)

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -5,7 +5,6 @@ import awkward as ak
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("isclose")
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):
@@ -63,3 +62,8 @@ def _impl(a, b, rtol, atol, equal_nan, highlevel, behavior):
     assert isinstance(out, tuple) and len(out) == 1
 
     return ak._util.wrap(out[0], behavior, highlevel)
+
+
+@ak._connect.numpy.implements("isclose")
+def _nep_18_impl(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    return isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("max")
 def max(
     array,
     axis=None,
@@ -90,7 +90,6 @@ def max(
         )
 
 
-@ak._connect.numpy.implements("nanmax")
 def nanmax(
     array,
     axis=None,
@@ -184,3 +183,17 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("amax")
+def _nep_18_impl_amax(
+    a, axis=None, out=unsupported, keepdims=False, initial=None, where=unsupported
+):
+    return max(a, axis=axis, keepdims=keepdims, initial=initial)
+
+
+@ak._connect.numpy.implements("nanmax")
+def _nep_18_impl_nanmax(
+    a, axis=None, out=unsupported, keepdims=False, initial=None, where=unsupported
+):
+    return nanmax(a, axis=axis, keepdims=keepdims, initial=initial)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("mean")
 def mean(
     x,
     weight=None,
@@ -101,7 +101,6 @@ def mean(
         return _impl(x, weight, axis, keepdims, mask_identity)
 
 
-@ak._connect.numpy.implements("nanmean")
 def nanmean(
     x,
     weight=None,
@@ -217,3 +216,29 @@ def _impl(x, weight, axis, keepdims, mask_identity):
                 behavior=None,
             )
         return ak._nplikes.nplike_of(sumwx, sumw).true_divide(sumwx, sumw)
+
+
+@ak._connect.numpy.implements("mean")
+def _nep_18_impl_mean(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return mean(a, axis=axis, keepdims=keepdims)
+
+
+@ak._connect.numpy.implements("nanmean")
+def _nep_18_impl_nanmean(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return nanmean(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("min")
 def min(
     array,
     axis=None,
@@ -88,7 +88,6 @@ def min(
         )
 
 
-@ak._connect.numpy.implements("nanmin")
 def nanmin(
     array,
     axis=None,
@@ -182,3 +181,27 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("amin")
+def _nep_18_impl_amin(
+    a,
+    axis=None,
+    out=unsupported,
+    keepdims=False,
+    initial=None,
+    where=unsupported,
+):
+    return min(a, axis=axis, keepdims=keepdims, initial=initial)
+
+
+@ak._connect.numpy.implements("nanmin")
+def _nep_18_impl_nanmin(
+    a,
+    axis=None,
+    out=unsupported,
+    keepdims=False,
+    initial=None,
+    where=unsupported,
+):
+    return nanmin(a, axis=axis, keepdims=keepdims, initial=initial)

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -5,7 +5,6 @@ import awkward as ak
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("nan_to_num")
 def nan_to_num(
     array,
     copy=True,
@@ -129,3 +128,8 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
         out = out[0]
 
     return ak._util.wrap(out, behavior, highlevel)
+
+
+@ak._connect.numpy.implements("nan_to_num")
+def _nep_18_impl(x, copy=True, nan=0.0, posinf=None, neginf=None):
+    return nan_to_num(x, copy=copy, nan=nan, posinf=posinf, neginf=neginf)

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("ones_like")
 def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
@@ -32,3 +32,10 @@ def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior, dtype):
     return ak.operations.ak_full_like._impl(array, 1, highlevel, behavior, dtype)
+
+
+@ak._connect.numpy.implements("ones_like")
+def _nep_18_impl(
+    a, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+):
+    return ones_like(a, dtype=dtype)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("prod")
 def prod(
     array,
     axis=None,
@@ -73,7 +73,6 @@ def prod(
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@ak._connect.numpy.implements("nanprod")
 def nanprod(
     array,
     axis=None,
@@ -153,3 +152,29 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("prod")
+def _nep_18_impl_prod(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    initial=unsupported,
+    where=unsupported,
+):
+    return prod(a, axis=axis, keepdims=keepdims)
+
+
+@ak._connect.numpy.implements("nanprod")
+def _nep_18_impl_nanprod(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    initial=unsupported,
+    where=unsupported,
+):
+    return nanprod(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("ptp")
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records=unset):
     """
     Args:
@@ -139,3 +139,8 @@ def _impl(array, axis, keepdims, mask_identity):
                     out = out[(slice(None, None),) * posaxis + (0,)]
 
         return out
+
+
+@ak._connect.numpy.implements("ptp")
+def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False):
+    return ptp(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("ravel")
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -65,3 +65,8 @@ def _impl(array, highlevel, behavior):
     result = ak._do.mergemany(out)
 
     return ak._util.wrap(result, behavior, highlevel, like=array)
+
+
+@ak._connect.numpy.implements("ravel")
+def _nep_18_impl(a, order=unsupported):
+    return ravel(a)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("sort")
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:
@@ -51,3 +51,18 @@ def _impl(array, axis, ascending, stable, highlevel, behavior):
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.sort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)
+
+
+@ak._connect.numpy.implements("sort")
+def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
+    if kind is None:
+        stable = False
+    elif kind == "stable":
+        stable = True
+    elif kind == "heapsort":
+        stable = False
+    else:
+        raise ak._errors.wrap_error(
+            ValueError("unsupported argument passed to overloaded NumPy function")
+        )
+    return sort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -63,6 +63,8 @@ def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
         stable = False
     else:
         raise ak._errors.wrap_error(
-            ValueError("unsupported argument passed to overloaded NumPy function")
+            ValueError(
+                f"unsupported value for 'kind' passed to overloaded NumPy function 'sort': {kind!r}"
+            )
         )
     return sort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("std")
 def std(
     x,
     weight=None,
@@ -84,7 +84,6 @@ def std(
         return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@ak._connect.numpy.implements("nanstd")
 def nanstd(
     x,
     weight=None,
@@ -180,3 +179,31 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
                 mask_identity,
             )
         )
+
+
+@ak._connect.numpy.implements("std")
+def _nep_18_impl_std(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    ddof=0,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return std(a, axis=axis, keepdims=keepdims, ddof=ddof)
+
+
+@ak._connect.numpy.implements("nanstd")
+def _nep_18_impl_nanstd(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    ddof=0,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return nanstd(a, axis=axis, keepdims=keepdims, ddof=ddof)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("sum")
 def sum(
     array,
     axis=None,
@@ -217,7 +217,6 @@ def sum(
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@ak._connect.numpy.implements("nansum")
 def nansum(
     array,
     axis=None,
@@ -301,3 +300,29 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
         return ak._util.wrap(out, behavior, highlevel=highlevel)
     else:
         return out
+
+
+@ak._connect.numpy.implements("sum")
+def _nep_18_impl_sum(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    initial=unsupported,
+    where=unsupported,
+):
+    return sum(a, axis=axis, keepdims=keepdims)
+
+
+@ak._connect.numpy.implements("nansum")
+def _nep_18_impl_nansum(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    keepdims=False,
+    initial=unsupported,
+    where=unsupported,
+):
+    return nansum(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 from awkward._util import unset
 
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-@ak._connect.numpy.implements("var")
 def var(
     x,
     weight=None,
@@ -90,7 +90,6 @@ def var(
         return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@ak._connect.numpy.implements("nanvar")
 def nanvar(
     x,
     weight=None,
@@ -217,3 +216,31 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
             ) * ak._nplikes.nplike_of(sumw).true_divide(sumw, sumw - ddof)
         else:
             return ak._nplikes.nplike_of(sumwxx, sumw).true_divide(sumwxx, sumw)
+
+
+@ak._connect.numpy.implements("var")
+def _nep_18_impl_var(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    ddof=0,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return var(a, axis=axis, keepdims=keepdims, ddof=ddof)
+
+
+@ak._connect.numpy.implements("nanvar")
+def _nep_18_impl_nanvar(
+    a,
+    axis=None,
+    dtype=unsupported,
+    out=unsupported,
+    ddof=0,
+    keepdims=False,
+    *,
+    where=unsupported,
+):
+    return nanvar(a, axis=axis, keepdims=keepdims, ddof=ddof)

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._connect.numpy import unsupported
 
 np = ak._nplikes.NumpyMetadata.instance()
 
@@ -8,7 +9,6 @@ np = ak._nplikes.NumpyMetadata.instance()
 _ZEROS = object()
 
 
-@ak._connect.numpy.implements("zeros_like")
 def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     Args:
@@ -37,3 +37,10 @@ def _impl(array, highlevel, behavior, dtype):
     if dtype is not None:
         return ak.operations.ak_full_like._impl(array, 0, highlevel, behavior, dtype)
     return ak.operations.ak_full_like._impl(array, _ZEROS, highlevel, behavior, dtype)
+
+
+@ak._connect.numpy.implements("zeros_like")
+def _nep_18_impl(
+    a, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+):
+    return zeros_like(a, dtype=dtype)


### PR DESCRIPTION
This PR closes #2088 by defining explicit NEP-18 translations ("implementations"). These map the NumPy argument spec onto the Awkward function, and translate incompatible arguments (e.g. NumPy's `kind` vs Awkward's `stable` for `ak.sort`).

The TLDR of the motivation for this PR is that some NumPy functions like `np.std` have incompatible differences with our implementations e.g. `ak.std`. By explicitly defining a translation, we can decouple the two APIs.

This adds a slight runtime cost; now a call to `np.sort()` jumps through two additional functions. However, this is not an area of performance that we should care about (and CPython 3.11 speeds function calls up slightly, so it's a solved problem /s).

We could also use this mechanism to define the translations for non-Awkward overloaded NumPy functions, which just need better translations that our default heuristic-based approach takes.