### PR TITLE
chore: move to Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,26 +1,6 @@
 [flake8]
-extend-select = C,B,B9,T,AK1,I25
-# B905 should be removed once python>=3.10
-extend-ignore = E203,E501,B950,E266,B905
-max-complexity = 100
-exclude = studies, pybind11, rapidjson, docs*, src/awkward/_typeparser/generated_parser.py
-per-file-ignores =
-    tests*/*: T, AK1, I25
-    dev/*: T, T201, AK1, I25
-    src/awkward/__init__.py: E402, F401, F403, AK1, F401, F403
-    src/awkward/operations/__init__.py: F401
-    src/awkward/_connect/*: I251
-    src/awkward/_nplikes/__init__.py: F401
-    src/awkward/_nplikes/*: I251
-    src/awkward/_typetracer.py: I251
-    src/awkward/_connect/numba/*: AK1, I25
-    src/awkward/_errors.py: AK1
-    src/awkward/typing.py: F405
-    src/awkward/_connect/rdataframe/to_rdataframe.py: B907, I25
-banned_modules =
-    numpy = "Use `numpy = ak._nplikes.Numpy.instance()` instead"
-    jax = "Use `jax = ak._nplikes.Jax.instance()` instead"
-    cupy = "Use `cupy = ak._nplikes.Cupy.instance()` instead"
+select = AK1
+exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generated_parser.py, tests/*, dev/*, src/awkward/__init__.py, src/awkward/_connect/numba/*, src/awkward/_errors.py
 
 [flake8:local-plugins]
 extension =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,23 +21,11 @@ repos:
   - id: name-tests-test
     args: ["--pytest-test-first"]
 
-- repo: https://github.com/PyCQA/isort
-  rev: "5.11.4"
-  hooks:
-    - id: isort
-      args: [--filter-files]
-
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v2.2.0
   hooks:
   - id: setup-cfg-fmt
     args: [--include-version-classifiers, --max-py-version=3.11]
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: "v3.3.1"
-  hooks:
-  - id: pyupgrade
-    args: ["--py37-plus"]
 
 - repo: https://github.com/psf/black
   rev: 22.12.0
@@ -70,7 +58,7 @@ repos:
 - repo: local
   hooks:
   - id: disallow-caps
-    name: Disallow improper capitalization
+    name: disallow improper capitalization
     language: pygrep
     entry: PyBind|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
@@ -83,7 +71,7 @@ repos:
 - repo: local
   hooks:
   - id: require-test-name-identifier
-    name: Require identifiers for test names
+    name: require identifiers for test names
     language: python
     entry: python dev/validate-test-names.py
     types: [file, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,12 @@ repos:
   rev: 6.0.0
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear, flake8-print>=5, flake8-tidy-imports]
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.228
+  hooks:
+  - id: ruff
+    args: ["--fix"]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,9 +262,7 @@ exclude = [
     "docs-*",
     "src/awkward/_typeparser/generated_parser.py",
 ]
-ignore = [
-    "E501", "C408", "E713", "E714",
-]
+ignore = ["E501", "C408", "E713", "E714", "UP030"]
 select = [
     "B0",
     "C",
@@ -272,6 +270,8 @@ select = [
     "F",
     "T20",
     "W",
+    "UP",
+    "I",
     "TID251"
 ]
 target-version = "py37"
@@ -293,6 +293,7 @@ mccabe.max-complexity = 100
     "F403",
     "F401",
     "F403",
+    "I001",
 ]
 "src/awkward/_connect/*" = [
     "TID251"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,3 +253,61 @@ module = [
 ]
 ignore_errors = true
 ignore_missing_imports = true
+
+[tool.ruff]
+exclude = [
+    "studies",
+    "pybind11",
+    "rapidjson",
+    "docs-*",
+    "src/awkward/_typeparser/generated_parser.py",
+]
+ignore = [
+    "E501", "C408", "E713", "E714",
+]
+select = [
+    "B0",
+    "C",
+    "E",
+    "F",
+    "T20",
+    "W",
+    "TID251"
+]
+target-version = "py37"
+typing-modules = ["awkward.typing"]
+src = ["src"]
+unfixable = ["T20"]
+
+mccabe.max-complexity = 100
+
+[tool.ruff.per-file-ignores]
+"src/awkward/typing.py" = ["F405"]
+"dev/*" = [
+    "T20",
+    "TID251"
+]
+"src/awkward/__init__.py" = [
+    "E402",
+    "F401",
+    "F403",
+    "F401",
+    "F403",
+]
+"src/awkward/_connect/*" = [
+    "TID251"
+]
+"src/awkward/_nplikes/*" = [
+    "TID251"
+]
+"rc/awkward/_connect/rdataframe/to_rdataframe.py" = [
+    "TID251"
+]
+"tests*/*" = ["T20", "TID251"]
+"src/awkward/operations/__init__.py" = ["F401"]
+
+
+[tool.ruff.flake8-tidy-imports.banned-api]
+"numpy".msg = "Use `numpy = ak._nplikes.Numpy.instance()` instead"
+"jax".msg = "Use `jax = ak._nplikes.Jax.instance()` instead"
+"cupy".msg = "Use `cupy = ak._nplikes.Cupy.instance()` instead"

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -471,17 +471,17 @@ def lower_complex_from_integer_or_float(context, builder, sig, args):
 
     if isinstance(xtype, numba.types.Integer) and xtype.signed:
         z_real = builder.sitofp(xval, context.get_value_type(numba.types.float64))
-        z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
+        z_imag = z_real.type(0)  # noqa: UP003
     elif isinstance(xtype, numba.types.Integer):
         z_real = builder.uitofp(xval, context.get_value_type(numba.types.float64))
-        z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
+        z_imag = z_real.type(0)  # noqa: UP003
     elif xtype.bitwidth < 64:
         z_real = builder.fpext(xval, context.get_value_type(numba.types.float64))
     elif xtype.bitwidth > 64:
         z_real = builder.fptrunc(xval, context.get_value_type(numba.types.float64))
     else:
         z_real = xval
-    z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
+    z_imag = z_real.type(0)  # noqa: UP003
 
     call(
         context,

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -471,17 +471,17 @@ def lower_complex_from_integer_or_float(context, builder, sig, args):
 
     if isinstance(xtype, numba.types.Integer) and xtype.signed:
         z_real = builder.sitofp(xval, context.get_value_type(numba.types.float64))
-        z_imag = z_real.type(0)
+        z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
     elif isinstance(xtype, numba.types.Integer):
         z_real = builder.uitofp(xval, context.get_value_type(numba.types.float64))
-        z_imag = z_real.type(0)
+        z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
     elif xtype.bitwidth < 64:
         z_real = builder.fpext(xval, context.get_value_type(numba.types.float64))
     elif xtype.bitwidth > 64:
         z_real = builder.fptrunc(xval, context.get_value_type(numba.types.float64))
     else:
         z_real = xval
-    z_imag = z_real.type(0)
+    z_imag = z_real.type(0)  # noqa: UP003 (this is not the Python 'int' type)
 
     call(
         context,

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -86,7 +86,7 @@ class ErrorContext:
                 valuestr = f"repr-raised-{type(err).__name__}"
 
         elif isinstance(value, np.ndarray):
-            import numpy  # noqa: I251
+            import numpy  # noqa: TID251
 
             if not numpy.__version__.startswith("1.13."):  # 'threshold' argument
                 prefix = f"{type(value).__module__}.{type(value).__name__}("

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -136,12 +136,10 @@ class CupyKernel(BaseKernel):
         assert len(args) == len(self._impl.dir)  # type: ignore
         # The first arg is the invocation index which raises itself by 8 in the kernel if there was no error before.
         # The second arg is the error_code.
-        args = tuple(
-            [
-                *args,
-                len(ak_cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][1]),
-                ak_cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][0],
-            ]
+        args = (
+            *args,
+            len(ak_cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][1]),
+            ak_cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][0],
         )
         ak_cuda.cuda_streamptr_to_contexts[cupy_stream_ptr][1].append(
             ak_cuda.Invocation(

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import awkward as ak
-from awkward.typing import TypeVar, TYPE_CHECKING
+from awkward.typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from awkward._nplikes.numpylike import ArrayLike, NumpyLike

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -153,7 +153,7 @@ class ArrayModuleNumpyLike(NumpyLike):
         *,
         axis: int = 0,
     ) -> ArrayLike:
-        arrays = [x for x in arrays]
+        arrays = list(arrays)
         return self._module.stack(arrays, axis=axis)
 
     def packbits(

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -37,7 +37,7 @@ def parse_version(version):
 
 
 def numpy_at_least(version):
-    import numpy  # noqa: I251
+    import numpy  # noqa: TID251
 
     return parse_version(numpy.__version__) >= parse_version(version)
 
@@ -858,12 +858,12 @@ def arrays_approx_equal(
 
 
 try:
-    import numpy  # noqa: I251
+    import numpy  # noqa: TID251
 
     NDArrayOperatorsMixin = numpy.lib.mixins.NDArrayOperatorsMixin
 
 except AttributeError:
-    from numpy.core import umath as um
+    from numpy.core import umath as um  # noqa: TID251
 
     def _disables_array_ufunc(obj):
         try:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -9,7 +9,7 @@ from numbers import Complex, Real
 import awkward as ak
 from awkward._backends import Backend
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._nplikes.typetracer import (
     TypeTracer,
     ensure_known_scalar,

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -32,7 +32,7 @@ def register_and_check():
     Register Awkward Array node types with JAX's tree mechanism.
     """
     try:
-        import jax  # noqa: I251, F401
+        import jax  # noqa: TID251, F401
 
     except ModuleNotFoundError:
         raise wrap_error(
@@ -140,6 +140,6 @@ def assert_registered():
 def import_jax():
     """Ensure that JAX integration is registered, and return the JAX module. Raise a RuntimeError if not."""
     assert_registered()
-    import jax  # noqa: I251
+    import jax  # noqa: TID251
 
     return jax

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -289,7 +289,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             for x in new_arrays:
                 layouts.append(x)
 
-        layouts = [x for x in layouts]
+        layouts = list(layouts)
 
         indexes = [
             ak.index.Index64(x.reshape(-1))

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -42,7 +42,7 @@ def to_numpy(array, *, allow_missing=True):
 
 
 def _impl(array, allow_missing):
-    import numpy  # noqa: I251
+    import numpy  # noqa: TID251
 
     with numpy.errstate(invalid="ignore"):
         layout = ak.to_layout(array, allow_record=False)

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -260,7 +260,7 @@ def to_parquet(
     elif isinstance(parquet_metadata_statistics, Sequence):
         replacement = []
         for specifier in parquet_metadata_statistics:
-            replacement.extend([x for x in parquet_columns(specifier)])
+            replacement.extend(list(parquet_columns(specifier)))
         parquet_metadata_statistics = replacement
 
     if parquet_dictionary_encoding is True:


### PR DESCRIPTION
For me, this reduces the time spent in pre-commit from about 12 seconds to 6.6 seconds. Ruff takes <1 second to process the entire codebase, and can do the work of several tools. I think "check YAML" is now the slowest check. :)

It has several checks that look very useful, and autofix is amazing, but this is a very minimal conversion to start with.

This should also stop the failures caused by plugins updating, since everything is one versioned binary.
