### PR TITLE
chore: ruff rewrite `not in`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,17 +262,18 @@ exclude = [
     "docs-*",
     "src/awkward/_typeparser/generated_parser.py",
 ]
-ignore = ["E501", "C408", "E713", "E714", "UP030"]
+ignore = [
+    "E501",
+    "C408",
+    "UP030",  # {0} -> {}
+]
 select = [
-    "B0",
-    "C",
-    "E",
-    "F",
-    "T20",
-    "W",
-    "UP",
-    "I",
-    "TID251"
+    "B0",                # flake8-bugbear
+    "C", "E", "F", "W",  # flake8
+    "I",                 # isort
+    "T20",               # flake8-print
+    "UP",                # pyupgrade
+    "TID251"             # flake8-tidy-imports
 ]
 target-version = "py37"
 typing-modules = ["awkward.typing"]

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -70,19 +70,19 @@ def get_field(data, field):
 def custom_str(current):
     if (
         issubclass(type(current), ak.highlevel.Record)
-        and not type(current).__str__ is ak.highlevel.Record.__str__
+        and type(current).__str__ is not ak.highlevel.Record.__str__
     ) or (
         issubclass(type(current), ak.highlevel.Array)
-        and not type(current).__str__ is ak.highlevel.Array.__str__
+        and type(current).__str__ is not ak.highlevel.Array.__str__
     ):
         return str(current)
 
     elif (
         issubclass(type(current), ak.highlevel.Record)
-        and not type(current).__repr__ is ak.highlevel.Record.__repr__
+        and type(current).__repr__ is not ak.highlevel.Record.__repr__
     ) or (
         issubclass(type(current), ak.highlevel.Array)
-        and not type(current).__repr__ is ak.highlevel.Array.__repr__
+        and type(current).__repr__ is not ak.highlevel.Array.__repr__
     ):
         return repr(current)
 

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -794,7 +794,7 @@ def arrays_approx_equal(
         if right.is_option:
             right = right.to_IndexedOptionArray64()
 
-        if not type(left) is type(right):
+        if type(left) is not type(right):
             return False
 
         if left.length != right.length:

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -56,7 +56,7 @@ class OptionType(Type):
             if params is None:
                 if isinstance(
                     self._content, (RegularType, ListType)
-                ) and not self._content.parameter("__array__") in (
+                ) and self._content.parameter("__array__") not in (
                     "string",
                     "bytestring",
                     "char",


### PR DESCRIPTION
Dropping a couple of skipped checks for `not x in y`, rewritten as `x not in y`.
