### PR TITLE
fix: remove string casting from `ak.to_layout`

### DIFF
--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -44,7 +44,7 @@ def _to_rectilinear(arg):
         return tuple(_to_rectilinear(x) for x in arg)
     elif isinstance(arg, list):
         return [_to_rectilinear(x) for x in arg]
-    elif ak._util.is_non_string_iterable(arg):
+    elif ak._util.is_non_string_like_iterable(arg):
         raise ak._errors.wrap_error(
             TypeError(
                 f"encountered an unsupported iterable value {arg!r} whilst converting arguments to NumPy-friendly "

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -7,7 +7,7 @@ import numbers
 import os
 import re
 import sys
-from collections.abc import Iterable, Mapping, Sized
+from collections.abc import Iterable, Mapping, Sequence, Sized
 
 import packaging.version
 from awkward_cpp.lib import _ext
@@ -59,8 +59,12 @@ def is_integer(x) -> bool:
     return isinstance(x, numbers.Integral) and not isinstance(x, bool)
 
 
-def is_non_string_iterable(obj) -> bool:
-    return not isinstance(obj, str) and isinstance(obj, Iterable)
+def is_non_string_like_iterable(obj) -> bool:
+    return not isinstance(obj, (str, bytes)) and isinstance(obj, Iterable)
+
+
+def is_non_string_like_sequence(obj) -> bool:
+    return not isinstance(obj, (str, bytes)) and isinstance(obj, Sequence)
 
 
 def tobytes(array):

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -246,6 +246,10 @@ def _string_numba_lower(
     return out
 
 
+def _cast_bytes_or_str_to_string(string):
+    return ak.to_layout([string])
+
+
 def register(behavior):
     behavior["byte"] = ByteBehavior
     behavior["__typestr__", "byte"] = "byte"
@@ -269,3 +273,6 @@ def register(behavior):
     behavior["__numba_lower__", "bytestring"] = _string_numba_lower
     behavior["__numba_typer__", "string"] = _string_numba_typer
     behavior["__numba_lower__", "string"] = _string_numba_lower
+
+    behavior["__cast__", str] = _cast_bytes_or_str_to_string
+    behavior["__cast__", bytes] = _cast_bytes_or_str_to_string

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1532,7 +1532,7 @@ class Record(NDArrayOperatorsMixin):
             contents = []
             for k, v in data.items():
                 fields.append(k)
-                if ak._util.is_non_string_iterable(v):
+                if ak._util.is_non_string_like_iterable(v):
                     contents.append(Array(v).layout[np.newaxis])
                 else:
                     contents.append(Array([v]).layout)

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -1,7 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-from collections.abc import Iterable
-
 from awkward_cpp.lib import _ext
 
 import awkward as ak
@@ -106,14 +104,7 @@ def _impl(array, allow_record, allow_other):
 
         return ak.contents.NumpyArray(array, parameters=None, backend=backend)
 
-    elif isinstance(array, (str, bytes)):
-        return _impl(
-            ak.operations.from_iter([array], highlevel=False),
-            allow_record,
-            allow_other,
-        )
-
-    elif isinstance(array, Iterable):
+    elif ak._util.is_non_string_iterable(array):
         return _impl(
             ak.operations.from_iter(array, highlevel=False),
             allow_record,
@@ -122,7 +113,9 @@ def _impl(array, allow_record, allow_other):
 
     elif not allow_other:
         raise _errors.wrap_error(
-            TypeError(f"{array} cannot be converted into an Awkward Array")
+            TypeError(
+                f"{array} cannot be converted into an Awkward Array, and non-array-like objects are not supported."
+            )
         )
 
     else:

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -104,7 +104,7 @@ def _impl(array, allow_record, allow_other):
 
         return ak.contents.NumpyArray(array, parameters=None, backend=backend)
 
-    elif ak._util.is_non_string_iterable(array):
+    elif ak._util.is_non_string_like_iterable(array):
         return _impl(
             ak.operations.from_iter(array, highlevel=False),
             allow_record,

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import copy
-from collections.abc import Sequence
 
 import awkward as ak
 
@@ -45,8 +44,7 @@ def _impl(base, what, where, highlevel, behavior):
         where is None
         or isinstance(where, str)
         or (
-            ak._util.is_non_string_iterable(where)
-            and isinstance(where, Sequence)
+            ak._util.is_non_string_like_sequence(where)
             and all(isinstance(x, str) for x in where)
         )
     ):
@@ -57,7 +55,7 @@ def _impl(base, what, where, highlevel, behavior):
             )
         )
 
-    if ak._util.is_non_string_iterable(where) and len(where) > 1:
+    if ak._util.is_non_string_like_sequence(where) and len(where) > 1:
         return _impl(
             base,
             _impl(
@@ -73,7 +71,7 @@ def _impl(base, what, where, highlevel, behavior):
         )
     else:
         # If we have an iterable here, pull out the only ti
-        if ak._util.is_non_string_iterable(where):
+        if ak._util.is_non_string_like_sequence(where):
             where = where[0]
 
         behavior = ak._util.behavior_of(base, what, behavior=behavior)

--- a/tests/test_2070_to_layout_string.py
+++ b/tests/test_2070_to_layout_string.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+@pytest.mark.parametrize("string", ["hello world!", b"hello world!"])
+def test(string):
+    with pytest.raises(TypeError):
+        ak.to_layout(string, allow_other=False)
+
+    assert ak.to_layout(string, allow_other=True) == string
+
+
+@pytest.mark.parametrize("string", ["hello world!", b"hello world!"])
+def test_ufunc(string):
+    array = ak.Array([string, string])
+    assert ak.all(array == string)


### PR DESCRIPTION
As per #2070, this PR changes `ak.to_layout("string")` to return the string (if `allow_other=True`). 

To support the primary use case of the old behaviour, a new `__cast__` behavior has been added for [byte]strings so that ufunc operations can accept Python strings.

### Changes
- Add new `is_non_string_like_sequence`, rename `is_non_string_like_iterable` helper
- Treat bytes/str as leaf types in `to_layout`
- Add `__cast__` support to string-likes
- Replaces usages of `is_non_string_like_iterable` with `is_non_string_like_sequence` where appropriate