### PR TITLE
fix: re-order cases to handle NumPy scalar types properly

### DIFF
--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -79,14 +79,6 @@ def type(array, *, behavior=None):
         return _impl(array, behavior)
 
 
-def _is_dtype_like(obj):
-    return (
-        isinstance(obj, np.dtype)
-        or isinstance(obj, np.generic)
-        or (inspect.isclass(obj) and issubclass(obj, np.generic))
-    )
-
-
 def _impl(array, behavior):
     behavior = ak._util.behavior_of(array, behavior=behavior)
 
@@ -105,7 +97,11 @@ def _impl(array, behavior):
     elif isinstance(array, ak.contents.Content):
         return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
 
-    elif _is_dtype_like(array):
+    elif (
+        isinstance(array, np.dtype)
+        or isinstance(array, np.generic)
+        or (inspect.isclass(array) and issubclass(array, np.generic))
+    ):
         return ak.types.ScalarType(
             ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(np.dtype(array)))
         )

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -86,11 +86,6 @@ def _impl(array, behavior):
         form = ak.forms.from_json(array.form())
         return ak.types.ArrayType(form.type_from_behavior(behavior), len(array))
 
-    elif isinstance(array, ak.ArrayBuilder):
-        behavior = ak._util.behavior_of(array, behavior=behavior)
-        form = ak.forms.from_json(array._layout.form())
-        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array._layout))
-
     elif isinstance(array, ak.record.Record):
         return ak.types.ScalarType(array.array.form.type_from_behavior(behavior))
 
@@ -123,6 +118,10 @@ def _impl(array, behavior):
 
     elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
         return ak.types.ScalarType(ak.types.NumpyType("timedelta"))
+
+    elif isinstance(array, ak.highlevel.ArrayBuilder):
+        # Don't go through `to_layout`: we want to avoid snapshotting this array
+        return _impl(array._layout, behavior)
 
     else:
         layout = ak.to_layout(array, allow_other=True, allow_record=True)

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -92,10 +92,8 @@ def _impl(array, behavior):
     elif isinstance(array, ak.contents.Content):
         return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
 
-    elif (
-        isinstance(array, np.dtype)
-        or isinstance(array, np.generic)
-        or (inspect.isclass(array) and issubclass(array, np.generic))
+    elif isinstance(array, (np.dtype, np.generic)) or (
+        inspect.isclass(array) and issubclass(array, np.generic)
     ):
         return ak.types.ScalarType(
             ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(np.dtype(array)))

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -1,5 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import inspect
 import numbers
 from datetime import datetime, timedelta
 
@@ -79,12 +80,11 @@ def type(array, *, behavior=None):
 
 
 def _is_dtype_like(obj):
-    try:
-        np.dtype(obj)
-    except TypeError:
-        return False
-    else:
-        return True
+    return (
+        isinstance(obj, np.dtype)
+        or isinstance(obj, np.generic)
+        or (inspect.isclass(obj) and issubclass(obj, np.generic))
+    )
 
 
 def _impl(array, behavior):

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import inspect
 import numbers
 from datetime import datetime, timedelta
 
@@ -92,9 +91,7 @@ def _impl(array, behavior):
     elif isinstance(array, ak.contents.Content):
         return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
 
-    elif isinstance(array, (np.dtype, np.generic)) or (
-        inspect.isclass(array) and issubclass(array, np.generic)
-    ):
+    elif isinstance(array, (np.dtype, np.generic)):
         return ak.types.ScalarType(
             ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(np.dtype(array)))
         )

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import builtins
 import numbers
 from datetime import datetime, timedelta
 
@@ -79,10 +78,36 @@ def type(array, *, behavior=None):
         return _impl(array, behavior)
 
 
+def _is_dtype_like(obj):
+    try:
+        np.dtype(obj)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
 def _impl(array, behavior):
-    if isinstance(array, np.dtype):
+    behavior = ak._util.behavior_of(array, behavior=behavior)
+
+    if isinstance(array, _ext.ArrayBuilder):
+        form = ak.forms.from_json(array.form())
+        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array))
+
+    elif isinstance(array, ak.ArrayBuilder):
+        behavior = ak._util.behavior_of(array, behavior=behavior)
+        form = ak.forms.from_json(array._layout.form())
+        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array._layout))
+
+    elif isinstance(array, ak.record.Record):
+        return ak.types.ScalarType(array.array.form.type_from_behavior(behavior))
+
+    elif isinstance(array, ak.contents.Content):
+        return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
+
+    elif _is_dtype_like(array):
         return ak.types.ScalarType(
-            ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(array))
+            ak.types.NumpyType(ak.types.numpytype.dtype_to_primitive(np.dtype(array)))
         )
 
     elif isinstance(array, bool):  # np.bool_ in np.generic (above)
@@ -103,36 +128,13 @@ def _impl(array, behavior):
     elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
         return ak.types.ScalarType(ak.types.NumpyType("timedelta"))
 
-    elif (
-        isinstance(array, np.generic)
-        or isinstance(array, builtins.type)
-        and issubclass(array, np.generic)
-    ):
-        primitive = ak.types.numpytype.dtype_to_primitive(np.dtype(array))
-        return ak.types.ScalarType(ak.types.NumpyType(primitive))
-
-    elif isinstance(array, _ext.ArrayBuilder):
-        form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array))
-
-    elif isinstance(array, ak.ArrayBuilder):
-        behavior = ak._util.behavior_of(array, behavior=behavior)
-        form = ak.forms.from_json(array._layout.form())
-        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array._layout))
-
     else:
-        behavior = ak._util.behavior_of(array, behavior=behavior)
         layout = ak.to_layout(array, allow_other=True, allow_record=True)
         if layout is None:
             return ak.types.ScalarType(ak.types.UnknownType())
 
-        elif isinstance(layout, ak.record.Record):
-            return ak.types.ScalarType(layout.array.form.type_from_behavior(behavior))
-
-        elif isinstance(layout, ak.contents.Content):
-            return ak.types.ArrayType(
-                layout.form.type_from_behavior(behavior), layout.length
-            )
+        elif isinstance(layout, (ak.contents.Content, ak.record.Record)):
+            return _impl(layout, behavior)
 
         else:
             raise ak._errors.wrap_error(

--- a/tests/test_1840_ak_type_to_handle_ndarray_dtype_and_nptypes.py
+++ b/tests/test_1840_ak_type_to_handle_ndarray_dtype_and_nptypes.py
@@ -17,10 +17,6 @@ def test_dtype():
     )
 
 
-def test_type():
-    assert ak.type(np.float64) == ak.types.ScalarType(ak.types.NumpyType("float64"))
-
-
 def test_type_instance():
     assert ak.type(np.float64(10.0)) == ak.types.ScalarType(
         ak.types.NumpyType("float64")

--- a/tests/test_2125_type_of_scalar.py
+++ b/tests/test_2125_type_of_scalar.py
@@ -12,3 +12,19 @@ def test():
     assert ak.type(np.dtype("complex128")) == ak.types.ScalarType(
         ak.types.NumpyType("complex128")
     )
+    assert ak.type("hello") == ak.types.ArrayType(
+        ak.types.NumpyType("uint8", parameters={"__array__": "char"}), 5
+    )
+    assert ak.type("int16") == ak.types.ArrayType(
+        ak.types.NumpyType("uint8", parameters={"__array__": "char"}), 5
+    )
+    assert ak.type(["int16"]) == ak.types.ArrayType(
+        ak.types.ListType(
+            ak.types.NumpyType(
+                "uint8", parameters={"__array__": "char"}, typestr="char"
+            ),
+            parameters={"__array__": "string"},
+            typestr="string",
+        ),
+        1,
+    )

--- a/tests/test_2125_type_of_scalar.py
+++ b/tests/test_2125_type_of_scalar.py
@@ -8,7 +8,9 @@ import awkward as ak
 
 def test():
     assert ak.type(np.int16()) == ak.types.ScalarType(ak.types.NumpyType("int16"))
-    assert ak.type(np.uint32) == ak.types.ScalarType(ak.types.NumpyType("uint32"))
+    with pytest.raises(TypeError):
+        assert ak.type(np.uint32) == ak.types.ScalarType(ak.types.UnknownType())
+    assert ak.type(None) == ak.types.ScalarType(ak.types.UnknownType())
     assert ak.type(np.dtype("complex128")) == ak.types.ScalarType(
         ak.types.NumpyType("complex128")
     )

--- a/tests/test_2125_type_of_scalar.py
+++ b/tests/test_2125_type_of_scalar.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    assert ak.type(np.int16()) == ak.types.ScalarType(ak.types.NumpyType("int16"))
+    assert ak.type(np.uint32) == ak.types.ScalarType(ak.types.NumpyType("uint32"))
+    assert ak.type(np.dtype("complex128")) == ak.types.ScalarType(
+        ak.types.NumpyType("complex128")
+    )


### PR DESCRIPTION
#2096 improved our type-handling, but had a sneaky bug in the ordering of the NumPy scalar type (`np.int16()`) handling: the generic `Integral` test would always catch these cases first, meaning that `ak.type(np.int16)` always produced `ScalarType(NumpyType("int64"))` etc.

This PR simplifies this logic by re-ordering the tests.