### PR TITLE
fix: add `ScalarType` and treat bare strings as char arrays

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1707,7 +1707,9 @@ class Record(NDArrayOperatorsMixin):
         Note that the outermost element of a Record's type is always a
         #ak.types.RecordType.
         """
-        return self._layout.array.form.type_from_behavior(self._behavior)
+        return ak.types.ScalarType(
+            self._layout.array.form.type_from_behavior(self._behavior)
+        )
 
     @property
     def typestr(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -449,12 +449,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def typestr(self):
         """
         The high-level type of this Array, presented as a string.
-
-        Note that the outermost element of an Array's type is always an
-        #ak.types.ArrayType, which specifies the number of elements in the array.
-
-        The type of a #ak.contents.Content (from #ak.Array.layout) is not
-        wrapped by an #ak.types.ArrayType.
         """
         return str(self.type)
 
@@ -1704,8 +1698,11 @@ class Record(NDArrayOperatorsMixin):
         """
         The high-level type of this Record; same as #ak.type.
 
-        Note that the outermost element of a Record's type is always a
-        #ak.types.RecordType.
+        Note that the outermost element of a Record's type is always an
+        #ak.types.ScalarType, which .
+
+        The type of a #ak.record.Record (from #ak.Array.layout) is not
+        wrapped by an #ak.types.ScalarType.
         """
         return ak.types.ScalarType(
             self._layout.array.form.type_from_behavior(self._behavior)
@@ -1715,9 +1712,6 @@ class Record(NDArrayOperatorsMixin):
     def typestr(self):
         """
         The high-level type of this Record, presented as a string.
-
-        Note that the outermost element of a Record's type is always a
-        #ak.types.RecordType.
         """
         return str(self.type)
 
@@ -2339,12 +2333,6 @@ class ArrayBuilder(Sized):
     def typestr(self):
         """
         The high-level type of this accumulated array, presented as a string.
-
-        Note that the outermost element of an Array's type is always an
-        #ak.types.ArrayType, which specifies the number of elements in the array.
-
-        The type of a #ak.contents.Content (from #ak.Array.layout) is not
-        wrapped by an #ak.types.ArrayType.
         """
         return str(self.type)
 

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+from collections.abc import Iterable
+
 from awkward_cpp.lib import _ext
 
 import awkward as ak
@@ -67,27 +69,15 @@ def _impl(array, allow_record, allow_other):
         return array.snapshot()
 
     elif numpy.is_own_array(array):
-        return _impl(
-            ak.operations.from_numpy(
-                array, regulararray=True, recordarray=True, highlevel=False
-            ),
-            allow_record,
-            allow_other,
+        return ak.operations.from_numpy(
+            array, regulararray=True, recordarray=True, highlevel=False
         )
 
     elif ak._nplikes.Cupy.is_own_array(array):
-        return _impl(
-            ak.operations.from_cupy(array, regulararray=True, highlevel=False),
-            allow_record,
-            allow_other,
-        )
+        return ak.operations.from_cupy(array, regulararray=True, highlevel=False)
 
     elif ak._nplikes.Jax.is_own_array(array):
-        return _impl(
-            ak.operations.from_jax(array, regulararray=True, highlevel=False),
-            allow_record,
-            allow_other,
-        )
+        return ak.operations.from_jax(array, regulararray=True, highlevel=False)
 
     elif ak._typetracer.TypeTracer.is_own_array(array):
         backend = ak._backends.TypeTracerBackend.instance()
@@ -104,7 +94,10 @@ def _impl(array, allow_record, allow_other):
 
         return ak.contents.NumpyArray(array, parameters=None, backend=backend)
 
-    elif ak._util.is_non_string_like_iterable(array):
+    elif isinstance(array, (str, bytes)):
+        return ak.operations.from_iter([array], highlevel=False)[0]
+
+    elif isinstance(array, Iterable):
         return _impl(
             ak.operations.from_iter(array, highlevel=False),
             allow_record,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -109,7 +109,7 @@ def _impl(array, behavior):
         and issubclass(array, np.generic)
     ):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
-        return ak.types.NumpyType(primitive)
+        return ak.types.ScalarType(ak.types.NumpyType(primitive))
 
     elif isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -11,7 +11,7 @@ import awkward as ak
 np = ak._nplikes.NumpyMetadata.instance()
 
 
-def type(array):
+def type(array, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -72,17 +72,50 @@ def type(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.type",
-        dict(array=array),
+        dict(array=array, highlevel=highlevel, behavior=behavior),
     ):
-        return _impl(array)
+        return _impl(array, highlevel, behavior)
 
 
-def _impl(array):
-    if array is None:
-        return ak.types.UnknownType()
+def _impl(array, highlevel, behavior):
+    if highlevel:
 
-    elif isinstance(array, np.dtype):
-        return ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(array))
+        def scalar_type(obj):
+            return ak.types.ScalarType(obj)
+
+        def array_type(obj, length):
+            return ak.types.ArrayType(obj, length)
+
+    else:
+
+        def scalar_type(obj):
+            return obj
+
+        def array_type(obj, length):
+            return obj
+
+    if isinstance(array, np.dtype):
+        return scalar_type(
+            ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(array))
+        )
+
+    elif isinstance(array, bool):  # np.bool_ in np.generic (above)
+        return scalar_type(ak.types.NumpyType("bool"))
+
+    elif isinstance(array, numbers.Integral):
+        return scalar_type(ak.types.NumpyType("int64"))
+
+    elif isinstance(array, numbers.Real):
+        return scalar_type(ak.types.NumpyType("float64"))
+
+    elif isinstance(array, numbers.Complex):
+        return scalar_type(ak.types.NumpyType("complex128"))
+
+    elif isinstance(array, datetime):  # np.datetime64 in np.generic (above)
+        return scalar_type(ak.types.NumpyType("datetime64"))
+
+    elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
+        return scalar_type(ak.types.NumpyType("timedelta"))
 
     elif (
         isinstance(array, np.generic)
@@ -92,54 +125,28 @@ def _impl(array):
         primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
         return ak.types.NumpyType(primitive)
 
-    elif isinstance(array, bool):  # np.bool_ in np.generic (above)
-        return ak.types.NumpyType("bool")
-
-    elif isinstance(array, numbers.Integral):
-        return ak.types.NumpyType("int64")
-
-    elif isinstance(array, numbers.Real):
-        return ak.types.NumpyType("float64")
-
-    elif isinstance(array, numbers.Complex):
-        return ak.types.NumpyType("complex128")
-
-    elif isinstance(array, datetime):  # np.datetime64 in np.generic (above)
-        return ak.types.NumpyType("datetime64")
-
-    elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
-        return ak.types.NumpyType("timedelta")
-
-    elif isinstance(
-        array,
-        (
-            ak.highlevel.Array,
-            ak.highlevel.Record,
-            ak.highlevel.ArrayBuilder,
-        ),
-    ):
-        return array.type
-
-    elif isinstance(array, np.ndarray):
-        if len(array.shape) == 0:
-            return _impl(array.reshape((1,))[0])
-        else:
-            primitive = ak.types.numpytype.dtype_to_primitive(array.dtype)
-            out = ak.types.NumpyType(primitive)
-            for x in array.shape[-1:0:-1]:
-                out = ak.types.RegularType(out, x)
-            return ak.types.ArrayType(out, array.shape[0])
-
     elif isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(form.type_from_behavior(None), len(array))
+        return array_type(form.type_from_behavior(behavior), len(array))
 
-    elif isinstance(array, ak.record.Record):
-        return array.array.form.type
-
-    elif isinstance(array, ak.contents.Content):
-        return array.form.type
+    elif isinstance(array, ak.ArrayBuilder):
+        behavior = ak._util.behavior_of(array, behavior=behavior)
+        form = ak.forms.from_json(array._layout.form())
+        return array_type(form.type_from_behavior(behavior), len(array._layout))
 
     else:
-        layout = ak.to_layout(array, allow_other=False)
-        return _impl(ak._util.wrap(layout))
+        behavior = ak._util.behavior_of(array, behavior=behavior)
+        layout = ak.to_layout(array, allow_other=True, allow_record=True)
+        if layout is None:
+            return scalar_type(ak.types.UnknownType())
+
+        elif isinstance(layout, ak.record.Record):
+            return scalar_type(layout.array.form.type_from_behavior(behavior))
+
+        elif isinstance(layout, ak.contents.Content):
+            return array_type(layout.form.type_from_behavior(behavior), layout.length)
+
+        else:
+            raise ak._errors.wrap_error(
+                TypeError(f"unrecognized array type: {array!r}")
+            )

--- a/src/awkward/types/__init__.py
+++ b/src/awkward/types/__init__.py
@@ -6,6 +6,7 @@ from awkward.types.numpytype import NumpyType  # noqa: F401
 from awkward.types.optiontype import OptionType  # noqa: F401
 from awkward.types.recordtype import RecordType  # noqa: F401
 from awkward.types.regulartype import RegularType  # noqa: F401
+from awkward.types.scalartype import ScalarType  # noqa: F401
 from awkward.types.type import Type, from_datashape  # noqa: F401
 from awkward.types.uniontype import UnionType  # noqa: F401
 from awkward.types.unknowntype import UnknownType  # noqa: F401

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -1,0 +1,40 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import sys
+
+import awkward as ak
+
+
+class ScalarType:
+    def __init__(self, content):
+        if not isinstance(content, ak.types.Type):
+            raise ak._errors.wrap_error(
+                TypeError(
+                    "{} all 'contents' must be Type subclasses, not {}".format(
+                        type(self).__name__, repr(content)
+                    )
+                )
+            )
+        self._content = content
+
+    @property
+    def content(self):
+        return self._content
+
+    def __str__(self):
+        return "".join(self._str("", True))
+
+    def show(self, stream=sys.stdout):
+        stream.write("".join(self._str("", False) + ["\n"]))
+
+    def _str(self, indent, compact):
+        return self._content._str(indent, compact)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self._content!r})"
+
+    def __eq__(self, other):
+        if isinstance(other, ScalarType):
+            return self._content == other._content
+        else:
+            return False

--- a/tests/test_0021_emptyarray.py
+++ b/tests/test_0021_emptyarray.py
@@ -13,9 +13,11 @@ def test_unknown():
     e = ak.contents.EmptyArray()
     a = ak.contents.ListOffsetArray(i, e)
     assert to_list(a) == [[], [], []]
-    assert str(ak.operations.type(a)) == "var * unknown"
-    assert ak.operations.type(a) == ak.types.ListType(ak.types.UnknownType())
-    assert not ak.operations.type(a) == ak.types.NumpyType("float64")
+    assert str(ak.operations.type(a)) == "3 * var * unknown"
+    assert ak.operations.type(a) == ak.types.ArrayType(
+        ak.types.ListType(ak.types.UnknownType()), 3
+    )
+    assert ak.operations.type(a) != ak.types.ArrayType(ak.types.NumpyType("float64"), 3)
 
     i = ak.index.Index64(np.array([0, 0, 0, 0, 0, 0], dtype=np.int64))
     ii = ak.index.Index64(np.array([0, 0, 2, 5], dtype=np.int64))
@@ -23,9 +25,9 @@ def test_unknown():
     a = ak.contents.ListOffsetArray(ii, a)
 
     assert to_list(a) == [[], [[], []], [[], [], []]]
-    assert str(ak.operations.type(a)) == "var * var * unknown"
-    assert ak.operations.type(a) == ak.types.ListType(
-        ak.types.ListType(ak.types.UnknownType())
+    assert str(ak.operations.type(a)) == "3 * var * var * unknown"
+    assert ak.operations.type(a) == ak.types.ArrayType(
+        ak.types.ListType(ak.types.ListType(ak.types.UnknownType())), 3
     )
 
 

--- a/tests/test_0023_regular_array.py
+++ b/tests/test_0023_regular_array.py
@@ -21,11 +21,11 @@ listarray = ak.contents.ListArray(starts, stops, regulararray)
 
 
 def test_simple_type():
-    assert str(ak.operations.type(content)) == "float64"
+    assert str(ak.operations.type(content)) == "10 * float64"
 
 
 def test_type():
-    assert str(ak.operations.type(regulararray)) == "2 * var * float64"
+    assert str(ak.operations.type(regulararray)) == "3 * 2 * var * float64"
 
 
 def test_iteration():

--- a/tests/test_0025_record_array.py
+++ b/tests/test_0025_record_array.py
@@ -229,22 +229,25 @@ def test_type():
     fields = None
     listoffsetarray = ak.contents.ListOffsetArray(offsets, content2)
     recordarray = ak.contents.RecordArray([content1, listoffsetarray], fields)
-    assert str(ak.operations.type(recordarray)) == "(int64, var * float64)"
+    assert str(ak.operations.type(recordarray)) == "5 * (int64, var * float64)"
 
-    assert ak.operations.type(recordarray) == ak.types.RecordType(
-        (
-            ak.types.NumpyType("int64"),
-            ak.types.ListType(ak.types.NumpyType("float64")),
+    assert ak.operations.type(recordarray) == ak.types.ArrayType(
+        ak.types.RecordType(
+            (
+                ak.types.NumpyType("int64"),
+                ak.types.ListType(ak.types.NumpyType("float64")),
+            ),
+            fields,
         ),
-        fields,
+        5,
     )
 
     recordarray = ak.contents.RecordArray(
         [content1, listoffsetarray], fields=["one", "two"]
     )
     assert str(ak.operations.type(recordarray)) in (
-        "{one: int64, two: var * float64}",
-        "{two: var * float64, one: int64}",
+        "5 * {one: int64, two: var * float64}",
+        "5 * {two: var * float64, one: int64}",
     )
 
     assert (
@@ -268,12 +271,14 @@ def test_recordtype():
     listoffsetarray = ak.contents.ListOffsetArray(offsets, content2)
     recordarray = ak.contents.RecordArray([content1, listoffsetarray], fields)
 
-    assert ak.operations.type(recordarray[2]) == ak.types.RecordType(
-        (
-            ak.types.NumpyType("int64"),
-            ak.types.ListType(ak.types.NumpyType("float64")),
-        ),
-        None,
+    assert ak.operations.type(recordarray[2]) == ak.types.ScalarType(
+        ak.types.RecordType(
+            (
+                ak.types.NumpyType("int64"),
+                ak.types.ListType(ak.types.NumpyType("float64")),
+            ),
+            None,
+        )
     )
     assert str(
         ak.types.RecordType(
@@ -287,19 +292,24 @@ def test_recordtype():
 
     recordarray = ak.contents.RecordArray([content1, listoffsetarray], ["one", "two"])
 
-    assert ak.operations.type(recordarray) == ak.types.RecordType(
-        (
-            ak.types.NumpyType("int64"),
-            ak.types.ListType(ak.types.NumpyType("float64")),
+    assert ak.operations.type(recordarray) == ak.types.ArrayType(
+        ak.types.RecordType(
+            (
+                ak.types.NumpyType("int64"),
+                ak.types.ListType(ak.types.NumpyType("float64")),
+            ),
+            ["one", "two"],
         ),
-        ["one", "two"],
+        5,
     )
-    assert ak.operations.type(recordarray[2]) == ak.types.RecordType(
-        (
-            ak.types.NumpyType("int64"),
-            ak.types.ListType(ak.types.NumpyType("float64")),
-        ),
-        ["one", "two"],
+    assert ak.operations.type(recordarray[2]) == ak.types.ScalarType(
+        ak.types.RecordType(
+            (
+                ak.types.NumpyType("int64"),
+                ak.types.ListType(ak.types.NumpyType("float64")),
+            ),
+            ["one", "two"],
+        )
     )
 
 

--- a/tests/test_0046_start_indexedarray.py
+++ b/tests/test_0046_start_indexedarray.py
@@ -52,10 +52,12 @@ def test_type():
     content = ak.contents.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4]))
     index = ak.index.Index32(np.array([2, 2, 0, 3, 4], dtype=np.int32))
     array = ak.contents.IndexedArray(index, content)
-    assert ak.operations.type(array) == ak.types.NumpyType("float64")
+    assert ak.operations.type(array) == ak.types.ArrayType(
+        ak.types.NumpyType("float64"), 5
+    )
     array = ak.contents.IndexedOptionArray(index, content)
-    assert ak.operations.type(array) == ak.types.OptionType(
-        ak.types.NumpyType("float64")
+    assert ak.operations.type(array) == ak.types.ArrayType(
+        ak.types.OptionType(ak.types.NumpyType("float64")), 5
     )
 
 

--- a/tests/test_0127_tomask_operation.py
+++ b/tests/test_0127_tomask_operation.py
@@ -1079,10 +1079,12 @@ def test_UnmaskedArray():
     )
     array = ak.contents.UnmaskedArray(content)
     assert to_list(array) == [1.1, 2.2, 3.3, 4.4, 5.5]
-    assert str(ak.operations.type(content)) == "float64"
+    assert str(ak.operations.type(content)) == "5 * float64"
     assert str(ak.operations.type(ak.highlevel.Array(content))) == "5 * float64"
-    assert str(ak.operations.type(array)) == "?float64"
+    assert str(ak.operations.type(array)) == "5 * ?float64"
     assert str(ak.operations.type(ak.highlevel.Array(array))) == "5 * ?float64"
+    assert str(content.form.type) == "float64"
+    assert str(array.form.type) == "?float64"
 
 
 def test_tomask():

--- a/tests/test_0173_astype_operation.py
+++ b/tests/test_0173_astype_operation.py
@@ -14,10 +14,12 @@ def test_UnmaskedArray():
     )
     array_float64 = ak.contents.UnmaskedArray(content_float64)
     assert to_list(array_float64) == [0.25, 0.5, 3.5, 4.5, 5.5]
-    assert str(ak.operations.type(content_float64)) == "float64"
+    assert str(ak.operations.type(content_float64)) == "5 * float64"
     assert str(ak.operations.type(ak.highlevel.Array(content_float64))) == "5 * float64"
-    assert str(ak.operations.type(array_float64)) == "?float64"
+    assert str(ak.operations.type(array_float64)) == "5 * ?float64"
     assert str(ak.operations.type(ak.highlevel.Array(array_float64))) == "5 * ?float64"
+    assert str(content_float64.form.type) == "float64"
+    assert str(array_float64.form.type) == "?float64"
 
     assert np.can_cast(np.float32, np.float64) is True
     assert np.can_cast(np.float64, np.float32, "unsafe") is True
@@ -28,32 +30,38 @@ def test_UnmaskedArray():
     )
     array_float32 = ak.contents.UnmaskedArray(content_float32)
     assert to_list(array_float32) == [0.25, 0.5, 3.5, 4.5, 5.5]
-    assert str(ak.operations.type(content_float32)) == "float32"
+    assert str(ak.operations.type(content_float32)) == "5 * float32"
     assert str(ak.operations.type(ak.highlevel.Array(content_float32))) == "5 * float32"
-    assert str(ak.operations.type(array_float32)) == "?float32"
+    assert str(ak.operations.type(array_float32)) == "5 * ?float32"
     assert str(ak.operations.type(ak.highlevel.Array(array_float32))) == "5 * ?float32"
+    assert str(content_float32.form.type) == "float32"
+    assert str(array_float32.form.type) == "?float32"
 
     content_int8 = ak.operations.values_astype(content_float64, "int8", highlevel=False)
     array_int8 = ak.contents.UnmaskedArray(content_int8)
     assert to_list(array_int8) == [0, 0, 3, 4, 5]
-    assert str(ak.operations.type(content_int8)) == "int8"
+    assert str(ak.operations.type(content_int8)) == "5 * int8"
     assert str(ak.operations.type(ak.highlevel.Array(content_int8))) == "5 * int8"
-    assert str(ak.operations.type(array_int8)) == "?int8"
+    assert str(ak.operations.type(array_int8)) == "5 * ?int8"
     assert str(ak.operations.type(ak.highlevel.Array(array_int8))) == "5 * ?int8"
+    assert str(content_int8.form.type) == "int8"
+    assert str(array_int8.form.type) == "?int8"
 
     content_from_int8 = ak.operations.values_astype(
         content_int8, "float64", highlevel=False
     )
     array_from_int8 = ak.contents.UnmaskedArray(content_from_int8)
     assert to_list(array_from_int8) == [0, 0, 3, 4, 5]
-    assert str(ak.operations.type(content_from_int8)) == "float64"
+    assert str(ak.operations.type(content_from_int8)) == "5 * float64"
     assert (
         str(ak.operations.type(ak.highlevel.Array(content_from_int8))) == "5 * float64"
     )
-    assert str(ak.operations.type(array_from_int8)) == "?float64"
+    assert str(ak.operations.type(array_from_int8)) == "5 * ?float64"
     assert (
         str(ak.operations.type(ak.highlevel.Array(array_from_int8))) == "5 * ?float64"
     )
+    assert str(content_from_int8.form.type) == "float64"
+    assert str(array_from_int8.form.type) == "?float64"
 
 
 def test_RegularArray_and_ListArray():
@@ -67,17 +75,17 @@ def test_RegularArray_and_ListArray():
     stops = ak.index.Index64(np.array([2, 3]))
     listarray = ak.contents.ListArray(starts, stops, regulararray)
 
-    assert str(ak.operations.type(content)) == "float64"
-    assert str(ak.operations.type(regulararray)) == "2 * var * float64"
-    assert str(ak.operations.type(listarray)) == "var * 2 * var * float64"
+    assert str(ak.operations.type(content)) == "10 * float64"
+    assert str(ak.operations.type(regulararray)) == "3 * 2 * var * float64"
+    assert str(ak.operations.type(listarray)) == "2 * var * 2 * var * float64"
 
     regulararray_int8 = ak.operations.values_astype(
         regulararray, "int8", highlevel=False
     )
-    assert str(ak.operations.type(regulararray_int8)) == "2 * var * int8"
+    assert str(ak.operations.type(regulararray_int8)) == "3 * 2 * var * int8"
 
     listarray_bool = ak.operations.values_astype(listarray, "bool", highlevel=False)
-    assert str(ak.operations.type(listarray_bool)) == "var * 2 * var * bool"
+    assert str(ak.operations.type(listarray_bool)) == "2 * var * 2 * var * bool"
 
 
 def test_ufunc_afterward():

--- a/tests/test_0395_complex_type_arrays.py
+++ b/tests/test_0395_complex_type_arrays.py
@@ -212,10 +212,12 @@ def test_astype_complex():
 
     array_float64 = ak.contents.UnmaskedArray(content_float64)
     assert to_list(array_float64) == [0.25, 0.5, 3.5, 4.5, 5.5]
-    assert str(ak.operations.type(content_float64)) == "float64"
+    assert str(ak.operations.type(content_float64)) == "5 * float64"
     assert str(ak.operations.type(ak.highlevel.Array(content_float64))) == "5 * float64"
-    assert str(ak.operations.type(array_float64)) == "?float64"
+    assert str(ak.operations.type(array_float64)) == "5 * ?float64"
     assert str(ak.operations.type(ak.highlevel.Array(array_float64))) == "5 * ?float64"
+    assert str(content_float64.form.type) == "float64"
+    assert str(array_float64.form.type) == "?float64"
 
     assert np.can_cast(np.float32, np.float64) is True
     assert np.can_cast(np.float64, np.float32, "unsafe") is True
@@ -247,15 +249,18 @@ def test_astype_complex():
         (4.5 + 0.0j),
         (5.5 + 0.0j),
     ]
-    assert str(ak.operations.type(content_complex64)) == "complex64"
+    assert str(ak.operations.type(content_complex64)) == "5 * complex64"
     assert (
         str(ak.operations.type(ak.highlevel.Array(content_complex64)))
         == "5 * complex64"
     )
-    assert str(ak.operations.type(array_complex64)) == "?complex64"
+    assert str(ak.operations.type(array_complex64)) == "5 * ?complex64"
     assert (
         str(ak.operations.type(ak.highlevel.Array(array_complex64))) == "5 * ?complex64"
     )
+    assert str(content_complex64.form.type) == "complex64"
+    assert str(array_complex64.form.type) == "?complex64"
+
     content = ak.contents.NumpyArray(
         np.array([1, (2.2 + 0.1j), 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
     )

--- a/tests/test_1135_rpad_operation.py
+++ b/tests/test_1135_rpad_operation.py
@@ -942,9 +942,9 @@ def test_rpad_listoffset_array():
         == ak._do.pad_none(listoffsetarray, 3, 0).form
     )
 
-    assert "option[" + str(ak.operations.type(listoffsetarray)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 3, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 6
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 3, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 7, 0)) == [
         [0.0, 1.1, 2.2],
@@ -960,9 +960,9 @@ def test_rpad_listoffset_array():
         == ak._do.pad_none(listoffsetarray, 7, 0).form
     )
 
-    assert "option[" + str(ak.operations.type(listoffsetarray)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 5, 1)) == [
         [0.0, 1.1, 2.2, None, None],
@@ -976,9 +976,10 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 5, 1).form
         == ak._do.pad_none(listoffsetarray, 5, 1).form
     )
-    assert (
-        str(ak.operations.type(ak._do.pad_none(listoffsetarray, 5, 1)))
-        == "var * ?float64"
+    assert ak.operations.type(
+        ak._do.pad_none(listoffsetarray, 5, 1)
+    ) == ak.types.ArrayType(
+        ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64"))), 6
     )
 
     assert to_list(ak._do.pad_none(listoffsetarray, 1, 1)) == [
@@ -1053,9 +1054,12 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 0).form
         == ak._do.pad_none(listoffsetarray, 1, 0).form
     )
-    assert f"option[{str(ak.operations.type(listoffsetarray))}]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64")))
+        ),
+        6,
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 6, 0)) == [
         [3.3],
@@ -1069,9 +1073,12 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 6, 0).form
         == ak._do.pad_none(listoffsetarray, 6, 0).form
     )
-    assert "option[" + str(ak.operations.type(listoffsetarray)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 6, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64")))
+        ),
+        6,
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 6, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 7, 0)) == [
         [3.3],
@@ -1086,9 +1093,9 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 7, 0).form
         == ak._do.pad_none(listoffsetarray, 7, 0).form
     )
-    assert "option[" + str(ak.operations.type(listoffsetarray)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.operations.type(listoffsetarray).content), 7
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 9, 0)) == [
         [3.3],
@@ -1105,9 +1112,9 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 9, 0).form
         == ak._do.pad_none(listoffsetarray, 9, 0).form
     )
-    assert "option[" + str(ak.operations.type(listoffsetarray)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 9, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.operations.type(listoffsetarray).content), 9
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 9, 0))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 1, 1)) == [
         [3.3],
@@ -1121,9 +1128,9 @@ def test_rpad_listoffset_array():
         ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 1).form
         == ak._do.pad_none(listoffsetarray, 1, 1).form
     )
-    assert str(ak.operations.type(listoffsetarray)) == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 1))
-    )
+    assert ak.types.ArrayType(
+        ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64"))), 6
+    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 1))
 
     assert to_list(ak._do.pad_none(listoffsetarray, 4, 1)) == [
         [3.3, None, None, None],
@@ -1133,8 +1140,8 @@ def test_rpad_listoffset_array():
         [None, None, None, None],
         [None, None, None, None],
     ]
-    assert str(ak.operations.type(listoffsetarray)) == str(
-        ak.operations.type(ak._do.pad_none(listoffsetarray, 4, 1))
+    assert ak.operations.type(listoffsetarray) == ak.operations.type(
+        ak._do.pad_none(listoffsetarray, 4, 1)
     )
 
 
@@ -1160,9 +1167,9 @@ def test_rpad_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert f"option[{str(ak.operations.type(array))}]" == str(
-        ak.operations.type(ak._do.pad_none(array, 1, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 5
+    ) == ak.operations.type(ak._do.pad_none(array, 1, 0))
 
     assert to_list(ak._do.pad_none(array, 2, 0)) == [
         [0.0, 1.1, 2.2],
@@ -1171,9 +1178,9 @@ def test_rpad_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert f"option[{str(ak.operations.type(array))}]" == str(
-        ak.operations.type(ak._do.pad_none(array, 2, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 5
+    ) == ak.operations.type(ak._do.pad_none(array, 2, 0))
 
     assert to_list(ak._do.pad_none(array, 7, 0)) == [
         [0.0, 1.1, 2.2],
@@ -1184,9 +1191,9 @@ def test_rpad_list_array():
         None,
         None,
     ]
-    assert "option[" + str(ak.operations.type(array)) + "]" == str(
-        ak.operations.type(ak._do.pad_none(array, 7, 0))
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
+    ) == ak.operations.type(ak._do.pad_none(array, 7, 0))
 
     assert to_list(ak._do.pad_none(array, 1, 1)) == [
         [0.0, 1.1, 2.2],
@@ -1241,18 +1248,18 @@ def test_rpad_and_clip_list_array():
         ak._do.pad_none(array.to_typetracer(), 1, 0, clip=True).form
         == ak._do.pad_none(array, 1, 0, clip=True).form
     )
-    assert "option[" + str(array.form.type) + "]" == str(
-        ak._do.pad_none(array, 1, 0, clip=True).form.type
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 1
+    ) == ak.operations.type(ak._do.pad_none(array, 1, 0, clip=True))
 
     assert to_list(ak._do.pad_none(array, 2, 0, clip=True)) == [[0.0, 1.1, 2.2], []]
     assert (
         ak._do.pad_none(array.to_typetracer(), 2, 0, clip=True).form
         == ak._do.pad_none(array, 2, 0, clip=True).form
     )
-    assert "option[" + str(array.form.type) + "]" == str(
-        ak._do.pad_none(array, 2, 0, clip=True).form.type
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 2
+    ) == ak.operations.type(ak._do.pad_none(array, 2, 0, clip=True))
 
     assert to_list(ak._do.pad_none(array, 7, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
@@ -1267,9 +1274,9 @@ def test_rpad_and_clip_list_array():
         ak._do.pad_none(array.to_typetracer(), 7, 0, clip=True).form
         == ak._do.pad_none(array, 7, 0, clip=True).form
     )
-    assert "option[" + str(array.form.type) + "]" == str(
-        ak._do.pad_none(array, 7, 0, clip=True).form.type
-    )
+    assert ak.types.ArrayType(
+        ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
+    ) == ak.operations.type(ak._do.pad_none(array, 7, 0, clip=True))
 
     assert to_list(ak._do.pad_none(array, 1, 1, clip=True)) == [
         [0.0],

--- a/tests/test_1840_ak_type_to_handle_ndarray_dtype_and_nptypes.py
+++ b/tests/test_1840_ak_type_to_handle_ndarray_dtype_and_nptypes.py
@@ -12,12 +12,16 @@ def test_array():
 
 
 def test_dtype():
-    assert ak.type(np.dtype(np.float64)) == ak.types.NumpyType("float64")
+    assert ak.type(np.dtype(np.float64)) == ak.types.ScalarType(
+        ak.types.NumpyType("float64")
+    )
 
 
 def test_type():
-    assert ak.type(np.float64) == ak.types.NumpyType("float64")
+    assert ak.type(np.float64) == ak.types.ScalarType(ak.types.NumpyType("float64"))
 
 
 def test_type_instance():
-    assert ak.type(np.float64(10.0)) == ak.types.NumpyType("float64")
+    assert ak.type(np.float64(10.0)) == ak.types.ScalarType(
+        ak.types.NumpyType("float64")
+    )

--- a/tests/test_2070_to_layout_string.py
+++ b/tests/test_2070_to_layout_string.py
@@ -1,5 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
@@ -7,10 +8,16 @@ import awkward as ak
 
 @pytest.mark.parametrize("string", ["hello world!", b"hello world!"])
 def test(string):
-    with pytest.raises(TypeError):
-        ak.to_layout(string, allow_other=False)
-
-    assert ak.to_layout(string, allow_other=True) == string
+    assert ak._util.arrays_approx_equal(
+        ak.to_layout(string),
+        ak.contents.NumpyArray(
+            np.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33],
+                dtype=np.uint8,
+            ),
+            parameters={"__array__": "char" if isinstance(string, str) else "byte"},
+        ),
+    )
 
 
 @pytest.mark.parametrize("string", ["hello world!", b"hello world!"])

--- a/tests/test_2096_ak_scalar_type.py
+++ b/tests/test_2096_ak_scalar_type.py
@@ -1,0 +1,58 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_array():
+    array = ak.Array(["this", {"x": ["is", 1, 2, None]}])
+    assert ak.type(array) == array.type
+    assert isinstance(array.type, ak.types.ArrayType)
+
+
+def test_record():
+    record = ak.Record({"y": ["this", {"x": ["is", 1, 2, None]}]})
+    assert ak.type(record) == record.type
+    assert isinstance(record.type, ak.types.ScalarType)
+
+
+def test_none():
+    assert ak.type(None) == ak.types.ScalarType(ak.types.UnknownType())
+
+
+def test_unknown():
+    with pytest.raises(TypeError):
+        ak.type(object())
+
+
+def test_bare_string():
+    assert ak.type("hello") == ak.types.ArrayType(
+        ak.types.NumpyType("uint8", parameters={"__array__": "char"}, typestr="char"), 5
+    )
+    assert ak.type(b"hello") == ak.types.ArrayType(
+        ak.types.NumpyType("uint8", parameters={"__array__": "byte"}, typestr="byte"), 5
+    )
+
+
+def test_array_string():
+    assert ak.type(["hello"]) == ak.types.ArrayType(
+        ak.types.ListType(
+            ak.types.NumpyType(
+                "uint8", parameters={"__array__": "char"}, typestr="char"
+            ),
+            parameters={"__array__": "string"},
+            typestr="string",
+        ),
+        1,
+    )
+    assert ak.type([b"hello"]) == ak.types.ArrayType(
+        ak.types.ListType(
+            ak.types.NumpyType(
+                "uint8", parameters={"__array__": "byte"}, typestr="byte"
+            ),
+            parameters={"__array__": "bytestring"},
+            typestr="bytes",
+        ),
+        1,
+    )

--- a/tests/test_2096_ak_scalar_type.py
+++ b/tests/test_2096_ak_scalar_type.py
@@ -1,8 +1,40 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        ak.contents.NumpyArray(np.arange(4)),
+        ak.contents.IndexedArray(
+            ak.index.Index64(np.arange(4, dtype=np.int64)),
+            ak.contents.NumpyArray(np.arange(4)),
+        ),
+        ak.contents.IndexedOptionArray(
+            ak.index.Index64(np.arange(4, dtype=np.int64)),
+            ak.contents.NumpyArray(np.arange(4)),
+        ),
+        ak.contents.ListOffsetArray(
+            ak.index.Index64(np.arange(4, dtype=np.int64)),
+            ak.contents.NumpyArray(np.arange(3)),
+        ),
+        ak.contents.ListArray(
+            ak.index.Index64(np.arange(3, dtype=np.int64)),
+            ak.index.Index64(np.arange(1, 4, dtype=np.int64)),
+            ak.contents.NumpyArray(np.arange(3)),
+        ),
+        ak.contents.RegularArray(ak.contents.NumpyArray(np.arange(12)), size=3),
+    ],
+)
+def test_highlevel_lowlevel(array):
+    layout = ak.to_layout(array)
+    assert isinstance(ak.type(layout), ak.types.ArrayType)
+    # Check that the highlevel of ak.Array yields low level from form
+    assert layout.form.type == ak.type(layout).content
 
 
 def test_array():


### PR DESCRIPTION
Fixes #2096, closes #2070, and adjusts #2098 to treat strings as character arrays.

The new `ScalarType` object let's us determine whether we have `ak.Record` or an `ak.Array` of records. It is the natural counterpart to the "high-level" `ArrayType`. Importantly, Awkward type objects _lose information_ if they're considered at the low-level, i.e. not wrapped by `ScalarType` or `ArrayType`; it is not possible to determine whether one has an Array or a Record. 


Note that this PR does not remove the `__cast__` implementation that converts string `ufunc` `*args` arguments to character arrays. This seems desirable in the main, unless there are well-known ufuncs that take string arguments?