### PR TITLE
fix: support `is_indexed` types in `ak.fill_none`

### DIFF
--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -117,10 +117,10 @@ def _impl(array, value, axis, highlevel, behavior):
         def action(layout, depth, **kwargs):
             posaxis = ak._util.maybe_posaxis(layout, axis, depth)
             if posaxis is not None and posaxis + 1 == depth:
-                if layout.is_union or layout.is_record:
-                    return None
-                elif layout.is_option:
+                if layout.is_option:
                     return ak._do.fill_none(layout, valuelayout)
+                elif layout.is_union or layout.is_record or layout.is_indexed:
+                    return None
                 else:
                     return layout
 

--- a/tests/test_2108_fill_none_indexed.py
+++ b/tests/test_2108_fill_none_indexed.py
@@ -1,0 +1,26 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    layout = ak.contents.IndexedArray(
+        ak.index.Index64(np.arange(10)),
+        ak.contents.RecordArray(
+            [
+                ak.contents.IndexedOptionArray(
+                    ak.index.Index64(
+                        np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, -1], dtype=np.int64)
+                    ),
+                    ak.contents.NumpyArray(np.arange(10)),
+                )
+            ],
+            ["x"],
+        ),
+    )
+    assert ak._util.arrays_approx_equal(
+        ak.fill_none(layout, 9, axis=0), ak.zip({"x": np.arange(10)})
+    )


### PR DESCRIPTION
Fixes #2107