### PR TITLE
docs: disable IPyParallel & load dependencies in reverse order

### DIFF
--- a/docs/getting-started/demo/what-is-an-awkward-array.ipynb
+++ b/docs/getting-started/demo/what-is-an-awkward-array.ipynb
@@ -2,17 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "53a4d322",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
    "source": [
     "- To run the code, click on the first cell (gray box) and press <kbd>Shift</kbd>+<kbd>Enter</kbd> (or click the play button) to run each cell.\n",
     "- Or, select `Run All Cells` from the `Run` menu.\n",
     "- Feel free to experiment, but if you need to restore the original code, reload this browser page. Any changes you make will be lost when you reload!\n",
     "- When you leave the page, you might get a \"Changes you made may not be saved\" message, which you can ignore."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "editable": false,
-    "deletable": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "# Install Awkward Array in the browser\n",
-    "import piplite; await piplite.install(\"awkward>=2.0.0rc0\")\n",
+    "import piplite; await piplite.install(\"awkward-cpp\"); await piplite.install(\"awkward>=2.0\")\n",
     "\n",
     "# Import normal libraries\n",
     "import numpy as np\n",
@@ -558,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.8"
   },
   "mystnb": {
    "execution_mode": "off"

--- a/docs/lite/jupyter-lite.json
+++ b/docs/lite/jupyter-lite.json
@@ -3,6 +3,9 @@
   "jupyter-config-data": {
     "enableMemoryStorage": true,
     "settingsStorageDrivers": ["memoryStorageDriver"],
-    "contentsStorageDrivers": ["memoryStorageDriver"]
+    "contentsStorageDrivers": ["memoryStorageDriver"],
+    "disabledExtensions": [
+      "ipyparallel-labextension"
+    ]
   }
 }


### PR DESCRIPTION
I've noticed intermittent failures in the "Try It" demo; sometimes we get a symbol definition error. However, it transpires that re-running the import fixes this. I added an explicit import for `awkward-cpp` that appears to fix the issue.

This PR also disables IPyParallel, which is a nuisance.