### PR TITLE
fix: support categorical counts in `ak.unflatten`

### DIFF
--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -93,9 +93,10 @@ def _impl(array, counts, axis, highlevel, behavior):
     if isinstance(counts, (numbers.Integral, np.integer)):
         current_offsets = None
     else:
-        counts = ak.operations.to_layout(
-            counts, allow_record=False, allow_other=False
-        ).to_packed()
+        counts = ak.operations.to_layout(counts, allow_record=False, allow_other=False)
+        if counts.is_indexed and not counts.is_option:
+            counts = counts.project()
+
         if counts.is_option and (counts.content.is_numpy or counts.content.is_unknown):
             mask = counts.mask_as_bool(valid_when=False)
             counts = backend.nplike.to_rectilinear(

--- a/tests/test_2071_unflatten_non_packed_counts.py
+++ b/tests/test_2071_unflatten_non_packed_counts.py
@@ -33,3 +33,10 @@ def test_option_counts():
         ak.unflatten([1.1, 2.2, 3.3, 4.4, 5.5], [None, 3, None, 0, 2]),
         [None, [1.1, 2.2, 3.3], None, [], [4.4, 5.5]],
     )
+
+
+def test_categorical_counts():
+    assert ak._util.arrays_approx_equal(
+        ak.unflatten([1.1, 2.2, 3.3, 4.4, 5.5], ak.to_categorical([3, 0, 2])),
+        [[1.1, 2.2, 3.3], [], [4.4, 5.5]],
+    )


### PR DESCRIPTION
Fully closes #2071 by generalising support for indexed types to any `indexed` layout type (not just non-categoricals).