### PR TITLE
fix: unflatten should accept non-packed `counts`

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -900,8 +900,10 @@ def arrays_approx_equal(
             return False
 
         if left.is_list:
-            return numpy.array_equal(left.offsets, right.offsets) and visitor(
-                left.content, right.content
+            return (
+                numpy.array_equal(left.starts, right.starts)
+                and numpy.array_equal(left.stops, right.stops)
+                and visitor(left.content, right.content)
             )
         elif left.is_regular:
             return (left.size == right.size) and visitor(left.content, right.content)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -205,7 +205,7 @@ def _impl(array, counts, axis, highlevel, behavior):
 
                 return ak.contents.ListOffsetArray(ak.index.Index64(positions), content)
 
-        out = ak._do.recursively_apply(apply, layout)
+        out = ak._do.recursively_apply(layout, apply)
 
     if current_offsets is not None and not (
         len(current_offsets) == 1 and current_offsets[0] == 0

--- a/tests/test_2071_unflatten_non_packed_counts.py
+++ b/tests/test_2071_unflatten_non_packed_counts.py
@@ -1,0 +1,35 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_indexed_counts():
+    counts = ak.contents.IndexedArray(
+        ak.index.Index64(np.arange(3)),
+        ak.contents.NumpyArray(np.array([3, 0, 2], dtype=np.int64)),
+    )
+    assert ak._util.arrays_approx_equal(
+        ak.unflatten([1.1, 2.2, 3.3, 4.4, 5.5], counts),
+        [[1.1, 2.2, 3.3], [], [4.4, 5.5]],
+    )
+
+
+def test_indexed_layout():
+    layout = ak.contents.IndexedArray(
+        ak.index.Index64(np.arange(5)),
+        ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64)),
+    )
+    assert ak._util.arrays_approx_equal(
+        ak.unflatten(layout, [3, 0, 2]),
+        [[1.1, 2.2, 3.3], [], [4.4, 5.5]],
+    )
+
+
+def test_option_counts():
+    assert ak._util.arrays_approx_equal(
+        ak.unflatten([1.1, 2.2, 3.3, 4.4, 5.5], [None, 3, None, 0, 2]),
+        [None, [1.1, 2.2, 3.3], None, [], [4.4, 5.5]],
+    )


### PR DESCRIPTION
- Fixes #2059 
- Replaces use of `np.ma` with our own option handling
- Fixes loss of recursion