### PR TITLE
chore: add helpful message if cpp install is not prepared

### DIFF
--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -16,9 +16,11 @@ if(NOT (EXISTS "header-only" AND EXISTS "include/awkward/kernels.h"))
   message(
     FATAL_ERROR
       "\
-awkward-cpp relies upon generated and copied artefacts such as the header-only libraries and generated kernel headers.\
-These could not be found, which indicates that the preparation step for building this package was skipped.\
-Please check CONTRIBUTING.md to learn more about this process.\
+awkward-cpp relies upon generated and copied artefacts such as the header-only libraries and generated kernel headers. \
+These could not be found, which indicates that\n\n\
+    nox -s prepare\
+\n\nwas skipped or failed. \
+Please check https://github.com/scikit-hep/awkward#installation-for-developers to learn more about this process.\
 ")
 endif()
 

--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -11,6 +11,17 @@ project(
 message(STATUS "CMake version ${CMAKE_VERSION}")
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
+# Check for header-only libraries
+if(NOT (EXISTS "header-only" AND EXISTS "include/awkward/kernels.h"))
+  message(
+    FATAL_ERROR
+      "\
+awkward-cpp relies upon generated and copied artefacts such as the header-only libraries and generated kernel headers.\
+These could not be found, which indicates that the preparation step for building this package was skipped.\
+Please check CONTRIBUTING.md to learn more about this process.\
+")
+endif()
+
 # Defaults for properties in this directory (and below)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Fixes #2140 by informing the user during the build of `awkward-cpp` if the header-only directory or `include/awkward/kernels.h` are missing.