### PR TITLE
fix: merging 1D `NumpyArray` with option

### DIFF
--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -342,9 +342,20 @@ class NumpyArray(Content):
             )
 
     def _mergeable_next(self, other, mergebool):
-
         if len(self.shape) > 1:
             return self._to_regular_primitive()._mergeable(other, mergebool)
+
+        if isinstance(
+            other,
+            (
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
+            ),
+        ):
+            return self._mergeable(other._content, mergebool)
 
         elif isinstance(other, ak.contents.NumpyArray):
             if self._data.ndim != other._data.ndim:

--- a/tests/test_2104_numpy_merge_option.py
+++ b/tests/test_2104_numpy_merge_option.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    assert ak._util.arrays_approx_equal(
+        ak.concatenate([ak.Array([1, 2, 3]), ak.Array([1, 2, None])]),
+        ak.contents.ByteMaskedArray(
+            ak.index.Index8(np.array([False, False, False, False, False, True])),
+            ak.contents.NumpyArray(np.array([1, 2, 3, 1, 2, 3], dtype=np.int64)),
+            valid_when=False,
+        ),
+    )


### PR DESCRIPTION
This used to work; I broke this in #2063 by removing this code block. I'm not sure how I managed to do so, I must have been tired and confused the ND `NumpyArray` duplicated code with the 1D case (that we still need).

Fixes #2104 