### PR TITLE
fix: support non-array types in `TypeTracerArray` ufunc operations

### DIFF
--- a/tests/test_2151_typetracers_ufunc_scalars.py
+++ b/tests/test_2151_typetracers_ufunc_scalars.py
@@ -1,0 +1,23 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_mixed():
+    a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([2.2]))
+    assert isinstance(b[0], ak._typetracer.UnknownScalar)
+    c = a + b[0]
+    assert c.dtype == np.dtype(np.float64)
+    assert c.shape[1] == 2
+
+
+def test_mixed_maybe_none():
+    a = ak._typetracer.TypeTracerArray.from_array(np.array([[1, 2], [3, 4], [5, 6]]))
+    b = ak._typetracer.TypeTracerArray.from_array(np.array([2.2]))
+    assert isinstance(b[9], ak._typetracer.UnknownScalar)
+    c = a + ak._typetracer.MaybeNone(b[0])
+    assert c.dtype == np.dtype(np.float64)
+    assert c.shape[1] == 2


### PR DESCRIPTION
This PR is very similar to #2150. Whilst that PR deals with `np.ufunc()` operations on `ak.Array` objects, this PR is concerned with `np.ufunc()` operations on the _low level_ `TypeTracerArray` object. Like #2150, this PR adds support for treating scalar types (`UnknownScalar`, `MaybeNone`) as 0-D arrays.