### PR TITLE
fix: unify typestr with `_repr`

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1127,7 +1127,7 @@ class TypeTracer(NumpyLike):
         suppress_small: bool | None = None,
     ):
         try_touch_data(x)
-        return "[?? ... ??]"
+        return "[## ... ##]"
 
     def can_cast(
         self, from_: np.dtype | TypeTracerArray, to: np.dtype | TypeTracerArray

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1927,18 +1927,13 @@ class Record(NDArrayOperatorsMixin):
 
         pytype = type(self).__name__
 
+        typestr = repr(str(self.type))[1:-1]
         if (
             self._layout.array.backend.nplike.known_shape
             and self._layout.array.backend.nplike.known_data
         ):
-            typestr = repr(str(self.type))[1:-1]
             valuestr = ""
-
         else:
-            # awkward._prettyprint.valuestr touches the data
-            typestr = repr(
-                str(self._layout._array.form.type_from_behavior(self._behavior))
-            )[1:-1]
             valuestr = "-typetracer"
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1188,18 +1188,13 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         except AttributeError:
             pytype = type(self).__name__
 
+        typestr = repr(str(self.type))[1:-1]
         if (
             self._layout.backend.nplike.known_shape
             and self._layout.backend.nplike.known_data
         ):
-            typestr = repr(str(self.type))[1:-1]
             valuestr = ""
-
         else:
-            # awkward._prettyprint.valuestr touches the data
-            typestr = repr(
-                "?? * " + str(self._layout.form.type_from_behavior(self._behavior))
-            )[1:-1]
             valuestr = "-typetracer"
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -44,7 +44,7 @@ class ArrayType:
         stream.write("".join(self._str("", False) + ["\n"]))
 
     def _str(self, indent, compact):
-        length_str = "??" if is_unknown_length(self._length) else str(self._length)
+        length_str = "##" if is_unknown_length(self._length) else str(self._length)
         return [f"{length_str} * "] + self._content._str(indent, compact)
 
     def __repr__(self):

--- a/tests/test_2115_fix_up_typetracers.py
+++ b/tests/test_2115_fix_up_typetracers.py
@@ -16,8 +16,16 @@ def test_repr():
     # feel free to change these if the string format ever changes
 
     array = ak.Array(ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).layout.to_typetracer())
-    assert repr(array) == "<Array-typetracer [...] type='?? * var * float64'>"
+    assert repr(array) == "<Array-typetracer [...] type='3 * var * float64'>"
     assert str(array) == "[...]"
+
+    array2 = ak.Array(
+        ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).layout.to_typetracer(
+            forget_length=True
+        )
+    )
+    assert repr(array2) == "<Array-typetracer [...] type='## * var * float64'>"
+    assert str(array2) == "[...]"
 
     record = ak.Array(ak.Array([{"x": 1.1, "y": [1, 2, 3]}]).layout.to_typetracer())[0]
     assert (


### PR DESCRIPTION
The `Array._repr` method diverges from `ArrayType.__str__`. I don't think that we need this special case any more; `str(type)` should not touch any data (well, it would potentially touch unknown scalars inside of the type, but that's already true and is a case that we've not considered up-to now).