### PR TITLE
fix: rework parameter merging rules

### DIFF
--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -406,7 +406,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 
         content = handle_arrow(paarray.dictionary, generate_bitmasks)
 
-        parameters = ak._util.merge_parameters(
+        parameters = ak.forms.form._merge_parameters(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:
@@ -701,7 +701,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         a, b = to_awkwardarrow_storage_types(storage_type.value_type)
         content = form_popbuffers(a, b)
 
-        parameters = ak._util.merge_parameters(
+        parameters = ak.forms.form._merge_parameters(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Sized
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward.forms.form import _parameters_union
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -406,7 +407,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 
         content = handle_arrow(paarray.dictionary, generate_bitmasks)
 
-        parameters = ak.forms.form._merge_parameters(
+        parameters = ak.forms.form._parameters_union(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:
@@ -701,7 +702,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         a, b = to_awkwardarrow_storage_types(storage_type.value_type)
         content = form_popbuffers(a, b)
 
-        parameters = ak.forms.form._merge_parameters(
+        parameters = _parameters_union(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -621,7 +621,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         # This is already an option-type and offsets-corrected, so no popbuffers_finalize.
         return ak.contents.IndexedOptionArray(
             ak.index.Index64(numpy.full(len(paarray), -1, dtype=np.int64)),
-            ak.contents.EmptyArray(parameters=node_parameters(awkwardarrow_type)),
+            ak.contents.EmptyArray(),
             parameters=mask_parameters(awkwardarrow_type),
         )
 
@@ -850,7 +850,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         # This is already an option-type, so no form_popbuffers_finalize.
         return ak.forms.IndexedOptionForm(
             "i64",
-            ak.forms.EmptyForm(parameters=node_parameters(awkwardarrow_type)),
+            ak.forms.EmptyForm(),
             parameters=mask_parameters(awkwardarrow_type),
         )
 

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -621,7 +621,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         # This is already an option-type and offsets-corrected, so no popbuffers_finalize.
         return ak.contents.IndexedOptionArray(
             ak.index.Index64(numpy.full(len(paarray), -1, dtype=np.int64)),
-            ak.contents.EmptyArray(),
+            ak.contents.EmptyArray(parameters=node_parameters(awkwardarrow_type)),
             parameters=mask_parameters(awkwardarrow_type),
         )
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -274,8 +274,14 @@ def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
 def merge_as_union(one: Content, two: Content) -> ak.contents.UnionArray:
     mylength = one.length
     theirlength = two.length
-    tags = ak.index.Index8.empty((mylength + theirlength), one.backend.index_nplike)
-    index = ak.index.Index64.empty((mylength + theirlength), one.backend.index_nplike)
+    tags = ak.index.Index8.empty(
+        one.backend.index_nplike.add_shape_item(mylength, theirlength),
+        one.backend.index_nplike,
+    )
+    index = ak.index.Index64.empty(
+        one.backend.index_nplike.add_shape_item(mylength, theirlength),
+        one.backend.index_nplike,
+    )
     contents = [one, two]
     assert tags.nplike is one.backend.index_nplike
     one._handle_error(

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -268,7 +268,7 @@ def num(layout, axis):
 
 
 def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
-    return one._mergeable(two, mergebool=mergebool)
+    return one._mergeable_next(two, mergebool=mergebool)
 
 
 def merge_as_union(one: Content, two: Content) -> ak.contents.UnionArray:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -557,18 +557,6 @@ def direct_Content_subclass_name(node):
         return out.__name__
 
 
-meaningful_parameters = frozenset(
-    {
-        ("__array__", "string"),
-        ("__array__", "bytestring"),
-        ("__array__", "char"),
-        ("__array__", "byte"),
-        ("__array__", "sorted_map"),
-        ("__array__", "categorical"),
-    }
-)
-
-
 def expand_braces(text, seen=None):
     if seen is None:
         seen = set()

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -569,43 +569,6 @@ meaningful_parameters = frozenset(
 )
 
 
-def merge_parameters(one, two, merge_equal=False, exclude=()):
-    if one is None and two is None:
-        return None
-
-    if len(exclude) != 0:
-        if one is None:
-            one = {}
-        if two is None:
-            two = {}
-
-    if one is None:
-        return two
-
-    elif two is None:
-        return one
-
-    elif merge_equal:
-        out = {}
-        for k, v in two.items():
-            if k in one.keys():
-                if len(exclude) == 0 or (k, v) not in exclude:
-                    if v == one[k]:
-                        out[k] = v
-        return out
-
-    else:
-        if len(exclude) != 0:
-            out = {k: v for k, v in one.items() if (k, v) not in exclude}
-        else:
-            out = dict(one)
-        for k, v in two.items():
-            if len(exclude) == 0 or (k, v) not in exclude:
-                if v is not None:
-                    out[k] = v
-        return out
-
-
 def expand_braces(text, seen=None):
     if seen is None:
         seen = set()

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -13,7 +13,7 @@ from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.index import Index
 from awkward.typing import Final, Self, final
 
@@ -469,9 +469,7 @@ class BitMaskedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            ) and _type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -13,6 +13,7 @@ from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
+from awkward.forms.form import _parameters_equal
 from awkward.index import Index
 from awkward.typing import Final, Self, final
 
@@ -461,20 +462,18 @@ class BitMaskedArray(Content):
         return self.to_ByteMaskedArray._offsets_and_flattened(axis, depth)
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._content._mergeable(other.content, mergebool)
-
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif other.is_option:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
         else:
-            return self._content._mergeable(other, mergebool)
+            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -466,7 +466,7 @@ class BitMaskedArray(Content):
         if other.is_identity_like or other.is_union:
             return True
         # We can only combine option types whose array-record parameters agree
-        elif other.is_option:
+        elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and _parameters_equal(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -637,7 +637,7 @@ class ByteMaskedArray(Content):
         if other.is_identity_like or other.is_union:
             return True
         # We can only combine option types whose array-record parameters agree
-        elif other.is_option:
+        elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and _parameters_equal(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -667,7 +667,7 @@ class ByteMaskedArray(Content):
                     x.length
                 )
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, True
+                    parameters, x._parameters, merge_equal=True
                 )
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -666,8 +666,8 @@ class ByteMaskedArray(Content):
                 length_scalar = self._backend.index_nplike.shape_item_as_scalar(
                     x.length
                 )
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, merge_equal=True
+                parameters = ak.forms.form._intersect_parameters(
+                    parameters, x._parameters
                 )
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -12,7 +12,7 @@ from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.index import Index
 from awkward.typing import Final, Self, final
 
@@ -640,9 +640,7 @@ class ByteMaskedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            ) and _type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 
@@ -668,7 +666,9 @@ class ByteMaskedArray(Content):
                 length_scalar = self._backend.index_nplike.shape_item_as_scalar(
                     x.length
                 )
-                parameters = ak._util.merge_parameters(parameters, x._parameters, True)
+                parameters = ak.forms.form._merge_parameters(
+                    parameters, x._parameters, True
+                )
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])
                 length = self._backend.index_nplike.add_shape_item(length, x.length)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -12,6 +12,7 @@ from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
+from awkward.forms.form import _parameters_equal
 from awkward.index import Index
 from awkward.typing import Final, Self, final
 
@@ -632,20 +633,18 @@ class ByteMaskedArray(Content):
                 return (outoffsets, flattened)
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._content._mergeable(other.content, mergebool)
-
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif other.is_option:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
         else:
-            return self._content._mergeable(other, mergebool)
+            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -658,18 +658,24 @@ class ByteMaskedArray(Content):
             for x in others
         ):
             parameters = self._parameters
-            masks = [self._mask.data[: self.length]]
+            self_length_scalar = self._backend.index_nplike.shape_item_as_scalar(
+                self.length
+            )
+            masks = [self._mask.data[:self_length_scalar]]
             tail_contents = []
             length = 0
             for x in others:
+                length_scalar = self._backend.index_nplike.shape_item_as_scalar(
+                    x.length
+                )
                 parameters = ak._util.merge_parameters(parameters, x._parameters, True)
-                masks.append(x._mask.data[: x.length])
-                tail_contents.append(x._content[: x.length])
-                length += x.length
+                masks.append(x._mask.data[:length_scalar])
+                tail_contents.append(x._content[:length_scalar])
+                length = self._backend.index_nplike.add_shape_item(length, x.length)
 
             return ByteMaskedArray(
                 ak.index.Index8(self._backend.nplike.concat(masks)),
-                self._content[: self.length]._mergemany(tail_contents),
+                self._content[:self_length_scalar]._mergemany(tail_contents),
                 self._valid_when,
                 parameters=parameters,
             )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -666,7 +666,7 @@ class ByteMaskedArray(Content):
                 length_scalar = self._backend.index_nplike.shape_item_as_scalar(
                     x.length
                 )
-                parameters = ak.forms.form._intersect_parameters(
+                parameters = ak.forms.form._parameters_intersect(
                     parameters, x._parameters
                 )
                 masks.append(x._mask.data[:length_scalar])

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -12,7 +12,8 @@ from awkward._nplikes import to_nplike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata, ShapeItem
 from awkward._nplikes.typetracer import TypeTracer
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward._util import unset
+from awkward.forms.form import Form, JSONMapping, _type_parameters_equal
 from awkward.typing import Any, AxisMaybeNone, Literal, Self, TypeAlias, TypedDict
 
 np = NumpyMetadata.instance()
@@ -1298,5 +1299,5 @@ class Content:
     def _fill_none(self, value: Content) -> Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def copy(self) -> Self:
+    def copy(self, *, parameters: JSONMapping | None = unset) -> Self:
         raise ak._errors.wrap_error(NotImplementedError)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -742,7 +742,10 @@ class Content:
     def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
         raise ak._errors.wrap_error(NotImplementedError)
 
-    def _mergemany(self, others: list[Content]) -> Content:
+    def _mergemany(
+        self,
+        others: list[Content],
+    ) -> Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _merging_strategy(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -12,7 +12,7 @@ from awkward._nplikes import to_nplike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata, ShapeItem
 from awkward._nplikes.typetracer import TypeTracer
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import Any, AxisMaybeNone, Literal, Self, TypeAlias, TypedDict
 
 np = NumpyMetadata.instance()
@@ -1282,9 +1282,7 @@ class Content:
         return (
             self.__class__ is other.__class__
             and len(self) == len(other)
-            and _parameters_equal(
-                self.parameters, other.parameters, only_array_record=False
-            )
+            and _type_parameters_equal(self.parameters, other.parameters)
             and self._is_equal_to(other, index_dtype, numpyarray)
         )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -738,21 +738,6 @@ class Content:
             localindex.data, parameters=None, backend=self._backend
         )
 
-    def _mergeable(self, other: Content, mergebool: bool = True) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
-            return False
-        # Finally, fall back upon the per-content implementation
-        else:
-            return self._mergeable_next(other, mergebool)
-
     def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
         raise ak._errors.wrap_error(NotImplementedError)
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -10,7 +10,7 @@ import awkward as ak
 from awkward._backends import Backend
 from awkward._nplikes import to_nplike
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
+from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata, ShapeItem
 from awkward._nplikes.typetracer import TypeTracer
 from awkward.forms.form import Form, _parameters_equal
 from awkward.typing import Any, AxisMaybeNone, Literal, Self, TypeAlias, TypedDict
@@ -192,7 +192,7 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     @property
-    def length(self) -> int:
+    def length(self) -> ShapeItem:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def _to_buffers(
@@ -206,7 +206,7 @@ class Content:
         raise ak._errors.wrap_error(NotImplementedError)
 
     def __len__(self) -> int:
-        return self.length
+        return int(self.length)
 
     def _repr_extra(self, indent: str) -> list[str]:
         out = []

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -22,6 +22,10 @@ class EmptyArray(Content):
     is_leaf = True
 
     def __init__(self, *, parameters=None, backend=None):
+        if not (parameters is None or len(parameters) == 0):
+            deprecate(
+                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
+            )
         if backend is None:
             backend = ak._backends.NumpyBackend.instance()
         self._init(parameters, backend)
@@ -34,7 +38,7 @@ class EmptyArray(Content):
         parameters=unset,
         backend=unset,
     ):
-        if parameters is not unset:
+        if not (parameters is unset or parameters is None or len(parameters) == 0):
             deprecate(
                 f"{type(self).__name__} cannot contain parameters", version="2.2.0"
             )
@@ -50,9 +54,8 @@ class EmptyArray(Content):
         return self.copy(parameters=copy.deepcopy(self._parameters, memo))
 
     @classmethod
-    def simplified(cls, *, parameters=unset, backend=None):
-        if parameters is not unset:
-            parameters = None
+    def simplified(cls, *, parameters=None, backend=None):
+        if not (parameters is None or len(parameters) == 0):
             deprecate(f"{cls.__name__} cannot contain parameters", version="2.2.0")
         return cls(parameters=parameters, backend=backend)
 
@@ -196,10 +199,10 @@ class EmptyArray(Content):
     def _mergemany(self, others):
         if len(others) == 0:
             return self
-
+        elif len(others) == 1:
+            return others[0]
         else:
-            tail_others = [self, *others[1:]]
-            return others[0]._mergemany(tail_others)
+            return others[0]._mergemany(others[1:])
 
     def _fill_none(self, value: Content) -> Content:
         return EmptyArray(parameters=self._parameters, backend=self._backend)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
+from awkward.forms.form import _parameters_is_empty
 from awkward.typing import Final, Self, final
 
 np = NumpyMetadata.instance()
@@ -23,6 +24,10 @@ class EmptyArray(Content):
     def __init__(self, *, parameters=None, backend=None):
         if backend is None:
             backend = ak._backends.NumpyBackend.instance()
+        if not _parameters_is_empty(parameters):
+            raise ak._errors.wrap_error(
+                TypeError(f"{type(self).__name__} cannot contain parameters")
+            )
         self._init(parameters, backend)
 
     form_cls: Final = EmptyForm

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -39,7 +39,6 @@ class EmptyArray(Content):
         backend=unset,
     ):
         return EmptyArray(
-            parameters=self._parameters if parameters is unset else parameters,
             backend=self._backend if backend is unset else backend,
         )
 
@@ -61,7 +60,6 @@ class EmptyArray(Content):
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         return EmptyArray(
-            parameters=self._parameters,
             backend=ak._backends.TypeTracerBackend.instance(),
         )
 
@@ -184,7 +182,7 @@ class EmptyArray(Content):
             offsets = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
             return (
                 offsets,
-                EmptyArray(parameters=self._parameters, backend=self._backend),
+                EmptyArray(backend=self._backend),
             )
 
     def _mergeable_next(self, other, mergebool):
@@ -199,7 +197,7 @@ class EmptyArray(Content):
             return others[0]._mergemany(tail_others)
 
     def _fill_none(self, value: Content) -> Content:
-        return EmptyArray(parameters=self._parameters, backend=self._backend)
+        return EmptyArray(backend=self._backend)
 
     def _local_index(self, axis, depth):
         posaxis = ak._util.maybe_posaxis(self, axis, depth)
@@ -215,9 +213,7 @@ class EmptyArray(Content):
             )
 
     def _numbers_to_type(self, name):
-        return ak.contents.EmptyArray(
-            parameters=self._parameters, backend=self._backend
-        )
+        return ak.contents.EmptyArray(backend=self._backend)
 
     def _is_unique(self, negaxis, starts, parents, outlength):
         return True
@@ -237,9 +233,7 @@ class EmptyArray(Content):
         return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        return ak.contents.EmptyArray(
-            parameters=self._parameters, backend=self._backend
-        )
+        return ak.contents.EmptyArray(backend=self._backend)
 
     def _reduce_next(
         self,
@@ -322,7 +316,7 @@ class EmptyArray(Content):
                 if options["keep_parameters"]:
                     return self
                 else:
-                    return EmptyArray(parameters=None, backend=self._backend)
+                    return EmptyArray(backend=self._backend)
 
         else:
 
@@ -358,7 +352,7 @@ class EmptyArray(Content):
         return []
 
     def _to_backend(self, backend: ak._backends.Backend) -> Self:
-        return EmptyArray(parameters=self._parameters, backend=backend)
+        return EmptyArray(backend=backend)
 
     def _is_equal_to(self, other, index_dtype, numpyarray):
         return True

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -194,11 +194,8 @@ class EmptyArray(Content):
         if len(others) == 0:
             return self
 
-        elif len(others) == 1:
-            return others[0]
-
         else:
-            tail_others = others[1:]
+            tail_others = [self, *others[1:]]
             return others[0]._mergemany(tail_others)
 
     def _fill_none(self, value: Content) -> Content:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -95,7 +95,7 @@ class IndexedArray(Content):
 
         if content.is_union and not is_cat:
             return content._carry(index, allow_lazy=False).copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 )
             )
@@ -126,7 +126,7 @@ class IndexedArray(Content):
                 return ak.contents.IndexedArray(
                     result,
                     content.content,
-                    parameters=ak.forms.form._merge_parameters(
+                    parameters=ak.forms.form._parameters_union(
                         content._parameters, parameters
                     ),
                 )
@@ -134,7 +134,7 @@ class IndexedArray(Content):
                 return ak.contents.IndexedOptionArray(
                     result,
                     content.content,
-                    parameters=ak.forms.form._merge_parameters(
+                    parameters=ak.forms.form._parameters_union(
                         content._parameters, parameters
                     ),
                 )
@@ -404,7 +404,7 @@ class IndexedArray(Content):
             )
             next = self._content._carry(nextcarry, False)
             return next.copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     next._parameters,
                     self._parameters,
                     exclude=(("__array__", "categorical"),),
@@ -504,7 +504,7 @@ class IndexedArray(Content):
         )
         # We can directly merge with other options and indexed types, but we must merge parameters
         if other.is_option or other.is_indexed:
-            parameters = ak.forms.form._merge_parameters(
+            parameters = ak.forms.form._parameters_union(
                 self._parameters, other._parameters
             )
         # Otherwise, this option parameters win out
@@ -550,8 +550,8 @@ class IndexedArray(Content):
             if isinstance(
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, merge_equal=True
+                parameters = ak.forms.form._parameters_intersect(
+                    parameters, array._parameters
                 )
 
                 contents.append(array.content)
@@ -970,7 +970,7 @@ class IndexedArray(Content):
                 next = self._content._carry(ak.index.Index(index), False)
 
             next2 = next.copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     next._parameters, self._parameters
                 )
             )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -515,7 +515,12 @@ class IndexedArray(Content):
                 theirlength,
             )
         )
-        parameters = ak._util.merge_parameters(self._parameters, other._parameters)
+        # We can directly merge with other options and indexed types, but we must merge parameters
+        if other.is_option or other.is_indexed:
+            parameters = ak._util.merge_parameters(self._parameters, other._parameters)
+        # Otherwise, this option parameters win out
+        else:
+            parameters = self._parameters
 
         return ak.contents.IndexedArray.simplified(
             index, content, parameters=parameters
@@ -543,8 +548,6 @@ class IndexedArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
-
             if isinstance(
                 array,
                 (
@@ -556,6 +559,10 @@ class IndexedArray(Content):
                 array = array.to_IndexedOptionArray64()
 
             if isinstance(array, ak.contents.IndexedArray):
+                parameters = ak._util.merge_parameters(
+                    parameters, array._parameters, True
+                )
+
                 contents.append(array.content)
                 array_index = array.index
                 assert (

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -421,17 +421,13 @@ class IndexedArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and _parameters_equal(
                 self._parameters, other._parameters, only_array_record=True
             )
-        ):
-            return False
-        # Finally, fall back upon the per-content implementation
-        elif other.is_option or other.is_indexed:
-            return self._content._mergeable_next(other.content, mergebool)
-
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -551,7 +551,7 @@ class IndexedArray(Content):
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, True
+                    parameters, array._parameters, merge_equal=True
                 )
 
                 contents.append(array.content)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -540,6 +540,9 @@ class IndexedArray(Content):
 
         parameters = self._parameters
         for array in head:
+            if isinstance(array, ak.contents.EmptyArray):
+                continue
+
             parameters = ak._util.merge_parameters(parameters, array._parameters, True)
 
             if isinstance(
@@ -574,9 +577,6 @@ class IndexedArray(Content):
                 )
                 contentlength_so_far += array.content.length
                 length_so_far += array.length
-
-            elif isinstance(array, ak.contents.EmptyArray):
-                pass
             else:
                 contents.append(array)
                 assert nextindex.nplike is self._backend.index_nplike

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -95,7 +95,9 @@ class IndexedArray(Content):
 
         if content.is_union and not is_cat:
             return content._carry(index, allow_lazy=False).copy(
-                parameters=ak._util.merge_parameters(content._parameters, parameters)
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                )
             )
 
         elif content.is_indexed or content.is_option:
@@ -124,7 +126,7 @@ class IndexedArray(Content):
                 return ak.contents.IndexedArray(
                     result,
                     content.content,
-                    parameters=ak._util.merge_parameters(
+                    parameters=ak.forms.form._merge_parameters(
                         content._parameters, parameters
                     ),
                 )
@@ -132,7 +134,7 @@ class IndexedArray(Content):
                 return ak.contents.IndexedOptionArray(
                     result,
                     content.content,
-                    parameters=ak._util.merge_parameters(
+                    parameters=ak.forms.form._merge_parameters(
                         content._parameters, parameters
                     ),
                 )
@@ -402,7 +404,7 @@ class IndexedArray(Content):
             )
             next = self._content._carry(nextcarry, False)
             return next.copy(
-                parameters=ak._util.merge_parameters(
+                parameters=ak.forms.form._merge_parameters(
                     next._parameters,
                     self._parameters,
                     exclude=(("__array__", "categorical"),),
@@ -425,9 +427,7 @@ class IndexedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            ) and _type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 
@@ -504,7 +504,9 @@ class IndexedArray(Content):
         )
         # We can directly merge with other options and indexed types, but we must merge parameters
         if other.is_option or other.is_indexed:
-            parameters = ak._util.merge_parameters(self._parameters, other._parameters)
+            parameters = ak.forms.form._merge_parameters(
+                self._parameters, other._parameters
+            )
         # Otherwise, this option parameters win out
         else:
             parameters = self._parameters
@@ -548,7 +550,7 @@ class IndexedArray(Content):
             if isinstance(
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
-                parameters = ak._util.merge_parameters(
+                parameters = ak.forms.form._merge_parameters(
                     parameters, array._parameters, True
                 )
 
@@ -968,7 +970,9 @@ class IndexedArray(Content):
                 next = self._content._carry(ak.index.Index(index), False)
 
             next2 = next.copy(
-                parameters=ak._util.merge_parameters(next._parameters, self._parameters)
+                parameters=ak.forms.form._merge_parameters(
+                    next._parameters, self._parameters
+                )
             )
             return next2._to_arrow(pyarrow, mask_node, validbytes, length, options)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -693,7 +693,7 @@ class IndexedOptionArray(Content):
             ):
                 # If we're merging an option, then merge parameters before pulling out `content`
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, True
+                    parameters, array._parameters, merge_equal=True
                 )
                 contents.append(array.content)
                 array_index = array.index

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -121,7 +121,7 @@ class IndexedOptionArray(Content):
             return IndexedOptionArray(
                 result,
                 content.content,
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )
@@ -645,7 +645,7 @@ class IndexedOptionArray(Content):
         )
         # We can directly merge with other options, but we must merge parameters
         if other.is_option:
-            parameters = ak.forms.form._merge_parameters(
+            parameters = ak.forms.form._parameters_union(
                 self._parameters, other._parameters
             )
         # Otherwise, this option parameters win out
@@ -692,8 +692,8 @@ class IndexedOptionArray(Content):
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
                 # If we're merging an option, then merge parameters before pulling out `content`
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, merge_equal=True
+                parameters = ak.forms.form._parameters_intersect(
+                    parameters, array._parameters
                 )
                 contents.append(array.content)
                 array_index = array.index

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -553,8 +553,8 @@ class IndexedOptionArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option:
+        # We can only combine option/indexd types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and _parameters_equal(
@@ -686,7 +686,9 @@ class IndexedOptionArray(Content):
             ):
                 array = array.to_IndexedOptionArray64()
 
-            if isinstance(array, ak.contents.IndexedOptionArray):
+            if isinstance(
+                array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
+            ):
                 # If we're merging an option, then merge parameters before pulling out `content`
                 parameters = ak._util.merge_parameters(
                     parameters, array._parameters, True

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1507,18 +1507,24 @@ class IndexedOptionArray(Content):
 
                 data[index_nplike.logical_not(mask0)] = content
 
-                if issubclass(content.dtype.type, (bool, np.bool_)):
+                if np.issubdtype(content.dtype, np.bool_):
                     data[mask0] = False
-                elif issubclass(content.dtype.type, np.floating):
+                elif np.issubdtype(content.dtype, np.floating):
                     data[mask0] = np.nan
-                elif issubclass(content.dtype.type, np.complexfloating):
+                elif np.issubdtype(content.dtype, np.complexfloating):
                     data[mask0] = np.nan + np.nan * 1j
-                elif issubclass(content.dtype.type, np.integer):
+                elif np.issubdtype(content.dtype, np.integer):
                     data[mask0] = np.iinfo(content.dtype).max
-                elif issubclass(content.dtype.type, (np.datetime64, np.timedelta64)):
+                elif np.issubdtype(content.dtype.type, np.datetime64) or np.issubdtype(
+                    content.dtype.type, np.timedelta64
+                ):
                     data[mask0] = nplike.asarray(
                         [np.iinfo(np.int64).max], dtype=content.dtype
                     )[0]
+                elif np.issubdtype(content.dtype, np.str_):
+                    data[mask0] = ""
+                elif np.issubdtype(content.dtype, np.bytes_):
+                    data[mask0] = b""
                 else:
                     raise ak._errors.wrap_error(
                         AssertionError(f"unrecognized dtype: {content.dtype}")

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -553,7 +553,7 @@ class IndexedOptionArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # We can only combine option/indexd types whose array-record parameters agree
+        # We can only combine option/indexed types whose array-record parameters agree
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -121,7 +121,9 @@ class IndexedOptionArray(Content):
             return IndexedOptionArray(
                 result,
                 content.content,
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
 
         else:
@@ -557,9 +559,7 @@ class IndexedOptionArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            ) and _type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 
@@ -645,7 +645,9 @@ class IndexedOptionArray(Content):
         )
         # We can directly merge with other options, but we must merge parameters
         if other.is_option:
-            parameters = ak._util.merge_parameters(self._parameters, other._parameters)
+            parameters = ak.forms.form._merge_parameters(
+                self._parameters, other._parameters
+            )
         # Otherwise, this option parameters win out
         else:
             parameters = self._parameters
@@ -690,7 +692,7 @@ class IndexedOptionArray(Content):
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
                 # If we're merging an option, then merge parameters before pulling out `content`
-                parameters = ak._util.merge_parameters(
+                parameters = ak.forms.form._merge_parameters(
                     parameters, array._parameters, True
                 )
                 contents.append(array.content)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -951,7 +951,7 @@ class ListArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (_type_parameters_equal(self._parameters, other._parameters)):
+        elif not _type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -947,6 +947,9 @@ class ListArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
             _parameters_equal(
@@ -954,19 +957,6 @@ class ListArray(Content):
             )
         ):
             return False
-        # Finally, fall back upon the per-content implementation
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
         elif isinstance(
             other,
             (
@@ -976,10 +966,8 @@ class ListArray(Content):
             ),
         ):
             return self._content._mergeable_next(other.content, mergebool)
-
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
             return self._mergeable_next(other._to_regular_primitive(), mergebool)
-
         else:
             return False
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1000,8 +1000,10 @@ class ListArray(Content):
         parameters = self._parameters
 
         for array in head:
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
+            if isinstance(array, ak.contents.EmptyArray):
+                continue
 
+            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
             if isinstance(
                 array,
                 (
@@ -1011,9 +1013,6 @@ class ListArray(Content):
                 ),
             ):
                 contents.append(array.content)
-
-            elif isinstance(array, ak.contents.EmptyArray):
-                pass
             else:
                 raise ak._errors.wrap_error(
                     ValueError(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
+from awkward.forms.form import _parameters_equal
 from awkward.forms.listform import ListForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -943,7 +944,18 @@ class ListArray(Content):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not (
+            _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
+        ):
+            return False
+        # Finally, fall back upon the per-content implementation
+        elif isinstance(
             other,
             (
                 ak.contents.IndexedArray,
@@ -953,7 +965,7 @@ class ListArray(Content):
                 ak.contents.UnmaskedArray,
             ),
         ):
-            return self._mergeable(other.content, mergebool)
+            return self._mergeable_next(other.content, mergebool)
 
         elif isinstance(
             other,
@@ -963,10 +975,10 @@ class ListArray(Content):
                 ak.contents.ListOffsetArray,
             ),
         ):
-            return self._content._mergeable(other.content, mergebool)
+            return self._content._mergeable_next(other.content, mergebool)
 
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable(other._to_regular_primitive(), mergebool)
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
 
         else:
             return False

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.listform import ListForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -951,11 +951,7 @@ class ListArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
+        elif not (_type_parameters_equal(self._parameters, other._parameters)):
             return False
         elif isinstance(
             other,
@@ -991,7 +987,9 @@ class ListArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
+            parameters = ak.forms.form._merge_parameters(
+                parameters, array._parameters, True
+            )
             if isinstance(
                 array,
                 (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -988,7 +988,7 @@ class ListArray(Content):
                 continue
 
             parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, True
+                parameters, array._parameters, merge_equal=True
             )
             if isinstance(
                 array,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -987,8 +987,8 @@ class ListArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, merge_equal=True
+            parameters = ak.forms.form._parameters_intersect(
+                parameters, array._parameters
             )
             if isinstance(
                 array,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
+from awkward.forms.form import _parameters_equal
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -700,7 +701,18 @@ class ListOffsetArray(Content):
                 )
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not (
+            _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
+        ):
+            return False
+        # Finally, fall back upon the per-content implementation
+        elif isinstance(
             other,
             (
                 ak.contents.IndexedArray,
@@ -710,7 +722,19 @@ class ListOffsetArray(Content):
                 ak.contents.UnmaskedArray,
             ),
         ):
-            return self._mergeable(other.content, mergebool)
+            return self._mergeable_next(other.content, mergebool)
+
+        elif isinstance(
+            other,
+            (
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
+            ),
+        ):
+            return self._mergeable_next(other.content, mergebool)
 
         elif isinstance(
             other,
@@ -720,10 +744,10 @@ class ListOffsetArray(Content):
                 ak.contents.ListOffsetArray,
             ),
         ):
-            return self._content._mergeable(other.content, mergebool)
+            return self._content._mergeable_next(other.content, mergebool)
 
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable(other._to_regular_primitive(), mergebool)
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
 
         else:
             return False

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -180,9 +180,9 @@ class ListOffsetArray(Content):
 
         if issubclass(self._offsets.dtype.type, np.int64):
             if (
-                not self._backend.nplike.known_data
+                self._offsets[0] == 0
                 or not start_at_zero
-                or self._offsets[0] == 0
+                or not self._backend.nplike.known_data
             ):
                 return self
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -708,7 +708,7 @@ class ListOffsetArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (_type_parameters_equal(self._parameters, other._parameters)):
+        elif not _type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -704,6 +704,9 @@ class ListOffsetArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
             _parameters_equal(
@@ -711,31 +714,6 @@ class ListOffsetArray(Content):
             )
         ):
             return False
-        # Finally, fall back upon the per-content implementation
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
         elif isinstance(
             other,
             (
@@ -745,10 +723,8 @@ class ListOffsetArray(Content):
             ),
         ):
             return self._content._mergeable_next(other.content, mergebool)
-
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
             return self._mergeable_next(other._to_regular_primitive(), mergebool)
-
         else:
             return False
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
 from awkward.typing import Final, Self, final
@@ -708,11 +708,7 @@ class ListOffsetArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
+        elif not (_type_parameters_equal(self._parameters, other._parameters)):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -180,9 +180,9 @@ class ListOffsetArray(Content):
 
         if issubclass(self._offsets.dtype.type, np.int64):
             if (
-                self._offsets[0] == 0
+                not self._backend.nplike.known_data
+                or self._offsets[0] == 0
                 or not start_at_zero
-                or not self._backend.nplike.known_data
             ):
                 return self
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.numpyform import NumpyForm
 from awkward.types.numpytype import primitive_to_dtype
 from awkward.typing import Final, Self, final
@@ -360,11 +360,7 @@ class NumpyArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
+        elif not (_type_parameters_equal(self._parameters, other._parameters)):
             return False
         # Simplify *this* branch to be 1D self
         elif len(self.shape) > 1:
@@ -421,7 +417,9 @@ class NumpyArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
+            parameters = ak.forms.form._merge_parameters(
+                parameters, array._parameters, True
+            )
             if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)
             else:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -418,7 +418,7 @@ class NumpyArray(Content):
                 continue
 
             parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, True
+                parameters, array._parameters, merge_equal=True
             )
             if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -428,10 +428,11 @@ class NumpyArray(Content):
 
         parameters = self._parameters
         for array in head:
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
             if isinstance(array, ak.contents.EmptyArray):
-                pass
-            elif isinstance(array, ak.contents.NumpyArray):
+                continue
+
+            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
+            if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)
             else:
                 raise ak._errors.wrap_error(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -417,8 +417,8 @@ class NumpyArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, merge_equal=True
+            parameters = ak.forms.form._parameters_intersect(
+                parameters, array._parameters
             )
             if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -360,7 +360,7 @@ class NumpyArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (_type_parameters_equal(self._parameters, other._parameters)):
+        elif not _type_parameters_equal(self._parameters, other._parameters):
             return False
         # Simplify *this* branch to be 1D self
         elif len(self.shape) > 1:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.recordform import RecordForm
 from awkward.record import Record
 from awkward.typing import Final, Self, final
@@ -540,11 +540,7 @@ class RecordArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
+        elif not (_type_parameters_equal(self._parameters, other._parameters)):
             return False
         elif isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:
@@ -591,7 +587,7 @@ class RecordArray(Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = ak._util.merge_parameters(
+                parameters = ak.forms.form._merge_parameters(
                     parameters, array._parameters, True
                 )
 
@@ -626,7 +622,7 @@ class RecordArray(Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = ak._util.merge_parameters(
+                parameters = ak.forms.form._merge_parameters(
                     parameters, array._parameters, True
                 )
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -587,8 +587,8 @@ class RecordArray(Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, merge_equal=True
+                parameters = ak.forms.form._parameters_intersect(
+                    parameters, array._parameters
                 )
 
                 if isinstance(array, ak.contents.RecordArray):
@@ -622,8 +622,8 @@ class RecordArray(Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, merge_equal=True
+                parameters = ak.forms.form._parameters_intersect(
+                    parameters, array._parameters
                 )
 
                 if isinstance(array, ak.contents.RecordArray):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -540,7 +540,7 @@ class RecordArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (_type_parameters_equal(self._parameters, other._parameters)):
+        elif not _type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -610,6 +610,9 @@ class RecordArray(Content):
 
         if self.is_tuple:
             for array in headless:
+                if isinstance(array, ak.contents.EmptyArray):
+                    continue
+
                 parameters = ak._util.merge_parameters(
                     parameters, array._parameters, True
                 )
@@ -630,8 +633,6 @@ class RecordArray(Content):
                         raise ak._errors.wrap_error(
                             ValueError("cannot merge tuple with non-tuple record")
                         )
-                elif isinstance(array, ak.contents.EmptyArray):
-                    pass
                 else:
                     raise ak._errors.wrap_error(
                         AssertionError(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -588,7 +588,7 @@ class RecordArray(Content):
                     continue
 
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, True
+                    parameters, array._parameters, merge_equal=True
                 )
 
                 if isinstance(array, ak.contents.RecordArray):
@@ -623,7 +623,7 @@ class RecordArray(Content):
 
             for array in headless:
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, array._parameters, True
+                    parameters, array._parameters, merge_equal=True
                 )
 
                 if isinstance(array, ak.contents.RecordArray):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -536,6 +536,9 @@ class RecordArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
             _parameters_equal(
@@ -543,32 +546,7 @@ class RecordArray(Content):
             )
         ):
             return False
-        # Finally, fall back upon the per-content implementation
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
-        if isinstance(other, RecordArray):
+        elif isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:
                 if len(self._contents) == len(other._contents):
                     for self_cont, other_cont in zip(self._contents, other._contents):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,6 +10,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 from awkward.contents.content import Content
+from awkward.forms.form import _parameters_equal
 from awkward.forms.recordform import RecordForm
 from awkward.record import Record
 from awkward.typing import Final, Self, final
@@ -532,7 +533,18 @@ class RecordArray(Content):
             )
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not (
+            _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
+        ):
+            return False
+        # Finally, fall back upon the per-content implementation
+        elif isinstance(
             other,
             (
                 ak.contents.IndexedArray,
@@ -542,13 +554,25 @@ class RecordArray(Content):
                 ak.contents.UnmaskedArray,
             ),
         ):
-            return self._mergeable(other.content, mergebool)
+            return self._mergeable_next(other.content, mergebool)
+
+        elif isinstance(
+            other,
+            (
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
+            ),
+        ):
+            return self._mergeable_next(other.content, mergebool)
 
         if isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:
                 if len(self._contents) == len(other._contents):
                     for self_cont, other_cont in zip(self._contents, other._contents):
-                        if not self_cont._mergeable(other_cont, mergebool):
+                        if not self_cont._mergeable_next(other_cont, mergebool):
                             return False
 
                     return True
@@ -560,7 +584,7 @@ class RecordArray(Content):
                 for i, field in enumerate(self._fields):
                     x = self._contents[i]
                     y = other._contents[other.field_to_index(field)]
-                    if not x._mergeable(y, mergebool):
+                    if not x._mergeable_next(y, mergebool):
                         return False
                 return True
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -633,6 +633,9 @@ class RegularArray(Content):
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not (
             _parameters_equal(
@@ -640,31 +643,6 @@ class RegularArray(Content):
             )
         ):
             return False
-        # Finally, fall back upon the per-content implementation
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._mergeable_next(other.content, mergebool)
-
         elif isinstance(
             other,
             (
@@ -674,10 +652,8 @@ class RegularArray(Content):
             ),
         ):
             return self._content._mergeable_next(other.content, mergebool)
-
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
             return self._mergeable_next(other._to_regular_primitive(), mergebool)
-
         else:
             return False
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,6 +8,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 from awkward.contents.content import Content
+from awkward.forms.form import _parameters_equal
 from awkward.forms.regularform import RegularForm
 from awkward.typing import Final, Self, final
 
@@ -629,7 +630,18 @@ class RegularArray(Content):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not (
+            _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
+        ):
+            return False
+        # Finally, fall back upon the per-content implementation
+        elif isinstance(
             other,
             (
                 ak.contents.IndexedArray,
@@ -639,7 +651,19 @@ class RegularArray(Content):
                 ak.contents.UnmaskedArray,
             ),
         ):
-            return self._mergeable(other.content, mergebool)
+            return self._mergeable_next(other.content, mergebool)
+
+        elif isinstance(
+            other,
+            (
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
+            ),
+        ):
+            return self._mergeable_next(other.content, mergebool)
 
         elif isinstance(
             other,
@@ -649,10 +673,10 @@ class RegularArray(Content):
                 ak.contents.ListOffsetArray,
             ),
         ):
-            return self._content._mergeable(other.content, mergebool)
+            return self._content._mergeable_next(other.content, mergebool)
 
         elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable(other._to_regular_primitive(), mergebool)
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
 
         else:
             return False

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -186,7 +186,7 @@ class RegularArray(Content):
             shape = (self._length, self._size) + content.data.shape[1:]
             return ak.contents.NumpyArray(
                 self._backend.nplike.reshape(content.data, shape),
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     self._parameters, content.parameters
                 ),
                 backend=content.backend,
@@ -671,8 +671,8 @@ class RegularArray(Content):
             tail_contents = []
             zeros_length = self._length
             for x in others:
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, merge_equal=True
+                parameters = ak.forms.form._intersect_parameters(
+                    parameters, x._parameters
                 )
                 tail_contents.append(
                     x._content[

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.regularform import RegularForm
 from awkward.typing import Final, Self, final
 
@@ -186,7 +186,7 @@ class RegularArray(Content):
             shape = (self._length, self._size) + content.data.shape[1:]
             return ak.contents.NumpyArray(
                 self._backend.nplike.reshape(content.data, shape),
-                parameters=ak._util.merge_parameters(
+                parameters=ak.forms.form._merge_parameters(
                     self._parameters, content.parameters
                 ),
                 backend=content.backend,
@@ -637,11 +637,7 @@ class RegularArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (
-            _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
-        ):
+        elif not (_type_parameters_equal(self._parameters, other._parameters)):
             return False
         elif isinstance(
             other,
@@ -675,7 +671,9 @@ class RegularArray(Content):
             tail_contents = []
             zeros_length = self._length
             for x in others:
-                parameters = ak._util.merge_parameters(parameters, x._parameters, True)
+                parameters = ak.forms.form._merge_parameters(
+                    parameters, x._parameters, True
+                )
                 tail_contents.append(
                     x._content[
                         : self._backend.index_nplike.mul_shape_item(x._length, x._size)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -671,7 +671,7 @@ class RegularArray(Content):
             tail_contents = []
             zeros_length = self._length
             for x in others:
-                parameters = ak.forms.form._intersect_parameters(
+                parameters = ak.forms.form._parameters_intersect(
                     parameters, x._parameters
                 )
                 tail_contents.append(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -637,7 +637,7 @@ class RegularArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not (_type_parameters_equal(self._parameters, other._parameters)):
+        elif not _type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -672,7 +672,7 @@ class RegularArray(Content):
             zeros_length = self._length
             for x in others:
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, True
+                    parameters, x._parameters, merge_equal=True
                 )
                 tail_contents.append(
                     x._content[

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1040,6 +1040,9 @@ class UnionArray(Content):
 
         parameters = self._parameters
         for array in head:
+            if isinstance(array, ak.contents.EmptyArray):
+                continue
+
             parameters = ak._util.merge_parameters(parameters, array._parameters, True)
             if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)
@@ -1082,9 +1085,6 @@ class UnionArray(Content):
                     length_so_far, array.length
                 )
                 nextcontents.extend(union_contents)
-
-            elif isinstance(array, ak.contents.EmptyArray):
-                pass
 
             else:
                 assert nexttags.nplike is self._backend.index_nplike

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -248,7 +248,7 @@ class UnionArray(Content):
                                 contents[k]
                                 ._mergemany([inner_cont])
                                 .copy(
-                                    parameters=ak._util.merge_parameters(
+                                    parameters=ak.forms.form._merge_parameters(
                                         old_parameters, inner_cont._parameters
                                     )
                                 )
@@ -331,7 +331,7 @@ class UnionArray(Content):
                             contents[k]
                             ._mergemany([self_cont])
                             .copy(
-                                parameters=ak._util.merge_parameters(
+                                parameters=ak.forms.form._merge_parameters(
                                     old_parameters, self_cont._parameters
                                 )
                             )
@@ -370,7 +370,7 @@ class UnionArray(Content):
         if len(contents) == 1:
             next = contents[0]._carry(index, True)
             return next.copy(
-                parameters=ak._util.merge_parameters(next._parameters, parameters)
+                parameters=ak.forms.form._merge_parameters(next._parameters, parameters)
             )
 
         else:
@@ -592,7 +592,7 @@ class UnionArray(Content):
             ak.index.Index(nexttags),
             ak.index.Index(nextindex),
             contents,
-            parameters=ak._util.merge_parameters(self._parameters, parameters),
+            parameters=ak.forms.form._merge_parameters(self._parameters, parameters),
         )
 
     def project(self, index):
@@ -1006,7 +1006,7 @@ class UnionArray(Content):
                 AssertionError("FIXME: handle UnionArray with more than 127 contents")
             )
 
-        parameters = ak._util.merge_parameters(
+        parameters = ak.forms.form._merge_parameters(
             self._parameters,
             other._parameters,
             exclude=ak._util.meaningful_parameters,
@@ -1043,7 +1043,9 @@ class UnionArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak._util.merge_parameters(parameters, array._parameters, True)
+            parameters = ak.forms.form._merge_parameters(
+                parameters, array._parameters, True
+            )
             if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)
                 union_index = ak.index.Index(array.index)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -249,16 +249,7 @@ class UnionArray(Content):
                                     contents[k].length,
                                 )
                             )
-                            old_parameters = contents[k]._parameters
-                            contents[k] = (
-                                contents[k]
-                                ._mergemany([inner_cont])
-                                .copy(
-                                    parameters=ak.forms.form._parameters_union(
-                                        old_parameters, inner_cont._parameters
-                                    )
-                                )
-                            )
+                            contents[k] = contents[k]._mergemany([inner_cont])
                             unmerged = False
                             break
 
@@ -332,16 +323,7 @@ class UnionArray(Content):
                                 contents[k].length,
                             )
                         )
-                        old_parameters = contents[k]._parameters
-                        contents[k] = (
-                            contents[k]
-                            ._mergemany([self_cont])
-                            .copy(
-                                parameters=ak.forms.form._parameters_union(
-                                    old_parameters, self_cont._parameters
-                                )
-                            )
-                        )
+                        contents[k] = contents[k]._mergemany([self_cont])
                         unmerged = False
                         break
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -218,6 +218,11 @@ class UnionArray(Content):
                 innerindex = self_cont._index
                 innercontents = self_cont._contents
 
+                # Update outermost parameters with this union's parameters
+                parameters = ak.forms.form._parameters_union(
+                    self_cont._parameters, parameters
+                )
+
                 # For each inner union content
                 for j, inner_cont in enumerate(innercontents):
                     unmerged = True
@@ -253,6 +258,7 @@ class UnionArray(Content):
                             unmerged = False
                             break
 
+                    # Did we fail to merge any of the final outer contents with this inner union content?
                     if unmerged:
                         Content._selfless_handle_error(
                             backend[

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1009,7 +1009,7 @@ class UnionArray(Content):
         parameters = ak.forms.form._merge_parameters(
             self._parameters,
             other._parameters,
-            exclude=ak._util.meaningful_parameters,
+            exclude=ak.forms.form.reserved_nominal_parameters,
         )
 
         return ak.contents.UnionArray.simplified(
@@ -1044,7 +1044,7 @@ class UnionArray(Content):
                 continue
 
             parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, True
+                parameters, array._parameters, merge_equal=True
             )
             if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -82,7 +82,7 @@ class UnionArray(Content):
                 )
 
         for content in contents[1:]:
-            if contents[0]._mergeable(content, mergebool=False):
+            if contents[0]._mergeable_next(content, mergebool=False):
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{0} cannot contain mergeable 'contents' ({1} of {2} and {3} of {4}); try {0}.simplified instead".format(
@@ -219,7 +219,7 @@ class UnionArray(Content):
                 for j, inner_cont in enumerate(innercontents):
                     unmerged = True
                     for k in range(len(contents)):
-                        if merge and contents[k]._mergeable(inner_cont, mergebool):
+                        if merge and contents[k]._mergeable_next(inner_cont, mergebool):
                             Content._selfless_handle_error(
                                 backend[
                                     "awkward_UnionArray_simplify",
@@ -307,7 +307,7 @@ class UnionArray(Content):
                         unmerged = False
                         break
 
-                    elif merge and contents[k]._mergeable(self_cont, mergebool):
+                    elif merge and contents[k]._mergeable_next(self_cont, mergebool):
                         Content._selfless_handle_error(
                             backend[
                                 "awkward_UnionArray_simplify_one",

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -210,15 +210,21 @@ class UnionArray(Content):
         index = ak.index.Index64.empty(length, backend.index_nplike)
         contents = []
 
+        # For each outer union content
         for i, self_cont in enumerate(self_contents):
+            # Is one of our new contents also a union?
             if isinstance(self_cont, UnionArray):
                 innertags = self_cont._tags
                 innerindex = self_cont._index
                 innercontents = self_cont._contents
 
+                # For each inner union content
                 for j, inner_cont in enumerate(innercontents):
                     unmerged = True
+
+                    # For each "final" outer union content
                     for k in range(len(contents)):
+                        # Try and merge inner union content with running outer-union contentca
                         if merge and contents[k]._mergeable_next(inner_cont, mergebool):
                             Content._selfless_handle_error(
                                 backend[
@@ -248,7 +254,7 @@ class UnionArray(Content):
                                 contents[k]
                                 ._mergemany([inner_cont])
                                 .copy(
-                                    parameters=ak.forms.form._merge_parameters(
+                                    parameters=ak.forms.form._parameters_union(
                                         old_parameters, inner_cont._parameters
                                     )
                                 )
@@ -331,7 +337,7 @@ class UnionArray(Content):
                             contents[k]
                             ._mergemany([self_cont])
                             .copy(
-                                parameters=ak.forms.form._merge_parameters(
+                                parameters=ak.forms.form._parameters_union(
                                     old_parameters, self_cont._parameters
                                 )
                             )
@@ -370,7 +376,7 @@ class UnionArray(Content):
         if len(contents) == 1:
             next = contents[0]._carry(index, True)
             return next.copy(
-                parameters=ak.forms.form._merge_parameters(next._parameters, parameters)
+                parameters=ak.forms.form._parameters_union(next._parameters, parameters)
             )
 
         else:
@@ -592,7 +598,7 @@ class UnionArray(Content):
             ak.index.Index(nexttags),
             ak.index.Index(nextindex),
             contents,
-            parameters=ak.forms.form._merge_parameters(self._parameters, parameters),
+            parameters=ak.forms.form._parameters_union(self._parameters, parameters),
         )
 
     def project(self, index):
@@ -1006,7 +1012,7 @@ class UnionArray(Content):
                 AssertionError("FIXME: handle UnionArray with more than 127 contents")
             )
 
-        parameters = ak.forms.form._merge_parameters(
+        parameters = ak.forms.form._parameters_union(
             self._parameters,
             other._parameters,
             exclude=ak.forms.form.reserved_nominal_parameters,
@@ -1043,8 +1049,8 @@ class UnionArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._merge_parameters(
-                parameters, array._parameters, merge_equal=True
+            parameters = ak.forms.form._parameters_intersect(
+                parameters, array._parameters
             )
             if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -291,7 +291,7 @@ class UnmaskedArray(Content):
             parameters = self._parameters
             tail_contents = []
             for x in others:
-                parameters = ak.forms.form._intersect_parameters(
+                parameters = ak.forms.form._parameters_intersect(
                     parameters, x._parameters
                 )
                 tail_contents.append(x._content)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -68,13 +68,13 @@ class UnmaskedArray(Content):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 )
             )
@@ -291,8 +291,8 @@ class UnmaskedArray(Content):
             parameters = self._parameters
             tail_contents = []
             for x in others:
-                parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, merge_equal=True
+                parameters = ak.forms.form._intersect_parameters(
+                    parameters, x._parameters
                 )
                 tail_contents.append(x._content)
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -10,6 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
 from awkward._util import unset
 from awkward.contents.content import Content
+from awkward.forms.form import _parameters_equal
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.typing import Final, Self, final
 
@@ -264,7 +265,11 @@ class UnmaskedArray(Content):
                 return (offsets, flattened)
 
     def _mergeable_next(self, other, mergebool):
-        if isinstance(
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif isinstance(
             other,
             (
                 ak.contents.IndexedArray,
@@ -274,10 +279,23 @@ class UnmaskedArray(Content):
                 ak.contents.UnmaskedArray,
             ),
         ):
-            return self._content._mergeable(other.content, mergebool)
+            return self._mergeable_next(other.content, mergebool) and _parameters_equal(
+                self._parameters, other._parameters, only_array_record=True
+            )
+        elif isinstance(
+            other,
+            (
+                ak.contents.IndexedArray,
+                ak.contents.IndexedOptionArray,
+                ak.contents.ByteMaskedArray,
+                ak.contents.BitMaskedArray,
+                ak.contents.UnmaskedArray,
+            ),
+        ):
+            return self._content._mergeable_next(other.content, mergebool)
 
         else:
-            return self._content._mergeable(other, mergebool)
+            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.typing import Final, Self, final
 
@@ -68,11 +68,15 @@ class UnmaskedArray(Content):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak._util.merge_parameters(content._parameters, parameters)
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                )
             )
         else:
             return cls(content, parameters=parameters)
@@ -270,9 +274,9 @@ class UnmaskedArray(Content):
             return True
         # We can only combine option types whose array-record parameters agree
         elif other.is_option or other.is_indexed:
-            return self._mergeable_next(other.content, mergebool) and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            return self._mergeable_next(
+                other.content, mergebool
+            ) and _type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 
@@ -287,7 +291,9 @@ class UnmaskedArray(Content):
             parameters = self._parameters
             tail_contents = []
             for x in others:
-                parameters = ak._util.merge_parameters(parameters, x._parameters, True)
+                parameters = ak.forms.form._merge_parameters(
+                    parameters, x._parameters, True
+                )
                 tail_contents.append(x._content)
 
             return UnmaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -292,7 +292,7 @@ class UnmaskedArray(Content):
             tail_contents = []
             for x in others:
                 parameters = ak.forms.form._merge_parameters(
-                    parameters, x._parameters, True
+                    parameters, x._parameters, merge_equal=True
                 )
                 tail_contents.append(x._content)
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -269,31 +269,10 @@ class UnmaskedArray(Content):
         if other.is_identity_like or other.is_union:
             return True
         # We can only combine option types whose array-record parameters agree
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
+        elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool) and _parameters_equal(
                 self._parameters, other._parameters, only_array_record=True
             )
-        elif isinstance(
-            other,
-            (
-                ak.contents.IndexedArray,
-                ak.contents.IndexedOptionArray,
-                ak.contents.ByteMaskedArray,
-                ak.contents.BitMaskedArray,
-                ak.contents.UnmaskedArray,
-            ),
-        ):
-            return self._content._mergeable_next(other.content, mergebool)
-
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -162,9 +162,7 @@ class BitMaskedForm(Form):
                 and self._mask == other._mask
                 and self._valid_when == other._valid_when
                 and self._lsb_order == other._lsb_order
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -57,7 +57,7 @@ class BitMaskedForm(Form):
         self._content = content
         self._valid_when = valid_when
         self._lsb_order = lsb_order
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def mask(self):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -47,7 +47,7 @@ class ByteMaskedForm(Form):
         self._mask = mask
         self._content = content
         self._valid_when = valid_when
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def mask(self):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -137,9 +137,7 @@ class ByteMaskedForm(Form):
                 self._form_key == other._form_key
                 and self._mask == other._mask
                 and self._valid_when == other._valid_when
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -14,21 +14,27 @@ class EmptyForm(Form):
     is_unknown = True
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
+        if not (parameters is None or len(parameters) == 0):
+            deprecate(
+                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
+            )
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = unset, form_key=unset
     ) -> EmptyForm:
-        if parameters is not unset:
+        if not (parameters is unset or parameters is None or len(parameters) == 0):
             deprecate(
                 f"{type(self).__name__} cannot contain parameters", version="2.2.0"
             )
-        return EmptyForm(parameters=parameters, form_key=form_key)
+        return EmptyForm(
+            parameters=self._parameters if parameters is unset else parameters,
+            form_key=self._form_key if form_key is unset else form_key,
+        )
 
     @classmethod
-    def simplified(cls, *, parameters=unset, form_key=None) -> Form:
-        if parameters is not unset:
-            parameters = None
+    def simplified(cls, *, parameters=None, form_key=None) -> Form:
+        if not (parameters is None or len(parameters) == 0):
             deprecate(f"{cls.__name__} cannot contain parameters", version="2.2.0")
         return cls(parameters=parameters, form_key=form_key)
 

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -1,8 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form
+from awkward.forms.form import Form, JSONMapping
 from awkward.typing import final
 
 
@@ -11,15 +12,21 @@ class EmptyForm(Form):
     is_numpy = True
     is_unknown = True
 
-    def __init__(self, *, parameters=None, form_key=None):
-        self._init(parameters, form_key)
+    def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
+        self._init(parameters=None, form_key=form_key)
 
-    def copy(self, *, parameters=unset, form_key=unset):
-        return EmptyForm(parameters=parameters, form_key=form_key)
+    @property
+    def parameters(self) -> JSONMapping:
+        return {}
+
+    def copy(
+        self, *, parameters: JSONMapping | None = unset, form_key=unset
+    ) -> EmptyForm:
+        return EmptyForm(form_key=form_key)
 
     @classmethod
-    def simplified(cls, *, parameters=None, form_key=None):
-        return cls(parameters=parameters, form_key=form_key)
+    def simplified(cls, *, parameters=None, form_key=None) -> Form:
+        return cls(form_key=form_key)
 
     def __repr__(self):
         args = self._repr_args()
@@ -34,24 +41,21 @@ class EmptyForm(Form):
             typestr=ak._util.gettypestr(self._parameters, typestrs),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return isinstance(other, EmptyForm) and self._form_key == other._form_key
 
     def to_NumpyForm(self, dtype):
         return ak.forms.numpyform.from_dtype(dtype, parameters=self._parameters)
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return None
-        else:
-            return self._parameters[key]
+    def purelist_parameter(self, key: str) -> None:
+        return None
 
     @property
-    def purelist_isregular(self):
+    def purelist_isregular(self) -> bool:
         return True
 
     @property
-    def purelist_depth(self):
+    def purelist_depth(self) -> int:
         return 1
 
     @property
@@ -65,23 +69,23 @@ class EmptyForm(Form):
         )
 
     @property
-    def minmax_depth(self):
+    def minmax_depth(self) -> tuple[int, int]:
         return (1, 1)
 
     @property
-    def branch_depth(self):
+    def branch_depth(self) -> tuple[bool, int]:
         return (False, 1)
 
     @property
-    def fields(self):
+    def fields(self) -> list[str]:
         return []
 
     @property
-    def is_tuple(self):
+    def is_tuple(self) -> bool:
         return False
 
     @property
-    def dimension_optiontype(self):
+    def dimension_optiontype(self) -> bool:
         return False
 
     def _columns(self, path, output, list_indicator):
@@ -92,5 +96,5 @@ class EmptyForm(Form):
             output.append(None)
         return self
 
-    def _column_types(self):
+    def _column_types(self) -> tuple[str, ...]:
         return ("empty",)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -55,8 +55,14 @@ class EmptyForm(Form):
         return 1
 
     @property
-    def is_identity_like(self):
-        return True
+    def is_identity_like(self) -> bool:
+        if self._parameters is None:
+            return True
+
+        return (
+            self._parameters.get("__array__") is None
+            and self._parameters.get("__categorical__") is None
+        )
 
     @property
     def minmax_depth(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -49,7 +49,7 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] == "EmptyArray":
-        return ak.forms.EmptyForm(parameters=parameters, form_key=form_key)
+        return ak.forms.EmptyForm(form_key=form_key)
 
     elif input["class"] == "RegularArray":
         return ak.forms.RegularForm(
@@ -353,7 +353,7 @@ class Form:
     is_record = False
     is_union = False
 
-    def _init(self, parameters, form_key):
+    def _init(self, *, parameters, form_key):
         if parameters is not None and not isinstance(parameters, dict):
             raise _errors.wrap_error(
                 TypeError(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -206,7 +206,7 @@ def _type_parameters_equal(
 
     elif two is None:
         for key in ("__array__", "__record__", "__categorical__"):
-            if two.get(key) is not None:
+            if one.get(key) is not None:
                 return allow_missing
         return True
 

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 import awkward as ak
 from awkward import _errors
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.typing import TypeAlias
+from awkward.typing import Final, TypeAlias
 
 np = NumpyMetadata.instance()
 numpy_backend = ak._backends.NumpyBackend.instance()
@@ -16,6 +16,18 @@ JSONSerialisable: TypeAlias = (
     "str | int | float | bool | None | list | tuple | JSONMapping"
 )
 JSONMapping: TypeAlias = "dict[str, JSONSerialisable]"
+
+
+reserved_nominal_parameters: Final = frozenset(
+    {
+        ("__array__", "string"),
+        ("__array__", "bytestring"),
+        ("__array__", "char"),
+        ("__array__", "byte"),
+        ("__array__", "sorted_map"),
+        ("__array__", "categorical"),
+    }
+)
 
 
 def from_dict(input: dict) -> Form:
@@ -291,6 +303,7 @@ def _parameters_is_empty(parameters: JSONMapping | None) -> bool:
 def _merge_parameters(
     one: JSONMapping | None,
     two: JSONMapping | None,
+    *,
     merge_equal: bool = False,
     exclude: tuple[str] = (),
 ) -> JSONMapping | None:

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_update, _type_parameters_equal
+from awkward.forms.form import Form, _parameters_union, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -75,7 +75,7 @@ class IndexedForm(Form):
 
         if content.is_union and not is_cat:
             return content.copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 )
             )
@@ -84,7 +84,7 @@ class IndexedForm(Form):
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )
@@ -93,7 +93,7 @@ class IndexedForm(Form):
             return IndexedForm(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )
@@ -122,8 +122,7 @@ class IndexedForm(Form):
             if out._parameters is None:
                 out._parameters = self._parameters
             else:
-                out._parameters = dict(out._parameters)
-                _parameters_update(out._parameters, self._parameters)
+                out._parameters = _parameters_union(out._parameters, self._parameters)
 
             if self._parameters.get("__array__") == "categorical":
                 if out._parameters is self._parameters:

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -37,7 +37,7 @@ class IndexedForm(Form):
 
         self._index = index
         self._content = content
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def index(self):

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal, _parameters_update
+from awkward.forms.form import Form, _parameters_update, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -75,21 +75,27 @@ class IndexedForm(Form):
 
         if content.is_union and not is_cat:
             return content.copy(
-                parameters=ak._util.merge_parameters(content._parameters, parameters)
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                )
             )
 
         elif content.is_option:
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
 
         elif content.is_indexed:
             return IndexedForm(
                 "i64",
                 content.content,
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
 
         else:
@@ -138,9 +144,7 @@ class IndexedForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._index == other._index
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -38,7 +38,7 @@ class IndexedOptionForm(Form):
 
         self._index = index
         self._content = content
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def index(self):

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -81,7 +81,9 @@ class IndexedOptionForm(Form):
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
 
         else:
@@ -120,9 +122,7 @@ class IndexedOptionForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._index == other._index
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -81,7 +81,7 @@ class IndexedOptionForm(Form):
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -122,9 +122,7 @@ class ListForm(Form):
                 self._form_key == other._form_key
                 and self._starts == other._starts
                 and self._stops == other._stops
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -47,7 +47,7 @@ class ListForm(Form):
         self._starts = starts
         self._stops = stops
         self._content = content
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def starts(self):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -80,9 +80,7 @@ class ListOffsetForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._offsets == other._offsets
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -22,7 +22,7 @@ class ListOffsetForm(Form):
 
         self._offsets = offsets
         self._content = content
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def offsets(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -62,7 +62,7 @@ class NumpyForm(Form):
 
         self._primitive = primitive
         self._inner_shape = tuple(inner_shape)
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def primitive(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 np = NumpyMetadata.instance()
@@ -147,9 +147,7 @@ class NumpyForm(Form):
                 self._form_key == other._form_key
                 and self._primitive == other._primitive
                 and self._inner_shape == other._inner_shape
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
             )
         else:
             return False

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -49,7 +49,7 @@ class RecordForm(Form):
 
         self._fields = fields
         self._contents = list(contents)
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def contents(self):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -189,9 +189,7 @@ class RecordForm(Form):
                 self._form_key == other._form_key
                 and self.is_tuple == other.is_tuple
                 and len(self._contents) == len(other._contents)
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
             ):
                 if self.is_tuple:
                     return self._contents == other._contents

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -80,9 +80,7 @@ class RegularForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._size == other._size
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -31,7 +31,7 @@ class RegularForm(Form):
 
         self._content = content
         self._size = int(size)
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def content(self):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -152,9 +152,7 @@ class UnionForm(Form):
             and self._tags == other._tags
             and self._index == other._index
             and len(self._contents) == len(other._contents)
-            and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            and _type_parameters_equal(self._parameters, other._parameters)
         ):
             return self._contents == other._contents
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -58,7 +58,7 @@ class UnionForm(Form):
         self._tags = tags
         self._index = index
         self._contents = list(contents)
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def tags(self):
@@ -246,9 +246,7 @@ class UnionForm(Form):
                 contents.append(next_content)
 
         if len(contents) == 0:
-            return ak.forms.EmptyForm(
-                parameters=self._parameters, form_key=self._form_key
-            )
+            return ak.forms.EmptyForm(form_key=self._form_key)
         elif len(contents) == 1:
             return contents[0]
         else:

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -57,13 +57,13 @@ class UnmaskedForm(Form):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 ),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak.forms.form._merge_parameters(
+                parameters=ak.forms.form._parameters_union(
                     content._parameters, parameters
                 )
             )

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_equal
+from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
 
 
@@ -57,11 +57,15 @@ class UnmaskedForm(Form):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak._util.merge_parameters(content._parameters, parameters),
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                ),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak._util.merge_parameters(content._parameters, parameters)
+                parameters=ak.forms.form._merge_parameters(
+                    content._parameters, parameters
+                )
             )
         else:
             return cls(content, parameters=parameters, form_key=form_key)
@@ -90,9 +94,7 @@ class UnmaskedForm(Form):
         if isinstance(other, UnmaskedForm):
             return (
                 self._form_key == other._form_key
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -27,7 +27,7 @@ class UnmaskedForm(Form):
             )
 
         self._content = content
-        self._init(parameters, form_key)
+        self._init(parameters=parameters, form_key=form_key)
 
     @property
     def content(self):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -170,7 +170,7 @@ def reconstitute(form, length, container, getkey, backend, byteorder, simplify):
             raise ak._errors.wrap_error(
                 ValueError(f"EmptyForm node, but the expected length is {length}")
             )
-        return ak.contents.EmptyArray(parameters=form.parameters)
+        return ak.contents.EmptyArray()
 
     elif isinstance(form, ak.forms.NumpyForm):
         dtype = ak.types.numpytype.primitive_to_dtype(form.primitive)

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -227,6 +227,12 @@ or
         else:
             columns = pandas.MultiIndex.from_tuples([col_names])
 
+        # Pandas can't handle masked strings
+        if np.issubdtype(column.dtype, np.str_):
+            column = numpy.ma.filled(column, "nan")
+        elif np.issubdtype(column.dtype, np.bytes_):
+            column = numpy.ma.filled(column, b"nan")
+
         if (
             last_row_arrays is not None
             and len(last_row_arrays) == len(row_arrays)

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -69,9 +69,7 @@ class ListType(Type):
     def __eq__(self, other):
         if isinstance(other, ListType):
             return (
-                _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -5,7 +5,7 @@ import re
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -163,8 +163,8 @@ class NumpyType(Type):
 
     def __eq__(self, other):
         if isinstance(other, NumpyType):
-            return self._primitive == other._primitive and _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
+            return self._primitive == other._primitive and _type_parameters_equal(
+                self._parameters, other._parameters
             )
         else:
             return False

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -103,7 +103,7 @@ class OptionType(Type):
                     contents.append(
                         OptionType(
                             content.content,
-                            parameters=ak.forms.form._merge_parameters(
+                            parameters=ak.forms.form._parameters_union(
                                 self._parameters, content._parameters
                             ),
                             typestr=typestr,

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
 from awkward.types.type import Type
@@ -86,9 +86,7 @@ class OptionType(Type):
     def __eq__(self, other):
         if isinstance(other, OptionType):
             return (
-                _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:
@@ -105,7 +103,7 @@ class OptionType(Type):
                     contents.append(
                         OptionType(
                             content.content,
-                            parameters=ak._util.merge_parameters(
+                            parameters=ak.forms.form._merge_parameters(
                                 self._parameters, content._parameters
                             ),
                             typestr=typestr,

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 import awkward._prettyprint
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -181,9 +181,7 @@ class RecordType(Type):
 
     def __eq__(self, other):
         if isinstance(other, RecordType):
-            if not _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            ):
+            if not _type_parameters_equal(self._parameters, other._parameters):
                 return False
 
             if self._fields is None and other._fields is None:

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -85,9 +85,7 @@ class RegularType(Type):
         if isinstance(other, RegularType):
             return (
                 self._size == other._size
-                and _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                and _type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -95,9 +95,7 @@ class UnionType(Type):
     def __eq__(self, other):
         if isinstance(other, UnionType):
             return (
-                _parameters_equal(
-                    self._parameters, other._parameters, only_array_record=True
-                )
+                _type_parameters_equal(self._parameters, other._parameters)
                 and self._contents == other._contents
             )
         else:

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._errors import deprecate
 from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
@@ -9,6 +10,10 @@ from awkward.typing import final
 @final
 class UnknownType(Type):
     def __init__(self, *, parameters=None, typestr=None):
+        if parameters is not None:
+            deprecate(
+                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
+            )
         if parameters is not None and not isinstance(parameters, dict):
             raise ak._errors.wrap_error(
                 TypeError(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward.forms.form import _parameters_equal
+from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
 
@@ -47,8 +47,6 @@ class UnknownType(Type):
 
     def __eq__(self, other):
         if isinstance(other, UnknownType):
-            return _parameters_equal(
-                self._parameters, other._parameters, only_array_record=True
-            )
+            return _type_parameters_equal(self._parameters, other._parameters)
         else:
             return False

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -12,8 +12,9 @@ def test_types_with_parameters():
     t = ak.types.UnknownType()
     assert t.parameters == {}
 
-    t = ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    with pytest.warns(DeprecationWarning):
+        t = ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
+        assert t.parameters == {"__array__": ["val", "ue"]}
 
     t = ak.types.NumpyType("int32", parameters={"__array__": ["val", "ue"]})
     assert t.parameters == {"__array__": ["val", "ue"]}
@@ -50,15 +51,16 @@ def test_types_with_parameters():
     )
     assert t.parameters == {"__array__": ["val", "ue"]}
 
-    t = ak.types.UnknownType(
-        parameters={"key1": ["val", "ue"], "__record__": "one \u2192 two"}
-    )
-    assert t.parameters == {"__record__": "one \u2192 two", "key1": ["val", "ue"]}
+    with pytest.warns(DeprecationWarning):
+        t = ak.types.UnknownType(
+            parameters={"key1": ["val", "ue"], "__record__": "one \u2192 two"}
+        )
+        assert t.parameters == {"__record__": "one \u2192 two", "key1": ["val", "ue"]}
 
-    assert t == ak.types.UnknownType(
-        parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
-    )
-    assert t != ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
+        assert t == ak.types.UnknownType(
+            parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
+        )
+        assert t != ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
 
 
 def test_dress():

--- a/tests/test_0057_introducing_forms.py
+++ b/tests/test_0057_introducing_forms.py
@@ -96,13 +96,14 @@ def test_forms():
         "form_key": "yowzers",
     }
 
-    form = ak.forms.EmptyForm(
-        parameters={"hey": ["you"]},
-        form_key="yowzers",
-    )
-    assert form == form
-    assert pickle.loads(pickle.dumps(form, -1)) == form
-    assert ak.forms.from_json(form.to_json()) == form
+    with pytest.warns(DeprecationWarning):
+        form = ak.forms.EmptyForm(
+            parameters={"hey": ["you"]},
+            form_key="yowzers",
+        )
+        assert form == form
+        assert pickle.loads(pickle.dumps(form, -1)) == form
+        assert ak.forms.from_json(form.to_json()) == form
     assert json.loads(form.to_json()) == {
         "class": "EmptyArray",
         "parameters": {"hey": ["you"]},

--- a/tests/test_0093_simplify_uniontypes_and_optiontypes.py
+++ b/tests/test_0093_simplify_uniontypes_and_optiontypes.py
@@ -19,7 +19,10 @@ def test_numpyarray_merge():
     assert to_list(ak1[1:, :-1, ::-1]._mergemany([ak2[1:, :-1, ::-1]])) == to_list(
         np.concatenate([np1[1:, :-1, ::-1], np2[1:, :-1, ::-1]])
     )
-    assert ak1()._mergemany([ak2.to_typetracer()]).form == ak1._mergemany([ak2]).form
+    assert (
+        ak1.to_typetracer()._mergemany([ak2.to_typetracer()]).form
+        == ak1._mergemany([ak2]).form
+    )
     assert (
         ak1[1:, :-1, ::-1].to_typetracer()._mergemany([ak2[1:, :-1, ::-1]]).form
         == ak1[1:, :-1, ::-1]._mergemany([ak2[1:, :-1, ::-1]]).form
@@ -67,11 +70,11 @@ def test_numpyarray_merge():
             assert to_list(emptyarray._mergemany([one])) == to_list(one)
 
             assert (
-                one()._mergemany([two.to_typetracer()]).form
+                one.to_typetracer()._mergemany([two.to_typetracer()]).form
                 == one._mergemany([two]).form
             )
             assert (
-                one()._mergemany([emptyarray.to_typetracer()]).form
+                one.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
                 == one._mergemany([emptyarray]).form
             )
             assert (
@@ -92,9 +95,12 @@ def test_regulararray_merge():
     assert to_list(ak1._mergemany([emptyarray])) == to_list(ak1)
     assert to_list(emptyarray._mergemany([ak1])) == to_list(ak1)
 
-    assert ak1()._mergemany([ak2.to_typetracer()]).form == ak1._mergemany([ak2]).form
     assert (
-        ak1()._mergemany([emptyarray.to_typetracer()]).form
+        ak1.to_typetracer()._mergemany([ak2.to_typetracer()]).form
+        == ak1._mergemany([ak2]).form
+    )
+    assert (
+        ak1.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == ak1._mergemany([emptyarray]).form
     )
     assert (
@@ -176,15 +182,15 @@ def test_listarray_merge():
         assert to_list(emptyarray._mergemany([array1])) == to_list(array1)
 
         assert (
-            array1()._mergemany([array2.to_typetracer()]).form
+            array1.to_typetracer()._mergemany([array2.to_typetracer()]).form
             == array1._mergemany([array2]).form
         )
         assert (
-            array2()._mergemany([array1.to_typetracer()]).form
+            array2.to_typetracer()._mergemany([array1.to_typetracer()]).form
             == array2._mergemany([array1]).form
         )
         assert (
-            array1()._mergemany([emptyarray.to_typetracer()]).form
+            array1.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
             == array1._mergemany([emptyarray]).form
         )
         assert (
@@ -297,15 +303,15 @@ def test_listoffsetarray_merge():
         assert to_list(emptyarray._mergemany([array1])) == to_list(array1)
 
         assert (
-            array1()._mergemany([array2.to_typetracer()]).form
+            array1.to_typetracer()._mergemany([array2.to_typetracer()]).form
             == array1._mergemany([array2]).form
         )
         assert (
-            array2()._mergemany([array1.to_typetracer()]).form
+            array2.to_typetracer()._mergemany([array1.to_typetracer()]).form
             == array2._mergemany([array1]).form
         )
         assert (
-            array1()._mergemany([emptyarray.to_typetracer()]).form
+            array1.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
             == array1._mergemany([emptyarray]).form
         )
         assert (
@@ -343,11 +349,11 @@ def test_listoffsetarray_merge():
         ]
 
         assert (
-            array1()._mergemany([regulararray.to_typetracer()]).form
+            array1.to_typetracer()._mergemany([regulararray.to_typetracer()]).form
             == array1._mergemany([regulararray]).form
         )
         assert (
-            regulararray()._mergemany([array1.to_typetracer()]).form
+            regulararray.to_typetracer()._mergemany([array1.to_typetracer()]).form
             == regulararray._mergemany([array1]).form
         )
 
@@ -500,35 +506,35 @@ def test_recordarray_merge():
     ]
 
     assert (
-        arrayr1()._mergemany([arrayr2.to_typetracer()]).form
+        arrayr1.to_typetracer()._mergemany([arrayr2.to_typetracer()]).form
         == arrayr1._mergemany([arrayr2]).form
     )
     assert (
-        arrayr2()._mergemany([arrayr1.to_typetracer()]).form
+        arrayr2.to_typetracer()._mergemany([arrayr1.to_typetracer()]).form
         == arrayr2._mergemany([arrayr1]).form
     )
     assert (
-        arrayr1()._mergemany([arrayr4.to_typetracer()]).form
+        arrayr1.to_typetracer()._mergemany([arrayr4.to_typetracer()]).form
         == arrayr1._mergemany([arrayr4]).form
     )
     assert (
-        arrayr4()._mergemany([arrayr1.to_typetracer()]).form
+        arrayr4.to_typetracer()._mergemany([arrayr1.to_typetracer()]).form
         == arrayr4._mergemany([arrayr1]).form
     )
     assert (
-        arrayr5()._mergemany([arrayr6.to_typetracer()]).form
+        arrayr5.to_typetracer()._mergemany([arrayr6.to_typetracer()]).form
         == arrayr5._mergemany([arrayr6]).form
     )
     assert (
-        arrayr6()._mergemany([arrayr5.to_typetracer()]).form
+        arrayr6.to_typetracer()._mergemany([arrayr5.to_typetracer()]).form
         == arrayr6._mergemany([arrayr5]).form
     )
     assert (
-        arrayt1()._mergemany([arrayt2.to_typetracer()]).form
+        arrayt1.to_typetracer()._mergemany([arrayt2.to_typetracer()]).form
         == arrayt1._mergemany([arrayt2]).form
     )
     assert (
-        arrayt2()._mergemany([arrayt1.to_typetracer()]).form
+        arrayt2.to_typetracer()._mergemany([arrayt1.to_typetracer()]).form
         == arrayt2._mergemany([arrayt1]).form
     )
 
@@ -565,31 +571,31 @@ def test_recordarray_merge():
     assert to_list(emptyarray._mergemany([arrayt7])) == to_list(arrayt7)
 
     assert (
-        arrayr1()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr1.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr1._mergemany([emptyarray]).form
     )
     assert (
-        arrayr2()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr2.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr2._mergemany([emptyarray]).form
     )
     assert (
-        arrayr3()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr3.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr3._mergemany([emptyarray]).form
     )
     assert (
-        arrayr4()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr4.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr4._mergemany([emptyarray]).form
     )
     assert (
-        arrayr5()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr5.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr5._mergemany([emptyarray]).form
     )
     assert (
-        arrayr6()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr6.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr6._mergemany([emptyarray]).form
     )
     assert (
-        arrayr7()._mergemany([emptyarray.to_typetracer()]).form
+        arrayr7.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr7._mergemany([emptyarray]).form
     )
 
@@ -623,31 +629,31 @@ def test_recordarray_merge():
     )
 
     assert (
-        arrayt1()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt1.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt1._mergemany([emptyarray]).form
     )
     assert (
-        arrayt2()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt2.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt2._mergemany([emptyarray]).form
     )
     assert (
-        arrayt3()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt3.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt3._mergemany([emptyarray]).form
     )
     assert (
-        arrayt4()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt4.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt4._mergemany([emptyarray]).form
     )
     assert (
-        arrayt5()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt5.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt5._mergemany([emptyarray]).form
     )
     assert (
-        arrayt6()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt6.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt6._mergemany([emptyarray]).form
     )
     assert (
-        arrayt7()._mergemany([emptyarray.to_typetracer()]).form
+        arrayt7.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt7._mergemany([emptyarray]).form
     )
 
@@ -736,15 +742,15 @@ def test_indexedarray_merge():
     ]
 
     assert (
-        indexedarray1()._mergemany([content2.to_typetracer()]).form
+        indexedarray1.to_typetracer()._mergemany([content2.to_typetracer()]).form
         == indexedarray1._mergemany([content2]).form
     )
     assert (
-        content2()._mergemany([indexedarray1.to_typetracer()]).form
+        content2.to_typetracer()._mergemany([indexedarray1.to_typetracer()]).form
         == content2._mergemany([indexedarray1]).form
     )
     assert (
-        indexedarray1()._mergemany([indexedarray1.to_typetracer()]).form
+        indexedarray1.to_typetracer()._mergemany([indexedarray1.to_typetracer()]).form
         == indexedarray1._mergemany([indexedarray1]).form
     )
 
@@ -827,10 +833,16 @@ def test_unionarray_merge():
         {"x": 2, "y": 2.2},
     ]
 
-    assert one()._mergemany([two.to_typetracer()]).form == one._mergemany([two]).form
-    assert two()._mergemany([one.to_typetracer()]).form == two._mergemany([one]).form
     assert (
-        one()._mergemany([emptyarray.to_typetracer()]).form
+        one.to_typetracer()._mergemany([two.to_typetracer()]).form
+        == one._mergemany([two]).form
+    )
+    assert (
+        two.to_typetracer()._mergemany([one.to_typetracer()]).form
+        == two._mergemany([one]).form
+    )
+    assert (
+        one.to_typetracer()._mergemany([emptyarray.to_typetracer()]).form
         == one._mergemany([emptyarray]).form
     )
     assert (
@@ -838,16 +850,20 @@ def test_unionarray_merge():
         == emptyarray._mergemany([one]).form
     )
     assert (
-        one()._mergemany([three.to_typetracer()]).form == one._mergemany([three]).form
+        one.to_typetracer()._mergemany([three.to_typetracer()]).form
+        == one._mergemany([three]).form
     )
     assert (
-        two()._mergemany([three.to_typetracer()]).form == two._mergemany([three]).form
+        two.to_typetracer()._mergemany([three.to_typetracer()]).form
+        == two._mergemany([three]).form
     )
     assert (
-        three()._mergemany([one.to_typetracer()]).form == three._mergemany([one]).form
+        three.to_typetracer()._mergemany([one.to_typetracer()]).form
+        == three._mergemany([one]).form
     )
     assert (
-        three()._mergemany([two.to_typetracer()]).form == three._mergemany([two]).form
+        three.to_typetracer()._mergemany([two.to_typetracer()]).form
+        == three._mergemany([two]).form
     )
 
 

--- a/tests/test_0093_simplify_uniontypes_and_optiontypes.py
+++ b/tests/test_0093_simplify_uniontypes_and_optiontypes.py
@@ -19,7 +19,7 @@ def test_numpyarray_merge():
     assert to_list(ak1[1:, :-1, ::-1]._mergemany([ak2[1:, :-1, ::-1]])) == to_list(
         np.concatenate([np1[1:, :-1, ::-1], np2[1:, :-1, ::-1]])
     )
-    assert ak1.to_typetracer()._mergemany([ak2]).form == ak1._mergemany([ak2]).form
+    assert ak1()._mergemany([ak2.to_typetracer()]).form == ak1._mergemany([ak2]).form
     assert (
         ak1[1:, :-1, ::-1].to_typetracer()._mergemany([ak2[1:, :-1, ::-1]]).form
         == ak1[1:, :-1, ::-1]._mergemany([ak2[1:, :-1, ::-1]]).form
@@ -67,14 +67,15 @@ def test_numpyarray_merge():
             assert to_list(emptyarray._mergemany([one])) == to_list(one)
 
             assert (
-                one.to_typetracer()._mergemany([two]).form == one._mergemany([two]).form
+                one()._mergemany([two.to_typetracer()]).form
+                == one._mergemany([two]).form
             )
             assert (
-                one.to_typetracer()._mergemany([emptyarray]).form
+                one()._mergemany([emptyarray.to_typetracer()]).form
                 == one._mergemany([emptyarray]).form
             )
             assert (
-                emptyarray.to_typetracer()._mergemany([one]).form
+                emptyarray.to_typetracer()._mergemany([one.to_typetracer()]).form
                 == emptyarray._mergemany([one]).form
             )
 
@@ -91,13 +92,13 @@ def test_regulararray_merge():
     assert to_list(ak1._mergemany([emptyarray])) == to_list(ak1)
     assert to_list(emptyarray._mergemany([ak1])) == to_list(ak1)
 
-    assert ak1.to_typetracer()._mergemany([ak2]).form == ak1._mergemany([ak2]).form
+    assert ak1()._mergemany([ak2.to_typetracer()]).form == ak1._mergemany([ak2]).form
     assert (
-        ak1.to_typetracer()._mergemany([emptyarray]).form
+        ak1()._mergemany([emptyarray.to_typetracer()]).form
         == ak1._mergemany([emptyarray]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([ak1]).form
+        emptyarray.to_typetracer()._mergemany([ak1.to_typetracer()]).form
         == emptyarray._mergemany([ak1]).form
     )
 
@@ -175,19 +176,19 @@ def test_listarray_merge():
         assert to_list(emptyarray._mergemany([array1])) == to_list(array1)
 
         assert (
-            array1.to_typetracer()._mergemany([array2]).form
+            array1()._mergemany([array2.to_typetracer()]).form
             == array1._mergemany([array2]).form
         )
         assert (
-            array2.to_typetracer()._mergemany([array1]).form
+            array2()._mergemany([array1.to_typetracer()]).form
             == array2._mergemany([array1]).form
         )
         assert (
-            array1.to_typetracer()._mergemany([emptyarray]).form
+            array1()._mergemany([emptyarray.to_typetracer()]).form
             == array1._mergemany([emptyarray]).form
         )
         assert (
-            emptyarray.to_typetracer()._mergemany([array1]).form
+            emptyarray.to_typetracer()._mergemany([array1.to_typetracer()]).form
             == emptyarray._mergemany([array1]).form
         )
 
@@ -296,19 +297,19 @@ def test_listoffsetarray_merge():
         assert to_list(emptyarray._mergemany([array1])) == to_list(array1)
 
         assert (
-            array1.to_typetracer()._mergemany([array2]).form
+            array1()._mergemany([array2.to_typetracer()]).form
             == array1._mergemany([array2]).form
         )
         assert (
-            array2.to_typetracer()._mergemany([array1]).form
+            array2()._mergemany([array1.to_typetracer()]).form
             == array2._mergemany([array1]).form
         )
         assert (
-            array1.to_typetracer()._mergemany([emptyarray]).form
+            array1()._mergemany([emptyarray.to_typetracer()]).form
             == array1._mergemany([emptyarray]).form
         )
         assert (
-            emptyarray.to_typetracer()._mergemany([array1]).form
+            emptyarray.to_typetracer()._mergemany([array1.to_typetracer()]).form
             == emptyarray._mergemany([array1]).form
         )
 
@@ -342,11 +343,11 @@ def test_listoffsetarray_merge():
         ]
 
         assert (
-            array1.to_typetracer()._mergemany([regulararray]).form
+            array1()._mergemany([regulararray.to_typetracer()]).form
             == array1._mergemany([regulararray]).form
         )
         assert (
-            regulararray.to_typetracer()._mergemany([array1]).form
+            regulararray()._mergemany([array1.to_typetracer()]).form
             == regulararray._mergemany([array1]).form
         )
 
@@ -499,35 +500,35 @@ def test_recordarray_merge():
     ]
 
     assert (
-        arrayr1.to_typetracer()._mergemany([arrayr2]).form
+        arrayr1()._mergemany([arrayr2.to_typetracer()]).form
         == arrayr1._mergemany([arrayr2]).form
     )
     assert (
-        arrayr2.to_typetracer()._mergemany([arrayr1]).form
+        arrayr2()._mergemany([arrayr1.to_typetracer()]).form
         == arrayr2._mergemany([arrayr1]).form
     )
     assert (
-        arrayr1.to_typetracer()._mergemany([arrayr4]).form
+        arrayr1()._mergemany([arrayr4.to_typetracer()]).form
         == arrayr1._mergemany([arrayr4]).form
     )
     assert (
-        arrayr4.to_typetracer()._mergemany([arrayr1]).form
+        arrayr4()._mergemany([arrayr1.to_typetracer()]).form
         == arrayr4._mergemany([arrayr1]).form
     )
     assert (
-        arrayr5.to_typetracer()._mergemany([arrayr6]).form
+        arrayr5()._mergemany([arrayr6.to_typetracer()]).form
         == arrayr5._mergemany([arrayr6]).form
     )
     assert (
-        arrayr6.to_typetracer()._mergemany([arrayr5]).form
+        arrayr6()._mergemany([arrayr5.to_typetracer()]).form
         == arrayr6._mergemany([arrayr5]).form
     )
     assert (
-        arrayt1.to_typetracer()._mergemany([arrayt2]).form
+        arrayt1()._mergemany([arrayt2.to_typetracer()]).form
         == arrayt1._mergemany([arrayt2]).form
     )
     assert (
-        arrayt2.to_typetracer()._mergemany([arrayt1]).form
+        arrayt2()._mergemany([arrayt1.to_typetracer()]).form
         == arrayt2._mergemany([arrayt1]).form
     )
 
@@ -564,118 +565,118 @@ def test_recordarray_merge():
     assert to_list(emptyarray._mergemany([arrayt7])) == to_list(arrayt7)
 
     assert (
-        arrayr1.to_typetracer()._mergemany([emptyarray]).form
+        arrayr1()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr1._mergemany([emptyarray]).form
     )
     assert (
-        arrayr2.to_typetracer()._mergemany([emptyarray]).form
+        arrayr2()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr2._mergemany([emptyarray]).form
     )
     assert (
-        arrayr3.to_typetracer()._mergemany([emptyarray]).form
+        arrayr3()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr3._mergemany([emptyarray]).form
     )
     assert (
-        arrayr4.to_typetracer()._mergemany([emptyarray]).form
+        arrayr4()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr4._mergemany([emptyarray]).form
     )
     assert (
-        arrayr5.to_typetracer()._mergemany([emptyarray]).form
+        arrayr5()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr5._mergemany([emptyarray]).form
     )
     assert (
-        arrayr6.to_typetracer()._mergemany([emptyarray]).form
+        arrayr6()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr6._mergemany([emptyarray]).form
     )
     assert (
-        arrayr7.to_typetracer()._mergemany([emptyarray]).form
+        arrayr7()._mergemany([emptyarray.to_typetracer()]).form
         == arrayr7._mergemany([emptyarray]).form
     )
 
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr1]).form
+        emptyarray.to_typetracer()._mergemany([arrayr1.to_typetracer()]).form
         == emptyarray._mergemany([arrayr1]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr2]).form
+        emptyarray.to_typetracer()._mergemany([arrayr2.to_typetracer()]).form
         == emptyarray._mergemany([arrayr2]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr3]).form
+        emptyarray.to_typetracer()._mergemany([arrayr3.to_typetracer()]).form
         == emptyarray._mergemany([arrayr3]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr4]).form
+        emptyarray.to_typetracer()._mergemany([arrayr4.to_typetracer()]).form
         == emptyarray._mergemany([arrayr4]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr5]).form
+        emptyarray.to_typetracer()._mergemany([arrayr5.to_typetracer()]).form
         == emptyarray._mergemany([arrayr5]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr6]).form
+        emptyarray.to_typetracer()._mergemany([arrayr6.to_typetracer()]).form
         == emptyarray._mergemany([arrayr6]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayr7]).form
+        emptyarray.to_typetracer()._mergemany([arrayr7.to_typetracer()]).form
         == emptyarray._mergemany([arrayr7]).form
     )
 
     assert (
-        arrayt1.to_typetracer()._mergemany([emptyarray]).form
+        arrayt1()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt1._mergemany([emptyarray]).form
     )
     assert (
-        arrayt2.to_typetracer()._mergemany([emptyarray]).form
+        arrayt2()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt2._mergemany([emptyarray]).form
     )
     assert (
-        arrayt3.to_typetracer()._mergemany([emptyarray]).form
+        arrayt3()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt3._mergemany([emptyarray]).form
     )
     assert (
-        arrayt4.to_typetracer()._mergemany([emptyarray]).form
+        arrayt4()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt4._mergemany([emptyarray]).form
     )
     assert (
-        arrayt5.to_typetracer()._mergemany([emptyarray]).form
+        arrayt5()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt5._mergemany([emptyarray]).form
     )
     assert (
-        arrayt6.to_typetracer()._mergemany([emptyarray]).form
+        arrayt6()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt6._mergemany([emptyarray]).form
     )
     assert (
-        arrayt7.to_typetracer()._mergemany([emptyarray]).form
+        arrayt7()._mergemany([emptyarray.to_typetracer()]).form
         == arrayt7._mergemany([emptyarray]).form
     )
 
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt1]).form
+        emptyarray.to_typetracer()._mergemany([arrayt1.to_typetracer()]).form
         == emptyarray._mergemany([arrayt1]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt2]).form
+        emptyarray.to_typetracer()._mergemany([arrayt2.to_typetracer()]).form
         == emptyarray._mergemany([arrayt2]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt3]).form
+        emptyarray.to_typetracer()._mergemany([arrayt3.to_typetracer()]).form
         == emptyarray._mergemany([arrayt3]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt4]).form
+        emptyarray.to_typetracer()._mergemany([arrayt4.to_typetracer()]).form
         == emptyarray._mergemany([arrayt4]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt5]).form
+        emptyarray.to_typetracer()._mergemany([arrayt5.to_typetracer()]).form
         == emptyarray._mergemany([arrayt5]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt6]).form
+        emptyarray.to_typetracer()._mergemany([arrayt6.to_typetracer()]).form
         == emptyarray._mergemany([arrayt6]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([arrayt7]).form
+        emptyarray.to_typetracer()._mergemany([arrayt7.to_typetracer()]).form
         == emptyarray._mergemany([arrayt7]).form
     )
 
@@ -735,15 +736,15 @@ def test_indexedarray_merge():
     ]
 
     assert (
-        indexedarray1.to_typetracer()._mergemany([content2]).form
+        indexedarray1()._mergemany([content2.to_typetracer()]).form
         == indexedarray1._mergemany([content2]).form
     )
     assert (
-        content2.to_typetracer()._mergemany([indexedarray1]).form
+        content2()._mergemany([indexedarray1.to_typetracer()]).form
         == content2._mergemany([indexedarray1]).form
     )
     assert (
-        indexedarray1.to_typetracer()._mergemany([indexedarray1]).form
+        indexedarray1()._mergemany([indexedarray1.to_typetracer()]).form
         == indexedarray1._mergemany([indexedarray1]).form
     )
 
@@ -826,20 +827,28 @@ def test_unionarray_merge():
         {"x": 2, "y": 2.2},
     ]
 
-    assert one.to_typetracer()._mergemany([two]).form == one._mergemany([two]).form
-    assert two.to_typetracer()._mergemany([one]).form == two._mergemany([one]).form
+    assert one()._mergemany([two.to_typetracer()]).form == one._mergemany([two]).form
+    assert two()._mergemany([one.to_typetracer()]).form == two._mergemany([one]).form
     assert (
-        one.to_typetracer()._mergemany([emptyarray]).form
+        one()._mergemany([emptyarray.to_typetracer()]).form
         == one._mergemany([emptyarray]).form
     )
     assert (
-        emptyarray.to_typetracer()._mergemany([one]).form
+        emptyarray.to_typetracer()._mergemany([one.to_typetracer()]).form
         == emptyarray._mergemany([one]).form
     )
-    assert one.to_typetracer()._mergemany([three]).form == one._mergemany([three]).form
-    assert two.to_typetracer()._mergemany([three]).form == two._mergemany([three]).form
-    assert three.to_typetracer()._mergemany([one]).form == three._mergemany([one]).form
-    assert three.to_typetracer()._mergemany([two]).form == three._mergemany([two]).form
+    assert (
+        one()._mergemany([three.to_typetracer()]).form == one._mergemany([three]).form
+    )
+    assert (
+        two()._mergemany([three.to_typetracer()]).form == two._mergemany([three]).form
+    )
+    assert (
+        three()._mergemany([one.to_typetracer()]).form == three._mergemany([one]).form
+    )
+    assert (
+        three()._mergemany([two.to_typetracer()]).form == three._mergemany([two]).form
+    )
 
 
 def test_merge_parameters():

--- a/tests/test_0331_pandas_indexedarray.py
+++ b/tests/test_0331_pandas_indexedarray.py
@@ -167,8 +167,7 @@ def test_union_to_record():
         df_unionarray["z"].values, np.array([np.nan, 999, np.nan])
     )
 
-    with pytest.warns(DeprecationWarning):
-        df_unionarray2 = ak.operations.to_dataframe(unionarray2)
+    df_unionarray2 = ak.operations.to_dataframe(unionarray2)
     np.testing.assert_array_equal(
         df_unionarray2["x"].values, [1, np.nan, np.nan, np.nan, 3]
     )

--- a/tests/test_0449_merge_many_arrays_in_one_pass.py
+++ b/tests/test_0449_merge_many_arrays_in_one_pass.py
@@ -453,7 +453,10 @@ def test_empty():
     assert to_list(one._mergemany([three, two, four])) == [1, 2, 3, 4, 5]
     assert to_list(one._mergemany([three, four, two])) == [1, 2, 3, 4, 5]
 
-    assert one()._mergemany([two.to_typetracer()]).form == one._mergemany([two]).form
+    assert (
+        one.to_typetracer()._mergemany([two.to_typetracer()]).form
+        == one._mergemany([two]).form
+    )
     assert (
         one.to_typetracer()._mergemany([two, one, two, one, two]).form
         == one._mergemany([two, one, two, one, two]).form
@@ -467,7 +470,8 @@ def test_empty():
         == one._mergemany([two, three, four]).form
     )
     assert (
-        one()._mergemany([three.to_typetracer()]).form == one._mergemany([three]).form
+        one.to_typetracer()._mergemany([three.to_typetracer()]).form
+        == one._mergemany([three]).form
     )
     assert (
         one.to_typetracer()._mergemany([three, four]).form

--- a/tests/test_0449_merge_many_arrays_in_one_pass.py
+++ b/tests/test_0449_merge_many_arrays_in_one_pass.py
@@ -453,7 +453,7 @@ def test_empty():
     assert to_list(one._mergemany([three, two, four])) == [1, 2, 3, 4, 5]
     assert to_list(one._mergemany([three, four, two])) == [1, 2, 3, 4, 5]
 
-    assert one.to_typetracer()._mergemany([two]).form == one._mergemany([two]).form
+    assert one()._mergemany([two.to_typetracer()]).form == one._mergemany([two]).form
     assert (
         one.to_typetracer()._mergemany([two, one, two, one, two]).form
         == one._mergemany([two, one, two, one, two]).form
@@ -466,7 +466,9 @@ def test_empty():
         one.to_typetracer()._mergemany([two, three, four]).form
         == one._mergemany([two, three, four]).form
     )
-    assert one.to_typetracer()._mergemany([three]).form == one._mergemany([three]).form
+    assert (
+        one()._mergemany([three.to_typetracer()]).form == one._mergemany([three]).form
+    )
     assert (
         one.to_typetracer()._mergemany([three, four]).form
         == one._mergemany([three, four]).form

--- a/tests/test_0773_typeparser.py
+++ b/tests/test_0773_typeparser.py
@@ -35,7 +35,8 @@ def test_unknown_1():
 
 def test_unknown_2():
     text = 'unknown[parameters={"wonky": ["parameter", 3.14]}]'
-    parsedtype = ak.types.from_datashape(text, highlevel=False)
+    with pytest.warns(DeprecationWarning):
+        parsedtype = ak.types.from_datashape(text, highlevel=False)
     assert isinstance(parsedtype, ak.types.UnknownType)
     assert str(parsedtype) == text
 
@@ -147,7 +148,8 @@ def test_option_unknown_1():
 
 def test_option_unknown_2():
     text = '?unknown[parameters={"foo": "bar"}]'
-    parsedtype = ak.types.from_datashape(text, highlevel=False)
+    with pytest.warns(DeprecationWarning):
+        parsedtype = ak.types.from_datashape(text, highlevel=False)
     assert isinstance(parsedtype, ak.types.OptionType)
     assert str(parsedtype) == text
 
@@ -487,18 +489,21 @@ def test_unknowntype():
 
 
 def test_unknowntype_parameter():
-    t = UnknownType(parameters={"__array__": "Something"})
-    assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.warns(DeprecationWarning):
+        t = UnknownType(parameters={"__array__": "Something"})
+        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
 
 
 def test_unknowntype_categorical():
-    t = UnknownType(parameters={"__categorical__": True})
-    assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.warns(DeprecationWarning):
+        t = UnknownType(parameters={"__categorical__": True})
+        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
 
 
 def test_unknowntype_categorical_parameter():
-    t = UnknownType(parameters={"__array__": "Something", "__categorical__": True})
-    assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.warns(DeprecationWarning):
+        t = UnknownType(parameters={"__array__": "Something", "__categorical__": True})
+        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
 
 
 def test_regulartype_numpytype():

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -8,48 +8,55 @@ import awkward as ak
 
 def test_UnknownType():
     assert str(ak.types.unknowntype.UnknownType()) == "unknown"
-    assert (
-        str(ak.types.unknowntype.UnknownType(parameters={"x": 123}))
-        == 'unknown[parameters={"x": 123}]'
-    )
+    with pytest.warns(DeprecationWarning):
+        assert (
+            str(ak.types.unknowntype.UnknownType(parameters={"x": 123}))
+            == 'unknown[parameters={"x": 123}]'
+        )
     assert (
         str(ak.types.unknowntype.UnknownType(parameters=None, typestr="override"))
         == "override"
     )
-    assert (
-        str(ak.types.unknowntype.UnknownType(parameters={"x": 123}, typestr="override"))
-        == "override"
-    )
-    assert (
-        str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
-        == "categorical[type=unknown]"
-    )
-    assert (
-        str(
-            ak.types.unknowntype.UnknownType(
-                parameters={"__categorical__": True, "x": 123}
+    with pytest.warns(DeprecationWarning):
+        assert (
+            str(
+                ak.types.unknowntype.UnknownType(
+                    parameters={"x": 123}, typestr="override"
+                )
             )
+            == "override"
         )
-        == 'categorical[type=unknown[parameters={"x": 123}]]'
-    )
-    assert (
-        str(
-            ak.types.unknowntype.UnknownType(
-                parameters={"__categorical__": True}, typestr="override"
+        assert (
+            str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
+            == "categorical[type=unknown]"
+        )
+        assert (
+            str(
+                ak.types.unknowntype.UnknownType(
+                    parameters={"__categorical__": True, "x": 123}
+                )
             )
+            == 'categorical[type=unknown[parameters={"x": 123}]]'
         )
-        == "categorical[type=override]"
-    )
+        assert (
+            str(
+                ak.types.unknowntype.UnknownType(
+                    parameters={"__categorical__": True}, typestr="override"
+                )
+            )
+            == "categorical[type=override]"
+        )
 
     assert repr(ak.types.unknowntype.UnknownType()) == "UnknownType()"
-    assert (
-        repr(
-            ak.types.unknowntype.UnknownType(
-                parameters={"__categorical__": True}, typestr="override"
+    with pytest.warns(DeprecationWarning):
+        assert (
+            repr(
+                ak.types.unknowntype.UnknownType(
+                    parameters={"__categorical__": True}, typestr="override"
+                )
             )
+            == "UnknownType(parameters={'__categorical__': True}, typestr='override')"
         )
-        == "UnknownType(parameters={'__categorical__': True}, typestr='override')"
-    )
 
 
 @pytest.mark.skipif(
@@ -1478,21 +1485,23 @@ def test_EmptyForm():
     "class": "EmptyArray"
 }"""
     )
-    assert (
-        str(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
-        == """{
+    with pytest.warns(DeprecationWarning):
+        assert (
+            str(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
+            == """{
     "class": "EmptyArray",
     "parameters": {
         "x": 123
     },
     "form_key": "hello"
 }"""
-    )
+        )
     assert repr(ak.forms.emptyform.EmptyForm()) == "EmptyForm()"
-    assert (
-        repr(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
-        == "EmptyForm(parameters={'x': 123}, form_key='hello')"
-    )
+    with pytest.warns(DeprecationWarning):
+        assert (
+            repr(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
+            == "EmptyForm(parameters={'x': 123}, form_key='hello')"
+        )
 
     assert ak.forms.emptyform.EmptyForm().to_dict(verbose=False) == {
         "class": "EmptyArray"
@@ -1502,29 +1511,31 @@ def test_EmptyForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.emptyform.EmptyForm(
-        parameters={"x": 123}, form_key="hello"
-    ).to_dict(verbose=False) == {
-        "class": "EmptyArray",
-        "parameters": {"x": 123},
-        "form_key": "hello",
-    }
+    with pytest.warns(DeprecationWarning):
+        assert ak.forms.emptyform.EmptyForm(
+            parameters={"x": 123}, form_key="hello"
+        ).to_dict(verbose=False) == {
+            "class": "EmptyArray",
+            "parameters": {"x": 123},
+            "form_key": "hello",
+        }
     assert ak.forms.from_dict({"class": "EmptyArray"}).to_dict() == {
         "class": "EmptyArray",
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.from_dict(
-        {
+    with pytest.warns(DeprecationWarning):
+        assert ak.forms.from_dict(
+            {
+                "class": "EmptyArray",
+                "parameters": {"x": 123},
+                "form_key": "hello",
+            }
+        ).to_dict() == {
             "class": "EmptyArray",
             "parameters": {"x": 123},
             "form_key": "hello",
         }
-    ).to_dict() == {
-        "class": "EmptyArray",
-        "parameters": {"x": 123},
-        "form_key": "hello",
-    }
 
 
 @pytest.mark.skipif(

--- a/tests/test_1125_to_arrow_from_arrow.py
+++ b/tests/test_1125_to_arrow_from_arrow.py
@@ -240,14 +240,15 @@ def test_indexedoptionarray_numpyarray(tmp_path, extensionarray):
 
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, extensionarray):
-    akarray = ak.contents.IndexedOptionArray(
-        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-        ak.contents.EmptyArray(parameters={"which": "inner"}),
-        parameters={"which": "outer"},
-    )
-    paarray = akarray.to_arrow(extensionarray=extensionarray)
-    arrow_round_trip(akarray, paarray, extensionarray)
-    parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
+    with pytest.warns(DeprecationWarning):
+        akarray = ak.contents.IndexedOptionArray(
+            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+            ak.contents.EmptyArray(parameters={"which": "inner"}),
+            parameters={"which": "outer"},
+        )
+        paarray = akarray.to_arrow(extensionarray=extensionarray)
+        arrow_round_trip(akarray, paarray, extensionarray)
+        parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
 
 @pytest.mark.parametrize("categorical_as_dictionary", [False, True])

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -288,17 +288,18 @@ def test_indexedoptionarray_numpyarray(tmp_path, through, extensionarray):
 @pytest.mark.parametrize("through", [through_arrow, through_parquet])
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, through, extensionarray):
-    akarray = ak.contents.IndexedOptionArray(
-        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-        ak.contents.EmptyArray(parameters={"which": "inner"}),
-        parameters={"which": "outer"},
-    )
+    with pytest.warns(DeprecationWarning):
+        akarray = ak.contents.IndexedOptionArray(
+            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+            ak.contents.EmptyArray(parameters={"which": "inner"}),
+            parameters={"which": "outer"},
+        )
 
-    schema_arrow, array_form = through(akarray, extensionarray, tmp_path)
-    predicted_form = ak._connect.pyarrow.form_handle_arrow(
-        schema_arrow, pass_empty_field=True
-    )
-    assert predicted_form == array_form
+        schema_arrow, array_form = through(akarray, extensionarray, tmp_path)
+        predicted_form = ak._connect.pyarrow.form_handle_arrow(
+            schema_arrow, pass_empty_field=True
+        )
+        assert predicted_form == array_form
 
 
 @pytest.mark.parametrize("categorical_as_dictionary", [False, True])

--- a/tests/test_1440_start_v2_to_parquet.py
+++ b/tests/test_1440_start_v2_to_parquet.py
@@ -211,12 +211,13 @@ def test_indexedoptionarray_numpyarray(tmp_path, extensionarray):
 
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, extensionarray):
-    akarray = ak.contents.IndexedOptionArray(
-        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-        ak.contents.EmptyArray(parameters={"which": "inner"}),
-        parameters={"which": "outer"},
-    )
-    parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
+    with pytest.warns(DeprecationWarning):
+        akarray = ak.contents.IndexedOptionArray(
+            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+            ak.contents.EmptyArray(parameters={"which": "inner"}),
+            parameters={"which": "outer"},
+        )
+        parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
 
 @pytest.mark.skip(

--- a/tests/test_1686_UnionArray_simplified_preserve_parameters.py
+++ b/tests/test_1686_UnionArray_simplified_preserve_parameters.py
@@ -20,5 +20,5 @@ def test():
         parameters={"some": "other"},
     )
     assert array.parameter("some") == "other"
-    assert array.parameter("left") == "leftie"
-    assert array.parameter("right") == "rightie"
+    assert array.parameter("left") is None
+    assert array.parameter("right") is None

--- a/tests/test_2179_parameer_merging_rules.py
+++ b/tests/test_2179_parameer_merging_rules.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+from itertools import permutations
+
 import numpy as np
 import pytest  # noqa: F401
 
@@ -41,3 +43,20 @@ def test_merge_optional_strings():
     assert ak._util.arrays_approx_equal(
         result, [{"a": "foo"}, {"a": "bar"}, {"a": None}]
     )
+
+
+def test_merge_permutations():
+    string_optional = ak.Array([{"a": "foo"}, {"a": None}])[0:0]
+    kinds = {
+        "optional": string_optional,
+        "empty": ak.Array([{"a": None}]),
+        "string": ak.Array([{"a": "baz"}]),
+    }
+    for perm in permutations(kinds, 3):
+        assert str(ak.concatenate([kinds[k] for k in perm]).type) == "2 * {a: ?string}"
+
+
+def test_merge_type_commutativity():
+    one = ak.concatenate((ak.with_parameter([1], "k", "v"), [None]))
+    two = ak.concatenate(([None], ak.with_parameter([1], "k", "v")))
+    assert type(one) == type(two)

--- a/tests/test_2179_parameer_merging_rules.py
+++ b/tests/test_2179_parameer_merging_rules.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    x = ak.with_parameter([1, 2, np.datetime64("now")], "x", 100).layout
+    y = ak.contents.NumpyArray(np.array([99, 88, 77], dtype=np.int64))
+    result = ak.contents.UnionArray.simplified(
+        ak.index.Index8(np.array([0, 0, 1, 1], dtype=np.int8)),
+        ak.index.Index64(np.array([0, 1, 0, 1], dtype=np.int64)),
+        [x, y],
+        parameters={"x": 100},
+    )
+    assert result.parameters == {"x": 100}
+
+    result2 = ak.contents.UnionArray.simplified(
+        ak.index.Index8(np.array([0, 0, 1, 1])),
+        ak.index.Index64(np.array([0, 1, 0, 1])),
+        [x, y],
+        parameters={"x": 200},
+    )
+    assert result2.parameters == {"x": 200}
+
+    result3 = ak.contents.UnionArray.simplified(
+        ak.index.Index8(np.array([0, 0, 1, 1])),
+        ak.index.Index64(np.array([0, 1, 0, 1])),
+        [x, y],
+    )
+    assert result3.parameters == {"x": 100}

--- a/tests/test_2179_parameer_merging_rules.py
+++ b/tests/test_2179_parameer_merging_rules.py
@@ -31,3 +31,13 @@ def test():
         [x, y],
     )
     assert result3.parameters == {"x": 100}
+
+
+def test_merge_optional_strings():
+    a = ak.Array([{"a": "foo"}, {"a": "bar"}])
+    b = ak.Array([{"a": None}])
+
+    result = ak.concatenate([a, b])
+    assert ak._util.arrays_approx_equal(
+        result, [{"a": "foo"}, {"a": "bar"}, {"a": None}]
+    )


### PR DESCRIPTION
## TL;DR

This PR fixes #2173 by two main changes: make `EmptyArray` a true identity (by ignoring parameters), and consolidate the parameter merging rules.

- Fixes #2173 
- Collapses `_mergeable` and `_mergeable_next` into `_mergeable_next`
- Replace `merge_parameters` with `_parameters_intersect` and `_parameters_union`
- Changes index/option merging rules:
   - option/index — option/index: merge option parameters, merge content parameters
   - option/index — non-option/non-index: keep option parameters, merge content parameters
- Changes union merging rules: 
  - Now always take intersection of merged content parameters
- Changes to union simplification logic:
  - Take union of outermost union parameters and inner union parameters
- Make the base `Content` and `Form` initialiser arguments keyword-only (non-breaking unless you are subclassing)
- Deprecates parameters on empty/unknown types/arrays/forms
- Treats `EmptyArray` as entirely invisible to merging
 

## TL;
This PR is a tentative direction for resolving #2173 by making two big changes:

### Consider `EmptyArray` as truly "empty"
The issue is caused by the fact that `EmptyArray` often has no parameters, which can occur for layouts with only-options, e.g. from Parquet (?) or `ArrayBuilder`. If we try and merge parameters with such layouts, the `merge_equal` rule will lead to the resulting parameter dictionary being empty. This means that we lose `__array__`.

A more permissive rule would fix #2173 is to *only* merge the non-array/record parameters of `EmptyArray`. Such a rule would preserve e.g. strings, but fail to preserve any other parameters whenever a bare `EmptyArray` is encountered. 

I prefer the blanket "EmptyArray-is-empty" approach, but I don't have a good feel for whether that's too restrictive. 

### Index/Option merging rules

In https://github.com/scikit-hep/awkward/discussions/2180 I raise the idea that we need to tighten our parameter rules. This PR makes a particular choice to treat (option, non-option) as merging only the contents. This will make it more obvious that our current logic for `__array__` doesn't look past the top-level node.

### Union merging/simplification

The simple logic followed in this PR is
- `simplified` → union of parameters in simplification
- `merge` → intersection of parameters

Changes to union merging/simplification now reflect this.