### PR TITLE
chore: drop unused nplike functions

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -605,7 +605,7 @@ def apply_step(
                         if mask is None:
                             mask = m
                         else:
-                            mask = backend.index_nplike.bitwise_or(mask, m, out=mask)
+                            mask = backend.index_nplike.logical_or(mask, m, out=mask)
 
                 nextmask = Index8(mask.view(np.int8))
                 index = backend.index_nplike.full(mask.shape[0], -1, dtype=np.int64)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -397,7 +397,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         if not isinstance(masked_index, ak.contents.UnmaskedArray):
             mask = masked_index.mask_as_bool(valid_when=False)
             if mask.any():
-                index = numpy.array(index, copy=True)
+                index = numpy.asarray(index, copy=True)
                 index[mask] = -1
 
         content = handle_arrow(paarray.dictionary, generate_bitmasks)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -196,38 +196,6 @@ if pyarrow is not None:
         pyarrow.duration("ns"): (False, np.dtype("m8[ns]")),
     }
 
-if not ak._util.numpy_at_least("1.17.0"):
-
-    def packbits(bytearray, lsb_order=True):
-        if lsb_order:
-            if len(bytearray) % 8 == 0:
-                ready_to_pack = bytearray
-            else:
-                ready_to_pack = numpy.empty(
-                    int(numpy.ceil(len(bytearray) / 8.0)) * 8,
-                    dtype=bytearray.dtype,
-                )
-                ready_to_pack[: len(bytearray)] = bytearray
-                ready_to_pack[len(bytearray) :] = 0
-            return numpy.packbits(ready_to_pack.reshape(-1, 8)[:, ::-1].reshape(-1))
-        else:
-            return numpy.packbits(bytearray)
-
-    def unpackbits(bitarray, lsb_order=True):
-        ready_to_bitswap = numpy.unpackbits(bitarray)
-        if lsb_order:
-            return ready_to_bitswap.reshape(-1, 8)[:, ::-1].reshape(-1)
-        else:
-            return ready_to_bitswap
-
-else:
-
-    def packbits(bytearray, lsb_order=True):
-        return numpy.packbits(bytearray, bitorder=("little" if lsb_order else "big"))
-
-    def unpackbits(bitarray, lsb_order=True):
-        return numpy.unpackbits(bitarray, bitorder=("little" if lsb_order else "big"))
-
 
 def and_validbytes(validbytes1, validbytes2):
     if validbytes1 is None:
@@ -242,7 +210,7 @@ def to_validbits(validbytes):
     if validbytes is None:
         return None
     else:
-        return pyarrow.py_buffer(packbits(validbytes))
+        return pyarrow.py_buffer(numpy.packbits(validbytes, bitorder="little"))
 
 
 def to_length(nparray, length):
@@ -659,7 +627,9 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         validbits = buffers.pop(0)
         bitdata = buffers.pop(0)
 
-        bytedata = unpackbits(numpy.frombuffer(bitdata, dtype=np.uint8))
+        bytedata = numpy.unpackbits(
+            numpy.frombuffer(bitdata, dtype=np.uint8), bitorder="little"
+        )
 
         out = ak.contents.NumpyArray(
             bytedata.view(np.bool_),

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -3,11 +3,10 @@
 import json
 from collections.abc import Iterable, Sized
 
-import numpy
-
 import awkward as ak
 
 np = ak._nplikes.NumpyMetadata.instance()
+numpy = ak._nplikes.Numpy.instance()
 
 try:
     import pyarrow

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -102,9 +102,9 @@ class NumpyLike(Singleton):
             else:
                 return self._module.asarray(obj, dtype=dtype)
 
-    def ascontiguousarray(self, *args, **kwargs):
+    def ascontiguousarray(self, array, *, dtype=None):
         # array[, dtype=]
-        return self._module.ascontiguousarray(*args, **kwargs)
+        return self._module.ascontiguousarray(array, dtype=dtype)
 
     def frombuffer(self, *args, **kwargs):
         # array[, dtype=]
@@ -154,17 +154,9 @@ class NumpyLike(Singleton):
         # array1, array2
         return self._module.array_equal(*args, **kwargs)
 
-    def size(self, *args, **kwargs):
-        # array
-        return self._module.size(*args, **kwargs)
-
     def searchsorted(self, *args, **kwargs):
         # haystack, needle, side="right"
         return self._module.searchsorted(*args, **kwargs)
-
-    def argsort(self, *args, **kwargs):
-        # array
-        return self._module.argsort(*args, **kwargs)
 
     ############################ manipulation
 
@@ -201,31 +193,23 @@ class NumpyLike(Singleton):
         # arrays
         return self._module.stack(*args, **kwargs)
 
-    def packbits(self, *args, **kwargs):
+    def packbits(self, array, *, axis=None, bitorder="big"):
         # array
-        return self._module.packbits(*args, **kwargs)
+        return self._module.packbits(array, axis=axis, bitorder=bitorder)
 
-    def unpackbits(self, *args, **kwargs):
+    def unpackbits(self, array, *, axis=None, count=None, bitorder="big"):
         # array
-        return self._module.unpackbits(*args, **kwargs)
+        return self._module.unpackbits(array, axis=axis, count=count, bitorder=bitorder)
 
     def broadcast_to(self, *args, **kwargs):
         # array, shape
         return self._module.broadcast_to(*args, **kwargs)
-
-    def where(self, *args, **kwargs):
-        # array, element
-        return self._module.where(*args, **kwargs)
 
     ############################ ufuncs
 
     def add(self, *args, **kwargs):
         # array1, array2
         return self._module.add(*args, **kwargs)
-
-    def multiply(self, *args, **kwargs):
-        # array1, array2
-        return self._module.multiply(*args, **kwargs)
 
     def logical_or(self, *args, **kwargs):
         # array1, array2
@@ -250,18 +234,6 @@ class NumpyLike(Singleton):
     def true_divide(self, *args, **kwargs):
         # array1, array2
         return self._module.true_divide(*args, **kwargs)
-
-    def equal(self, *args, **kwargs):
-        # array1, array2
-        return self._module.equal(*args, **kwargs)
-
-    def minimum(self, *args, **kwargs):
-        # array1, array2
-        return self._module.minimum(*args, **kwargs)
-
-    def maximum(self, *args, **kwargs):
-        # array1, array2
-        return self._module.maximum(*args, **kwargs)
 
     ############################ almost-ufuncs
 
@@ -293,14 +265,6 @@ class NumpyLike(Singleton):
         # array
         return self._module.count_nonzero(*args, **kwargs)
 
-    def sum(self, *args, **kwargs):
-        # array
-        return self._module.sum(*args, **kwargs)
-
-    def prod(self, *args, **kwargs):
-        # array
-        return self._module.prod(*args, **kwargs)
-
     def min(self, *args, **kwargs):
         # array
         return self._module.min(*args, **kwargs)
@@ -308,14 +272,6 @@ class NumpyLike(Singleton):
     def max(self, *args, **kwargs):
         # array
         return self._module.max(*args, **kwargs)
-
-    def argmin(self, *args, **kwargs):
-        # array[, axis=]
-        return self._module.argmin(*args, **kwargs)
-
-    def argmax(self, *args, **kwargs):
-        # array[, axis=]
-        return self._module.argmax(*args, **kwargs)
 
     def array_str(self, *args, **kwargs):
         # array, max_line_width, precision=None, suppress_small=None
@@ -430,24 +386,6 @@ class Cupy(NumpyLike):
     def ndarray(self):
         return self._module.ndarray
 
-    def asarray(self, array, dtype=None, order=None):
-        if isinstance(
-            array,
-            (
-                ak.highlevel.Array,
-                ak.highlevel.Record,
-                ak.contents.Content,
-                ak.record.Record,
-            ),
-        ):
-            out = ak.operations.ak_to_cupy.to_cupy(array)
-            if dtype is not None and out.dtype != dtype:
-                return self._module.asarray(out, dtype=dtype, order=order)
-            else:
-                return out
-        else:
-            return self._module.asarray(array, dtype=dtype, order=order)
-
     def raw(self, array, nplike):
         if isinstance(nplike, Cupy):
             return array
@@ -465,24 +403,6 @@ class Cupy(NumpyLike):
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax"
                 )
             )
-
-    def ascontiguousarray(self, array, dtype=None):
-        if isinstance(
-            array,
-            (
-                ak.highlevel.Array,
-                ak.highlevel.Record,
-                ak.contents.Content,
-                ak.record.Record,
-            ),
-        ):
-            out = ak.operations.ak_to_cupy.to_cupy(array)
-            if dtype is not None and out.dtype != dtype:
-                return self._module.ascontiguousarray(out, dtype=dtype)
-            else:
-                return out
-        else:
-            return self._module.ascontiguousarray(array, dtype=dtype)
 
     def zeros(self, *args, **kwargs):
         return self._module.zeros(*args, **kwargs)
@@ -632,27 +552,6 @@ class Jax(NumpyLike):
     def ndarray(self):
         return self._module.ndarray
 
-    def asarray(self, array, dtype=None, order=None):
-        return self._module.asarray(array, dtype=dtype, order="K")
-
-    def ascontiguousarray(self, array, dtype=None):
-        if isinstance(
-            array,
-            (
-                ak.highlevel.Array,
-                ak.highlevel.Record,
-                ak.contents.Content,
-                ak.record.Record,
-            ),
-        ):
-            out = ak.operations.ak_to_jax.to_jax(array)
-            if dtype is not None and out.dtype != dtype:
-                return self._module.ascontiguousarray(out, dtype=dtype)
-            else:
-                return out
-        else:
-            return self._module.ascontiguousarray(array, dtype=dtype)
-
     def raw(self, array, nplike):
         if isinstance(nplike, Jax):
             return array
@@ -746,6 +645,12 @@ class Jax(NumpyLike):
 
     def is_c_contiguous(self, array) -> bool:
         return True
+
+    def ascontiguousarray(self, array, *, dtype=None):
+        if dtype is not None:
+            return array.astype(dtype)
+        else:
+            return array
 
 
 # Temporary sentinel marking "argument not given"

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -106,9 +106,6 @@ class NumpyLike(Singleton):
         # array[, dtype=]
         return self._module.ascontiguousarray(*args, **kwargs)
 
-    def isscalar(self, *args, **kwargs):
-        return self._module.isscalar(*args, **kwargs)
-
     def frombuffer(self, *args, **kwargs):
         # array[, dtype=]
         return self._module.frombuffer(*args, **kwargs)
@@ -153,10 +150,6 @@ class NumpyLike(Singleton):
 
     ############################ testing
 
-    def shape(self, *args, **kwargs):
-        # array
-        return self._module.shape(*args, **kwargs)
-
     def array_equal(self, *args, **kwargs):
         # array1, array2
         return self._module.array_equal(*args, **kwargs)
@@ -183,10 +176,6 @@ class NumpyLike(Singleton):
         # arrays[, out=]
         return self._module.cumsum(*args, **kwargs)
 
-    def cumprod(self, *args, **kwargs):
-        # arrays[, out=]
-        return self._module.cumprod(*args, **kwargs)
-
     def nonzero(self, *args, **kwargs):
         # array
         return self._module.nonzero(*args, **kwargs)
@@ -212,10 +201,6 @@ class NumpyLike(Singleton):
         # arrays
         return self._module.stack(*args, **kwargs)
 
-    def vstack(self, *args, **kwargs):
-        # arrays
-        return self._module.vstack(*args, **kwargs)
-
     def packbits(self, *args, **kwargs):
         # array
         return self._module.packbits(*args, **kwargs)
@@ -224,17 +209,9 @@ class NumpyLike(Singleton):
         # array
         return self._module.unpackbits(*args, **kwargs)
 
-    def atleast_1d(self, *args, **kwargs):
-        # *arrays
-        return self._module.atleast_1d(*args, **kwargs)
-
     def broadcast_to(self, *args, **kwargs):
         # array, shape
         return self._module.broadcast_to(*args, **kwargs)
-
-    def append(self, *args, **kwargs):
-        # array, element
-        return self._module.append(*args, **kwargs)
 
     def where(self, *args, **kwargs):
         # array, element
@@ -274,17 +251,9 @@ class NumpyLike(Singleton):
         # array1, array2
         return self._module.true_divide(*args, **kwargs)
 
-    def bitwise_or(self, *args, **kwargs):
-        # array1, array2[, out=output]
-        return self._module.bitwise_or(*args, **kwargs)
-
     def equal(self, *args, **kwargs):
         # array1, array2
         return self._module.equal(*args, **kwargs)
-
-    def ceil(self, *args, **kwargs):
-        # array
-        return self._module.ceil(*args, **kwargs)
 
     def minimum(self, *args, **kwargs):
         # array1, array2
@@ -307,18 +276,6 @@ class NumpyLike(Singleton):
     def isnan(self, *args, **kwargs):
         # array
         return self._module.isnan(*args, **kwargs)
-
-    def isneginf(self, *args, **kwargs):
-        # array
-        return self._module.isneginf(*args, **kwargs)
-
-    def isposinf(self, *args, **kwargs):
-        # array
-        return self._module.isposinf(*args, **kwargs)
-
-    def isfinite(self, *args, **kwargs):
-        # array
-        return self._module.isfinite(*args, **kwargs)
 
     ############################ reducers
 
@@ -363,9 +320,6 @@ class NumpyLike(Singleton):
     def array_str(self, *args, **kwargs):
         # array, max_line_width, precision=None, suppress_small=None
         return self._module.array_str(*args, **kwargs)
-
-    def datetime_as_string(self, *args, **kwargs):
-        return self._module.datetime_as_string(*args, **kwargs)
 
     def can_cast(self, *args, **kwargs):
         return self._module.can_cast(*args, **kwargs)

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -679,10 +679,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
     known_data = False
     known_shape = False
 
-    @property
-    def index_nplike(self):
-        return self
-
     def to_rectilinear(self, array, *args, **kwargs):
         try_touch_shape(array)
         raise ak._errors.wrap_error(NotImplementedError)
@@ -818,35 +814,17 @@ class TypeTracer(ak._nplikes.NumpyLike):
 
     ############################ testing
 
-    def shape(self, *args, **kwargs):
-        # array
-        for x in args:
-            try_touch_shape(x)
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def array_equal(self, *args, **kwargs):
         # array1, array2
         for x in args:
             try_touch_data(x)
         return False
 
-    def size(self, *args, **kwargs):
-        # array
-        for x in args:
-            try_touch_shape(x)
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def searchsorted(self, *args, **kwargs):
         # haystack, needle, side="right"
         for x in args:
             try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
-
-    def argsort(self, array, *args, **kwargs):
-        # array
-        for x in args:
-            try_touch_data(x)
-        return TypeTracerArray(np.int64, array.shape)
 
     ############################ manipulation
 
@@ -909,43 +887,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
             return TypeTracerArray(out.dtype)
         else:
             return out
-
-    def multiply(self, x, y):
-        try_touch_data(x)
-        try_touch_data(y)
-        # array1, array2[, out=]
-        return self.add(x, y)
-
-    def maximum(self, x, y):
-        try_touch_data(x)
-        try_touch_data(y)
-        # array1, array2[, out=]
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            is_array = True
-            x = x[0]
-        if isinstance(y, TypeTracerArray):
-            is_array = True
-            y = y[0]
-        is_maybenone = False
-        if isinstance(x, MaybeNone):
-            is_maybenone = True
-            x = x.content
-        if isinstance(y, MaybeNone):
-            is_maybenone = True
-            y = y.content
-        out = x + y
-        if is_array:
-            return TypeTracerArray(out.dtype)
-        elif is_maybenone:
-            return MaybeNone(out)
-        else:
-            return out
-
-    def minimum(self, x, y):
-        try_touch_data(x)
-        try_touch_data(y)
-        return self.maximum(x, y)
 
     def cumsum(self, *args, **kwargs):
         # arrays[, out=]
@@ -1029,12 +970,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         # array, shape
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def where(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array, element
-        raise ak._errors.wrap_error(NotImplementedError)
-
     ############################ ufuncs
 
     def sqrt(self, *args, **kwargs):
@@ -1100,12 +1035,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         else:
             return UnknownScalar(dtype)
 
-    def equal(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array1, array2
-        raise ak._errors.wrap_error(NotImplementedError)
-
     ############################ almost-ufuncs
 
     def nan_to_num(self, *args, **kwargs):
@@ -1138,18 +1067,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def sum(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def prod(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def min(self, *args, **kwargs):
         for x in args:
             try_touch_data(x)
@@ -1160,18 +1077,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         for x in args:
             try_touch_data(x)
         # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def argmin(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array[, axis=]
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def argmax(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array[, axis=]
         raise ak._errors.wrap_error(NotImplementedError)
 
     def array_str(

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -747,11 +747,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         try_touch_data(array)
         return TypeTracerArray.from_array(array, dtype=dtype)
 
-    def isscalar(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def frombuffer(self, *args, **kwargs):
         # array[, dtype=]
         for x in args:
@@ -958,12 +953,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
             try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def cumprod(self, *args, **kwargs):
-        # arrays[, out=]
-        for x in args:
-            try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def nonzero(self, array):
         # array
         try_touch_data(array)
@@ -1022,12 +1011,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         # arrays
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def vstack(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # arrays
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def packbits(self, *args, **kwargs):
         for x in args:
             try_touch_data(x)
@@ -1040,22 +1023,10 @@ class TypeTracer(ak._nplikes.NumpyLike):
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def atleast_1d(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # *arrays
-        raise ak._errors.wrap_error(NotImplementedError)
-
     def broadcast_to(self, *args, **kwargs):
         for x in args:
             try_touch_data(x)
         # array, shape
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def append(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array, element
         raise ak._errors.wrap_error(NotImplementedError)
 
     def where(self, *args, **kwargs):
@@ -1082,12 +1053,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         for x in args:
             try_touch_data(x)
         # array1, array2
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def bitwise_or(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array1, array2[, out=output]
         raise ak._errors.wrap_error(NotImplementedError)
 
     def logical_and(self, x, y, *, dtype=None):
@@ -1139,12 +1104,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
         for x in args:
             try_touch_data(x)
         # array1, array2
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def ceil(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ almost-ufuncs
@@ -1224,11 +1183,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
 
     def can_cast(self, *args, **kwargs):
         return numpy.can_cast(*args, **kwargs)
-
-    def datetime_as_string(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
 
     @classmethod
     def is_own_array(cls, obj) -> bool:

--- a/src/awkward/behaviors/categorical.py
+++ b/src/awkward/behaviors/categorical.py
@@ -104,6 +104,9 @@ def _apply_ufunc(ufunc, method, inputs, kwargs):
 
 
 def register(behavior):
+    # Import NumPy explicitly for registering behaviours
+    import numpy as _numpy
+
     behavior["categorical"] = CategoricalBehavior
-    behavior[ak._nplikes.numpy.equal, "categorical", "categorical"] = _categorical_equal
-    behavior[ak._nplikes.numpy.ufunc, "categorical"] = _apply_ufunc
+    behavior[_numpy.equal, "categorical", "categorical"] = _categorical_equal
+    behavior[_numpy.ufunc, "categorical"] = _apply_ufunc

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -251,6 +251,9 @@ def _cast_bytes_or_str_to_string(string):
 
 
 def register(behavior):
+    # Import NumPy explicitly for registering behaviours
+    import numpy as _numpy
+
     behavior["byte"] = ByteBehavior
     behavior["__typestr__", "byte"] = "byte"
     behavior["char"] = CharBehavior
@@ -261,10 +264,10 @@ def register(behavior):
     behavior["string"] = StringBehavior
     behavior["__typestr__", "string"] = "string"
 
-    behavior[ak._nplikes.numpy.equal, "bytestring", "bytestring"] = _string_equal
-    behavior[ak._nplikes.numpy.equal, "string", "string"] = _string_equal
-    behavior[ak._nplikes.numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
-    behavior[ak._nplikes.numpy.not_equal, "string", "string"] = _string_notequal
+    behavior[_numpy.equal, "bytestring", "bytestring"] = _string_equal
+    behavior[_numpy.equal, "string", "string"] = _string_equal
+    behavior[_numpy.not_equal, "bytestring", "bytestring"] = _string_notequal
+    behavior[_numpy.not_equal, "string", "string"] = _string_notequal
 
     behavior["__broadcast__", "bytestring"] = _string_broadcast
     behavior["__broadcast__", "string"] = _string_broadcast

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -313,7 +313,9 @@ class BitMaskedArray(Content):
                 return self
             else:
                 return BitMaskedArray(
-                    ak.index.IndexU8(~self._mask.data),
+                    ak.index.IndexU8(
+                        self._backend.index_nplike.logical_not(self._mask.data)
+                    ),
                     self._content,
                     valid_when,
                     self._length,
@@ -322,12 +324,11 @@ class BitMaskedArray(Content):
                 )
 
         else:
-            import awkward._connect.pyarrow
-
-            bytemask = awkward._connect.pyarrow.unpackbits(
-                self._mask.data, self._lsb_order
+            bit_order = "little" if lsb_order else "big"
+            bytemask = self.backend.index_nplike.unpackbits(
+                self._mask.data, bitorder=bit_order
             )
-            bitmask = awkward._connect.pyarrow.packbits(bytemask, lsb_order)
+            bitmask = self.backend.index_nplike.packbits(bytemask, bitorder=bit_order)
 
             if valid_when != self._valid_when:
                 bitmask = ~bitmask

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -265,13 +265,12 @@ class ByteMaskedArray(Content):
             )
 
         else:
-            import awkward._connect.pyarrow
-
-            bytearray = self.mask_as_bool(valid_when).view(np.uint8)
-            bitarray = awkward._connect.pyarrow.packbits(bytearray, lsb_order)
+            bit_order = "little" if lsb_order else "big"
+            bytemask = self.mask_as_bool(valid_when).view(np.uint8)
+            bitmask = self.backend.index_nplike.packbits(bytemask, bitorder=bit_order)
 
             return ak.contents.BitMaskedArray(
-                ak.index.IndexU8(bitarray),
+                ak.index.IndexU8(bitmask),
                 self._content,
                 valid_when,
                 self.length,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -973,7 +973,7 @@ class IndexedArray(Content):
             and self._index.length != 0
         ):
             npindex = self._index.data
-            indexmin = npindex.min()
+            indexmin = self._backend.index_nplike.min(npindex)
             index = ak.index.Index(
                 npindex - indexmin, nplike=self._backend.index_nplike
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1512,7 +1512,7 @@ class IndexedOptionArray(Content):
             npindex = self._index.data
             npselect = npindex >= 0
             if self._backend.index_nplike.any(npselect):
-                indexmin = npindex[npselect].min()
+                indexmin = self._backend.index_nplike.min(npindex[npselect])
                 index = ak.index.Index(
                     npindex - indexmin, nplike=self._backend.index_nplike
                 )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1375,14 +1375,16 @@ class ListArray(Content):
             and self._backend.nplike.known_data
             and self._starts.length != 0
         ):
-            startsmin = self._starts.data.min().item()
+            startsmin = self._backend.index_nplike.min(self._starts.data).item()
             starts = ak.index.Index(
                 self._starts.data - startsmin, nplike=self._backend.index_nplike
             )
             stops = ak.index.Index(
                 self._stops.data - startsmin, nplike=self._backend.index_nplike
             )
-            content = self._content[startsmin : self._stops.data.max().item()]
+            content = self._content[
+                startsmin : self._backend.index_nplike.max(self._stops.data).item()
+            ]
         else:
             self._touch_data(recursive=False)
             starts, stops, content = self._starts, self._stops, self._content

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2074,8 +2074,8 @@ class ListOffsetArray(Content):
         if numpy.count_nonzero(nonempty) == 0:
             mini, maxi = 0, 0
         else:
-            mini = starts_data.min()
-            maxi = stops_data.max()
+            mini = self._backend.index_nplike.min(starts_data)
+            maxi = self._backend.index_nplike.max(stops_data)
 
         starts_data = starts_data - mini
         stops_data = stops_data - mini

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1172,7 +1172,7 @@ class NumpyArray(Content):
         storage_type = pyarrow.from_numpy_dtype(nparray.dtype)
 
         if issubclass(nparray.dtype.type, (bool, np.bool_)):
-            nparray = ak._connect.pyarrow.packbits(nparray)
+            nparray = numpy.packbits(nparray, bitorder="little")
 
         return pyarrow.Array.from_buffers(
             ak._connect.pyarrow.to_awkwardarrow_type(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import math
 
 import awkward as ak
 from awkward._util import unset
@@ -136,7 +137,7 @@ class UnmaskedArray(Content):
         )
 
     def to_BitMaskedArray(self, valid_when, lsb_order):
-        bitlength = int(numpy.ceil(self._content.length / 8.0))
+        bitlength = int(math.ceil(self._content.length / 8.0))
         if valid_when:
             bitmask = self._backend.index_nplike.full(
                 bitlength, np.uint8(255), dtype=np.uint8


### PR DESCRIPTION
Our nplikes include several functions that are not used or tested. This means that modifications to this code are untested and add to the maintenance budget. This PR removes such functions, and in the process adds some explicit signatures to any touched functions.