### PR TITLE
feat: implement all ufuncs on TypeTracer.

### DIFF
--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -662,7 +662,7 @@ class TypeTracerArray(NDArrayOperatorsMixin):
         if method != "__call__" or len(inputs) == 0 or "out" in kwargs:
             raise ak._errors.wrap_error(NotImplementedError)
 
-        return TypeTracer._module._generic_ufunc_func(ufunc)(*inputs, **kwargs)
+        return TypeTracer.instance()._module._generic_ufunc_func(ufunc)(*inputs, **kwargs)
 
 
 def try_touch_data(array):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -662,7 +662,9 @@ class TypeTracerArray(NDArrayOperatorsMixin):
         if method != "__call__" or len(inputs) == 0 or "out" in kwargs:
             raise ak._errors.wrap_error(NotImplementedError)
 
-        return TypeTracer.instance()._module._generic_ufunc_func(ufunc)(*inputs, **kwargs)
+        return TypeTracer.instance()._module._generic_ufunc_func(ufunc)(
+            *inputs, **kwargs
+        )
 
 
 def try_touch_data(array):

--- a/src/awkward/_typetracer.py
+++ b/src/awkward/_typetracer.py
@@ -907,23 +907,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
             TypeTracerArray(x.dtype, [UnknownLength] + shape) for x in [first] + rest
         ]
 
-    def add(self, x, y):
-        # array1, array2[, out=]
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
-            is_array = True
-            x = x[0]
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
-            is_array = True
-            y = y[0]
-        out = x + y
-        if is_array:
-            return TypeTracerArray(out.dtype)
-        else:
-            return out
-
     def cumsum(self, *args, **kwargs):
         # arrays[, out=]
         for x in args:
@@ -1005,71 +988,6 @@ class TypeTracer(ak._nplikes.NumpyLike):
             try_touch_data(x)
         # array, shape
         raise ak._errors.wrap_error(NotImplementedError)
-
-    ############################ ufuncs
-
-    def sqrt(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def exp(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def true_divide(self, *args, **kwargs):
-        for x in args:
-            try_touch_data(x)
-        # array1, array2
-        raise ak._errors.wrap_error(NotImplementedError)
-
-    def logical_and(self, x, y, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
-
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
-            is_array = True
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
-            is_array = True
-        if is_array:
-            return TypeTracerArray(dtype)
-        else:
-            return UnknownScalar(dtype)
-
-    def logical_or(self, x, y, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
-
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
-            is_array = True
-        if isinstance(y, TypeTracerArray):
-            y.touch_data()
-            is_array = True
-        if is_array:
-            return TypeTracerArray(dtype)
-        else:
-            return UnknownScalar(dtype)
-
-    def logical_not(self, x, *, dtype=None):
-        if dtype is None:
-            dtype = np.bool_
-
-        is_array = False
-        if isinstance(x, TypeTracerArray):
-            x.touch_data()
-            is_array = True
-        if is_array:
-            return TypeTracerArray(dtype)
-        else:
-            return UnknownScalar(dtype)
 
     ############################ almost-ufuncs
 

--- a/tests/test_2115_fix_up_typetracers.py
+++ b/tests/test_2115_fix_up_typetracers.py
@@ -41,10 +41,12 @@ def test_typetracer_binary_operator():
     b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
     c = a / b
     assert c.dtype == np.dtype(np.float64)
+    assert c.shape[1] == 2
 
 
 def test_typetracer_formal_ufunc():
     a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
     b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
-    c = ak._typetracer.TypeTracer.true_divide(a, b)
+    c = ak._typetracer.TypeTracer.instance().true_divide(a, b)
     assert c.dtype == np.dtype(np.float64)
+    assert c.shape[1] == 2

--- a/tests/test_2115_fix_up_typetracers.py
+++ b/tests/test_2115_fix_up_typetracers.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numpy as np
+
 import awkward as ak
 
 
@@ -32,3 +34,17 @@ def test_issue_1864():
 def test_numpy_touch_data():
     array = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], backend="typetracer")
     assert str((array - [100, 200, 300]).layout.form.type) == "var * float64"
+
+
+def test_typetracer_binary_operator():
+    a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
+    c = a / b
+    assert c.dtype == np.dtype(np.float64)
+
+
+def test_typetracer_formal_ufunc():
+    a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
+    c = ak._typetracer.TypeTracer.true_divide(a, b)
+    assert c.dtype == np.dtype(np.float64)

--- a/tests/test_2115_fix_up_typetracers.py
+++ b/tests/test_2115_fix_up_typetracers.py
@@ -38,15 +38,15 @@ def test_numpy_touch_data():
 
 def test_typetracer_binary_operator():
     a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
-    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
-    c = a / b
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1.1], [2.2], [3.3]]))
+    c = a + b
     assert c.dtype == np.dtype(np.float64)
     assert c.shape[1] == 2
 
 
 def test_typetracer_formal_ufunc():
     a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
-    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1], [2], [3]]))
-    c = ak._typetracer.TypeTracer.instance().true_divide(a, b)
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([[1.1], [2.2], [3.3]]))
+    c = ak._typetracer.TypeTracer.instance().add(a, b)
     assert c.dtype == np.dtype(np.float64)
     assert c.shape[1] == 2


### PR DESCRIPTION
This won't go in until #2148 is done, and then it will be on top of that (i.e. update this branch).

The first commit only adds code, and I'm 99% sure that it will merge easily with #2148.

What remains is to remove the `NotImplementedError` stubs of all the _ufuncs_ (only ufuncs) on `TypeTracer`.

Some of them have been implemented already, and if there are tests for the existing implementations, they would be a good check on the correctness of the general implementation.

Oops, I forgot to add broadcasting. Next commit.