### PR TITLE
fix: some usages of `len(layout)` under typetracer

### DIFF
--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -103,10 +103,12 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
                 parameters={"__array__": "bytestring"},
@@ -121,10 +123,11 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
 
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.index.Index64(
-                    index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
+                    index_nplike.full(layout.length, len(asbytes), dtype=np.int64)
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "byte"}),
                 parameters={"__array__": "bytestring"},
@@ -134,10 +137,12 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             asbytes = nplike.frombuffer(b"", dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
                 parameters={"__array__": "string"},
@@ -148,10 +153,11 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
             asbytes = nplike.frombuffer(asstr, dtype=np.uint8)
             return ak.contents.ListArray(
                 ak.index.Index64(
-                    index_nplike.zeros(len(layout), dtype=np.int64), nplike=index_nplike
+                    index_nplike.zeros(layout.length, dtype=np.int64),
+                    nplike=index_nplike,
                 ),
                 ak.index.Index64(
-                    index_nplike.full(len(layout), len(asbytes), dtype=np.int64)
+                    index_nplike.full(layout.length, len(asbytes), dtype=np.int64)
                 ),
                 ak.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
                 parameters={"__array__": "string"},

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -45,7 +45,7 @@ def _impl(array, name, highlevel, behavior):
             parameters = dict(layout.parameters)
             parameters["__record__"] = name
             return ak.contents.RecordArray(
-                layout.contents, layout.fields, len(layout), parameters=parameters
+                layout.contents, layout.fields, layout.length, parameters=parameters
             )
         else:
             return None

--- a/tests/test_2181_with_name_len.py
+++ b/tests/test_2181_with_name_len.py
@@ -11,7 +11,7 @@ def test():
     assert ak.parameters(named) == {"__record__": "x_like"}
 
 
-@pytest.xfail("TypeTracer.frombuffer not implemented")
+@pytest.mark.xfail(reason="TypeTracer.frombuffer not implemented")
 def test_strings():
     layout = ak.to_layout(["hello", "world"]).to_typetracer(forget_length=True)
     ak.zeros_like(layout)

--- a/tests/test_2181_with_name_len.py
+++ b/tests/test_2181_with_name_len.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    layout = ak.to_layout([{"x": 10}]).to_typetracer(forget_length=True)
+    named = ak.with_name(layout, "x_like")
+    assert ak.parameters(named) == {"__record__": "x_like"}
+
+
+@pytest.xfail("TypeTracer.frombuffer not implemented")
+def test_strings():
+    layout = ak.to_layout(["hello", "world"]).to_typetracer(forget_length=True)
+    ak.zeros_like(layout)


### PR DESCRIPTION
This PR fixes a few (but certainly not all) places where we're using `len(layout)`, or otherwise relying on a layout to be non-typetracer