### PR TITLE
refactor: remove `to_arraylib`

### DIFF
--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -239,7 +239,9 @@ def from_rdataframe(data_frame, columns):
 
             if col == "awkward_index_":
                 contents_index = ak.index.Index64(
-                    array.layout.to_numpy(allow_missing=True)
+                    array.layout.to_backend_array(
+                        allow_missing=True, backend=ak._backends.NumpyBackend.instance()
+                    )
                 )
             else:
                 contents[col] = array.layout

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -372,6 +372,9 @@ class NumpyLike(Singleton):
     def can_cast(self, *args, **kwargs):
         return self._module.can_cast(*args, **kwargs)
 
+    def raw(self, array, nplike):
+        raise ak._errors.wrap_error(NotImplementedError)
+
     @classmethod
     def is_own_array(cls, obj) -> bool:
         """

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -169,6 +169,7 @@ class ArgMax(Reducer):
 class Count(Reducer):
     name: Final = "count"
     preferred_dtype: Final = np.int64
+    needs_position: Final = False
 
     @classmethod
     def return_dtype(cls, given_dtype):
@@ -197,6 +198,7 @@ class Count(Reducer):
 class CountNonzero(Reducer):
     name: Final = "count_nonzero"
     preferred_dtype: Final = np.float64
+    needs_position: Final = False
 
     @classmethod
     def return_dtype(cls, given_dtype):
@@ -247,6 +249,7 @@ class CountNonzero(Reducer):
 class Sum(Reducer):
     name: Final = "sum"
     preferred_dtype: Final = np.float64
+    needs_position: Final = False
 
     def apply(self, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
@@ -351,6 +354,7 @@ class Sum(Reducer):
 class Prod(Reducer):
     name: Final = "prod"
     preferred_dtype: Final = np.int64
+    needs_position: Final = False
 
     def apply(self, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
@@ -437,6 +441,7 @@ class Prod(Reducer):
 class Any(Reducer):
     name: Final = "any"
     preferred_dtype: Final = np.bool_
+    needs_position: Final = False
 
     @classmethod
     def return_dtype(cls, given_dtype):
@@ -487,6 +492,7 @@ class Any(Reducer):
 class All(Reducer):
     name: Final = "all"
     preferred_dtype: Final = np.bool_
+    needs_position: Final = False
 
     @classmethod
     def return_dtype(cls, given_dtype):
@@ -537,6 +543,7 @@ class All(Reducer):
 class Min(Reducer):
     name: Final = "min"
     preferred_dtype: Final = np.float64
+    needs_position: Final = False
 
     def __init__(self, initial: float | None):
         self._initial = initial
@@ -637,6 +644,7 @@ class Min(Reducer):
 class Max(Reducer):
     name: Final = "max"
     preferred_dtype: Final = np.float64
+    needs_position: Final = False
 
     def __init__(self, initial):
         self._initial = initial

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import Any as AnyType
 
 import awkward as ak
@@ -12,11 +13,19 @@ numpy = ak._nplikes.Numpy.instance()
 DTypeLike = AnyType
 
 
-class Reducer:
+class Reducer(ABC):
     name: str
 
     # Does the output correspond to array positions?
-    needs_position: Final = False
+    @property
+    @abstractmethod
+    def needs_position(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def preferred_dtype(self) -> DTypeLike:
+        ...
 
     @classmethod
     def highlevel_function(cls):
@@ -46,9 +55,11 @@ class Reducer:
             type = np.float32
         return type
 
+    @abstractmethod
     def identity_for(self, dtype: DTypeLike | None):
         raise ak._errors.wrap_error(NotImplementedError)
 
+    @abstractmethod
     def apply(self, array, parents, outlength: int):
         raise ak._errors.wrap_error(NotImplementedError)
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -697,7 +697,7 @@ class BitMaskedArray(Content):
 
         return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         mask = self._mask.to_nplike(backend.index_nplike)
         return BitMaskedArray(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -575,8 +575,8 @@ class BitMaskedArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_ByteMaskedArray()._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        return self.to_ByteMaskedArray()._to_backend_array(allow_missing, backend)
 
     def _completely_flatten(self, backend, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -958,8 +958,8 @@ class ByteMaskedArray(Content):
             options,
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_IndexedOptionArray64()._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        return self.to_IndexedOptionArray64()._to_backend_array(allow_missing, backend)
 
     def _completely_flatten(self, backend, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1066,7 +1066,7 @@ class ByteMaskedArray(Content):
 
         return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         mask = self._mask.to_nplike(backend.index_nplike)
         return ByteMaskedArray(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1028,7 +1028,9 @@ class Content:
             allow_missing
         )
 
-    def to_backend_array(self, allow_missing: bool = True, *, backend=None):
+    def to_backend_array(
+        self, allow_missing: bool = True, *, backend: Backend | str | None = None
+    ):
         if backend is None:
             backend = self._backend
         else:
@@ -1209,7 +1211,14 @@ class Content:
     ) -> tuple[ak.index.Index, Content]:
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def to_backend(self, backend: Backend) -> Self:
+    def to_backend(self, backend: Backend | str | None = None) -> Self:
+        if backend is None:
+            backend = self._backend
+        else:
+            backend = ak._backends.regularize_backend(backend)
+        return self._to_backend(backend)
+
+    def _to_backend(self, backend: Backend) -> Self:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def with_parameter(self, key: str, value: Any) -> Self:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1019,9 +1019,23 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def to_numpy(self, allow_missing: bool = True):
-        return self._to_numpy(allow_missing)
+        ak._errors.deprecate(
+            "`Content.to_numpy` is deprecated. Please replace calls to "
+            "`Content.to_numpy(...)` with `Content.to_backend_array(..., backend='cpu')`.",
+            "2.2.0",
+        )
+        return self.to_backend(ak._backends.NumpyBackend.instance())._to_backend_array(
+            allow_missing
+        )
 
-    def _to_numpy(self, allow_missing: bool):
+    def to_backend_array(self, allow_missing: bool = True, *, backend=None):
+        if backend is None:
+            backend = self._backend
+        else:
+            backend = ak._backends.regularize_backend(backend)
+        return self._to_backend_array(allow_missing, backend)
+
+    def _to_backend_array(self, allow_missing: bool, backend: ak._backends.Backend):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def drop_none(self):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -347,7 +347,7 @@ class EmptyArray(Content):
     def _to_list(self, behavior, json_conversions):
         return []
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         return EmptyArray(parameters=self._parameters, backend=backend)
 
     def _is_equal_to(self, other, index_dtype, numpyarray):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -295,12 +295,14 @@ class EmptyArray(Content):
         else:
             dtype = np.dtype(options["emptyarray_to"])
             next = ak.contents.NumpyArray(
-                numpy.empty(length, dtype), self._parameters, backend=self._backend
+                numpy.empty(length, dtype),
+                parameters=self._parameters,
+                backend=self._backend,
             )
             return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-    def _to_numpy(self, allow_missing):
-        return self._backend.nplike.empty(0, dtype=np.float64)
+    def _to_backend_array(self, allow_missing, backend):
+        return backend.nplike.empty(0, dtype=np.float64)
 
     def _completely_flatten(self, backend, options):
         return []

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -958,8 +958,8 @@ class IndexedArray(Content):
             )
             return next2._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-    def _to_numpy(self, allow_missing):
-        return self.project()._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        return self.project()._to_backend_array(allow_missing, backend)
 
     def _completely_flatten(self, backend, options):
         return self.project()._completely_flatten(backend, options)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1053,7 +1053,7 @@ class IndexedArray(Content):
         nextcontent = self._content._carry(ak.index.Index(index), False)
         return nextcontent._to_list(behavior, json_conversions)
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         index = self._index.to_nplike(backend.index_nplike)
         return IndexedArray(index, content, parameters=self._parameters)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1620,7 +1620,7 @@ class IndexedOptionArray(Content):
 
         return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         index = self._index.to_nplike(backend.index_nplike)
         return IndexedOptionArray(index, content, parameters=self._parameters)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1438,20 +1438,22 @@ class IndexedOptionArray(Content):
             options,
         )
 
-    def _to_numpy(self, allow_missing):
-        content = self.project()._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        nplike = backend.nplike
 
-        shape = list(content.shape)
-        shape[0] = self.length
-        data = numpy.empty(shape, dtype=content.dtype)
-        mask0 = numpy.asarray(self.mask_as_bool(valid_when=False)).view(np.bool_)
+        content = self.project()._to_backend_array(allow_missing, backend)
+        shape = [self.length, *content.shape[1:]]
+        data = nplike.empty(shape, dtype=content.dtype)
+        mask0 = backend.index_nplike.asarray(self.mask_as_bool(valid_when=False)).view(
+            np.bool_
+        )
         if mask0.any():
             if allow_missing:
-                mask = numpy.broadcast_to(
+                mask = backend.index_nplike.broadcast_to(
                     mask0.reshape((shape[0],) + (1,) * (len(shape) - 1)), shape
                 )
-                if isinstance(content, numpy.ma.MaskedArray):
-                    mask1 = numpy.ma.getmaskarray(content)
+                if isinstance(content, nplike.ma.MaskedArray):
+                    mask1 = nplike.ma.getmaskarray(content)
                     mask = mask.copy()
                     mask[~mask0] |= mask1
 
@@ -1466,7 +1468,7 @@ class IndexedOptionArray(Content):
                 elif issubclass(content.dtype.type, np.integer):
                     data[mask0] = np.iinfo(content.dtype).max
                 elif issubclass(content.dtype.type, (np.datetime64, np.timedelta64)):
-                    data[mask0] = numpy.array([np.iinfo(np.int64).max], content.dtype)[
+                    data[mask0] = nplike.array([np.iinfo(np.int64).max], content.dtype)[
                         0
                     ]
                 else:
@@ -1474,18 +1476,18 @@ class IndexedOptionArray(Content):
                         AssertionError(f"unrecognized dtype: {content.dtype}")
                     )
 
-                return numpy.ma.MaskedArray(data, mask)
+                return nplike.ma.MaskedArray(data, mask)
             else:
                 raise ak._errors.wrap_error(
                     ValueError(
-                        "ak.to_numpy cannot convert 'None' values to "
+                        "Content.to_nplike cannot convert 'None' values to "
                         "np.ma.MaskedArray unless the "
                         "'allow_missing' parameter is set to True"
                     )
                 )
         else:
             if allow_missing:
-                return numpy.ma.MaskedArray(content)
+                return nplike.ma.MaskedArray(content)
             else:
                 return content
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1345,8 +1345,8 @@ class ListArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_numpy(self, allow_missing):
-        return self.to_RegularArray()._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
     def _completely_flatten(self, backend, options):
         if (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1440,7 +1440,7 @@ class ListArray(Content):
     def _to_list(self, behavior, json_conversions):
         return ListOffsetArray._to_list(self, behavior, json_conversions)
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         starts = self._starts.to_nplike(backend.index_nplike)
         stops = self._stops.to_nplike(backend.index_nplike)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2125,7 +2125,7 @@ class ListOffsetArray(Content):
                 out[i] = content[starts_data[i] : stops_data[i]]
             return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         offsets = self._offsets.to_nplike(backend.index_nplike)
         return ListOffsetArray(offsets, content, parameters=self._parameters)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1949,14 +1949,12 @@ class ListOffsetArray(Content):
                 ),
             )
 
-    def _to_numpy(self, allow_missing):
+    def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
-            return self._backend.nplike.array(self.to_list())
+            return backend.nplike.array(self.to_list())
 
-        return ak.operations.to_numpy(
-            self.to_RegularArray(), allow_missing=allow_missing
-        )
+        return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
     def _completely_flatten(self, backend, options):
         if (

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1192,12 +1192,8 @@ class NumpyArray(Content):
             ),
         )
 
-    def _to_numpy(self, allow_missing):
-        out = numpy.asarray(self._data)
-        if type(out).__module__.startswith("cupy."):
-            return out.get()
-        else:
-            return out
+    def _to_backend_array(self, allow_missing, backend):
+        return self._backend.nplike.raw(self.data, backend.nplike)
 
     def _completely_flatten(self, backend, options):
         return [

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1306,7 +1306,7 @@ class NumpyArray(Content):
 
             return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         return NumpyArray(
             self._raw(backend.nplike),
             parameters=self._parameters,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1010,7 +1010,7 @@ class RecordArray(Content):
                 out[i] = dict(zip(fields, [x[i] for x in contents]))
             return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         contents = [content.to_backend(backend) for content in self._contents]
         return RecordArray(
             contents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -857,23 +857,23 @@ class RecordArray(Content):
             children=values,
         )
 
-    def _to_numpy(self, allow_missing):
+    def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
-            return self._backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_numpy(allow_missing) for x in self._contents]
+            return backend.nplike.empty(self.length, dtype=[])
+        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ak._errors.wrap_error(
                 ValueError(f"cannot convert {self} into np.ndarray")
             )
-        out = self._backend.nplike.empty(
+        out = backend.nplike.empty(
             self.length,
             dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],
         )
         mask = None
         for n, x in zip(self.fields, contents):
-            if isinstance(x, self._backend.nplike.ma.MaskedArray):
+            if allow_missing and isinstance(x, self._backend.nplike.ma.MaskedArray):
                 if mask is None:
-                    mask = self._backend.index_nplike.ma.zeros(
+                    mask = backend.index_nplike.ma.zeros(
                         self.length, [(n, np.bool_) for n in self.fields]
                     )
                 if x.mask is not None:
@@ -881,7 +881,7 @@ class RecordArray(Content):
             out[n] = x
 
         if mask is not None:
-            out = self._backend.nplike.ma.MaskedArray(out, mask)
+            out = backend.nplike.ma.MaskedArray(out, mask)
 
         return out
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1138,12 +1138,12 @@ class RegularArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_numpy(self, allow_missing):
+    def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
-            return self._backend.nplike.array(self.to_list())
+            return backend.nplike.array(self.to_list())
 
-        out = self._content.to_numpy(allow_missing)
+        out = self._content._to_backend_array(allow_missing, backend)
         shape = (self._length, self._size) + out.shape[1:]
         return out[: self._length * self._size].reshape(shape)
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1333,7 +1333,7 @@ class RegularArray(Content):
                 out[i] = content[(i) * size : (i + 1) * size]
             return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         return RegularArray(
             content, self._size, zeros_length=self._length, parameters=self._parameters

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1571,7 +1571,7 @@ class UnionArray(Content):
             out[i] = contents[tag][index[i]]
         return out
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         tags = self._tags.to_nplike(backend.index_nplike)
         index = self._index.to_nplike(backend.index_nplike)
         contents = [content.to_backend(backend) for content in self._contents]

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1426,30 +1426,39 @@ class UnionArray(Content):
             children=values,
         )
 
-    def _to_numpy(self, allow_missing):
+    def _to_backend_array(self, allow_missing, backend):
+        ak._errors.deprecate(
+            "Conversion of irreducible unions to backend arrays is deprecated.", "2.2.0"
+        )
+
         contents = [
-            self.project(i)._to_numpy(allow_missing) for i in range(len(self.contents))
+            self.project(i)._to_backend_array(allow_missing, backend)
+            for i in range(len(self.contents))
         ]
 
-        if any(isinstance(x, self._backend.nplike.ma.MaskedArray) for x in contents):
+        if any(isinstance(x, backend.nplike.ma.MaskedArray) for x in contents):
             try:
-                out = self._backend.nplike.ma.concatenate(contents)
+                out = backend.nplike.ma.concatenate(contents)
             except Exception as err:
                 raise ak._errors.wrap_error(
                     ValueError(f"cannot convert {self} into numpy.ma.MaskedArray")
                 ) from err
         else:
             try:
-                out = numpy.concatenate(contents)
+                out = backend.nplike.concatenate(contents)
             except Exception as err:
                 raise ak._errors.wrap_error(
                     ValueError(f"cannot convert {self} into np.ndarray")
                 ) from err
 
-        tags = numpy.asarray(self.tags)
+        tags = backend.index_nplike.asarray(self.tags)
         for tag, content in enumerate(contents):
             mask = tags == tag
-            out[mask] = content
+            if ak._nplikes.Jax.is_own_array(out):
+                out = out.at[mask].set(content)
+            else:
+                out[mask] = content
+
         return out
 
     def _completely_flatten(self, backend, options):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -413,10 +413,10 @@ class UnmaskedArray(Content):
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self._content._to_arrow(pyarrow, self, None, length, options)
 
-    def _to_numpy(self, allow_missing):
-        content = self.content._to_numpy(allow_missing)
+    def _to_backend_array(self, allow_missing, backend):
+        content = self.content._to_backend_array(allow_missing, backend)
         if allow_missing:
-            return self._backend.nplike.ma.MaskedArray(content)
+            return backend.nplike.ma.MaskedArray(content)
         else:
             return content
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -492,7 +492,7 @@ class UnmaskedArray(Content):
 
         return self._content._to_list(behavior, json_conversions)
 
-    def to_backend(self, backend: ak._backends.Backend) -> Self:
+    def _to_backend(self, backend: ak._backends.Backend) -> Self:
         content = self._content.to_backend(backend)
         return UnmaskedArray(content, parameters=self._parameters)
 

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -24,7 +24,13 @@ def to_cupy(array):
         "ak.to_cupy",
         dict(array=array),
     ):
-        from awkward._connect.cuda import import_cupy
+        return _impl(array)
 
-        cupy = import_cupy()
-        return ak._util.to_arraylib(cupy, array, True)
+
+def _impl(array):
+    layout = ak.to_layout(array, allow_record=False)
+
+    backend = ak._backends.CupyBackend.instance()
+    cupy_layout = layout.to_backend(backend)
+
+    return cupy_layout.to_backend_array(allow_missing=False)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-from awkward import _errors, _util, jax
+import awkward as ak
 
 
 def to_jax(array):
@@ -20,8 +20,17 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
-    with _errors.OperationErrorContext(
+    with ak._errors.OperationErrorContext(
         "ak.to_jax",
         dict(array=array),
     ):
-        return _util.to_arraylib(jax.import_jax().numpy, array, True)
+        return _impl(array)
+
+
+def _impl(array):
+    layout = ak.to_layout(array, allow_record=False)
+
+    backend = ak._backends.JaxBackend.instance()
+    numpy_layout = layout.to_backend(backend)
+
+    return numpy_layout.to_backend_array(allow_missing=False)

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -50,4 +50,4 @@ def _impl(array, allow_missing):
         backend = ak._backends.NumpyBackend.instance()
         numpy_layout = layout.to_backend(backend)
 
-        return numpy_layout.to_backend_array(allow_missing=True)
+        return numpy_layout.to_backend_array(allow_missing=allow_missing)

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -40,5 +40,14 @@ def to_numpy(array, *, allow_missing=True):
         "ak.to_numpy",
         dict(array=array, allow_missing=allow_missing),
     ):
-        with numpy.errstate(invalid="ignore"):
-            return ak._util.to_arraylib(numpy, array, allow_missing)
+        return _impl(array, allow_missing)
+
+
+def _impl(array, allow_missing):
+    with numpy.errstate(invalid="ignore"):
+        layout = ak.to_layout(array, allow_record=False)
+
+        backend = ak._backends.NumpyBackend.instance()
+        numpy_layout = layout.to_backend(backend)
+
+        return numpy_layout.to_backend_array(allow_missing=True)

--- a/tests/test_0089_numpy_functions.py
+++ b/tests/test_0089_numpy_functions.py
@@ -192,16 +192,17 @@ def test_tonumpy():
     array = ak.highlevel.Array(
         ak.contents.UnionArray(tags, index, [content0, content1]), check_valid=True
     )
-    assert ak.operations.to_numpy(array).tolist() == [
-        "1.1",
-        "1",
-        "2",
-        "2.2",
-        "3.3",
-        "4.4",
-        "3",
-        "5.5",
-    ]
+    with pytest.warns(DeprecationWarning):
+        assert ak.operations.to_numpy(array).tolist() == [
+            "1.1",
+            "1",
+            "2",
+            "2.2",
+            "3.3",
+            "4.4",
+            "3",
+            "5.5",
+        ]
 
     assert ak.operations.to_numpy(
         ak.highlevel.Array([1.1, 2.2, None, None, 3.3], check_valid=True)
@@ -280,16 +281,17 @@ def test_numpy_array():
     array = ak.highlevel.Array(
         ak.contents.UnionArray(tags, index, [content0, content1]), check_valid=True
     )
-    assert np.asarray(array).tolist() == [
-        "1.1",
-        "1",
-        "2",
-        "2.2",
-        "3.3",
-        "4.4",
-        "3",
-        "5.5",
-    ]
+    with pytest.warns(DeprecationWarning):
+        assert np.asarray(array).tolist() == [
+            "1.1",
+            "1",
+            "2",
+            "2.2",
+            "3.3",
+            "4.4",
+            "3",
+            "5.5",
+        ]
 
     assert ak.operations.to_numpy(
         ak.highlevel.Array([1.1, 2.2, None, None, 3.3], check_valid=True)

--- a/tests/test_0331_pandas_indexedarray.py
+++ b/tests/test_0331_pandas_indexedarray.py
@@ -167,7 +167,8 @@ def test_union_to_record():
         df_unionarray["z"].values, np.array([np.nan, 999, np.nan])
     )
 
-    df_unionarray2 = ak.operations.to_dataframe(unionarray2)
+    with pytest.warns(DeprecationWarning):
+        df_unionarray2 = ak.operations.to_dataframe(unionarray2)
     np.testing.assert_array_equal(
         df_unionarray2["x"].values, [1, np.nan, np.nan, np.nan, 3]
     )

--- a/tests/test_1765_add_ioanas_test_of_to_arraylib.py
+++ b/tests/test_1765_add_ioanas_test_of_to_arraylib.py
@@ -8,12 +8,14 @@ import awkward as ak
 
 def test():
     aa = ak.contents.NumpyArray(np.frombuffer(b"hellothere", "u1"))
-    b = ak._util.to_arraylib(np, aa, False)
+    b = aa.to_backend_array(allow_missing=False)
     assert b.tolist() == [104, 101, 108, 108, 111, 116, 104, 101, 114, 101]
     assert b.dtype == np.dtype(np.uint8)
 
     c = ak.contents.NumpyArray(np.array([0, 1577836800], dtype="datetime64[s]"))
-    assert [d.isoformat() for d in ak._util.to_arraylib(np, c, False).tolist()] == [
+    assert [
+        d.isoformat() for d in c.to_backend_array(allow_missing=False).tolist()
+    ] == [
         "1970-01-01T00:00:00",
         "2020-01-01T00:00:00",
     ]
@@ -22,7 +24,7 @@ def test():
         [ak.contents.NumpyArray(np.array([1, 2, 3, 4, 5], dtype=np.int64))],
         fields=["one"],
     )
-    assert ak._util.to_arraylib(np, recordarray, False).tolist() == [
+    assert recordarray.to_backend_array(allow_missing=False).tolist() == [
         (1,),
         (2,),
         (3,),


### PR DESCRIPTION
This PR
- Removes `ak._util.to_arraylib` and
- Deprecates `NumpyArray.to_numpy(allow_missing)` in favour of
- Adds `NumpyArray.to_backend_array(allow_missing, backend)`
- Deprecates support of `UnionArray` in `to_backend_array()`.

`to_arraylib()` duplicates much of `to_numpy()`'s logic, and we also don't need to enshrine NumPy as more special than the general backend-agnos