### PR TITLE
fix: support `mask_identity=True` for `axis=None` in `ptp`, `std`, etc.

### DIFF
--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -186,16 +186,16 @@ def _impl(x, weight, axis, keepdims, mask_identity):
             sumw = ak.operations.ak_count._impl(
                 x,
                 axis,
-                keepdims,
-                mask_identity,
+                keepdims=True,
+                mask_identity=True,
                 highlevel=True,
                 behavior=None,
             )
             sumwx = ak.operations.ak_sum._impl(
                 x,
                 axis,
-                keepdims,
-                mask_identity,
+                keepdims=True,
+                mask_identity=True,
                 highlevel=True,
                 behavior=None,
             )
@@ -211,12 +211,26 @@ def _impl(x, weight, axis, keepdims, mask_identity):
             sumwx = ak.operations.ak_sum._impl(
                 x * weight,
                 axis,
-                keepdims,
-                mask_identity,
+                keepdims=True,
+                mask_identity=True,
                 highlevel=True,
                 behavior=None,
             )
-        return sumwx / sumw
+
+        out = sumwx / sumw
+
+        if not mask_identity:
+            out = ak.highlevel.Array(ak.operations.fill_none(out, np.nan, axis=-1))
+
+        if axis is None:
+            if not keepdims:
+                out = out[(0,) * out.ndim]
+        else:
+            if not keepdims:
+                posaxis = ak._util.maybe_posaxis(out.layout, axis, 1)
+                out = out[(slice(None, None),) * posaxis + (0,)]
+
+        return out
 
 
 @ak._connect.numpy.implements("mean")

--- a/tests/test_2020_reduce_axis_none.py
+++ b/tests/test_2020_reduce_axis_none.py
@@ -128,7 +128,6 @@ def test_std():
     assert np.isnan(ak.std(array[2], axis=None, mask_identity=False))
 
 
-@pytest.mark.xfail(reason="fix mask_identity=False")
 def test_std_no_mask_axis_none():
     assert ak._util.arrays_approx_equal(
         ak.std(array[-1:], axis=None, keepdims=True, mask_identity=True),
@@ -150,7 +149,6 @@ def test_var():
     assert np.isnan(ak.var(array[2], axis=None, mask_identity=False))
 
 
-@pytest.mark.xfail(reason="fix mask_identity=False")
 def test_var_no_mask_axis_none():
     assert ak._util.arrays_approx_equal(
         ak.var(array[-1:], axis=None, keepdims=True, mask_identity=True),
@@ -172,7 +170,6 @@ def test_mean():
     assert np.isnan(ak.mean(array[2], axis=None, mask_identity=False))
 
 
-@pytest.mark.xfail(reason="fix mask_identity=False")
 def test_mean_no_mask_axis_none():
     assert ak._util.arrays_approx_equal(
         ak.mean(array[-1:], axis=None, keepdims=True, mask_identity=True),
@@ -191,10 +188,9 @@ def test_ptp():
         ak.ptp(array, axis=None, keepdims=True, mask_identity=True),
         ak.Array([10.0]).mask[[True]],
     )
-    assert np.isinf(ak.ptp(array[2], axis=None, mask_identity=False))
+    assert ak.ptp(array[2], axis=None, mask_identity=False) == pytest.approx(0.0)
 
 
-@pytest.mark.xfail(reason="fix mask_identity=False")
 def test_ptp_no_mask_axis_none():
     assert ak._util.arrays_approx_equal(
         ak.ptp(array[-1:], axis=None, keepdims=True, mask_identity=True),


### PR DESCRIPTION
In #2020, these tests were `xfail`ed. I must have done so whilst working locally, and committed the change. 

This PR restores support for `mask_identity=True` for the `axis=None` case of these composite reductions by pulling out the result as the final operation. As such, we choose what the identity value is for these reductions (`np.nan`, except for `ptp` which returns `0`)