### PR TITLE
refactor: make `nplike.zeros` et al. use Array API type signatures

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -639,7 +639,7 @@ def apply_step(
                     if isinstance(x, optiontypes):
                         x._touch_data(recursive=False)
                         index = Index64(
-                            backend.index_nplike.empty((x.length,), np.int64)
+                            backend.index_nplike.empty(x.length, dtype=np.int64)
                         )
                         nextinputs.append(x.content)
                     else:
@@ -759,7 +759,7 @@ def apply_step(
                         x._touch_data(recursive=False)
                         offsets = Index64(
                             backend.index_nplike.empty(
-                                (x.offsets.data.shape[0],), np.int64
+                                x.offsets.data.shape[0], dtype=np.int64
                             ),
                             nplike=backend.index_nplike,
                         )
@@ -768,7 +768,7 @@ def apply_step(
                         x._touch_data(recursive=False)
                         offsets = Index64(
                             backend.index_nplike.empty(
-                                (x.starts.data.shape[0] + 1,), np.int64
+                                x.starts.data.shape[0] + 1, dtype=np.int64
                             ),
                             nplike=backend.index_nplike,
                         )

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -229,12 +229,12 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         if isinstance(x.data, ak._typetracer.TypeTracerArray):
                             x.data.touch_data()
                         shape = x.shape
-                        args.append(numpy.empty((0,) + x.shape[1:], x.dtype))
+                        args.append(numpy.empty((0,) + x.shape[1:], dtype=x.dtype))
                     else:
                         args.append(x)
                 assert shape is not None
                 tmp = getattr(ufunc, method)(*args, **kwargs)
-                result = nplike.empty((shape[0],) + tmp.shape[1:], tmp.dtype)
+                result = nplike.empty((shape[0],) + tmp.shape[1:], dtype=tmp.dtype)
             return (NumpyArray(result, backend=backend, parameters=parameters),)
 
         for x in inputs:

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -71,7 +71,7 @@ def from_rdataframe(data_frame, columns):
     def empty_buffers(cpp_buffers_self, names_nbytes):
         buffers = {}
         for item in names_nbytes:
-            buffers[item.first] = ak._nplikes.numpy.empty(item.second, dtype=np.uint8)
+            buffers[item.first] = ak._nplikes.numpy.empty(item.second)
             cpp_buffers_self.append(
                 item.first,
                 buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -71,7 +71,7 @@ def from_rdataframe(data_frame, columns):
     def empty_buffers(cpp_buffers_self, names_nbytes):
         buffers = {}
         for item in names_nbytes:
-            buffers[item.first] = ak._nplikes.numpy.empty(item.second)
+            buffers[item.first] = ak._nplikes.numpy.empty(item.second, dtype=np.uint8)
             cpp_buffers_self.append(
                 item.first,
                 buffers[item.first].ctypes.data_as(ctypes.POINTER(ctypes.c_ubyte)),

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -73,6 +73,9 @@ if hasattr(numpy, "timedelta64"):
     NumpyMetadata.timedelta64 = numpy.timedelta64
 
 
+np = NumpyMetadata.instance()
+
+
 class NumpyLike(Singleton):
     known_data = True
     known_shape = True
@@ -113,33 +116,28 @@ class NumpyLike(Singleton):
         # array[, dtype=]
         return self._module.frombuffer(*args, **kwargs)
 
-    def zeros(self, *args, **kwargs):
+    def zeros(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
         # shape/len[, dtype=]
-        return self._module.zeros(*args, **kwargs)
+        return self._module.zeros(shape, dtype=dtype)
 
-    def ones(self, *args, **kwargs):
-        # shape/len[, dtype=]
-        return self._module.ones(*args, **kwargs)
+    def ones(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
+        return self._module.ones(shape, dtype=dtype)
 
-    def empty(self, *args, **kwargs):
-        # shape/len[, dtype=]
-        return self._module.empty(*args, **kwargs)
+    def empty(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
+        return self._module.empty(shape, dtype=dtype)
 
-    def full(self, *args, **kwargs):
+    def full(self, shape: int | tuple[int, ...], fill_value, *, dtype: np.dtype):
         # shape/len, value[, dtype=]
-        return self._module.full(*args, **kwargs)
+        return self._module.full(shape, fill_value, dtype=dtype)
 
-    def zeros_like(self, *args, **kwargs):
-        # array
-        return self._module.zeros_like(*args, **kwargs)
+    def zeros_like(self, x, *, dtype: np.dtype | None = None):
+        return self._module.zeros_like(x, dtype=dtype)
 
-    def ones_like(self, *args, **kwargs):
-        # array
-        return self._module.ones_like(*args, **kwargs)
+    def ones_like(self, x, *, dtype: np.dtype | None = None):
+        return self._module.ones_like(x, dtype=dtype)
 
-    def full_like(self, *args, **kwargs):
-        # array, fill_value
-        return self._module.full_like(*args, **kwargs)
+    def full_like(self, x, fill_value, *, dtype: np.dtype | None = None):
+        return self._module.full_like(x, fill_value, dtype=dtype)
 
     def arange(self, *args, **kwargs):
         # stop[, dtype=]

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -328,7 +328,9 @@ def normalise_item_nested(item):
             item.content._carry(ak.index.Index64(positions_where_valid), False)
         )
 
-        nextindex = item.backend.index_nplike.full(is_valid.shape[0], -1, np.int64)
+        nextindex = item.backend.index_nplike.full(
+            is_valid.shape[0], -1, dtype=np.int64
+        )
         nextindex[positions_where_valid] = item.backend.index_nplike.arange(
             positions_where_valid.shape[0], dtype=np.int64
         )
@@ -373,7 +375,7 @@ def normalise_item_bool_to_int(item):
             nextcontent = localindex.content.data[item.content.data]
 
             cumsum = item.backend.index_nplike.empty(
-                item.content.data.shape[0] + 1, np.int64
+                item.content.data.shape[0] + 1, dtype=np.int64
             )
             cumsum[0] = 0
             cumsum[1:] = item.backend.index_nplike.asarray(
@@ -385,7 +387,7 @@ def normalise_item_bool_to_int(item):
             item._touch_data(recursive=False)
             nextoffsets = item.offsets
             nextcontent = item.backend.nplike.empty(
-                (ak._typetracer.UnknownLength,), dtype=np.int64
+                ak._typetracer.UnknownLength, dtype=np.int64
             )
 
         return ak.contents.ListOffsetArray(
@@ -417,7 +419,7 @@ def normalise_item_bool_to_int(item):
                 expanded = item.content.content.data[safeindex]
             else:
                 expanded = item.content.content.backend.nplike.ones(
-                    safeindex.shape[0], np.bool_
+                    safeindex.shape[0], dtype=np.bool_
                 )
 
             localindex = ak._do.local_index(item, axis=1)
@@ -428,13 +430,15 @@ def normalise_item_bool_to_int(item):
 
             # list offsets do include missing values
             expanded[isnegative] = True
-            cumsum = item.backend.nplike.empty(expanded.shape[0] + 1, np.int64)
+            cumsum = item.backend.nplike.empty(expanded.shape[0] + 1, dtype=np.int64)
             cumsum[0] = 0
             cumsum[1:] = item.backend.nplike.cumsum(expanded)
             nextoffsets = cumsum[item.offsets]
 
             # outindex fits into the lists; non-missing are sequential
-            outindex = item.backend.index_nplike.full(nextoffsets[-1], -1, np.int64)
+            outindex = item.backend.index_nplike.full(
+                nextoffsets[-1], -1, dtype=np.int64
+            )
             outindex[~isnegative[expanded]] = item.backend.index_nplike.arange(
                 nextcontent.shape[0], dtype=np.int64
             )
@@ -444,7 +448,7 @@ def normalise_item_bool_to_int(item):
             nextoffsets = item.offsets
             outindex = item.content.index
             nextcontent = item.backend.nplike.empty(
-                (ak._typetracer.UnknownLength,), dtype=np.int64
+                ak._typetracer.UnknownLength, dtype=np.int64
             )
 
         return ak.contents.ListOffsetArray(
@@ -487,7 +491,7 @@ def normalise_item_bool_to_int(item):
                     expanded = item.content.data[safeindex]
                 else:
                     expanded = item.content.backend.nplike.ones(
-                        safeindex.shape[0], np.bool_
+                        safeindex.shape[0], dtype=np.bool_
                     )
 
                 # nextcontent does not include missing values
@@ -499,7 +503,7 @@ def normalise_item_bool_to_int(item):
                 lenoutindex = item.backend.nplike.count_nonzero(expanded)
 
                 # non-missing are sequential
-                outindex = item.backend.nplike.full(lenoutindex, -1, np.int64)
+                outindex = item.backend.nplike.full(lenoutindex, -1, dtype=np.int64)
                 outindex[~isnegative[expanded]] = item.backend.nplike.arange(
                     nextcontent.shape[0], dtype=np.int64
                 )
@@ -508,7 +512,7 @@ def normalise_item_bool_to_int(item):
                 item._touch_data(recursive=False)
                 outindex = item.index
                 nextcontent = item.backend.nplike.empty(
-                    (ak._typetracer.UnknownLength,), dtype=np.int64
+                    ak._typetracer.UnknownLength, dtype=np.int64
                 )
 
             return ak.contents.IndexedOptionArray(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -85,11 +85,13 @@ class EmptyArray(Content):
     def to_NumpyArray(self, dtype, backend=None):
         backend = backend or self._backend
         return ak.contents.NumpyArray(
-            backend.nplike.empty(0, dtype), parameters=self._parameters, backend=backend
+            backend.nplike.empty(0, dtype=dtype),
+            parameters=self._parameters,
+            backend=backend,
         )
 
     def __array__(self, **kwargs):
-        return numpy.empty((0,))
+        return numpy.empty(0, dtype=np.float64)
 
     def __iter__(self):
         return iter([])
@@ -199,7 +201,7 @@ class EmptyArray(Content):
         posaxis = ak._util.maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return ak.contents.NumpyArray(
-                self._backend.nplike.empty(0, np.int64),
+                self._backend.nplike.empty(0, dtype=np.int64),
                 parameters=None,
                 backend=self._backend,
             )
@@ -295,7 +297,7 @@ class EmptyArray(Content):
         else:
             dtype = np.dtype(options["emptyarray_to"])
             next = ak.contents.NumpyArray(
-                numpy.empty(length, dtype),
+                numpy.empty(length, dtype=dtype),
                 parameters=self._parameters,
                 backend=self._backend,
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1442,7 +1442,7 @@ class IndexedOptionArray(Content):
         nplike = backend.nplike
 
         content = self.project()._to_backend_array(allow_missing, backend)
-        shape = [self.length, *content.shape[1:]]
+        shape = (self.length, *content.shape[1:])
         data = nplike.empty(shape, dtype=content.dtype)
         mask0 = backend.index_nplike.asarray(self.mask_as_bool(valid_when=False)).view(
             np.bool_

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2135,7 +2135,7 @@ class ListOffsetArray(Content):
             strings = self.to_list()
             if any(item in nonfinit_dict for item in strings):
                 numbers = self._backend.index_nplike.empty(
-                    self.starts.length, np.float64
+                    self.starts.length, dtype=np.float64
                 )
                 has_another_string = False
                 for i, val in enumerate(strings):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -470,7 +470,7 @@ class NumpyArray(Content):
     def _subranges_equal(self, starts, stops, length, sorted=True):
         is_equal = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
 
-        tmp = self._backend.nplike.empty(length, self.dtype)
+        tmp = self._backend.nplike.empty(length, dtype=self.dtype)
         self._handle_error(
             self._backend[
                 "awkward_NumpyArray_fill",
@@ -544,7 +544,7 @@ class NumpyArray(Content):
         outoffsets = ak.index.Index64.empty(
             offsets.length, nplike=self._backend.index_nplike
         )
-        out = self._backend.nplike.empty(self.shape[0], self.dtype)
+        out = self._backend.nplike.empty(self.shape[0], dtype=self.dtype)
 
         assert (
             offsets.nplike is self._backend.index_nplike
@@ -650,7 +650,7 @@ class NumpyArray(Content):
                 if self._data.dtype.kind.upper() == "M"
                 else self._data.dtype
             )
-            out = self._backend.nplike.empty(offsets[1], dtype)
+            out = self._backend.nplike.empty(offsets[1], dtype=dtype)
             assert offsets.nplike is self._backend.index_nplike
             self._handle_error(
                 self._backend[
@@ -739,7 +739,7 @@ class NumpyArray(Content):
                 )
             )
 
-            out = self._backend.nplike.empty(self.length, self.dtype)
+            out = self._backend.nplike.empty(self.length, dtype=self.dtype)
             assert offsets.nplike is self._backend.index_nplike
             self._handle_error(
                 self._backend[
@@ -977,7 +977,7 @@ class NumpyArray(Content):
                 if self._data.dtype.kind.upper() == "M"
                 else self._data.dtype
             )
-            out = self._backend.nplike.empty(self.length, dtype)
+            out = self._backend.nplike.empty(self.length, dtype=dtype)
             assert offsets.nplike is self._backend.index_nplike
             self._handle_error(
                 self._backend[

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -718,7 +718,7 @@ class RecordArray(Content):
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
         if self._fields is None or len(self._fields) == 0:
             return ak.contents.NumpyArray(
-                self._backend.nplike.instance().empty(0, np.int64),
+                self._backend.nplike.instance().empty(0, dtype=np.int64),
                 parameters=None,
                 backend=self._backend,
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -910,7 +910,7 @@ class RegularArray(Content):
         if not branch and negaxis == depth:
             if self.size == 0:
                 nextstarts = ak.index.Index64(
-                    self._backend.index_nplike.full(0, len(self)),
+                    self._backend.index_nplike.zeros(len(self), dtype=np.int64),
                     nplike=self._backend.index_nplike,
                 )
             else:
@@ -918,7 +918,7 @@ class RegularArray(Content):
                     self._backend.index_nplike.arange(0, nextlen, self.size),
                     nplike=self._backend.index_nplike,
                 )
-                assert nextstarts.length == len(self)
+            assert nextstarts.length == len(self)
 
             nextcarry = ak.index.Index64.empty(
                 nextlen, nplike=self._backend.index_nplike
@@ -993,13 +993,13 @@ class RegularArray(Content):
 
             if self._size > 0:
                 nextstarts = ak.index.Index64(
-                    self._backend.index_nplike.arange(0, len(nextparents), self._size),
+                    self._backend.index_nplike.arange(0, nextlen, self._size),
                     nplike=self._backend.index_nplike,
                 )
             else:
-                assert len(nextparents) == 0
+                assert nextlen == 0
                 nextstarts = ak.index.Index64(
-                    self._backend.index_nplike.zeros(0),
+                    self._backend.index_nplike.zeros(nextlen, dtype=np.int64),
                     nplike=self._backend.index_nplike,
                 )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1225,7 +1225,7 @@ class UnionArray(Content):
         )
         if simplified.length == 0:
             return ak.contents.NumpyArray(
-                self._backend.nplike.empty(0, np.int64),
+                self._backend.nplike.empty(0, dtype=np.int64),
                 parameters=None,
                 backend=self._backend,
             )

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -176,7 +176,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                         )
                     sizes.append(regulararrays[-1].size)
 
-                prototype = backend.index_nplike.empty(sum(sizes), np.int8)
+                prototype = backend.index_nplike.empty(sum(sizes), dtype=np.int8)
                 start = 0
                 for tag, size in enumerate(sizes):
                     prototype[start : start + size] = tag

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -654,7 +654,9 @@ def build_assembly(schema, container, instructions):
             index = f"node{len(container)}"
             container[index + "-index"] = None
             offsets = f"node{len(container)}"
-            container[offsets + "-offsets"] = numpy.empty(len(strings) + 1, np.int64)
+            container[offsets + "-offsets"] = numpy.empty(
+                len(strings) + 1, dtype=np.int64
+            )
             container[offsets + "-offsets"][0] = 0
             container[offsets + "-offsets"][1:] = numpy.cumsum(
                 [len(x) for x in bytestrings]

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -96,7 +96,7 @@ def _impl(array, highlevel, behavior):
 
     def lengths_of(data, offsets):
         if len(data) == 0:
-            return backend.index_nplike.empty(0, np.int64), offsets
+            return backend.index_nplike.empty(0, dtype=np.int64), offsets
         else:
             diffs = data[1:] != data[:-1]
 
@@ -120,7 +120,9 @@ def _impl(array, highlevel, behavior):
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True
             positions = backend.index_nplike.nonzero(diffs)[0]
-            full_positions = backend.index_nplike.empty(len(positions) + 2, np.int64)
+            full_positions = backend.index_nplike.empty(
+                len(positions) + 2, dtype=np.int64
+            )
             full_positions[0] = 0
             full_positions[-1] = len(data)
             full_positions[1:-1] = positions + 1

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -118,7 +118,7 @@ def _impl(array, counts, axis, highlevel, behavior):
         if not issubclass(counts.dtype.type, np.integer):
             raise ak._errors.wrap_error(ValueError("counts must be integers"))
 
-        current_offsets = backend.index_nplike.empty(len(counts) + 1, np.int64)
+        current_offsets = backend.index_nplike.empty(len(counts) + 1, dtype=np.int64)
         current_offsets[0] = 0
         backend.index_nplike.cumsum(counts, out=current_offsets[1:])
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -96,7 +96,7 @@ def _impl(base, what, where, highlevel, behavior):
                 if what is None:
                     what = ak.contents.IndexedOptionArray(
                         ak.index.Index64(
-                            backend.index_nplike.full(len(base), -1, np.int64),
+                            backend.index_nplike.full(len(base), -1, dtype=np.int64),
                             nplike=backend.index_nplike,
                         ),
                         ak.contents.EmptyArray(),


### PR DESCRIPTION
This is another PR to slowly move our nplikes over towards the array API, in order to improve the safety & maintainability.