### PR TITLE
fix: use `object.__new__(ak.Array)` for pickling constructor

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1445,7 +1445,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         return object.__new__, (Array,), (form.to_dict(), length, container, behavior)
 
     def __setstate__(self, state):
-        form, length, container, behavior = state
+        form, length, container, behavior, *_ = state
         layout = ak.operations.from_buffers(
             form,
             length,
@@ -2087,7 +2087,7 @@ class Record(NDArrayOperatorsMixin):
         )
 
     def __setstate__(self, state):
-        form, length, container, behavior, at = state
+        form, length, container, behavior, at, *_ = state
         layout = ak.operations.from_buffers(
             form,
             length,

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1430,7 +1430,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         return numba.typeof(self._numbaview)
 
-    def __getstate__(self):
+    def __reduce__(self):
         packed = ak.operations.to_packed(self._layout, highlevel=False)
         form, length, container = ak.operations.to_buffers(
             packed,
@@ -1442,7 +1442,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             behavior = None
         else:
             behavior = self._behavior
-        return form.to_dict(), length, container, behavior
+        return object.__new__, (Array,), (form.to_dict(), length, container, behavior)
 
     def __setstate__(self, state):
         form, length, container, behavior = state
@@ -2068,7 +2068,7 @@ class Record(NDArrayOperatorsMixin):
 
         return numba.typeof(self._numbaview)
 
-    def __getstate__(self):
+    def __reduce__(self):
         packed = ak.operations.to_packed(self._layout, highlevel=False)
         form, length, container = ak.operations.to_buffers(
             packed.array,
@@ -2080,7 +2080,11 @@ class Record(NDArrayOperatorsMixin):
             behavior = None
         else:
             behavior = self._behavior
-        return form.to_dict(), length, container, behavior, packed.at
+        return (
+            object.__new__,
+            (Record,),
+            (form.to_dict(), length, container, behavior, packed.at),
+        )
 
     def __setstate__(self, state):
         form, length, container, behavior, at = state

--- a/tests/test_2106_pickle_class.py
+++ b/tests/test_2106_pickle_class.py
@@ -1,0 +1,47 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pickle
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def impl():
+    behavior = {}
+
+    @ak.mixin_class(behavior, "my_array")
+    class MyArray:
+        @property
+        def meaning_of_life(self):
+            return 42
+
+    array = ak.Array(
+        [None, [{"x": [None, 1, "hi"]}]], with_name="my_array", behavior=behavior
+    )
+    return pickle.dumps(array)
+
+
+def global_impl():
+    @ak.mixin_class(ak.behavior, "my_array")
+    class MyArray:
+        @property
+        def meaning_of_life(self):
+            return 42
+
+    array = ak.Array([None, [{"x": [None, 1, "hi"]}]], with_name="my_array")
+    return pickle.dumps(array)
+
+
+def test():
+    other = pickle.loads(impl())
+    assert other.meaning_of_life == 42
+
+
+def test_global(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(ak, "behavior", {})
+        data = global_impl()
+
+    other = pickle.loads(data)
+    assert other.meaning_of_life == 42

--- a/tests/test_2106_pickle_class.py
+++ b/tests/test_2106_pickle_class.py
@@ -64,6 +64,9 @@ class MyArray:
 
 def test():
     data = impl()
+
+    # Using a custom behavior dictionary will always break unpickling if
+    # the objects in the dictionary can't be resolved
     with pytest.raises(ModuleNotFoundError):
         pickle.loads(data)
 
@@ -73,6 +76,9 @@ def test_global(monkeypatch):
         m.setattr(ak, "behavior", {})
         data = global_impl()
 
+    # The global ak.behavior is not written to the pickle
+    # Awkward can create arrays with missing behavior classes
     other = pickle.loads(data)
+    # But it won't have their methods / properties when asked for
     with pytest.raises(AttributeError):
         assert other.meaning_of_life == 42


### PR DESCRIPTION
When pickling an Awkward Array, the use of pickle's `__getstate__` interface means that pickle stores a reference to `type(array)` in the ensuing bytestream. For arrays with a behavior class, this might not be available at unpickle time. e.g. if the author adds their class in `ak.behavior`, it will not be found in a new session during unpickling, unless the same registration is performed. Whilst this is a somewhat sensible constraint, we should not needlessly force this upon the user. 

Conventionally, arrays can have `__name__`s that aren't found in their respective behaviours; these aren't currently errors, so we shouldn't fail to unpickle them. We can fix this situation this by removing the reference to the `type(array)` in favour of `object.__new__(ak.Array)`, so that only the `behavior` member references the class.

Note that arrays with local behaviors (`ak.Array(..., behavior=...)`) will always fail to unpickle in the event that the references inside the behaviour can't be resolved!

Fixes #2106