### PR TITLE
docs: remove reference to sorting implementation

### DIFF
--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -19,10 +19,8 @@ def argsort(
         ascending (bool): If True, the first value in each sorted group
             will be smallest, the last value largest; if False, the order
             is from largest to smallest.
-        stable (bool): If True, use a stable sorting algorithm (introsort:
-            a hybrid of quicksort, heapsort, and insertion sort); if False,
-            use a sorting algorithm that is not guaranteed to be stable
-            (heapsort).
+        stable (bool): If True, use a stable sorting algorithm; if False,
+            use a sorting algorithm that is not guaranteed to be stable.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -17,10 +17,8 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
         ascending (bool): If True, the first value in each sorted group
             will be smallest, the last value largest; if False, the order
             is from largest to smallest.
-        stable (bool): If True, use a stable sorting algorithm (introsort:
-            a hybrid of quicksort, heapsort, and insertion sort); if False,
-            use a sorting algorithm that is not guaranteed to be stable
-            (heapsort).
+        stable (bool): If True, use a stable sorting algorithm; if False,
+            use a sorting algorithm that is not guaranteed to be stable.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if


### PR DESCRIPTION
We don't want users to worry about the specific sorting algorithm being used, so here we hide the implementation details. I'm also fairly sure these are old docs - we use `std::stable_sort` and `std::sort` on CPU as of writing, which is `mergesort` and `introsort` respectively