### PR TITLE
refactor: move `Singleton` to its own module

### DIFF
--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -14,9 +14,9 @@ from awkward._nplikes import (
     NumpyKernel,
     NumpyLike,
     NumpyMetadata,
-    Singleton,
     nplike_of,
 )
+from awkward._singleton import Singleton
 from awkward._typetracer import NoKernel, TypeTracer
 from awkward.typing import Callable, Final, Tuple, TypeAlias, TypeVar, Unpack
 

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -6,21 +6,8 @@ import ctypes
 import numpy
 
 import awkward as ak
+from awkward._singleton import Singleton
 from awkward.typing import TypeVar
-
-
-class Singleton:
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        assert cls._instance is None
-        return super().__new__(cls, *args, **kwargs)
-
-    @classmethod
-    def instance(cls):
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance
 
 
 class NumpyMetadata(Singleton):

--- a/src/awkward/_singleton.py
+++ b/src/awkward/_singleton.py
@@ -6,6 +6,9 @@ from awkward.typing import Protocol, Self
 class Singleton(Protocol):
     _instance: type[Self]
 
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, **kwargs)
+
     @classmethod
     def instance(cls) -> Self:
         try:

--- a/src/awkward/_singleton.py
+++ b/src/awkward/_singleton.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from awkward.typing import Protocol, Self
+
+
+class Singleton(Protocol):
+    _instance: type[Self]
+
+    @classmethod
+    def instance(cls) -> Self:
+        try:
+            return cls._instance
+        except AttributeError:
+            cls._instance = cls()
+            return cls._instance


### PR DESCRIPTION
This tiny PR is part of the process of solidifying our typetracer / nplike mechanism. A long-term refactoring goal is to make imports more explicit, i.e.
```python
from awkward._util import some_func
```
instead of
```python
import awkward as ak

def use_some_func():
	return some_func()
```
so by reducing the number of independent concepts in `_util`, we can avoid the import problems that stem from this.