### PR TITLE
refactor: move typetracer ufunc handling to backend [1 of 2]

### DIFF
--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -175,13 +175,18 @@ class TypeTracerBackend(Backend):
             if isinstance(x, ak._typetracer.TypeTracerArray):
                 x.touch_data()
                 shape = x.shape
-                numpy_args.append(numpy.empty((0,) + x.shape[1:], x.dtype))
+                numpy_args.append(numpy.empty((0,) + x.shape[1:], dtype=x.dtype))
+            # Convert scalars to 0-d arrays
+            elif isinstance(x, ak._typetracer.UnknownScalar):
+                numpy_args.append(numpy.empty((0,), dtype=x.dtype))
+            elif x is ak._typetracer.UnknownLength:
+                numpy_args.append(numpy.empty((0,), dtype=np.int64))
             else:
                 numpy_args.append(x)
 
         assert shape is not None
         tmp = getattr(ufunc, method)(*numpy_args, **kwargs)
-        return self._typetracer.empty((shape[0],) + tmp.shape[1:], tmp.dtype)
+        return self._typetracer.empty((shape[0],) + tmp.shape[1:], dtype=tmp.dtype)
 
 
 def _backend_for_nplike(nplike: ak._nplikes.NumpyLike) -> Backend:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -209,32 +209,16 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                 inputs
             )
             (parameters,) = parameters_factory(1)
-            if nplike.known_data:
-                args = []
-                for x in inputs:
-                    if isinstance(x, NumpyArray):
-                        args.append(x._raw(nplike))
-                    else:
-                        args.append(x)
 
-                result = backend.apply_ufunc(ufunc, method, args, kwargs)
+            args = []
+            for x in inputs:
+                if isinstance(x, NumpyArray):
+                    args.append(x._raw(nplike))
+                else:
+                    args.append(x)
 
-            else:
-                shape = None
-                args = []
-                for x in inputs:
-                    if isinstance(x, NumpyArray):
-                        # some ufuncs have multiple array arguments, and they might
-                        # not all be typetracers
-                        if isinstance(x.data, ak._typetracer.TypeTracerArray):
-                            x.data.touch_data()
-                        shape = x.shape
-                        args.append(numpy.empty((0,) + x.shape[1:], dtype=x.dtype))
-                    else:
-                        args.append(x)
-                assert shape is not None
-                tmp = getattr(ufunc, method)(*args, **kwargs)
-                result = nplike.empty((shape[0],) + tmp.shape[1:], dtype=tmp.dtype)
+            result = backend.apply_ufunc(ufunc, method, args, kwargs)
+
             return (NumpyArray(result, backend=backend, parameters=parameters),)
 
         for x in inputs:

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -484,12 +484,13 @@ class Numpy(NumpyLike):
         if isinstance(nplike, Numpy):
             return array
         elif isinstance(nplike, Cupy):
-            return nplike.asarray(array, order="C")
+            cupy = Cupy.instance()
+            return cupy.asarray(array, dtype=array.dtype, order="C")
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return nplike.asarray(array)
+            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         elif isinstance(nplike, Jax):
             jax = Jax.instance()
-            return jax.asarray(array)
+            return jax.asarray(array, dtype=array.dtype)
         else:
             raise ak._errors.wrap_error(
                 TypeError(
@@ -595,11 +596,13 @@ class Cupy(NumpyLike):
         if isinstance(nplike, Cupy):
             return array
         elif isinstance(nplike, Numpy):
-            return nplike.asarray(array.get(), dtype=array.dtype, order="C")
+            numpy = Numpy.instance()
+            return numpy.asarray(array.get(), dtype=array.dtype, order="C")
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return nplike.asarray(array, dtype=array.dtype)
+            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         elif isinstance(nplike, Jax):
-            return nplike.asarray(array.get(), dtype=array.dtype)
+            jax = Jax.instance()
+            return jax.asarray(array.get(), dtype=array.dtype)
         else:
             raise ak._errors.wrap_error(
                 TypeError(
@@ -760,11 +763,13 @@ class Jax(NumpyLike):
         if isinstance(nplike, Jax):
             return array
         elif isinstance(nplike, ak._nplikes.Cupy):
-            return nplike.asarray(array)
+            cupy = ak._nplikes.Cupy.instance()
+            return cupy.asarray(array)
         elif isinstance(nplike, ak._nplikes.Numpy):
-            return nplike.asarray(array)
+            numpy = ak._nplikes.Numpy.instance()
+            return numpy.asarray(array)
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return nplike.asarray(array, dtype=array.dtype)
+            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
         else:
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/_nplikes.py
+++ b/src/awkward/_nplikes.py
@@ -484,13 +484,12 @@ class Numpy(NumpyLike):
         if isinstance(nplike, Numpy):
             return array
         elif isinstance(nplike, Cupy):
-            cupy = Cupy.instance()
-            return cupy.asarray(array, dtype=array.dtype, order="C")
+            return nplike.asarray(array, order="C")
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
+            return nplike.asarray(array)
         elif isinstance(nplike, Jax):
             jax = Jax.instance()
-            return jax.asarray(array, dtype=array.dtype)
+            return jax.asarray(array)
         else:
             raise ak._errors.wrap_error(
                 TypeError(
@@ -596,13 +595,11 @@ class Cupy(NumpyLike):
         if isinstance(nplike, Cupy):
             return array
         elif isinstance(nplike, Numpy):
-            numpy = Numpy.instance()
-            return numpy.asarray(array.get(), dtype=array.dtype, order="C")
+            return nplike.asarray(array.get(), dtype=array.dtype, order="C")
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
+            return nplike.asarray(array, dtype=array.dtype)
         elif isinstance(nplike, Jax):
-            jax = Jax.instance()
-            return jax.asarray(array.get(), dtype=array.dtype)
+            return nplike.asarray(array.get(), dtype=array.dtype)
         else:
             raise ak._errors.wrap_error(
                 TypeError(
@@ -763,13 +760,11 @@ class Jax(NumpyLike):
         if isinstance(nplike, Jax):
             return array
         elif isinstance(nplike, ak._nplikes.Cupy):
-            cupy = ak._nplikes.Cupy.instance()
-            return cupy.asarray(array)
+            return nplike.asarray(array)
         elif isinstance(nplike, ak._nplikes.Numpy):
-            numpy = ak._nplikes.Numpy.instance()
-            return numpy.asarray(array)
+            return nplike.asarray(array)
         elif isinstance(nplike, ak._typetracer.TypeTracer):
-            return ak._typetracer.TypeTracerArray(dtype=array.dtype, shape=array.shape)
+            return nplike.asarray(array, dtype=array.dtype)
         else:
             raise ak._errors.wrap_error(
                 TypeError(

--- a/tests/test_2150_typetracer_high_level_ufunc.py
+++ b/tests/test_2150_typetracer_high_level_ufunc.py
@@ -1,0 +1,53 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array([1, 2, 3, 4])
+    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    typetracer_result = np.sqrt(typetracer_array)
+
+    assert typetracer_result.type == ak.types.ArrayType(
+        ak.types.NumpyType("float64"), ak._typetracer.UnknownLength
+    )
+
+
+def test_add():
+    left = ak.Array([1, 2, 3, 4])
+    right = ak.Array([1, 2, 3, 4.0])
+    typetracer_left = ak.Array(left.layout.to_typetracer(forget_length=True))
+    typetracer_right = ak.Array(right.layout.to_typetracer(forget_length=True))
+    typetracer_result = np.add(typetracer_left, typetracer_right)
+
+    assert typetracer_result.type == ak.types.ArrayType(
+        ak.types.NumpyType("float64"), ak._typetracer.UnknownLength
+    )
+
+
+def test_add_scalar():
+    array = ak.Array([1, 2, 3, 4])
+    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    other = ak.min(typetracer_array, mask_identity=False, initial=10)
+    assert isinstance(other, ak._typetracer.UnknownScalar)
+
+    typetracer_result = np.add(typetracer_array, other)
+    assert typetracer_result.type == ak.types.ArrayType(
+        ak.types.NumpyType("int64"), ak._typetracer.UnknownLength
+    )
+
+
+def test_add_none_scalar():
+    array = ak.Array([1, 2, 3, 4])
+    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    other = ak.min(typetracer_array, mask_identity=True, initial=10)
+    assert isinstance(other, ak._typetracer.MaybeNone)
+    assert isinstance(other.content, ak._typetracer.UnknownScalar)
+
+    typetracer_result = np.add(typetracer_array, other)
+    assert typetracer_result.type == ak.types.ArrayType(
+        ak.types.NumpyType("int64"), ak._typetracer.UnknownLength
+    )


### PR DESCRIPTION
This PR splits the `TypeTracer` ufunc logic handling from #2127, using the `Backend.apply_ufunc` machinery to implement `ufunc` operations on `ak.Array`s backed by `TypeTracer.

It implements "coercion" from `UnknownScalar`, `UnknownLength`, and `MaybeNone` values to the appropriate NumPy empty arrays, before applying the ufunc.