### PR TITLE
fix: off-by-one error in `run_lengths`

### DIFF
--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -115,7 +115,7 @@ def _impl(array, highlevel, behavior):
                 # To consider only the interior boundaries, we ignore the start and end
                 # offset values. These can be repeated with empty sublists, so we mask them out.
                 is_interior = backend.nplike.logical_and(
-                    0 < offsets, offsets < len(data) - 1
+                    0 < offsets, offsets < len(data)
                 )
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True

--- a/tests/test_0733_run_lengths.py
+++ b/tests/test_0733_run_lengths.py
@@ -21,6 +21,17 @@ def test():
     ]
 
 
+def test_all_same():
+    array = ak.Array([[3, 3, 3, 3], [3], [], [3, 3, 3], [3, 3, 3, 3]])
+    assert ak.operations.run_lengths(array).to_list() == [
+        [4],
+        [1],
+        [],
+        [3],
+        [4],
+    ]
+
+
 def test_groupby():
     array = ak.Array(
         [

--- a/tests/test_0733_run_lengths.py
+++ b/tests/test_0733_run_lengths.py
@@ -22,13 +22,13 @@ def test():
 
 
 def test_all_same():
-    array = ak.Array([[3, 3, 3, 3], [3], [], [3, 3, 3], [3, 3, 3, 3]])
+    array = ak.Array([[3, 3, 3, 3], [3], [], [3, 3, 3], [3]])
     assert ak.operations.run_lengths(array).to_list() == [
         [4],
         [1],
         [],
         [3],
-        [4],
+        [1],
     ]
 
 


### PR DESCRIPTION
`ak.run_lengths([[3, 3, 3, 3], [3]])` does not correctly consider the inner list boundary. This PR fixes the causative off-by-one error.

The cause of this bug is that the logic that forcibly splits runs across list boundaries was ignoring one-length sublists at the end of the list. This off-by-one error meant that runs were incorrectly computed across a boundary in such cases.