### PR TITLE
feat: start hardening nplike signatures

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -606,7 +606,7 @@ def apply_step(
                             mask = m
                         else:
                             mask = backend.index_nplike.logical_or(
-                                mask, m, maybe_reuse=mask
+                                mask, m, maybe_out=mask
                             )
 
                 nextmask = Index8(mask.view(np.int8))

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -605,7 +605,9 @@ def apply_step(
                         if mask is None:
                             mask = m
                         else:
-                            mask = backend.index_nplike.logical_or(mask, m, out=mask)
+                            mask = backend.index_nplike.logical_or(
+                                mask, m, maybe_reuse=mask
+                            )
 
                 nextmask = Index8(mask.view(np.int8))
                 index = backend.index_nplike.full(mask.shape[0], -1, dtype=np.int64)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -267,7 +267,7 @@ def popbuffers_finalize(
     if isinstance(awkwardarrow_type, AwkwardArrowType):
         if awkwardarrow_type.mask_type == "UnmaskedArray":
             assert validbits is None or numpy.all(
-                numpy.frombuffer(validbits, np.uint8)[: len(out) // 8] == 0xFF
+                numpy.frombuffer(validbits, dtype=np.uint8)[: len(out) // 8] == 0xFF
             )
             return revertable(
                 ak.contents.UnmaskedArray.simplified(

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -172,9 +172,9 @@ class NumpyLike(Singleton):
                 return self._module.asarray(obj, dtype=dtype)
 
     def ascontiguousarray(
-        self, array: ArrayLike, *, dtype: np.dtype | None = None
+        self, x: ArrayLike, *, dtype: np.dtype | None = None
     ) -> ArrayLike:
-        return self._module.ascontiguousarray(array, dtype=dtype)
+        return self._module.ascontiguousarray(x, dtype=dtype)
 
     def frombuffer(
         self, buffer, *, dtype: np.dtype | None = None, count: int = -1
@@ -284,13 +284,24 @@ class NumpyLike(Singleton):
         arrays = [x for x in arrays]
         return self._module.stack(arrays, axis=axis)
 
-    def packbits(self, x: ArrayLike, *, axis=None, bitorder="big") -> ArrayLike:
+    def packbits(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
+    ) -> ArrayLike:
         return self._module.packbits(x, axis=axis, bitorder=bitorder)
 
     def unpackbits(
-        self, array: ArrayLike, *, axis=None, count=None, bitorder="big"
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        count: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLike:
-        return self._module.unpackbits(array, axis=axis, count=count, bitorder=bitorder)
+        return self._module.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
 
     def broadcast_to(self, x: ArrayLike, shape: tuple[SupportsInt, ...]) -> ArrayLike:
         return self._module.broadcast_to(x, shape)
@@ -443,7 +454,7 @@ class NumpyLike(Singleton):
         """
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def is_c_contiguous(self, array: ArrayLike) -> bool:
+    def is_c_contiguous(self, x: ArrayLike) -> bool:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def to_rectilinear(self, array: ArrayLike) -> ArrayLike:
@@ -498,8 +509,8 @@ class Numpy(NumpyLike):
         """
         return isinstance(obj, numpy.ndarray)
 
-    def is_c_contiguous(self, array: ArrayLike) -> bool:
-        return array.flags["C_CONTIGUOUS"]
+    def is_c_contiguous(self, x: ArrayLike) -> bool:
+        return x.flags["C_CONTIGUOUS"]
 
     def packbits(
         self,
@@ -529,18 +540,18 @@ class Numpy(NumpyLike):
 
     def unpackbits(
         self,
-        array: ArrayLike,
+        x: ArrayLike,
         *,
         axis: int | None = None,
         count: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ):
         if ak._util.numpy_at_least("1.17.0"):
-            return numpy.unpackbits(array, axis=axis, count=count, bitorder=bitorder)
+            return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
         else:
             assert axis is None, "unsupported argument value for axis given"
             assert count is None, "unsupported argument value for count given"
-            ready_to_bitswap = numpy.unpackbits(array)
+            ready_to_bitswap = numpy.unpackbits(x)
             if bitorder == "little":
                 return ready_to_bitswap.reshape(-1, 8)[:, ::-1].reshape(-1)
             else:
@@ -801,16 +812,16 @@ class Jax(NumpyLike):
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "jax"
 
-    def is_c_contiguous(self, array: ArrayLike) -> bool:
+    def is_c_contiguous(self, x: ArrayLike) -> bool:
         return True
 
     def ascontiguousarray(
-        self, array: ArrayLike, *, dtype: np.dtype | None = None
+        self, x: ArrayLike, *, dtype: np.dtype | None = None
     ) -> ArrayLike:
         if dtype is not None:
-            return array.astype(dtype)
+            return x.astype(dtype)
         else:
-            return array
+            return x
 
 
 # Temporary sentinel marking "argument not given"

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -8,10 +8,10 @@ import numpy
 
 import awkward as ak
 from awkward._singleton import Singleton
-from awkward.typing import Protocol, Self, SupportsIndex, SupportsInt, TypeVar
+from awkward.typing import Literal, Protocol, Self, SupportsIndex, SupportsInt, TypeVar
 
 
-class Array(Protocol):
+class ArrayLike(Protocol):
     @property
     @abstractmethod
     def dtype(self) -> dtype:
@@ -34,7 +34,7 @@ class Array(Protocol):
 
     @property
     @abstractmethod
-    def T(self: Array) -> Array:
+    def T(self) -> Self:
         ...
 
     @overload
@@ -63,6 +63,10 @@ class Array(Protocol):
 
     @abstractmethod
     def __index__(self) -> int:
+        ...
+
+    @abstractmethod
+    def __len__(self) -> int:
         ...
 
     @abstractmethod
@@ -152,7 +156,7 @@ class NumpyLike(Singleton):
         *,
         dtype: numpy.dtype | None = None,
         copy: bool | None = None,
-    ):
+    ) -> ArrayLike:
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
         elif copy is None:
@@ -167,180 +171,265 @@ class NumpyLike(Singleton):
             else:
                 return self._module.asarray(obj, dtype=dtype)
 
-    def ascontiguousarray(self, array, *, dtype=None):
-        # array[, dtype=]
+    def ascontiguousarray(
+        self, array: ArrayLike, *, dtype: np.dtype | None = None
+    ) -> ArrayLike:
         return self._module.ascontiguousarray(array, dtype=dtype)
 
-    def frombuffer(self, *args, **kwargs):
-        # array[, dtype=]
-        return self._module.frombuffer(*args, **kwargs)
+    def frombuffer(
+        self, buffer, *, dtype: np.dtype | None = None, count: int = -1
+    ) -> ArrayLike:
+        return self._module.frombuffer(buffer, dtype=dtype, count=count)
 
-    def zeros(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
-        # shape/len[, dtype=]
+    def zeros(self, shape: int | tuple[int, ...], *, dtype: np.dtype) -> ArrayLike:
         return self._module.zeros(shape, dtype=dtype)
 
-    def ones(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
+    def ones(self, shape: int | tuple[int, ...], *, dtype: np.dtype) -> ArrayLike:
         return self._module.ones(shape, dtype=dtype)
 
-    def empty(self, shape: int | tuple[int, ...], *, dtype: np.dtype):
+    def empty(self, shape: int | tuple[int, ...], *, dtype: np.dtype) -> ArrayLike:
         return self._module.empty(shape, dtype=dtype)
 
-    def full(self, shape: int | tuple[int, ...], fill_value, *, dtype: np.dtype):
-        # shape/len, value[, dtype=]
+    def full(
+        self, shape: int | tuple[int, ...], fill_value, *, dtype: np.dtype
+    ) -> ArrayLike:
         return self._module.full(shape, fill_value, dtype=dtype)
 
-    def zeros_like(self, x, *, dtype: np.dtype | None = None):
+    def zeros_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
         return self._module.zeros_like(x, dtype=dtype)
 
-    def ones_like(self, x, *, dtype: np.dtype | None = None):
+    def ones_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
         return self._module.ones_like(x, dtype=dtype)
 
-    def full_like(self, x, fill_value, *, dtype: np.dtype | None = None):
+    def full_like(
+        self, x: ArrayLike, fill_value, *, dtype: np.dtype | None = None
+    ) -> ArrayLike:
         return self._module.full_like(x, fill_value, dtype=dtype)
 
-    def arange(self, *args, **kwargs):
-        # stop[, dtype=]
-        # start, stop[, dtype=]
-        # start, stop, step[, dtype=]
-        return self._module.arange(*args, **kwargs)
+    def arange(
+        self,
+        start: float | int,
+        stop: float | int | None = None,
+        step: float | int = 1,
+        *,
+        dtype: np.dtype | None = None,
+    ) -> ArrayLike:
+        return self._module.arange(start, stop, step, dtype=dtype)
 
-    def meshgrid(self, *args, **kwargs):
-        # *arrays, indexing="ij"
-        return self._module.meshgrid(*args, **kwargs)
+    def meshgrid(
+        self, *arrays: ArrayLike, indexing: Literal["xy", "ij"] = "xy"
+    ) -> list[ArrayLike]:
+        return self._module.meshgrid(*arrays, indexing=indexing)
 
     ############################ testing
 
-    def array_equal(self, *args, **kwargs):
-        # array1, array2
-        return self._module.array_equal(*args, **kwargs)
+    def array_equal(
+        self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
+    ) -> bool:
+        return self._module.array_equal(x1, x2, equal_nan=equal_nan)
 
-    def searchsorted(self, *args, **kwargs):
-        # haystack, needle, side="right"
-        return self._module.searchsorted(*args, **kwargs)
+    def searchsorted(
+        self,
+        x: ArrayLike,
+        values: ArrayLike,
+        *,
+        side: Literal["left", "right"] = "left",
+        sorter: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.searchsorted(x, values, side=side, sorter=sorter)
 
     ############################ manipulation
 
-    def broadcast_arrays(self, *args, **kwargs):
-        # array1[, array2[, ...]]
-        return self._module.broadcast_arrays(*args, **kwargs)
+    def broadcast_arrays(self, *arrays: ArrayLike) -> list[ArrayLike]:
+        return self._module.broadcast_arrays(*arrays)
 
-    def cumsum(self, *args, **kwargs):
-        # arrays[, out=]
-        return self._module.cumsum(*args, **kwargs)
+    def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
+        return self._module.nonzero(x)
 
-    def nonzero(self, *args, **kwargs):
-        # array
-        return self._module.nonzero(*args, **kwargs)
+    def unique_values(self, x: ArrayLike) -> ArrayLike:
+        return self._module.unique(
+            x,
+            return_counts=False,
+            return_index=False,
+            return_inverse=False,
+            equal_nan=False,
+        )
 
-    def unique(self, *args, **kwargs):
-        # array
-        return self._module.unique(*args, **kwargs)
+    def concat(
+        self,
+        arrays: list[ArrayLike] | tuple[ArrayLike, ...],
+        *,
+        axis: int | None = 0,
+    ) -> ArrayLike:
+        return self._module.concatenate(arrays, axis=axis, casting="same_kind")
 
-    def concatenate(self, *args, **kwargs):
-        # arrays
-        return self._module.concatenate(*args, **kwargs)
+    def repeat(
+        self,
+        x: ArrayLike,
+        repeats: ArrayLike | int,
+        *,
+        axis: int | None = None,
+    ) -> ArrayLike:
+        return self._module.repeat(x, repeats=repeats, axis=axis)
 
-    def repeat(self, *args, **kwargs):
-        # array, int
-        # array1, array2
-        return self._module.repeat(*args, **kwargs)
+    def tile(self, x: ArrayLike, reps: int) -> ArrayLike:
+        return self._module.tile(x, reps)
 
-    def tile(self, *args, **kwargs):
-        # array, int
-        return self._module.tile(*args, **kwargs)
+    def stack(
+        self,
+        arrays: list[ArrayLike] | tuple[ArrayLike, ...],
+        *,
+        axis: int = 0,
+    ) -> ArrayLike:
+        arrays = [x for x in arrays]
+        return self._module.stack(arrays, axis=axis)
 
-    def stack(self, *args, **kwargs):
-        # arrays
-        return self._module.stack(*args, **kwargs)
-
-    def packbits(self, array, *, axis=None, bitorder="big"):
-        # array
+    def packbits(self, array: ArrayLike, *, axis=None, bitorder="big") -> ArrayLike:
         return self._module.packbits(array, axis=axis, bitorder=bitorder)
 
-    def unpackbits(self, array, *, axis=None, count=None, bitorder="big"):
-        # array
+    def unpackbits(
+        self, array: ArrayLike, *, axis=None, count=None, bitorder="big"
+    ) -> ArrayLike:
         return self._module.unpackbits(array, axis=axis, count=count, bitorder=bitorder)
 
-    def broadcast_to(self, *args, **kwargs):
-        # array, shape
-        return self._module.broadcast_to(*args, **kwargs)
+    def broadcast_to(self, x: ArrayLike, shape: tuple[SupportsInt, ...]) -> ArrayLike:
+        return self._module.broadcast_to(x, shape)
 
     ############################ ufuncs
 
-    def add(self, *args, **kwargs):
-        # array1, array2
-        return self._module.add(*args, **kwargs)
+    def add(
+        self, x1: ArrayLike, x2: ArrayLike, maybe_reuse: ArrayLike | None = None
+    ) -> ArrayLike:
+        return self._module.add(x1, x2, out=maybe_reuse)
 
-    def logical_or(self, *args, **kwargs):
-        # array1, array2
-        return self._module.logical_or(*args, **kwargs)
+    def logical_or(
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_reuse: ArrayLike | None = None
+    ) -> ArrayLike:
+        return self._module.logical_or(x1, x2, out=maybe_reuse)
 
-    def logical_and(self, *args, **kwargs):
-        # array1, array2
-        return self._module.logical_and(*args, **kwargs)
+    def logical_and(
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_reuse: ArrayLike | None = None
+    ) -> ArrayLike:
+        return self._module.logical_and(x1, x2, out=maybe_reuse)
 
-    def logical_not(self, *args, **kwargs):
-        # array1, array2
-        return self._module.logical_not(*args, **kwargs)
+    def logical_not(
+        self, x: ArrayLike, maybe_reuse: ArrayLike | None = None
+    ) -> ArrayLike:
+        return self._module.logical_not(x, out=maybe_reuse)
 
-    def sqrt(self, *args, **kwargs):
-        # array
-        return self._module.sqrt(*args, **kwargs)
+    def sqrt(self, x: ArrayLike, maybe_reuse: ArrayLike | None = None) -> ArrayLike:
+        return self._module.sqrt(x, out=maybe_reuse)
 
-    def exp(self, *args, **kwargs):
-        # array
-        return self._module.exp(*args, **kwargs)
+    def exp(self, x: ArrayLike, maybe_reuse: ArrayLike | None = None) -> ArrayLike:
+        return self._module.exp(x, out=maybe_reuse)
 
-    def true_divide(self, *args, **kwargs):
-        # array1, array2
-        return self._module.true_divide(*args, **kwargs)
+    def true_divide(
+        self, x1: ArrayLike, x2: ArrayLike, maybe_reuse: ArrayLike | None = None
+    ) -> ArrayLike:
+        return self._module.true_divide(x1, x2, out=maybe_reuse)
 
     ############################ almost-ufuncs
 
-    def nan_to_num(self, *args, **kwargs):
-        # array, copy=True, nan=0.0, posinf=None, neginf=None
-        return self._module.nan_to_num(*args, **kwargs)
+    def nan_to_num(
+        self,
+        x: ArrayLike,
+        *,
+        copy: bool = True,
+        nan: int | float | None = 0.0,
+        posinf: int | float | None = None,
+        neginf: int | float | None = None,
+    ) -> ArrayLike:
+        return self._module.nan_to_num(
+            x, copy=copy, nan=nan, posinf=posinf, neginf=neginf
+        )
 
-    def isclose(self, *args, **kwargs):
-        # a, b, rtol=1e-05, atol=1e-08, equal_nan=False
-        return self._module.isclose(*args, **kwargs)
+    def isclose(
+        self,
+        x1: ArrayLike,
+        x2: ArrayLike,
+        *,
+        rtol: float = 1e-5,
+        atol: float = 1e-8,
+        equal_nan: bool = False,
+    ) -> ArrayLike:
+        return self._module.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
-    def isnan(self, *args, **kwargs):
-        # array
+    def isnan(self, *args, **kwargs) -> ArrayLike:
         return self._module.isnan(*args, **kwargs)
 
-    ############################ reducers
+    def all(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.all(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
 
-    def all(self, *args, **kwargs):
-        # array
-        kwargs.pop("prefer", None)
-        return self._module.all(*args, **kwargs)
+    def any(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.any(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
 
-    def any(self, *args, **kwargs):
-        # array
-        kwargs.pop("prefer", None)
-        return self._module.any(*args, **kwargs)
+    def min(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
 
-    def count_nonzero(self, *args, **kwargs):
-        # array
-        return self._module.count_nonzero(*args, **kwargs)
+    def max(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
 
-    def min(self, *args, **kwargs):
-        # array
-        return self._module.min(*args, **kwargs)
+    def count_nonzero(
+        self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
+    ) -> ArrayLike:
+        return self._module.count_nonzero(x, axis=axis, keepdims=keepdims)
 
-    def max(self, *args, **kwargs):
-        # array
-        return self._module.max(*args, **kwargs)
+    def cumsum(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        return self._module.cumsum(x, axis=axis, out=maybe_reuse)
 
-    def array_str(self, *args, **kwargs):
-        # array, max_line_width, precision=None, suppress_small=None
-        return self._module.array_str(*args, **kwargs)
+    def array_str(
+        self,
+        x: ArrayLike,
+        *,
+        max_line_width: int | None = None,
+        precision: int | None = None,
+        suppress_small: bool | None = None,
+    ):
+        return self._module.array_str(
+            x,
+            max_line_width=max_line_width,
+            precision=precision,
+            suppress_small=suppress_small,
+        )
 
-    def can_cast(self, *args, **kwargs):
-        return self._module.can_cast(*args, **kwargs)
+    def can_cast(self, from_: np.dtype | ArrayLike, to: np.dtype | ArrayLike) -> bool:
+        return self._module.can_cast(from_, to, casting="same_kind")
 
-    def raw(self, array, nplike):
+    def raw(self, array: ArrayLike, nplike: NumpyLike) -> ArrayLike:
         raise ak._errors.wrap_error(NotImplementedError)
 
     @classmethod
@@ -354,10 +443,10 @@ class NumpyLike(Singleton):
         """
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def is_c_contiguous(self, array) -> bool:
+    def is_c_contiguous(self, array: ArrayLike) -> bool:
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def to_rectilinear(self, array):
+    def to_rectilinear(self, array: ArrayLike) -> ArrayLike:
         raise ak._errors.wrap_error(NotImplementedError)
 
 
@@ -380,7 +469,7 @@ class Numpy(NumpyLike):
     def ndarray(self):
         return self._module.ndarray
 
-    def raw(self, array, nplike):
+    def raw(self, array: ArrayLike, nplike: NumpyLike) -> ArrayLike:
         if isinstance(nplike, Numpy):
             return array
         elif isinstance(nplike, Cupy):
@@ -409,30 +498,43 @@ class Numpy(NumpyLike):
         """
         return isinstance(obj, numpy.ndarray)
 
-    def is_c_contiguous(self, array) -> bool:
+    def is_c_contiguous(self, array: ArrayLike) -> bool:
         return array.flags["C_CONTIGUOUS"]
 
-    def packbits(self, array, *, axis=None, bitorder="big"):
+    def packbits(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
+    ):
         if ak._util.numpy_at_least("1.17.0"):
-            return numpy.packbits(array, axis=axis, bitorder=bitorder)
+            return numpy.packbits(x, axis=axis, bitorder=bitorder)
         else:
             assert axis is None, "unsupported argument value for axis given"
             if bitorder == "little":
-                if len(array) % 8 == 0:
-                    ready_to_pack = array
+                if len(x) % 8 == 0:
+                    ready_to_pack = x
                 else:
                     ready_to_pack = numpy.empty(
-                        int(numpy.ceil(len(array) / 8.0)) * 8,
-                        dtype=array.dtype,
+                        int(numpy.ceil(len(x) / 8.0)) * 8,
+                        dtype=x.dtype,
                     )
-                    ready_to_pack[: len(array)] = array
-                    ready_to_pack[len(array) :] = 0
+                    ready_to_pack[: len(x)] = x
+                    ready_to_pack[len(x) :] = 0
                 return numpy.packbits(ready_to_pack.reshape(-1, 8)[:, ::-1].reshape(-1))
             else:
                 assert bitorder == "bit"
-                return numpy.packbits(array)
+                return numpy.packbits(x)
 
-    def unpackbits(self, array, *, axis=None, count=None, bitorder="big"):
+    def unpackbits(
+        self,
+        array: ArrayLike,
+        *,
+        axis: int | None = None,
+        count: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
+    ):
         if ak._util.numpy_at_least("1.17.0"):
             return numpy.unpackbits(array, axis=axis, count=count, bitorder=bitorder)
         else:
@@ -479,7 +581,7 @@ class Cupy(NumpyLike):
     def ndarray(self):
         return self._module.ndarray
 
-    def raw(self, array, nplike):
+    def raw(self, array: ArrayLike, nplike: NumpyLike) -> ArrayLike:
         if isinstance(nplike, Cupy):
             return array
         elif isinstance(nplike, Numpy):
@@ -497,21 +599,25 @@ class Cupy(NumpyLike):
                 )
             )
 
-    def zeros(self, *args, **kwargs):
-        return self._module.zeros(*args, **kwargs)
+    def frombuffer(
+        self, buffer, *, dtype: np.dtype | None = None, count: int = -1
+    ) -> ArrayLike:
+        np_array = numpy.frombuffer(buffer, dtype=dtype, count=count)
+        return self._module.asarray(np_array)
 
-    def frombuffer(self, *args, **kwargs):
-        np_array = numpy.frombuffer(*args, **kwargs)
-        return self._module.array(np_array)
-
-    def array_equal(self, array1, array2):
-        # CuPy issue?
-        if array1.shape != array2.shape:
+    def array_equal(self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False):
+        if x1.shape != x2.shape:
             return False
         else:
-            return self._module.all(array1 - array2 == 0)
+            return self._module.all(x1 - x2 == 0)
 
-    def repeat(self, array, repeats):
+    def repeat(
+        self, x: ArrayLike, repeats: ArrayLike | int, *, axis: int | None = None
+    ):
+        if axis is not None:
+            raise ak._errors.wrap_error(
+                NotImplementedError(f"repeat for CuPy with axis={axis!r}")
+            )
         # https://github.com/cupy/cupy/issues/3849
         if isinstance(repeats, self._module.ndarray):
             all_stops = self._module.cumsum(repeats)
@@ -519,75 +625,76 @@ class Cupy(NumpyLike):
             stops, stop_counts = self._module.unique(all_stops[:-1], return_counts=True)
             parents[stops] = stop_counts
             self._module.cumsum(parents, out=parents)
-            return array[parents]
+            return x[parents]
         else:
-            return self._module.repeat(array, repeats)
-
-    def nan_to_num(self, *args, **kwargs):
-        self._module.nan_to_num(*args, **kwargs)
+            return self._module.repeat(x, repeats=repeats)
 
     # For all reducers: https://github.com/cupy/cupy/issues/3819
 
-    def all(self, array, axis=None, **kwargs):
-        kwargs.pop("prefer", None)
-        out = self._module.all(array, axis=axis)
+    def all(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        out = self._module.all(x, axis=axis, out=maybe_reuse)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
             return out
 
-    def any(self, array, axis=None, **kwargs):
-        kwargs.pop("prefer", None)
-        out = self._module.any(array, axis=axis)
+    def any(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        out = self._module.any(x, axis=axis, out=maybe_reuse)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
             return out
 
-    def count_nonzero(self, array, axis=None):
-        out = self._module.count_nonzero(array, axis=axis)
+    def count_nonzero(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+    ) -> ArrayLike:
+        out = self._module.count_nonzero(x, axis=axis)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
             return out
 
-    def sum(self, array, axis=None):
-        out = self._module.sum(array, axis=axis)
+    def min(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        out = self._module.min(x, axis=axis, out=maybe_reuse)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
             return out
 
-    def prod(self, array, axis=None):
-        out = self._module.prod(array, axis=axis)
-        if axis is None and isinstance(out, self._module.ndarray):
-            return out.item()
-        else:
-            return out
-
-    def min(self, array, axis=None):
-        out = self._module.min(array, axis=axis)
-        if axis is None and isinstance(out, self._module.ndarray):
-            return out.item()
-        else:
-            return out
-
-    def max(self, array, axis=None):
-        out = self._module.max(array, axis=axis)
-        if axis is None and isinstance(out, self._module.ndarray):
-            return out.item()
-        else:
-            return out
-
-    def argmin(self, array, axis=None):
-        out = self._module.argmin(array, axis=axis)
-        if axis is None and isinstance(out, self._module.ndarray):
-            return out.item()
-        else:
-            return out
-
-    def argmax(self, array, axis=None):
-        out = self._module.argmax(array, axis=axis)
+    def max(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: ArrayLike | None = None,
+    ) -> ArrayLike:
+        out = self._module.max(x, axis=axis, out=maybe_reuse)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
@@ -596,7 +703,6 @@ class Cupy(NumpyLike):
     def array_str(
         self, array, max_line_width=None, precision=None, suppress_small=None
     ):
-        # array, max_line_width, precision=None, suppress_small=None
         return self._module.array_str(array, max_line_width, precision, suppress_small)
 
     @classmethod
@@ -610,9 +716,6 @@ class Cupy(NumpyLike):
         """
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "cupy"
-
-    def is_c_contiguous(self, array) -> bool:
-        return array.flags["C_CONTIGUOUS"]
 
 
 class Jax(NumpyLike):
@@ -645,7 +748,7 @@ class Jax(NumpyLike):
     def ndarray(self):
         return self._module.ndarray
 
-    def raw(self, array, nplike):
+    def raw(self, array: ArrayLike, nplike: NumpyLike) -> ArrayLike:
         if isinstance(nplike, Jax):
             return array
         elif isinstance(nplike, ak._nplikes.Cupy):
@@ -662,44 +765,6 @@ class Jax(NumpyLike):
                     "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer or Jax",
                 )
             )
-
-    # For all reducers: JAX returns zero-dimensional arrays like CuPy
-
-    def all(self, *args, **kwargs):
-        out = self._module.all(*args, **kwargs)
-        return out
-
-    def any(self, *args, **kwargs):
-        out = self._module.any(*args, **kwargs)
-        return out
-
-    def count_nonzero(self, *args, **kwargs):
-        out = self._module.count_nonzero(*args, **kwargs)
-        return out
-
-    def sum(self, *args, **kwargs):
-        out = self._module.sum(*args, **kwargs)
-        return out
-
-    def prod(self, *args, **kwargs):
-        out = self._module.prod(*args, **kwargs)
-        return out
-
-    def min(self, *args, **kwargs):
-        out = self._module.min(*args, **kwargs)
-        return out
-
-    def max(self, *args, **kwargs):
-        out = self._module.max(*args, **kwargs)
-        return out
-
-    def argmin(self, *args, **kwargs):
-        out = self._module.argmin(*args, **kwargs)
-        return out
-
-    def argmax(self, *args, **kwargs):
-        out = self._module.argmax(*args, **kwargs)
-        return out
 
     @classmethod
     def is_own_array(cls, obj) -> bool:
@@ -736,10 +801,12 @@ class Jax(NumpyLike):
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "jax"
 
-    def is_c_contiguous(self, array) -> bool:
+    def is_c_contiguous(self, array: ArrayLike) -> bool:
         return True
 
-    def ascontiguousarray(self, array, *, dtype=None):
+    def ascontiguousarray(
+        self, array: ArrayLike, *, dtype: np.dtype | None = None
+    ) -> ArrayLike:
         if dtype is not None:
             return array.astype(dtype)
         else:

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -365,8 +365,8 @@ class NumpyLike(Singleton):
     ) -> ArrayLike:
         return self._module.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
-    def isnan(self, *args, **kwargs) -> ArrayLike:
-        return self._module.isnan(*args, **kwargs)
+    def isnan(self, x: ArrayLike) -> ArrayLike:
+        return self._module.isnan(x)
 
     def all(
         self,

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -284,8 +284,8 @@ class NumpyLike(Singleton):
         arrays = [x for x in arrays]
         return self._module.stack(arrays, axis=axis)
 
-    def packbits(self, array: ArrayLike, *, axis=None, bitorder="big") -> ArrayLike:
-        return self._module.packbits(array, axis=axis, bitorder=bitorder)
+    def packbits(self, x: ArrayLike, *, axis=None, bitorder="big") -> ArrayLike:
+        return self._module.packbits(x, axis=axis, bitorder=bitorder)
 
     def unpackbits(
         self, array: ArrayLike, *, axis=None, count=None, bitorder="big"

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -334,10 +334,10 @@ class NumpyLike(Singleton):
     def exp(self, x: ArrayLike, maybe_reuse: ArrayLike | None = None) -> ArrayLike:
         return self._module.exp(x, out=maybe_reuse)
 
-    def true_divide(
+    def divide(
         self, x1: ArrayLike, x2: ArrayLike, maybe_reuse: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.true_divide(x1, x2, out=maybe_reuse)
+        return self._module.divide(x1, x2, out=maybe_reuse)
 
     ############################ almost-ufuncs
 

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -309,35 +309,35 @@ class NumpyLike(Singleton):
     ############################ ufuncs
 
     def add(
-        self, x1: ArrayLike, x2: ArrayLike, maybe_reuse: ArrayLike | None = None
+        self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.add(x1, x2, out=maybe_reuse)
+        return self._module.add(x1, x2, out=maybe_out)
 
     def logical_or(
-        self, x1: ArrayLike, x2: ArrayLike, *, maybe_reuse: ArrayLike | None = None
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.logical_or(x1, x2, out=maybe_reuse)
+        return self._module.logical_or(x1, x2, out=maybe_out)
 
     def logical_and(
-        self, x1: ArrayLike, x2: ArrayLike, *, maybe_reuse: ArrayLike | None = None
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.logical_and(x1, x2, out=maybe_reuse)
+        return self._module.logical_and(x1, x2, out=maybe_out)
 
     def logical_not(
-        self, x: ArrayLike, maybe_reuse: ArrayLike | None = None
+        self, x: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.logical_not(x, out=maybe_reuse)
+        return self._module.logical_not(x, out=maybe_out)
 
-    def sqrt(self, x: ArrayLike, maybe_reuse: ArrayLike | None = None) -> ArrayLike:
-        return self._module.sqrt(x, out=maybe_reuse)
+    def sqrt(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
+        return self._module.sqrt(x, out=maybe_out)
 
-    def exp(self, x: ArrayLike, maybe_reuse: ArrayLike | None = None) -> ArrayLike:
-        return self._module.exp(x, out=maybe_reuse)
+    def exp(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
+        return self._module.exp(x, out=maybe_out)
 
     def divide(
-        self, x1: ArrayLike, x2: ArrayLike, maybe_reuse: ArrayLike | None = None
+        self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
-        return self._module.divide(x1, x2, out=maybe_reuse)
+        return self._module.divide(x1, x2, out=maybe_out)
 
     ############################ almost-ufuncs
 
@@ -374,9 +374,9 @@ class NumpyLike(Singleton):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        return self._module.all(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
+        return self._module.all(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def any(
         self,
@@ -384,9 +384,9 @@ class NumpyLike(Singleton):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        return self._module.any(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
+        return self._module.any(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def min(
         self,
@@ -394,9 +394,9 @@ class NumpyLike(Singleton):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
+        return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def max(
         self,
@@ -404,9 +404,9 @@ class NumpyLike(Singleton):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_reuse)
+        return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def count_nonzero(
         self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
@@ -418,9 +418,9 @@ class NumpyLike(Singleton):
         x: ArrayLike,
         *,
         axis: int | None = None,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        return self._module.cumsum(x, axis=axis, out=maybe_reuse)
+        return self._module.cumsum(x, axis=axis, out=maybe_out)
 
     def array_str(
         self,
@@ -648,9 +648,9 @@ class Cupy(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        out = self._module.all(x, axis=axis, out=maybe_reuse)
+        out = self._module.all(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
@@ -662,9 +662,9 @@ class Cupy(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        out = self._module.any(x, axis=axis, out=maybe_reuse)
+        out = self._module.any(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
@@ -689,9 +689,9 @@ class Cupy(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        out = self._module.min(x, axis=axis, out=maybe_reuse)
+        out = self._module.min(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:
@@ -703,9 +703,9 @@ class Cupy(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: ArrayLike | None = None,
+        maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        out = self._module.max(x, axis=axis, out=maybe_reuse)
+        out = self._module.max(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
         else:

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -1,11 +1,73 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from abc import abstractmethod
+from typing import overload
+
 import numpy
 
 import awkward as ak
 from awkward._singleton import Singleton
-from awkward.typing import TypeVar
+from awkward.typing import Protocol, Self, SupportsIndex, SupportsInt, TypeVar
+
+
+class Array(Protocol):
+    @property
+    @abstractmethod
+    def dtype(self) -> dtype:
+        ...
+
+    @property
+    @abstractmethod
+    def ndim(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def shape(self) -> tuple[SupportsInt, ...]:
+        ...
+
+    @property
+    @abstractmethod
+    def size(self) -> SupportsInt:
+        ...
+
+    @property
+    @abstractmethod
+    def T(self: Array) -> Array:
+        ...
+
+    @overload
+    def __getitem__(
+        self, index: SupportsIndex
+    ) -> int | float | complex | str | bytes | bytes:
+        ...
+
+    @overload
+    def __getitem__(
+        self, index: slice | Ellipsis | tuple[SupportsIndex | slice | Ellipsis, ...]
+    ) -> Self:
+        ...
+
+    @abstractmethod
+    def __getitem__(self, index) -> Self:
+        ...
+
+    @abstractmethod
+    def __bool__(self) -> bool:
+        ...
+
+    @abstractmethod
+    def __int__(self) -> int:
+        ...
+
+    @abstractmethod
+    def __index__(self) -> int:
+        ...
+
+    @abstractmethod
+    def view(self, dtype: dtype) -> Self:
+        ...
 
 
 class NumpyMetadata(Singleton):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -1048,7 +1048,7 @@ class TypeTracer(NumpyLike):
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def true_divide(
+    def divide(
         self,
         x1: TypeTracerArray,
         x2: TypeTracerArray,

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -917,7 +917,7 @@ class TypeTracer(NumpyLike):
         x1: TypeTracerArray,
         x2: TypeTracerArray,
         *,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x1)
         try_touch_data(x2)
@@ -940,7 +940,7 @@ class TypeTracer(NumpyLike):
         x: TypeTracerArray,
         *,
         axis: int | None = None,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
@@ -1035,14 +1035,14 @@ class TypeTracer(NumpyLike):
     ############################ ufuncs
 
     def sqrt(
-        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+        self, x: TypeTracerArray, maybe_out: TypeTracerArray | None = None
     ) -> TypeTracerArray:
         try_touch_data(x)
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
     def exp(
-        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+        self, x: TypeTracerArray, maybe_out: TypeTracerArray | None = None
     ) -> TypeTracerArray:
         try_touch_data(x)
         if np.issubdtype(x.dtype, np.integer):
@@ -1053,7 +1053,7 @@ class TypeTracer(NumpyLike):
         self,
         x1: TypeTracerArray,
         x2: TypeTracerArray,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x1)
         try_touch_data(x2)
@@ -1064,7 +1064,7 @@ class TypeTracer(NumpyLike):
         self,
         x1: TypeTracerArray,
         x2: TypeTracerArray,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x1)
         try_touch_data(x2)
@@ -1085,7 +1085,7 @@ class TypeTracer(NumpyLike):
         self,
         x1: TypeTracerArray,
         x2: TypeTracerArray,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x1)
         try_touch_data(x2)
@@ -1102,7 +1102,7 @@ class TypeTracer(NumpyLike):
             return UnknownScalar(dtype)
 
     def logical_not(
-        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+        self, x: TypeTracerArray, maybe_out: TypeTracerArray | None = None
     ) -> TypeTracerArray:
         try_touch_data(x)
         dtype = np.bool_
@@ -1152,7 +1152,7 @@ class TypeTracer(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
         if axis is None:
@@ -1166,7 +1166,7 @@ class TypeTracer(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
         if axis is None:
@@ -1186,7 +1186,7 @@ class TypeTracer(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
@@ -1197,7 +1197,7 @@ class TypeTracer(NumpyLike):
         *,
         axis: int | tuple[int, ...] | None = None,
         keepdims: bool = False,
-        maybe_reuse: TypeTracerArray | None = None,
+        maybe_out: TypeTracerArray | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -7,8 +7,9 @@ import numpy
 
 import awkward as ak
 from awkward import _nplikes, index
+from awkward._nplikes import ArrayLike, NumpyLike
 from awkward._util import NDArrayOperatorsMixin
-from awkward.typing import TypeVar
+from awkward.typing import Final, Literal, Self
 
 np = _nplikes.NumpyMetadata.instance()
 
@@ -79,7 +80,7 @@ def _emptyarray(x):
 
 
 class UnknownScalar:
-    def __init__(self, dtype):
+    def __init__(self, dtype: np.dtype):
         self._dtype = np.dtype(dtype)
 
     @property
@@ -292,12 +293,9 @@ def _length_after_slice(slice, original_length):
         return 0
 
 
-TTypeTracerArray = TypeVar("TTypeTracerArray", bound="TypeTracerArray")
-
-
-class TypeTracerArray(NDArrayOperatorsMixin):
+class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     @classmethod
-    def from_array(cls: TTypeTracerArray, array, dtype=None) -> TTypeTracerArray:
+    def from_array(cls, array, dtype: np.dtype | None = None) -> Self:
         """
         Args:
             array: array-like object, e.g. np.ndarray, #ak.index.Index
@@ -333,7 +331,7 @@ class TypeTracerArray(NDArrayOperatorsMixin):
 
         return cls(dtype, array.shape, form_key, report)
 
-    def __init__(self, dtype, shape=None, form_key=None, report=None):
+    def __init__(self, dtype: np.dtype, shape=None, form_key=None, report=None):
         self.form_key = form_key
         self.report = report
 
@@ -348,8 +346,24 @@ class TypeTracerArray(NDArrayOperatorsMixin):
         return f"TypeTracerArray({dtype}{shape})"
 
     @property
+    def T(self) -> Self:
+        return TypeTracerArray(
+            self.dtype, self._shape[::-1], self.form_key, self.report
+        )
+
+    @property
     def dtype(self):
         return self._dtype
+
+    @property
+    def size(self) -> int | UnknownLength:
+        size = 1
+        for item in self._shape:
+            if ak._util.is_integer(item):
+                size += item
+            else:
+                return UnknownLength
+        return size
 
     @property
     def shape(self):
@@ -413,11 +427,11 @@ class TypeTracerArray(NDArrayOperatorsMixin):
         self.touch_shape()
         return len(self._shape)
 
-    def astype(self, dtype):
+    def astype(self, dtype: np.dtype):
         self.touch_data()
         return self.__class__(np.dtype(dtype), self._shape)
 
-    def view(self, dtype):
+    def view(self, dtype: np.dtype):
         if (
             self.itemsize != np.dtype(dtype).itemsize
             and self._shape[-1] != UnknownLength
@@ -666,6 +680,15 @@ class TypeTracerArray(NDArrayOperatorsMixin):
         result = getattr(ufunc, method)(*replacements, **kwargs)
         return TypeTracerArray(result.dtype, shape=self._shape)
 
+    def __bool__(self) -> bool:
+        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+
+    def __int__(self) -> int:
+        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+
+    def __index__(self) -> int:
+        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+
 
 def try_touch_data(array):
     if isinstance(array, TypeTracerArray):
@@ -677,9 +700,9 @@ def try_touch_shape(array):
         array.touch_shape()
 
 
-class TypeTracer(ak._nplikes.NumpyLike):
-    known_data = False
-    known_shape = False
+class TypeTracer(NumpyLike):
+    known_data: Final = False
+    known_shape: Final = False
 
     def to_rectilinear(self, array, *args, **kwargs):
         try_touch_shape(array)
@@ -697,11 +720,9 @@ class TypeTracer(ak._nplikes.NumpyLike):
     def ndarray(self):
         return TypeTracerArray
 
-    def raw(self, array, nplike):
-        if isinstance(nplike, TypeTracer):
+    def raw(self, array: TypeTracerArray, nplike: NumpyLike) -> ArrayLike:
+        if nplike is self:
             return TypeTracerArray.from_array(array)
-        elif isinstance(array, TypeTracerArray):
-            return self
         elif hasattr(nplike, "known_data") and nplike.known_data:
             raise ak._errors.wrap_error(
                 TypeError(
@@ -711,7 +732,7 @@ class TypeTracer(ak._nplikes.NumpyLike):
         else:
             raise ak._errors.wrap_error(
                 TypeError(
-                    "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, Typetracer"
+                    "Invalid nplike, choose between nplike.Numpy, nplike.Cupy, nplike.Jax, or Typetracer"
                 )
             )
 
@@ -723,7 +744,7 @@ class TypeTracer(ak._nplikes.NumpyLike):
         *,
         dtype: numpy.dtype | None = None,
         copy: bool | None = None,
-    ):
+    ) -> TypeTracerArray:
         try_touch_data(obj)
         result = TypeTracerArray.from_array(obj, dtype=dtype)
         # If we want a copy, by the dtypes don't match
@@ -740,62 +761,75 @@ class TypeTracer(ak._nplikes.NumpyLike):
         else:
             return result
 
-    def ascontiguousarray(self, array, dtype=None, **kwargs):
-        # array[, dtype=]
+    def ascontiguousarray(
+        self, array: TypeTracerArray, *, dtype=None
+    ) -> TypeTracerArray:
         try_touch_data(array)
         return TypeTracerArray.from_array(array, dtype=dtype)
 
-    def frombuffer(self, *args, **kwargs):
-        # array[, dtype=]
-        for x in args:
+    def frombuffer(
+        self, buffer, *, dtype: np.dtype | None = None, count: int = -1
+    ) -> TypeTracerArray:
+        for x in (buffer, count):
             try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def zeros(self, shape, dtype=np.float64, **kwargs):
-        # shape/len[, dtype=]
+    def zeros(
+        self, shape: int | tuple[int, ...], *, dtype: np.dtype
+    ) -> TypeTracerArray:
         return TypeTracerArray(dtype, shape)
 
-    def ones(self, shape, dtype=np.float64, **kwargs):
-        # shape/len[, dtype=]
+    def ones(self, shape: int | tuple[int, ...], *, dtype: np.dtype) -> TypeTracerArray:
         return TypeTracerArray(dtype, shape)
 
-    def empty(self, shape, dtype=np.float64, **kwargs):
-        # shape/len[, dtype=]
+    def empty(
+        self, shape: int | tuple[int, ...], *, dtype: np.dtype
+    ) -> TypeTracerArray:
         return TypeTracerArray(dtype, shape)
 
-    def full(self, shape, value, dtype=None, **kwargs):
-        array = TypeTracerArray.from_array(value, dtype=dtype)
+    def full(
+        self, shape: int | tuple[int, ...], fill_value, *, dtype: np.dtype
+    ) -> TypeTracerArray:
+        array = TypeTracerArray.from_array(fill_value, dtype=dtype)
         return array.reshape(shape)
 
-    def zeros_like(self, a, dtype=None, **kwargs):
-        try_touch_shape(a)
-        if isinstance(a, UnknownScalar):
+    def zeros_like(
+        self, x: TypeTracerArray, *, dtype: np.dtype | None = None
+    ) -> TypeTracerArray:
+        try_touch_shape(x)
+        if isinstance(x, UnknownScalar):
             return UnknownScalar(dtype)
-        return TypeTracerArray.from_array(a, dtype=dtype)
+        return TypeTracerArray.from_array(x, dtype=dtype)
 
-    def ones_like(self, a, dtype=None, **kwargs):
-        try_touch_shape(a)
-        return self.zeros_like(a, dtype)
+    def ones_like(
+        self, x: TypeTracerArray, *, dtype: np.dtype | None = None
+    ) -> TypeTracerArray:
+        try_touch_shape(x)
+        return self.zeros_like(x, dtype=dtype)
 
-    def full_like(self, a, fill_value, dtype=None, **kwargs):
-        try_touch_shape(a)
-        return self.zeros_like(a, dtype)
+    def full_like(
+        self, x: TypeTracerArray, fill_value, *, dtype: np.dtype | None = None
+    ) -> TypeTracerArray:
+        try_touch_shape(x)
+        return self.zeros_like(x, dtype=dtype)
 
-    def arange(self, *args, **kwargs):
-        # stop[, dtype=]
-        # start, stop[, dtype=]
-        # start, stop, step[, dtype=]
-        assert 1 <= len(args) <= 3
+    def arange(
+        self,
+        start: float | int,
+        stop: float | int | None = None,
+        step: float | int = 1,
+        *,
+        dtype: np.dtype | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(start)
+        try_touch_data(stop)
+        try_touch_data(step)
+        # TODO default type computation
         assert (
-            "dtype" in kwargs
+            dtype is not None
         ), "internal error: calling arange without dtype (platform dependence)"
-
-        if len(args) == 1:
-            start, stop, step = 0, args[0], 1
-        elif len(args) == 2:
-            start, stop, step = args[0], args[1], 1
-        elif len(args) == 3:
-            start, stop, step = args[0], args[1], args[2]
+        if stop is None:
+            start, stop = 0, start
 
         if (
             ak._util.is_integer(start)
@@ -806,33 +840,40 @@ class TypeTracer(ak._nplikes.NumpyLike):
         else:
             length = UnknownLength
 
-        return TypeTracerArray(kwargs["dtype"], (length,))
+        return TypeTracerArray(dtype, (length,))
 
-    def meshgrid(self, *args, **kwargs):
-        # *arrays, indexing="ij"
-        for x in args:
+    def meshgrid(
+        self, *arrays: TypeTracerArray, indexing: Literal["xy", "ij"] = "xy"
+    ) -> list[TypeTracerArray]:
+        for x in arrays:
             try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ testing
 
-    def array_equal(self, *args, **kwargs):
-        # array1, array2
-        for x in args:
-            try_touch_data(x)
+    def array_equal(
+        self, x1: TypeTracerArray, x2: TypeTracerArray, *, equal_nan: bool = False
+    ) -> bool:
+        try_touch_data(x1)
+        try_touch_data(x2)
         return False
 
-    def searchsorted(self, *args, **kwargs):
-        # haystack, needle, side="right"
-        for x in args:
-            try_touch_data(x)
+    def searchsorted(
+        self,
+        x: TypeTracerArray,
+        values: TypeTracerArray,
+        *,
+        side: Literal["left", "right"] = "left",
+        sorter: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
+        try_touch_data(values)
+        try_touch_data(sorter)
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ manipulation
 
-    def broadcast_arrays(self, *arrays):
-        # array1[, array2[, ...]]
-
+    def broadcast_arrays(self, *arrays: TypeTracerArray) -> list[TypeTracerArray]:
         for x in arrays:
             try_touch_data(x)
 
@@ -873,41 +914,49 @@ class TypeTracer(ak._nplikes.NumpyLike):
             TypeTracerArray(x.dtype, [UnknownLength] + shape) for x in [first] + rest
         ]
 
-    def add(self, x, y):
-        # array1, array2[, out=]
+    def add(
+        self,
+        x1: TypeTracerArray,
+        x2: TypeTracerArray,
+        *,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x1)
+        try_touch_data(x2)
+
         is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
+        if isinstance(x1, TypeTracerArray):
             is_array = True
-            x = x[0]
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
+            x1 = x1[0]
+        if isinstance(x2, TypeTracerArray):
             is_array = True
-            y = y[0]
-        out = x + y
+            x2 = x2[0]
+        out = x1 + x2
         if is_array:
             return TypeTracerArray(out.dtype)
         else:
             return out
 
-    def cumsum(self, *args, **kwargs):
-        # arrays[, out=]
-        for x in args:
-            try_touch_data(x)
+    def cumsum(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | None = None,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def nonzero(self, array):
+    def nonzero(self, array: TypeTracerArray) -> tuple[TypeTracerArray, ...]:
         # array
         try_touch_data(array)
         return (TypeTracerArray(np.int64, (UnknownLength,)),) * len(array.shape)
 
-    def unique(self, *args, **kwargs):
-        # array
-        for x in args:
-            try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+    def unique_values(self, x: TypeTracerArray) -> TypeTracerArray:
+        try_touch_data(x)
+        return TypeTracerArray(x.dtype)
 
-    def concatenate(self, arrays, casting="same_kind"):
+    def concat(self, arrays, *, casting="same_kind") -> TypeTracerArray:
         for x in arrays:
             try_touch_data(x)
 
@@ -935,102 +984,119 @@ class TypeTracer(ak._nplikes.NumpyLike):
             numpy.concatenate(emptyarrays).dtype, (UnknownLength,) + inner_shape
         )
 
-    def repeat(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array, int
-        # array1, array2
+    def repeat(
+        self,
+        x: TypeTracerArray,
+        repeats: TypeTracerArray | int,
+        *,
+        axis: int | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
+        try_touch_data(repeats)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def tile(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array, int
+    def tile(self, x: TypeTracerArray, reps: int) -> TypeTracerArray:
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def stack(self, *args, **kwargs):
-        for x in args:
+    def stack(
+        self,
+        arrays: list[TypeTracerArray] | tuple[TypeTracerArray, ...],
+        *,
+        axis: int = 0,
+    ) -> TypeTracerArray:
+        for x in arrays:
             try_touch_data(x)
-        # arrays
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def packbits(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
+    def packbits(
+        self, array: TypeTracerArray, *, axis=None, bitorder="big"
+    ) -> TypeTracerArray:
+        try_touch_data(array)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def unpackbits(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def broadcast_to(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array, shape
+    def unpackbits(
+        self, array: TypeTracerArray, *, axis=None, count=None, bitorder="big"
+    ) -> TypeTracerArray:
+        try_touch_data(array)
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ ufuncs
 
-    def sqrt(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
+    def sqrt(
+        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def exp(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
+    def exp(
+        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         # array
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def true_divide(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
+    def true_divide(
+        self,
+        x1: TypeTracerArray,
+        x2: TypeTracerArray,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x1)
+        try_touch_data(x2)
         # array1, array2
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def logical_and(self, x, y, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
+    def logical_and(
+        self,
+        x1: TypeTracerArray,
+        x2: TypeTracerArray,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x1)
+        try_touch_data(x2)
+
+        dtype = np.bool_
 
         is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
+        if isinstance(x1, TypeTracerArray):
             is_array = True
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
+        if isinstance(x2, TypeTracerArray):
             is_array = True
         if is_array:
             return TypeTracerArray(dtype)
         else:
             return UnknownScalar(dtype)
 
-    def logical_or(self, x, y, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
+    def logical_or(
+        self,
+        x1: TypeTracerArray,
+        x2: TypeTracerArray,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x1)
+        try_touch_data(x2)
+        dtype = np.bool_
 
         is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
+        if isinstance(x1, TypeTracerArray):
             is_array = True
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
+        if isinstance(x2, TypeTracerArray):
             is_array = True
         if is_array:
             return TypeTracerArray(dtype)
         else:
             return UnknownScalar(dtype)
 
-    def logical_not(self, x, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
+    def logical_not(
+        self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
+    ) -> TypeTracerArray:
+        try_touch_data(x)
+        dtype = np.bool_
 
         is_array = False
         if isinstance(x, TypeTracerArray):
-            x.touch_data()
             is_array = True
         if is_array:
             return TypeTracerArray(dtype)
@@ -1039,61 +1105,110 @@ class TypeTracer(ak._nplikes.NumpyLike):
 
     ############################ almost-ufuncs
 
-    def nan_to_num(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
+    def nan_to_num(
+        self,
+        x: TypeTracerArray,
+        *,
+        copy: bool = True,
+        nan: int | float | None = 0.0,
+        posinf: int | float | None = None,
+        neginf: int | float | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         # array, copy=True, nan=0.0, posinf=None, neginf=None
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def isclose(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
+    def isclose(
+        self,
+        x1: TypeTracerArray,
+        x2: TypeTracerArray,
+        *,
+        rtol: float = 1e-5,
+        atol: float = 1e-8,
+        equal_nan: bool = False,
+    ) -> TypeTracerArray:
+        try_touch_data(x1)
+        try_touch_data(x2)
         # a, b, rtol=1e-05, atol=1e-08, equal_nan=False
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ reducers
 
-    def all(self, array, prefer):
-        try_touch_data(array)
-        # array
-        return prefer
+    def all(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
+        if axis is None:
+            return UnknownScalar(np.bool_)
+        else:
+            raise ak._errors.wrap_error(NotImplementedError)
 
-    def any(self, array, prefer):
-        try_touch_data(array)
-        # array
-        return prefer
+    def any(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
+        if axis is None:
+            return UnknownScalar(np.bool_)
+        else:
+            raise ak._errors.wrap_error(NotImplementedError)
 
-    def count_nonzero(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
+    def count_nonzero(
+        self, x: TypeTracerArray, *, axis: int | None = None, keepdims: bool = False
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def min(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
+    def min(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def max(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
+    def max(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_reuse: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
     def array_str(
-        self, array, max_line_width=None, precision=None, suppress_small=None
+        self,
+        x: TypeTracerArray,
+        *,
+        max_line_width: int | None = None,
+        precision: int | None = None,
+        suppress_small: bool | None = None,
     ):
-        try_touch_data(array)
-        # array, max_line_width, precision=None, suppress_small=None
+        try_touch_data(x)
         return "[?? ... ??]"
 
-    def can_cast(self, *args, **kwargs):
-        return numpy.can_cast(*args, **kwargs)
+    def can_cast(
+        self, from_: np.dtype | TypeTracerArray, to: np.dtype | TypeTracerArray
+    ) -> bool:
+        return numpy.can_cast(from_, to, casting="same_kind")
 
     @classmethod
     def is_own_array(cls, obj) -> bool:
         return isinstance(obj, TypeTracerArray)
 
-    def is_c_contiguous(self, array) -> bool:
+    def is_c_contiguous(self, array: TypeTracerArray) -> bool:
         return True

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -761,11 +761,9 @@ class TypeTracer(NumpyLike):
         else:
             return result
 
-    def ascontiguousarray(
-        self, array: TypeTracerArray, *, dtype=None
-    ) -> TypeTracerArray:
-        try_touch_data(array)
-        return TypeTracerArray.from_array(array, dtype=dtype)
+    def ascontiguousarray(self, x: TypeTracerArray, *, dtype=None) -> TypeTracerArray:
+        try_touch_data(x)
+        return TypeTracerArray.from_array(x, dtype=dtype)
 
     def frombuffer(
         self, buffer, *, dtype: np.dtype | None = None, count: int = -1
@@ -1014,15 +1012,24 @@ class TypeTracer(NumpyLike):
         raise ak._errors.wrap_error(NotImplementedError)
 
     def packbits(
-        self, array: TypeTracerArray, *, axis=None, bitorder="big"
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
     ) -> TypeTracerArray:
-        try_touch_data(array)
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
     def unpackbits(
-        self, array: TypeTracerArray, *, axis=None, count=None, bitorder="big"
+        self,
+        x: ArrayLike,
+        *,
+        axis: int | None = None,
+        count: int | None = None,
+        bitorder: Literal["big", "little"] = "big",
     ) -> TypeTracerArray:
-        try_touch_data(array)
+        try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
     ############################ ufuncs
@@ -1214,5 +1221,5 @@ class TypeTracer(NumpyLike):
     def is_own_array(cls, obj) -> bool:
         return isinstance(obj, TypeTracerArray)
 
-    def is_c_contiguous(self, array: TypeTracerArray) -> bool:
+    def is_c_contiguous(self, x: TypeTracerArray) -> bool:
         return True

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -1045,7 +1045,8 @@ class TypeTracer(NumpyLike):
         self, x: TypeTracerArray, maybe_reuse: TypeTracerArray | None = None
     ) -> TypeTracerArray:
         try_touch_data(x)
-        # array
+        if np.issubdtype(x.dtype, np.integer):
+            return
         raise ak._errors.wrap_error(NotImplementedError)
 
     def divide(

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -947,16 +947,20 @@ class TypeTracer(NumpyLike):
         try_touch_data(x)
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def nonzero(self, array: TypeTracerArray) -> tuple[TypeTracerArray, ...]:
+    def nonzero(self, x: TypeTracerArray) -> tuple[TypeTracerArray, ...]:
         # array
-        try_touch_data(array)
-        return (TypeTracerArray(np.int64, (UnknownLength,)),) * len(array.shape)
+        try_touch_data(x)
+        return (TypeTracerArray(np.int64, (UnknownLength,)),) * len(x.shape)
 
     def unique_values(self, x: TypeTracerArray) -> TypeTracerArray:
         try_touch_data(x)
         return TypeTracerArray(x.dtype)
 
-    def concat(self, arrays, *, casting="same_kind") -> TypeTracerArray:
+    def concat(self, arrays, *, axis: int | None = 0) -> TypeTracerArray:
+        if axis is None:
+            assert all(x.ndim == 1 for x in arrays)
+        elif axis != 0:
+            raise ak._errors.wrap_error(NotImplementedError("concat with axis != 0"))
         for x in arrays:
             try_touch_data(x)
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -658,7 +658,7 @@ class ByteMaskedArray(Content):
                 length += x.length
 
             return ByteMaskedArray(
-                ak.index.Index8(self._backend.nplike.concatenate(masks)),
+                ak.index.Index8(self._backend.nplike.concat(masks)),
                 self._content[: self.length]._mergemany(tail_contents),
                 self._valid_when,
                 parameters=parameters,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -192,7 +192,9 @@ class IndexedOptionArray(Content):
 
         carry = self._index.data
         too_negative = carry < -1
-        if self._backend.nplike.any(too_negative, prefer=False):
+        if self._backend.index_nplike.known_data and self._backend.index_nplike.any(
+            too_negative
+        ):
             carry = carry.copy()
             carry[too_negative] = -1
         carry = ak.index.Index(carry)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -386,10 +386,8 @@ class NumpyArray(Content):
             # Default merging (can we cast one to the other)
             else:
                 return self.backend.nplike.can_cast(
-                    self.dtype, other.dtype, casting="same_kind"
-                ) or self.backend.nplike.can_cast(
-                    other.dtype, self.dtype, casting="same_kind"
-                )
+                    self.dtype, other.dtype
+                ) or self.backend.nplike.can_cast(other.dtype, self.dtype)
 
         else:
             return False
@@ -422,9 +420,7 @@ class NumpyArray(Content):
                     )
                 )
 
-        contiguous_arrays = self._backend.nplike.concatenate(
-            contiguous_arrays, casting="same_kind"
-        )
+        contiguous_arrays = self._backend.nplike.concat(contiguous_arrays)
 
         next = NumpyArray(
             contiguous_arrays, parameters=parameters, backend=self._backend

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -374,11 +374,12 @@ class RecordArray(Content):
                 where = where.copy()
 
             negative = where < 0
-            if self._backend.index_nplike.any(negative, prefer=False):
-                where[negative] += self._length
+            if self._backend.index_nplike.known_data:
+                if self._backend.index_nplike.any(negative):
+                    where[negative] += self._length
 
-            if self._backend.index_nplike.any(where >= self._length, prefer=False):
-                raise ak._errors.index_error(self, where)
+                if self._backend.index_nplike.any(where >= self._length):
+                    raise ak._errors.index_error(self, where)
 
             nextindex = ak.index.Index64(where, nplike=self._backend.index_nplike)
             return ak.contents.IndexedArray(nextindex, self, parameters=None)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -244,14 +244,15 @@ class RegularArray(Content):
             copied = True
 
         negative = where < 0
-        if self._backend.index_nplike.any(negative, prefer=False):
-            if not copied:
-                where = where.copy()
-                copied = True
-            where[negative] += self._length
+        if self._backend.index_nplike.known_data:
+            if self._backend.index_nplike.any(negative):
+                if not copied:
+                    where = where.copy()
+                    copied = True
+                where[negative] += self._length
 
-        if self._backend.index_nplike.any(where >= self._length, prefer=False):
-            raise ak._errors.index_error(self, where)
+            if self._backend.index_nplike.any(where >= self._length):
+                raise ak._errors.index_error(self, where)
 
         nextcarry = ak.index.Index64.empty(
             where.shape[0] * self._size, self._backend.index_nplike

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1362,7 +1362,7 @@ class UnionArray(Content):
             if validbytes is not None:
                 # If this_index is a filtered permutation, we can just filter-permute
                 # the mask to have the same order the content.
-                if numpy.unique(this_index).shape[0] == this_index.shape[0]:
+                if numpy.unique_values(this_index).shape[0] == this_index.shape[0]:
                     this_validbytes = numpy.zeros(this_index.shape[0], dtype=np.int8)
                     this_validbytes[this_index] = validbytes[selected_tags]
 
@@ -1445,7 +1445,7 @@ class UnionArray(Content):
                 ) from err
         else:
             try:
-                out = backend.nplike.concatenate(contents)
+                out = backend.nplike.concat(contents)
             except Exception as err:
                 raise ak._errors.wrap_error(
                     ValueError(f"cannot convert {self} into np.ndarray")

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -229,7 +229,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     o, f = x._offsets_and_flattened(1, 1)
                     o = backend.index_nplike.asarray(o)
                     c = o[1:] - o[:-1]
-                    backend.index_nplike.add(counts, c, out=counts)
+                    backend.index_nplike.add(counts, c, maybe_reuse=counts)
                     all_counts.append(c)
                     all_flatten.append(f)
 
@@ -237,7 +237,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     len(nextinputs[0]) + 1, dtype=np.int64
                 )
                 offsets[0] = 0
-                backend.index_nplike.cumsum(counts, out=offsets[1:])
+                backend.index_nplike.cumsum(counts, maybe_reuse=offsets[1:])
 
                 offsets = ak.index.Index64(offsets, nplike=backend.index_nplike)
 

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -229,7 +229,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     o, f = x._offsets_and_flattened(1, 1)
                     o = backend.index_nplike.asarray(o)
                     c = o[1:] - o[:-1]
-                    backend.index_nplike.add(counts, c, maybe_reuse=counts)
+                    backend.index_nplike.add(counts, c, maybe_out=counts)
                     all_counts.append(c)
                     all_flatten.append(f)
 
@@ -237,7 +237,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     len(nextinputs[0]) + 1, dtype=np.int64
                 )
                 offsets[0] = 0
-                backend.index_nplike.cumsum(counts, maybe_reuse=offsets[1:])
+                backend.index_nplike.cumsum(counts, maybe_out=offsets[1:])
 
                 offsets = ak.index.Index64(offsets, nplike=backend.index_nplike)
 

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as _numpy_ufuncs
+
 import awkward as ak
 from awkward._util import unset
 
@@ -150,5 +152,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 highlevel=True,
                 behavior=behavior,
             )
-        nplike = ak._nplikes.nplike_of(sumwxy, sumwxx, sumwyy)
-        return nplike.true_divide(sumwxy, nplike.sqrt(sumwxx * sumwyy))
+        return sumwxy / _numpy_ufuncs.sqrt(sumwxx * sumwyy)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -130,4 +130,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 highlevel=True,
                 behavior=behavior,
             )
-        return ak._nplikes.nplike_of(sumwxy, sumw).true_divide(sumwxy, sumw)
+        return sumwxy / sumw

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as _numpy_ufuncs
+
 import awkward as ak
 from awkward._util import unset
 
@@ -185,10 +187,10 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 behavior=behavior,
             )
         delta = (sumw * sumwxx) - (sumwx * sumwx)
-        intercept = nplike.true_divide(((sumwxx * sumwy) - (sumwx * sumwxy)), delta)
-        slope = nplike.true_divide(((sumw * sumwxy) - (sumwx * sumwy)), delta)
-        intercept_error = nplike.sqrt(nplike.true_divide(sumwxx, delta))
-        slope_error = nplike.sqrt(nplike.true_divide(sumw, delta))
+        intercept = ((sumwxx * sumwy) - (sumwx * sumwxy)) / delta
+        slope = ((sumw * sumwxy) - (sumwx * sumwy)) / delta
+        intercept_error = _numpy_ufuncs.sqrt(sumwxx / delta)
+        slope_error = _numpy_ufuncs.sqrt(sumw / delta)
 
         intercept = ak.operations.to_layout(
             intercept, allow_record=True, allow_other=True

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -215,7 +215,7 @@ def _impl(x, weight, axis, keepdims, mask_identity):
                 highlevel=True,
                 behavior=None,
             )
-        return ak._nplikes.nplike_of(sumwx, sumw).true_divide(sumwx, sumw)
+        return sumwx / sumw
 
 
 @ak._connect.numpy.implements("mean")

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -128,4 +128,4 @@ def _impl(x, n, weight, axis, keepdims, mask_identity):
                 highlevel=True,
                 behavior=behavior,
             )
-        return ak._nplikes.nplike_of(sumwxn, sumw).true_divide(sumwxn, sumw)
+        return sumwxn / sumw

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -65,7 +65,9 @@ def _impl(array, axis, highlevel, behavior):
                 offsets = nplike.empty(layout.length + 1, dtype=np.int64)
                 offsets[0] = 0
 
-                nplike.cumsum(layout.mask_as_bool(valid_when=True), out=offsets[1:])
+                nplike.cumsum(
+                    layout.mask_as_bool(valid_when=True), maybe_reuse=offsets[1:]
+                )
 
                 return ak.contents.ListOffsetArray(
                     ak.index.Index64(offsets), layout.project()

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -66,7 +66,7 @@ def _impl(array, axis, highlevel, behavior):
                 offsets[0] = 0
 
                 nplike.cumsum(
-                    layout.mask_as_bool(valid_when=True), maybe_reuse=offsets[1:]
+                    layout.mask_as_bool(valid_when=True), maybe_out=offsets[1:]
                 )
 
                 return ak.contents.ListOffsetArray(

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as _numpy_ufuncs
+
 import awkward as ak
 from awkward._util import unset
 
@@ -71,8 +73,7 @@ def _impl(x, axis, keepdims, mask_identity):
     )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        nplike = ak._nplikes.nplike_of(x)
-        expx = nplike.exp(x)
+        expx = _numpy_ufuncs.exp(x)
         denom = ak.operations.ak_sum._impl(
             expx,
             axis,
@@ -81,4 +82,4 @@ def _impl(x, axis, keepdims, mask_identity):
             highlevel=True,
             behavior=behavior,
         )
-        return nplike.true_divide(expx, denom)
+        return expx / denom

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -120,7 +120,7 @@ def _impl(array, counts, axis, highlevel, behavior):
 
         current_offsets = backend.index_nplike.empty(len(counts) + 1, dtype=np.int64)
         current_offsets[0] = 0
-        backend.index_nplike.cumsum(counts, maybe_reuse=current_offsets[1:])
+        backend.index_nplike.cumsum(counts, maybe_out=current_offsets[1:])
 
     def unflatten_this_layout(layout):
         nonlocal current_offsets

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -120,7 +120,7 @@ def _impl(array, counts, axis, highlevel, behavior):
 
         current_offsets = backend.index_nplike.empty(len(counts) + 1, dtype=np.int64)
         current_offsets[0] = 0
-        backend.index_nplike.cumsum(counts, out=current_offsets[1:])
+        backend.index_nplike.cumsum(counts, maybe_reuse=current_offsets[1:])
 
     def unflatten_this_layout(layout):
         nonlocal current_offsets

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -211,11 +211,9 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
                 behavior=None,
             )
         if ddof != 0:
-            return ak._nplikes.nplike_of(sumwxx, sumw).true_divide(
-                sumwxx, sumw
-            ) * ak._nplikes.nplike_of(sumw).true_divide(sumw, sumw - ddof)
+            return (sumwxx / sumw) * (sumw / sumw - ddof)
         else:
-            return ak._nplikes.nplike_of(sumwxx, sumw).true_divide(sumwxx, sumw)
+            return sumwxx / sumw
 
 
 @ak._connect.numpy.implements("var")

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -211,7 +211,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
                 behavior=None,
             )
         if ddof != 0:
-            return (sumwxx / sumw) * (sumw / sumw - ddof)
+            return (sumwxx / sumw) * (sumw / (sumw - ddof))
         else:
             return sumwxx / sumw
 

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -17,6 +17,7 @@ __all__ = list(
         "AxisMaybeNone",
         "TypedDict",
         "Literal",
+        "SupportsIndex",
         *typing.__all__,
     }
 )
@@ -31,6 +32,7 @@ if sys.version_info < (3, 11):
         Literal,
         Protocol,
         Self,
+        SupportsIndex,
         TypeAlias,
         TypedDict,
         Unpack,
@@ -43,6 +45,7 @@ else:
         Literal,
         Protocol,
         Self,
+        SupportsIndex,
         TypeAlias,
         TypedDict,
         Unpack,


### PR DESCRIPTION
This PR hardens[^1] the NumpyLike interface to accept concrete parameters, and require keyword-only usage of some arguments e.g. `dtype`.

It is the first in a series of PRs that will gradually split `_nplikes` into a package containing a file-per-nplike, and a subsequent full implementation of typetracer that removes `UnknownScalar`

I chose to introduce `maybe_reuse` which is similar to the existing `out` parameter that we use. The purpose of the rename is to make it clear that the nplike can ignore this, and the return result therefore may be a new array. I think we need this optimisation; it's used in broadcasting.

[^1]: "hardening" just means replacing `*args` with concrete types and names.