### PR TITLE
chore: apply changes from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,6 @@ per-file-ignores =
     src/awkward/_connect/numba/*: AK1
     src/awkward/_errors.py: AK1
     src/awkward/typing.py: F405
-    src/awkward/typing.py: F405
     src/awkward/_connect/rdataframe/to_rdataframe.py: B028
 
 [flake8:local-plugins]

--- a/.flake8
+++ b/.flake8
@@ -12,6 +12,8 @@ per-file-ignores =
     src/awkward/_connect/numba/*: AK1
     src/awkward/_errors.py: AK1
     src/awkward/typing.py: F405
+    src/awkward/typing.py: F405
+    src/awkward/_connect/rdataframe/to_rdataframe.py: B028
 
 [flake8:local-plugins]
 extension =

--- a/dev/flake8_awkward.py
+++ b/dev/flake8_awkward.py
@@ -20,10 +20,10 @@ class Visitor(ast.NodeVisitor):
         if isinstance(node.exc, ast.Call):
             if isinstance(node.exc.func, ast.Attribute):
                 if node.exc.func.attr in {"wrap_error", "index_error"}:
-                    return
+                    return self.generic_visit(node)
             if isinstance(node.exc.func, ast.Name):
                 if node.exc.func.id in {"ImportError"}:
-                    return
+                    return self.generic_visit(node)
 
         self.errors.append(
             Flake8ASTErrorInfo(node.lineno, node.col_offset, self.msg, type(self))

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -169,7 +169,7 @@ def from_rdataframe(data_frame, columns):
 
             if form_str == "unsupported type":
                 raise ak._errors.wrap_error(
-                    TypeError(f'"{col}" column\'s type "{col_type}" is not supported.')
+                    TypeError(f"{col!r} column's type {col_type!r} is not supported.")
                 )
             elif form_str == "awkward type":
                 raise ak._errors.wrap_error(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -558,9 +558,9 @@ class BitMaskedArray(Content):
 
     def _validity_error(self, path):
         if self.mask.length * 8 < self.length:
-            return f'at {path} ("{type(self)}"): len(mask) * 8 < length'
+            return f"at {path} ({type(self)!r}): len(mask) * 8 < length"
         elif self._content.length < self.length:
-            return f'at {path} ("{type(self)}"): len(content) < length'
+            return f"at {path} ({type(self)!r}): len(content) < length"
         else:
             return self._content._validity_error(path + ".content")
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -904,7 +904,7 @@ class ByteMaskedArray(Content):
 
     def _validity_error(self, path):
         if self._backend.nplike.known_shape and self._content.length < self.mask.length:
-            return f'at {path} ("{type(self)}"): len(content) < len(mask)'
+            return f"at {path} ({type(self)!r}): len(content) < len(mask)"
         else:
             return self._content._validity_error(path + ".content")
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1200,7 +1200,7 @@ class ListArray(Content):
 
     def _validity_error(self, path):
         if self._backend.nplike.known_shape and self.stops.length < self.starts.length:
-            return f'at {path} ("{type(self)}"): len(stops) < len(starts)'
+            return f"at {path} ({type(self)!r}): len(stops) < len(starts)"
         assert (
             self.starts.nplike is self._backend.index_nplike
             and self.stops.nplike is self._backend.index_nplike

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1696,7 +1696,7 @@ class ListOffsetArray(Content):
 
     def _validity_error(self, path):
         if self.offsets.length < 1:
-            return f'at {path} ("{type(self)}"): len(offsets) < 1'
+            return f"at {path} ({type(self)!r}): len(offsets) < 1"
         assert (
             self.starts.nplike is self._backend.index_nplike
             and self.stops.nplike is self._backend.index_nplike

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1130,13 +1130,13 @@ class NumpyArray(Content):
 
     def _validity_error(self, path):
         if len(self.shape) == 0:
-            return f'at {path} ("{type(self)}"): shape is zero-dimensional'
+            return f"at {path} ({type(self)!r}): shape is zero-dimensional"
         for i, dim in enumerate(self.shape):
             if dim < 0:
-                return f'at {path} ("{type(self)}"): shape[{i}] < 0'
+                return f"at {path} ({type(self)!r}): shape[{i}] < 0"
         for i, stride in enumerate(self.strides):
             if stride % self.dtype.itemsize != 0:
-                return f'at {path} ("{type(self)}"): shape[{i}] % itemsize != 0'
+                return f"at {path} ({type(self)!r}): shape[{i}] % itemsize != 0"
         return ""
 
     def _pad_none(self, target, axis, depth, clip):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -789,7 +789,7 @@ class RecordArray(Content):
     def _validity_error(self, path):
         for i, cont in enumerate(self.contents):
             if cont.length < self.length:
-                return f'at {path} ("{type(self)}"): len(field({i})) < len(recordarray)'
+                return f"at {path} ({type(self)!r}): len(field({i})) < len(recordarray)"
         for i, cont in enumerate(self.contents):
             sub = cont._validity_error(f"{path}.field({i})")
             if sub != "":

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1091,7 +1091,7 @@ class RegularArray(Content):
 
     def _validity_error(self, path):
         if self.size < 0:
-            return f'at {path} ("{type(self)}"): size < 0'
+            return f"at {path} ({type(self)!r}): size < 0"
 
         return self._content._validity_error(path + ".content")
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1286,7 +1286,7 @@ class UnionArray(Content):
                 self._backend.nplike.known_shape
                 and self.index.length < self.tags.length
             ):
-                return f'at {path} ("{type(self)}"): len(index) < len(tags)'
+                return f"at {path} ({type(self)!r}): len(index) < len(tags)"
 
             lencontents = self._backend.index_nplike.empty(
                 len(self.contents), dtype=np.int64

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -319,7 +319,7 @@ def from_datashape(datashape, highlevel=True):
         else:
             raise ak._errors.wrap_error(
                 ValueError(
-                    f"type '{type(out).__name__}' is not compatible with highlevel=True"
+                    f"type {type(out).__name__!r} is not compatible with highlevel=True"
                 )
             )
 


### PR DESCRIPTION
Recent updates to flake8-bugbear introduced B028 which warns for `f'"{str}"'` vs `f"{str!r}"`, and B906 which warns for non-exhaustive AST visitors.