### PR TITLE
refactor: use `nplike.asarray`

### DIFF
--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -5,10 +5,10 @@ from abc import ABC, abstractmethod
 import awkward_cpp
 
 import awkward as ak
-from awkward._kernels import CupyKernel, JaxKernel, NumpyKernel
+from awkward._kernels import CupyKernel, JaxKernel, NumpyKernel, TypeTracerKernel
 from awkward._nplikes import Cupy, Jax, Numpy, NumpyLike, NumpyMetadata, nplike_of
 from awkward._singleton import Singleton
-from awkward._typetracer import NoKernel, TypeTracer
+from awkward._typetracer import TypeTracer
 from awkward.typing import Callable, Final, Tuple, TypeAlias, TypeVar, Unpack
 
 np = NumpyMetadata.instance()
@@ -160,8 +160,8 @@ class TypeTracerBackend(Backend):
     def __init__(self):
         self._typetracer = TypeTracer.instance()
 
-    def __getitem__(self, index: KernelKeyType) -> NoKernel:
-        return NoKernel(index)
+    def __getitem__(self, index: KernelKeyType) -> TypeTracerKernel:
+        return TypeTracerKernel(index)
 
 
 def _backend_for_nplike(nplike: ak._nplikes.NumpyLike) -> Backend:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -537,7 +537,7 @@ def apply_step(
 
                 combos = backend.index_nplike.stack(tagslist, axis=-1)
 
-                all_combos = backend.index_nplike.array(
+                all_combos = backend.index_nplike.asarray(
                     list(itertools.product(*[range(x) for x in numtags])),
                     dtype=[(str(i), combos.dtype) for i in range(len(tagslist))],
                 )

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -83,7 +83,7 @@ class Sum(Reducer):
 
         if array.dtype.kind == "m":
             return ak.contents.NumpyArray(
-                array.backend.nplike.asarray(result, array.dtype)
+                array.backend.nplike.asarray(result, dtype=array.dtype)
             )
         elif array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(result.view(array.dtype))
@@ -184,7 +184,9 @@ class Min(Reducer):
 
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result.view(array.dtype), array.dtype),
+                array.backend.nplike.asarray(
+                    result.view(array.dtype), dtype=array.dtype
+                ),
                 backend=array.backend,
             )
         else:
@@ -230,7 +232,9 @@ class Max(Reducer):
         result = jax.numpy.maximum(result, cls._max_initial(cls.initial, array.dtype))
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result.view(array.dtype), array.dtype),
+                array.backend.nplike.asarray(
+                    result.view(array.dtype), dtype=array.dtype
+                ),
                 backend=array.backend,
             )
         else:

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -5,6 +5,7 @@ import operator
 import numba
 import numba.core.typing
 import numba.core.typing.ctypes_utils
+import numpy
 
 import awkward as ak
 
@@ -865,7 +866,7 @@ def array_supported(dtype):
     ) or isinstance(dtype, (numba.types.NPDatetime, numba.types.NPTimedelta))
 
 
-@numba.extending.overload(ak._nplikes.numpy.array)
+@numba.extending.overload(numpy.array)
 def overload_np_array(array, dtype=None):
     if isinstance(array, ArrayViewType):
         ndim = array.type.ndim
@@ -934,7 +935,7 @@ def array_impl(array, dtype=None):
             )
 
 
-@numba.extending.type_callable(ak._nplikes.numpy.asarray)
+@numba.extending.type_callable(numpy.asarray)
 def type_asarray(context):
     def typer(arrayview):
         if (
@@ -948,7 +949,7 @@ def type_asarray(context):
     return typer
 
 
-@numba.extending.lower_builtin(ak._nplikes.numpy.asarray, ArrayViewType)
+@numba.extending.lower_builtin(numpy.asarray, ArrayViewType)
 def lower_asarray(context, builder, sig, args):
     rettype, (viewtype,) = sig.return_type, sig.args
     (viewval,) = args

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -3,12 +3,10 @@
 import numba
 import numba.core.typing
 import numba.core.typing.ctypes_utils
+import numpy
 from awkward_cpp import libawkward
 
 import awkward as ak
-
-numpy = ak._nplikes.Numpy.instance()
-
 
 dynamic_addrs = {}
 

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -6,9 +6,6 @@ import numba
 
 import awkward as ak
 
-np = ak._nplikes.NumpyMetadata.instance()
-numpy = ak._nplikes.Numpy.instance()
-
 
 @numba.extending.typeof_impl.register(ak.contents.Content)
 @numba.extending.typeof_impl.register(ak.index.Index)

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -19,7 +19,7 @@ class Lookup:
         self.nplike = layout.backend.nplike
         self.generator = generator
         self.positions = positions
-        self.arrayptrs = self.nplike.array(
+        self.arrayptrs = self.nplike.asarray(
             [arrayptr(x) for x in positions], dtype=np.intp
         )
 

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -81,10 +81,6 @@ class NumpyLike(Singleton):
 
     ############################ array creation
 
-    def array(self, *args, **kwargs):
-        # data[, dtype=[, copy=]]
-        return self._module.array(*args, **kwargs)
-
     def asarray(
         self,
         obj,

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -85,9 +85,26 @@ class NumpyLike(Singleton):
         # data[, dtype=[, copy=]]
         return self._module.array(*args, **kwargs)
 
-    def asarray(self, *args, **kwargs):
-        # array[, dtype=][, order=]
-        return self._module.asarray(*args, **kwargs)
+    def asarray(
+        self,
+        obj,
+        *,
+        dtype: numpy.dtype | None = None,
+        copy: bool | None = None,
+    ):
+        if copy:
+            return self._module.array(obj, dtype=dtype, copy=True)
+        elif copy is None:
+            return self._module.asarray(obj, dtype=dtype)
+        else:
+            if getattr(obj, "dtype", dtype) != dtype:
+                raise ak._errors.wrap_error(
+                    ValueError(
+                        "asarray was called with copy=False for an array of a different dtype"
+                    )
+                )
+            else:
+                return self._module.asarray(obj, dtype=dtype)
 
     def ascontiguousarray(self, *args, **kwargs):
         # array[, dtype=]

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -334,7 +334,7 @@ class Sum(Reducer):
 
         if array.dtype.kind == "m":
             return ak.contents.NumpyArray(
-                array.backend.nplike.asarray(result, array.dtype)
+                array.backend.nplike.asarray(result, dtype=array.dtype)
             )
         elif array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(result.view(array.dtype))
@@ -348,7 +348,7 @@ class Sum(Reducer):
         if dtype in {np.timedelta64, np.datetime64}:
             return np.timedelta64(0)
         else:
-            return numpy.array(0, dtype=dtype)[()]
+            return numpy.asarray(0, dtype=dtype)[()]
 
 
 class Prod(Reducer):
@@ -435,7 +435,7 @@ class Prod(Reducer):
         if dtype in {np.timedelta64, np.datetime64}:
             return np.timedelta64(0)
         else:
-            return numpy.array(1, dtype=dtype)[()]
+            return numpy.asarray(1, dtype=dtype)[()]
 
 
 class Any(Reducer):
@@ -633,11 +633,13 @@ class Min(Reducer):
             )
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result.view(array.dtype), array.dtype)
+                array.backend.nplike.asarray(
+                    result.view(array.dtype), dtype=array.dtype
+                )
             )
         else:
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result, array.dtype)
+                array.backend.nplike.asarray(result, dtype=array.dtype)
             )
 
 
@@ -734,9 +736,11 @@ class Max(Reducer):
             )
         if array.dtype.type in (np.complex128, np.complex64):
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result.view(array.dtype), array.dtype)
+                array.backend.nplike.asarray(
+                    result.view(array.dtype), dtype=array.dtype
+                )
             )
         else:
             return ak.contents.NumpyArray(
-                array.backend.nplike.array(result, array.dtype)
+                array.backend.nplike.asarray(result, dtype=array.dtype)
             )

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -719,11 +719,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
 
     ############################ array creation
 
-    def array(self, data, dtype=None, **kwargs):
-        # data[, dtype=[, copy=]]
-        try_touch_data(data)
-        return TypeTracerArray.from_array(data, dtype=dtype)
-
     def asarray(
         self,
         obj,
@@ -734,7 +729,11 @@ class TypeTracer(ak._nplikes.NumpyLike):
         try_touch_data(obj)
         result = TypeTracerArray.from_array(obj, dtype=dtype)
         # If we want a copy, by the dtypes don't match
-        if not copy and dtype is not None and getattr(obj, "dtype", dtype) != dtype:
+        if (
+            not (copy is None or copy)
+            and dtype is not None
+            and getattr(obj, "dtype", dtype) != dtype
+        ):
             raise ak._errors.wrap_error(
                 ValueError(
                     "asarray was called with copy=False for an array of a different dtype"

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -12,32 +12,6 @@ from awkward.typing import TypeVar
 np = _nplikes.NumpyMetadata.instance()
 
 
-class NoError:
-    def __init__(self):
-        self.str = None
-        self.filename = None
-        self.pass_through = False
-        self.attempt = ak._util.kSliceNone
-        self.id = ak._util.kSliceNone
-
-
-class NoKernel:
-    def __init__(self, index):
-        self._name_and_types = index
-
-    def __call__(self, *args):
-        for x in args:
-            try_touch_data(x)
-        return NoError()
-
-    def __repr__(self):
-        return "<{} {}{}>".format(
-            type(self).__name__,
-            self._name_and_types[0],
-            "".join(", " + str(numpy.dtype(x)) for x in self._name_and_types[1:]),
-        )
-
-
 class UnknownLengthType:
     def __repr__(self):
         return "UnknownLength"
@@ -711,9 +685,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
     def to_rectilinear(self, array, *args, **kwargs):
         try_touch_shape(array)
         raise ak._errors.wrap_error(NotImplementedError)
-
-    def __getitem__(self, name_and_types):
-        return NoKernel(name_and_types)
 
     @property
     def ma(self):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -743,7 +743,7 @@ class TypeTracer(ak._nplikes.NumpyLike):
                     )
                 )
             else:
-                result
+                return result
 
     def ascontiguousarray(self, array, dtype=None, **kwargs):
         # array[, dtype=]

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import numbers
 

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -733,17 +733,15 @@ class TypeTracer(ak._nplikes.NumpyLike):
     ):
         try_touch_data(obj)
         result = TypeTracerArray.from_array(obj, dtype=dtype)
-        if copy or copy is None:
-            return result
-        else:
-            if getattr(obj, "dtype", dtype) != dtype:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "asarray was called with copy=False for an array of a different dtype"
-                    )
+        # If we want a copy, by the dtypes don't match
+        if not copy and getattr(obj, "dtype", dtype) != dtype:
+            raise ak._errors.wrap_error(
+                ValueError(
+                    "asarray was called with copy=False for an array of a different dtype"
                 )
-            else:
-                return result
+            )
+        else:
+            return result
 
     def ascontiguousarray(self, array, dtype=None, **kwargs):
         # array[, dtype=]

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -723,10 +723,26 @@ class TypeTracer(ak._nplikes.NumpyLike):
         try_touch_data(data)
         return TypeTracerArray.from_array(data, dtype=dtype)
 
-    def asarray(self, array, dtype=None, **kwargs):
-        # array[, dtype=][, order=]
-        try_touch_data(array)
-        return TypeTracerArray.from_array(array, dtype=dtype)
+    def asarray(
+        self,
+        obj,
+        *,
+        dtype: numpy.dtype | None = None,
+        copy: bool | None = None,
+    ):
+        try_touch_data(obj)
+        result = TypeTracerArray.from_array(obj, dtype=dtype)
+        if copy or copy is None:
+            return result
+        else:
+            if getattr(obj, "dtype", dtype) != dtype:
+                raise ak._errors.wrap_error(
+                    ValueError(
+                        "asarray was called with copy=False for an array of a different dtype"
+                    )
+                )
+            else:
+                result
 
     def ascontiguousarray(self, array, dtype=None, **kwargs):
         # array[, dtype=]

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -734,7 +734,7 @@ class TypeTracer(ak._nplikes.NumpyLike):
         try_touch_data(obj)
         result = TypeTracerArray.from_array(obj, dtype=dtype)
         # If we want a copy, by the dtypes don't match
-        if not copy and getattr(obj, "dtype", dtype) != dtype:
+        if not copy and dtype is not None and getattr(obj, "dtype", dtype) != dtype:
             raise ak._errors.wrap_error(
                 ValueError(
                     "asarray was called with copy=False for an array of a different dtype"

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1468,9 +1468,9 @@ class IndexedOptionArray(Content):
                 elif issubclass(content.dtype.type, np.integer):
                     data[mask0] = np.iinfo(content.dtype).max
                 elif issubclass(content.dtype.type, (np.datetime64, np.timedelta64)):
-                    data[mask0] = nplike.array([np.iinfo(np.int64).max], content.dtype)[
-                        0
-                    ]
+                    data[mask0] = nplike.asarray(
+                        [np.iinfo(np.int64).max], dtype=content.dtype
+                    )[0]
                 else:
                     raise ak._errors.wrap_error(
                         AssertionError(f"unrecognized dtype: {content.dtype}")

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1416,7 +1416,7 @@ class IndexedOptionArray(Content):
             )
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        index = numpy.array(self._index, copy=True)
+        index = numpy.asarray(self._index, copy=True)
         this_validbytes = self.mask_as_bool(valid_when=True)
         index[~this_validbytes] = 0
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1862,8 +1862,8 @@ class ListOffsetArray(Content):
             nonzeros = npoffsets[1:] != npoffsets[:-1]
             maskedbytes = validbytes == 0
             if numpy.any(maskedbytes & nonzeros):  # null and count > 0
-                new_starts = numpy.array(npoffsets[:-1], copy=True)
-                new_stops = numpy.array(npoffsets[1:], copy=True)
+                new_starts = numpy.asarray(npoffsets[:-1], copy=True)
+                new_stops = numpy.asarray(npoffsets[1:], copy=True)
                 new_starts[maskedbytes] = 0
                 new_stops[maskedbytes] = 0
                 next = ak.contents.ListArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -245,7 +245,7 @@ class ListOffsetArray(Content):
         offsets = self._offsets[start : stop + 1]
         if offsets.length == 0:
             offsets = Index(
-                self._backend.index_nplike.array([0], dtype=self._offsets.dtype),
+                self._backend.index_nplike.asarray([0], dtype=self._offsets.dtype),
                 nplike=self._backend.index_nplike,
             )
         return ListOffsetArray(offsets, self._content, parameters=self._parameters)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1952,7 +1952,7 @@ class ListOffsetArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
-            return backend.nplike.array(self.to_list())
+            return backend.nplike.asarray(self.to_list())
 
         return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -191,8 +191,8 @@ class NumpyArray(Content):
     def maybe_to_NumpyArray(self) -> Self:
         return self
 
-    def __array__(self, *args, **kwargs):
-        return self._backend.nplike.asarray(self._data, *args, **kwargs)
+    def __array__(self, dtype=None):
+        return self._backend.nplike.asarray(self._data, dtype=dtype)
 
     def __iter__(self):
         return iter(self._data)
@@ -685,7 +685,7 @@ class NumpyArray(Content):
             )
 
             return ak.contents.NumpyArray(
-                self._backend.nplike.asarray(out[: nextlength[0]], self.dtype),
+                self._backend.nplike.asarray(out[: nextlength[0]], dtype=self.dtype),
                 parameters=None,
                 backend=self._backend,
             )
@@ -997,7 +997,7 @@ class NumpyArray(Content):
                 )
             )
             return ak.contents.NumpyArray(
-                self._backend.nplike.asarray(out, self.dtype),
+                self._backend.nplike.asarray(out, dtype=self.dtype),
                 parameters=None,
                 backend=self._backend,
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1141,7 +1141,7 @@ class RegularArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
-            return backend.nplike.array(self.to_list())
+            return backend.nplike.asarray(self.to_list())
 
         out = self._content._to_backend_array(allow_missing, backend)
         shape = (self._length, self._size) + out.shape[1:]

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1377,7 +1377,7 @@ class UnionArray(Content):
                     content = content[this_index]
                     if not copied_index:
                         copied_index = True
-                        npindex = numpy.array(npindex, copy=True)
+                        npindex = numpy.asarray(npindex, copy=True)
                     npindex[selected_tags] = numpy.arange(
                         this_index.shape[0], dtype=npindex.dtype
                     )

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -48,7 +48,12 @@ class Index:
                 TypeError("Index metadata must be None or a dict")
             )
         self._metadata = metadata
-        self._data = self._nplike.asarray(data, dtype=self._expected_dtype, order="C")
+        # We don't care about F, C (it's one dimensional), but we do need
+        # the array to be contiguous. This should _not_ return a copy if already
+        self._data = self._nplike.ascontiguousarray(
+            self._nplike.asarray(data, dtype=self._expected_dtype)
+        )
+
         if len(self._data.shape) != 1:
             raise ak._errors.wrap_error(TypeError("Index data must be one-dimensional"))
 
@@ -138,8 +143,8 @@ class Index:
     def __len__(self):
         return self.length
 
-    def __array__(self, *args, **kwargs):
-        return self._nplike.asarray(self._data, *args, **kwargs)
+    def __array__(self, dtype=None):
+        return self._nplike.asarray(self._data, dtype=dtype)
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -206,7 +206,7 @@ def _impl(
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(ak._nplikes.nplike_of(*arrays).array([y]))
+            y = ak.contents.NumpyArray(ak._nplikes.nplike_of(*arrays).asarray([y]))
         inputs.append(y)
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -168,7 +168,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                             ak.contents.RegularArray(
                                 ak.contents.NumpyArray(
                                     backend.nplike.broadcast_to(
-                                        backend.nplike.array([x]), (length,)
+                                        backend.nplike.asarray([x]), (length,)
                                     )
                                 ),
                                 1,
@@ -215,7 +215,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                                 ),
                                 ak.contents.NumpyArray(
                                     backend.nplike.broadcast_to(
-                                        backend.nplike.array([x]), (length,)
+                                        backend.nplike.asarray([x]), (length,)
                                     )
                                 ),
                             )

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -96,7 +96,7 @@ def _impl(array, value, axis, highlevel, behavior):
             valuelayout = valuelayout.array[valuelayout.at : valuelayout.at + 1]
         elif len(valuelayout) == 0:
             offsets = ak.index.Index64(
-                backend.index_nplike.array([0, 0], dtype=np.int64)
+                backend.index_nplike.asarray([0, 0], dtype=np.int64)
             )
             valuelayout = ak.contents.ListOffsetArray(offsets, valuelayout)
         else:

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -72,7 +72,9 @@ def _impl(array, axis, highlevel, behavior):
                 nplike = layout._backend.index_nplike
 
                 # this is a copy of the raw array
-                index = starts = nplike.array(layout.starts.raw(nplike), dtype=np.int64)
+                index = starts = nplike.asarray(
+                    layout.starts.raw(nplike), dtype=np.int64, copy=True
+                )
 
                 # this might be a view
                 stops = layout.stops.raw(nplike)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -180,7 +180,7 @@ def _impl(array, axis, highlevel, behavior):
             backend = layout.backend
 
             if layout.is_unknown:
-                return apply(ak.contents.NumpyArray(backend.nplike.array([])))
+                return apply(ak.contents.NumpyArray(backend.nplike.asarray([])))
 
             elif layout.is_indexed:
                 return apply(layout.project())

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -193,7 +193,7 @@ def _impl(array, axis, highlevel, behavior):
                     return layout
 
                 tags = backend.index_nplike.asarray(layout.tags)
-                index = backend.index_nplike.array(
+                index = backend.index_nplike.asarray(
                     backend.nplike.asarray(layout.index), copy=True
                 )
                 bigmask = backend.index_nplike.empty(len(index), dtype=np.bool_)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -82,7 +82,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         # converting the fill avoids a ValueError.
         dtype = np.dtype(dtype)
         nplike = ak._nplikes.nplike_of(array)
-        fill_value = nplike.array([fill_value], dtype=dtype)[0]
+        fill_value = nplike.asarray([fill_value], dtype=dtype)[0]
         # Also, if the fill_value cannot be converted to the dtype
         # this should throw a clear, early, error.
         if dtype == np.dtype(np.bool_):

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -209,7 +209,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            intercept = ak.contents.NumpyArray(nplike.array([intercept]))
+            intercept = ak.contents.NumpyArray(nplike.asarray([intercept]))
             scalar = True
         if not isinstance(
             slope,
@@ -218,7 +218,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            slope = ak.contents.NumpyArray(nplike.array([slope]))
+            slope = ak.contents.NumpyArray(nplike.asarray([slope]))
             scalar = True
         if not isinstance(
             intercept_error,
@@ -227,7 +227,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            intercept_error = ak.contents.NumpyArray(nplike.array([intercept_error]))
+            intercept_error = ak.contents.NumpyArray(nplike.asarray([intercept_error]))
             scalar = True
         if not isinstance(
             slope_error,
@@ -236,7 +236,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            slope_error = ak.contents.NumpyArray(nplike.array([slope_error]))
+            slope_error = ak.contents.NumpyArray(nplike.asarray([slope_error]))
             scalar = True
 
         out = ak.contents.RecordArray(

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -136,7 +136,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             position = (
                 backend.index_nplike.searchsorted(
                     current_offsets,
-                    backend.index_nplike.array([len(layout)]),
+                    backend.index_nplike.asarray([len(layout)]),
                     side="right",
                 )[0]
                 - 1

--- a/tests/test_1672_broadcast_parameters.py
+++ b/tests/test_1672_broadcast_parameters.py
@@ -1,10 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as np
 import pytest
 
 import awkward as ak
-
-numpy = ak._nplikes.Numpy.instance()
 
 
 @pytest.mark.skip("string broadcasting is broken")
@@ -57,7 +56,7 @@ def test_broadcast_strings_2d():
 def test_broadcast_string_int():
     this = ak.Array(["one", "two", "one", "nine"])
     that = ak.contents.NumpyArray(
-        numpy.array([1, 2, 1, 9], dtype="int32"), parameters={"kind": "integer"}
+        np.array([1, 2, 1, 9], dtype="int32"), parameters={"kind": "integer"}
     )
     this_next, that_next = ak.operations.ak_broadcast_arrays.broadcast_arrays(
         this, that
@@ -69,10 +68,10 @@ def test_broadcast_string_int():
 
 def test_broadcast_float_int():
     this = ak.contents.NumpyArray(
-        numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64"), parameters={"name": "this"}
+        np.array([1.0, 2.0, 3.0, 4.0], dtype="float64"), parameters={"name": "this"}
     )
     that = ak.contents.NumpyArray(
-        numpy.array([1, 2, 1, 9], dtype="int32"), parameters={"name": "that"}
+        np.array([1, 2, 1, 9], dtype="int32"), parameters={"name": "that"}
     )
     this_next, that_next = ak.operations.ak_broadcast_arrays.broadcast_arrays(
         this, that, highlevel=False
@@ -83,11 +82,11 @@ def test_broadcast_float_int():
 
 
 def test_broadcast_float_int_option():
-    this = ak.contents.NumpyArray(numpy.arange(4), parameters={"name": "this"})
+    this = ak.contents.NumpyArray(np.arange(4), parameters={"name": "this"})
     that = ak.contents.ByteMaskedArray(
-        ak.index.Index8(numpy.array([0, 1, 0, 1])),
+        ak.index.Index8(np.array([0, 1, 0, 1])),
         ak.contents.NumpyArray(
-            numpy.arange(4),
+            np.arange(4),
         ),
         valid_when=True,
         parameters={"name": "that"},
@@ -101,24 +100,24 @@ def test_broadcast_float_int_option():
 
 
 def test_broadcast_float_int_union():
-    this = ak.contents.NumpyArray(numpy.arange(4), parameters={"name": "this"})
+    this = ak.contents.NumpyArray(np.arange(4), parameters={"name": "this"})
     that_1 = ak.contents.ByteMaskedArray(
-        ak.index.Index8(numpy.array([0, 1, 0, 1], dtype="int8")),
+        ak.index.Index8(np.array([0, 1, 0, 1], dtype="int8")),
         ak.contents.NumpyArray(
-            numpy.arange(4),
+            np.arange(4),
         ),
         valid_when=True,
         parameters={"name": "that"},
     )
     that_2 = ak.contents.ByteMaskedArray(
-        ak.index.Index8(numpy.array([0, 1, 0, 1], dtype="int8")),
+        ak.index.Index8(np.array([0, 1, 0, 1], dtype="int8")),
         ak.from_iter(["1", "2", "3", "4"], highlevel=False),
         valid_when=True,
         parameters={"name": "other"},
     )
     that = ak.contents.UnionArray(
-        ak.index.Index8(numpy.array([0, 1, 0, 1], dtype="int8")),
-        ak.index.Index32(numpy.array([0, 0, 1, 1], dtype="int32")),
+        ak.index.Index8(np.array([0, 1, 0, 1], dtype="int8")),
+        ak.index.Index32(np.array([0, 0, 1, 1], dtype="int32")),
         [that_1, that_2],
     )
     this_next, that_next = ak.operations.ak_broadcast_arrays.broadcast_arrays(
@@ -131,13 +130,13 @@ def test_broadcast_float_int_union():
 
 def test_broadcast_float_int_2d():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={"name": "this"},
     )
     that = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1, 2, 1, 9], dtype="int64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 2, 1, 9], dtype="int64")),
         parameters={"name": "that"},
     )
     this_next, that_next = ak.operations.ak_broadcast_arrays.broadcast_arrays(
@@ -153,12 +152,12 @@ def test_broadcast_float_int_2d():
 
 def test_broadcast_float_int_2d_right_broadcast():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={"name": "this"},
     )
     that = ak.contents.RegularArray(
-        ak.contents.NumpyArray(numpy.array([1, 9], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 9], dtype="int64")),
         size=1,
         parameters={"name": "that"},
     )
@@ -175,12 +174,12 @@ def test_broadcast_float_int_2d_right_broadcast():
 
 def test_broadcast_float_int_2d_regular():
     this = ak.contents.RegularArray(
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         size=2,
         parameters={"name": "this"},
     )
     that = ak.contents.RegularArray(
-        ak.contents.NumpyArray(numpy.array([1, 9], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 9], dtype="int64")),
         size=1,
         parameters={"name": "that"},
     )
@@ -209,13 +208,13 @@ def test_broadcast_string_self():
 
 def test_transform_float_int_2d_same():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={"name": "this"},
     )
     that = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1, 2, 1, 9], dtype="int64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 2, 1, 9], dtype="int64")),
         parameters={"name": "this"},
     )
     this_next, that_next = ak.operations.ak_transform.transform(
@@ -228,13 +227,13 @@ def test_transform_float_int_2d_same():
 
 def test_transform_float_int_2d_different_one_to_one():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={"name": "this"},
     )
     that = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1, 2, 1, 9], dtype="int64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 2, 1, 9], dtype="int64")),
         parameters={"name": "that"},
     )
     this_next, that_next = ak.operations.ak_transform.transform(
@@ -251,8 +250,8 @@ def test_transform_float_int_2d_different_one_to_one():
 
 def test_transform_float_int_2d_different_intersect():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={
             "name": "this",
             "key": "value",
@@ -261,8 +260,8 @@ def test_transform_float_int_2d_different_intersect():
         },
     )
     that = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1, 2, 1, 9], dtype="int64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 2, 1, 9], dtype="int64")),
         parameters={
             "name": "that",
             "key": "value",
@@ -284,13 +283,13 @@ def test_transform_float_int_2d_different_intersect():
 
 def test_transform_float_int_2d_one_to_one_error():
     this = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0], dtype="float64")),
         parameters={"name": "this"},
     )
     that = ak.contents.ListOffsetArray(
-        ak.index.Index64(numpy.array([0, 3, 4], dtype="int64")),
-        ak.contents.NumpyArray(numpy.array([1, 2, 1, 9], dtype="int64")),
+        ak.index.Index64(np.array([0, 3, 4], dtype="int64")),
+        ak.contents.NumpyArray(np.array([1, 2, 1, 9], dtype="int64")),
         parameters={"name": "that"},
     )
 

--- a/tests/test_1707_broadcast_parameters_ufunc.py
+++ b/tests/test_1707_broadcast_parameters_ufunc.py
@@ -1,22 +1,21 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
-
-numpy = ak._nplikes.Numpy.instance()
 
 
 def test_numpy_1d():
     x = ak.Array(
         ak.contents.NumpyArray(
-            numpy.array([1, 2, 3]),
+            np.asarray([1, 2, 3]),
             parameters={"attrs": {"not": "hashable"}, "name": "x"},
         )
     )
     y = ak.Array(
         ak.contents.NumpyArray(
-            numpy.array([1, 2, 3]),
+            np.asarray([1, 2, 3]),
             parameters={"attrs": {"not": "hashable"}, "name": "y"},
         )
     )
@@ -27,13 +26,13 @@ def test_numpy_1d():
 def test_numpy_2d():
     x = ak.Array(
         ak.contents.NumpyArray(
-            numpy.array([[1, 2, 3]]),
+            np.asarray([[1, 2, 3]]),
             parameters={"attrs": {"not": "hashable"}, "name": "x"},
         )
     )
     y = ak.Array(
         ak.contents.NumpyArray(
-            numpy.array([[1, 2, 3]]),
+            np.asarray([[1, 2, 3]]),
             parameters={"attrs": {"not": "hashable"}, "name": "y"},
         )
     )
@@ -45,7 +44,7 @@ def test_regular_array_numpy_1d():
     x = ak.Array(
         ak.contents.RegularArray(
             ak.contents.NumpyArray(
-                numpy.array([1, 2, 3, 4, 5, 6]),
+                np.asarray([1, 2, 3, 4, 5, 6]),
                 parameters={"attrs": {"not": "hashable"}, "name": "x"},
             ),
             3,
@@ -54,7 +53,7 @@ def test_regular_array_numpy_1d():
     y = ak.Array(
         ak.contents.RegularArray(
             ak.contents.NumpyArray(
-                numpy.array([7, 8, 9, 10, 11, 12]),
+                np.asarray([7, 8, 9, 10, 11, 12]),
                 parameters={"attrs": {"not": "hashable"}, "name": "y"},
             ),
             3,


### PR DESCRIPTION
The work to move to an array-API inspired UX requires that we drop `array` and `asarray` distinctions; now `asarray` takes a `copy` parameter, and drops the `order` parameter.

I'm gradually dropping `nplike` usage in our tests, where appropriate; we should probably focus on testing L1 and L2, not L3.