### PR TITLE
chore: ruff rewrite dicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,8 +263,7 @@ exclude = [
     "src/awkward/_typeparser/generated_parser.py",
 ]
 ignore = [
-    "E501",
-    "C408",
+    "E501",   # line too long
     "UP030",  # {0} -> {}
 ]
 select = [

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1016,7 +1016,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         with ak._errors.OperationErrorContext(
             "ak.Array.__setitem__",
-            dict(self=self, field_name=where, field_value=what),
+            {"self": self, "field_name": where, "field_value": what},
         ):
             if not (
                 isinstance(where, str)
@@ -1049,7 +1049,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         with ak._errors.OperationErrorContext(
             "ak.Array.__delitem__",
-            dict(self=self, field_name=where),
+            {"self": self, "field_name": where},
         ):
             if not (
                 isinstance(where, str)
@@ -1765,7 +1765,7 @@ class Record(NDArrayOperatorsMixin):
         """
         with ak._errors.OperationErrorContext(
             "ak.Record.__setitem__",
-            dict(self=self, field_name=where, field_value=what),
+            {"self": self, "field_name": where, "field_value": what},
         ):
             if not (
                 isinstance(where, str)
@@ -1799,7 +1799,7 @@ class Record(NDArrayOperatorsMixin):
         """
         with ak._errors.OperationErrorContext(
             "ak.Record.__delitem__",
-            dict(self=self, field_name=where),
+            {"self": self, "field_name": where},
         ):
             if not (
                 isinstance(where, str)

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -52,14 +52,14 @@ def all(
     """
     with ak._errors.OperationErrorContext(
         "ak.all",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -52,14 +52,14 @@ def any(
     """
     with ak._errors.OperationErrorContext(
         "ak.any",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -84,15 +84,15 @@ def argcartesian(
     """
     with ak._errors.OperationErrorContext(
         "ak.argcartesian",
-        dict(
-            arrays=arrays,
-            axis=axis,
-            nested=nested,
-            parameters=parameters,
-            with_name=with_name,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "arrays": arrays,
+            "axis": axis,
+            "nested": nested,
+            "parameters": parameters,
+            "with_name": with_name,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -54,17 +54,17 @@ def argcombinations(
     """
     with ak._errors.OperationErrorContext(
         "ak.argcombinations",
-        dict(
-            array=array,
-            n=n,
-            replacement=replacement,
-            axis=axis,
-            fields=fields,
-            parameters=parameters,
-            with_name=with_name,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "n": n,
+            "replacement": replacement,
+            "axis": axis,
+            "fields": fields,
+            "parameters": parameters,
+            "with_name": with_name,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(
             array,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -59,14 +59,14 @@ def argmax(
     """
     with ak._errors.OperationErrorContext(
         "ak.argmax",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -123,14 +123,14 @@ def nanargmax(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanargmax",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -59,14 +59,14 @@ def argmin(
     """
     with ak._errors.OperationErrorContext(
         "ak.argmin",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -122,14 +122,14 @@ def nanargmin(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanargmin",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -47,14 +47,14 @@ def argsort(
     """
     with ak._errors.OperationErrorContext(
         "ak.argsort",
-        dict(
-            array=array,
-            axis=axis,
-            ascending=ascending,
-            stable=stable,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "ascending": ascending,
+            "stable": stable,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, axis, ascending, stable, highlevel, behavior)
 

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -174,15 +174,15 @@ def broadcast_arrays(
     """
     with ak._errors.OperationErrorContext(
         "ak.broadcast_arrays",
-        dict(
-            arrays=arrays,
-            depth_limit=depth_limit,
-            broadcast_parameters_rule=broadcast_parameters_rule,
-            left_broadcast=left_broadcast,
-            right_broadcast=right_broadcast,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "arrays": arrays,
+            "depth_limit": depth_limit,
+            "broadcast_parameters_rule": broadcast_parameters_rule,
+            "left_broadcast": left_broadcast,
+            "right_broadcast": right_broadcast,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(
             arrays,

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -191,15 +191,15 @@ def cartesian(
     """
     with ak._errors.OperationErrorContext(
         "ak.cartesian",
-        dict(
-            arrays=arrays,
-            axis=axis,
-            nested=nested,
-            parameters=parameters,
-            with_name=with_name,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "arrays": arrays,
+            "axis": axis,
+            "nested": nested,
+            "parameters": parameters,
+            "with_name": with_name,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -18,7 +18,7 @@ def categories(array, highlevel=True):
     """
     with ak._errors.OperationErrorContext(
         "ak.categories",
-        dict(array=array, highlevel=highlevel),
+        {"array": array, "highlevel": highlevel},
     ):
         return _impl(array, highlevel)
 

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -175,17 +175,17 @@ def combinations(
     """
     with ak._errors.OperationErrorContext(
         "ak.combinations",
-        dict(
-            array=array,
-            n=n,
-            replacement=replacement,
-            axis=axis,
-            fields=fields,
-            parameters=parameters,
-            with_name=with_name,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "n": n,
+            "replacement": replacement,
+            "axis": axis,
+            "fields": fields,
+            "parameters": parameters,
+            "with_name": with_name,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(
             array,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -34,13 +34,13 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
     """
     with ak._errors.OperationErrorContext(
         "ak.concatenate",
-        dict(
-            arrays=arrays,
-            axis=axis,
-            mergebool=mergebool,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "arrays": arrays,
+            "axis": axis,
+            "mergebool": mergebool,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(arrays, axis, mergebool, highlevel, behavior)
 

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -59,7 +59,7 @@ def copy(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.fill_none",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -60,14 +60,14 @@ def corr(
     """
     with ak._errors.OperationErrorContext(
         "ak.corr",
-        dict(
-            x=x,
-            y=y,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "y": y,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -94,14 +94,14 @@ def count(
     """
     with ak._errors.OperationErrorContext(
         "ak.count",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -53,14 +53,14 @@ def count_nonzero(
     """
     with ak._errors.OperationErrorContext(
         "ak.count_nonzero",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -56,14 +56,14 @@ def covar(
     """
     with ak._errors.OperationErrorContext(
         "ak.covar",
-        dict(
-            x=x,
-            y=y,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "y": y,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -40,7 +40,7 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.drop_none",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -24,7 +24,7 @@ def fields(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.fields",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -55,9 +55,13 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.fill_none",
-        dict(
-            array=array, value=value, axis=axis, highlevel=highlevel, behavior=behavior
-        ),
+        {
+            "array": array,
+            "value": value,
+            "axis": axis,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, value, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -39,7 +39,7 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.firsts",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -157,7 +157,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.flatten",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -33,12 +33,12 @@ def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None)
     """
     with ak._errors.OperationErrorContext(
         "ak.from_arrow",
-        dict(
-            array=array,
-            generate_bitmasks=generate_bitmasks,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "generate_bitmasks": generate_bitmasks,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, generate_bitmasks, highlevel, behavior)
 

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -17,7 +17,7 @@ def from_arrow_schema(schema):
     """
     with ak._errors.OperationErrorContext(
         "ak.from_arrow_schema",
-        dict(schema=schema),
+        {"schema": schema},
     ):
         return _impl(schema)
 

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -31,13 +31,13 @@ def from_avro_file(
 
     with ak._errors.OperationErrorContext(
         "ak.from_avro_file",
-        dict(
-            file=file,
-            highlevel=highlevel,
-            behavior=behavior,
-            limit_entries=limit_entries,
-            debug_forth=debug_forth,
-        ),
+        {
+            "file": file,
+            "highlevel": highlevel,
+            "behavior": behavior,
+            "limit_entries": limit_entries,
+            "debug_forth": debug_forth,
+        },
     ):
 
         if isinstance(file, pathlib.Path):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -69,16 +69,16 @@ def from_buffers(
     """
     with ak._errors.OperationErrorContext(
         "ak.from_buffers",
-        dict(
-            form=form,
-            length=length,
-            container=container,
-            buffer_key=buffer_key,
-            backend=backend,
-            byteorder=byteorder,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "form": form,
+            "length": length,
+            "container": container,
+            "buffer_key": buffer_key,
+            "backend": backend,
+            "byteorder": byteorder,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(
             form,

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -24,7 +24,7 @@ def from_categorical(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.from_categorical",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -29,11 +29,11 @@ def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.from_cupy",
-        dict(
-            array=array,
-            regulararray=regulararray,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "regulararray": regulararray,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return ak._util.from_arraylib(array, regulararray, False, highlevel, behavior)

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -58,14 +58,14 @@ def from_iter(
     """
     with ak._errors.OperationErrorContext(
         "ak.from_iter",
-        dict(
-            iterable=iterable,
-            allow_record=allow_record,
-            highlevel=highlevel,
-            behavior=behavior,
-            initial=initial,
-            resize=resize,
-        ),
+        {
+            "iterable": iterable,
+            "allow_record": allow_record,
+            "highlevel": highlevel,
+            "behavior": behavior,
+            "initial": initial,
+            "resize": resize,
+        },
     ):
         return _impl(iterable, highlevel, behavior, allow_record, initial, resize)
 

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -29,12 +29,12 @@ def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     with _errors.OperationErrorContext(
         "ak.from_jax",
-        dict(
-            array=array,
-            regulararray=regulararray,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "regulararray": regulararray,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         jax.assert_registered()
         return _util.from_arraylib(array, regulararray, False, highlevel, behavior)

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -319,20 +319,20 @@ def from_json(
     """
     with ak._errors.OperationErrorContext(
         "ak.from_json",
-        dict(
-            source=source,
-            line_delimited=line_delimited,
-            schema=schema,
-            nan_string=nan_string,
-            posinf_string=posinf_string,
-            neginf_string=neginf_string,
-            complex_record_fields=complex_record_fields,
-            buffersize=buffersize,
-            initial=initial,
-            resize=resize,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "source": source,
+            "line_delimited": line_delimited,
+            "schema": schema,
+            "nan_string": nan_string,
+            "posinf_string": posinf_string,
+            "neginf_string": neginf_string,
+            "complex_record_fields": complex_record_fields,
+            "buffersize": buffersize,
+            "initial": initial,
+            "resize": resize,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if schema is None:
             return _no_schema(

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -39,13 +39,13 @@ def from_numpy(
     """
     with ak._errors.OperationErrorContext(
         "ak.from_numpy",
-        dict(
-            array=array,
-            regulararray=regulararray,
-            recordarray=recordarray,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "regulararray": regulararray,
+            "recordarray": recordarray,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return ak._util.from_arraylib(
             array, regulararray, recordarray, highlevel, behavior

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -51,18 +51,18 @@ def from_parquet(
     """
     with ak._errors.OperationErrorContext(
         "ak.from_parquet",
-        dict(
-            path=path,
-            columns=columns,
-            row_groups=row_groups,
-            storage_options=storage_options,
-            max_gap=max_gap,
-            max_block=max_block,
-            footer_sample_size=footer_sample_size,
-            generate_bitmasks=generate_bitmasks,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "path": path,
+            "columns": columns,
+            "row_groups": row_groups,
+            "storage_options": storage_options,
+            "max_gap": max_gap,
+            "max_block": max_block,
+            "footer_sample_size": footer_sample_size,
+            "generate_bitmasks": generate_bitmasks,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         import awkward._connect.pyarrow  # noqa: F401
 

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -23,7 +23,7 @@ def from_rdataframe(rdf, columns):
     See also #ak.to_rdataframe.
     """
     with ak._errors.OperationErrorContext(
-        "ak.from_rdataframe", dict(rdf=rdf, columns=columns)
+        "ak.from_rdataframe", {"rdf": rdf, "columns": columns}
     ):
         return _impl(rdf, columns)
 

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -36,7 +36,7 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.from_regular",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -68,13 +68,13 @@ def full_like(array, fill_value, *, dtype=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.full_like",
-        dict(
-            array=array,
-            fill_value=fill_value,
-            dtype=dtype,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "fill_value": fill_value,
+            "dtype": dtype,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, fill_value, highlevel, behavior, dtype)
 

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -17,7 +17,7 @@ def is_categorical(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.is_categorical",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -24,7 +24,7 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.is_none",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -13,7 +13,7 @@ def is_tuple(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.is_tuple",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -19,7 +19,7 @@ def is_valid(array, *, exception=False):
     """
     with ak._errors.OperationErrorContext(
         "ak.is_valid",
-        dict(array=array, exception=exception),
+        {"array": array, "exception": exception},
     ):
         return _impl(array, exception)
 

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -27,15 +27,15 @@ def isclose(
     """
     with ak._errors.OperationErrorContext(
         "ak.isclose",
-        dict(
-            a=a,
-            b=b,
-            rtol=rtol,
-            atol=atol,
-            equal_nan=equal_nan,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "a": a,
+            "b": b,
+            "rtol": rtol,
+            "atol": atol,
+            "equal_nan": equal_nan,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(a, b, rtol, atol, equal_nan, highlevel, behavior)
 

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -75,14 +75,14 @@ def linear_fit(
     """
     with ak._errors.OperationErrorContext(
         "ak.linear_fit",
-        dict(
-            x=x,
-            y=y,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "y": y,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         return _impl(x, y, weight, axis, keepdims, mask_identity)
 

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -72,7 +72,7 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.local_index",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -89,13 +89,13 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.mask",
-        dict(
-            array=array,
-            mask=mask,
-            valid_when=valid_when,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "mask": mask,
+            "valid_when": valid_when,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, mask, valid_when, highlevel, behavior)
 

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -60,15 +60,15 @@ def max(
     """
     with ak._errors.OperationErrorContext(
         "ak.max",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            initial=initial,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "initial": initial,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -134,15 +134,15 @@ def nanmax(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanmax",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            initial=initial,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "initial": initial,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -81,13 +81,13 @@ def mean(
     """
     with ak._errors.OperationErrorContext(
         "ak.mean",
-        dict(
-            x=x,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -144,13 +144,13 @@ def nanmean(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanmean",
-        dict(
-            x=x,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -60,10 +60,10 @@ def metadata_from_parquet(
 
     with ak._errors.OperationErrorContext(
         "ak.metadata_from_parquet",
-        dict(
-            path=path,
-            storage_options=storage_options,
-        ),
+        {
+            "path": path,
+            "storage_options": storage_options,
+        },
     ):
         return _impl(
             path,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -60,13 +60,13 @@ def min(
     """
     with ak._errors.OperationErrorContext(
         "ak.min",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            initial=initial,
-            mask_identity=mask_identity,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "initial": initial,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -132,15 +132,15 @@ def nanmin(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanmin",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            initial=initial,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "initial": initial,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -60,14 +60,14 @@ def moment(
     """
     with ak._errors.OperationErrorContext(
         "ak.moment",
-        dict(
-            x=x,
-            n=n,
-            weight=weight,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "n": n,
+            "weight": weight,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -22,11 +22,11 @@ def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.nan_to_none",
-        dict(
-            array=array,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -39,15 +39,15 @@ def nan_to_num(
     """
     with ak._errors.OperationErrorContext(
         "ak.nan_to_num",
-        dict(
-            array=array,
-            copy=copy,
-            nan=nan,
-            posinf=posinf,
-            neginf=neginf,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "copy": copy,
+            "nan": nan,
+            "posinf": posinf,
+            "neginf": neginf,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, copy, nan, posinf, neginf, highlevel, behavior)
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -67,7 +67,7 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.num",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -26,7 +26,7 @@ def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.ones_like",
-        dict(array=array, dtype=dtype, highlevel=highlevel, behavior=behavior),
+        {"array": array, "dtype": dtype, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior, dtype)
 

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -95,14 +95,14 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
     """
     with ak._errors.OperationErrorContext(
         "ak.pad_none",
-        dict(
-            array=array,
-            target=target,
-            axis=axis,
-            clip=clip,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "target": target,
+            "axis": axis,
+            "clip": clip,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, target, axis, clip, highlevel, behavior)
 

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -29,7 +29,7 @@ def parameters(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.parameters",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -52,14 +52,14 @@ def prod(
     """
     with ak._errors.OperationErrorContext(
         "ak.prod",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -112,14 +112,14 @@ def nanprod(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanprod",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -57,12 +57,12 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
     """
     with ak._errors.OperationErrorContext(
         "ak.ptp",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -50,7 +50,7 @@ def ravel(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.ravel",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -83,11 +83,11 @@ def run_lengths(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.run_lengths",
-        dict(
-            array=array,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -39,7 +39,7 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.singletons",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -45,12 +45,12 @@ def softmax(
     """
     with ak._errors.OperationErrorContext(
         "ak.softmax",
-        dict(
-            x=x,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -34,14 +34,14 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
     """
     with ak._errors.OperationErrorContext(
         "ak.sort",
-        dict(
-            array=array,
-            axis=axis,
-            ascending=ascending,
-            stable=stable,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "ascending": ascending,
+            "stable": stable,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, axis, ascending, stable, highlevel, behavior)
 

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -64,14 +64,14 @@ def std(
     """
     with ak._errors.OperationErrorContext(
         "ak.std",
-        dict(
-            x=x,
-            weight=weight,
-            ddof=ddof,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "ddof": ddof,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -132,14 +132,14 @@ def nanstd(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanstd",
-        dict(
-            x=x,
-            weight=weight,
-            ddof=ddof,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "ddof": ddof,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -43,7 +43,7 @@ def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.strings_astype",
-        dict(array=array, to=to, highlevel=highlevel, behavior=behavior),
+        {"array": array, "to": to, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, to, highlevel, behavior)
 

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -196,14 +196,14 @@ def sum(
     """
     with ak._errors.OperationErrorContext(
         "ak.sum",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -260,14 +260,14 @@ def nansum(
     """
     with ak._errors.OperationErrorContext(
         "ak.nansum",
-        dict(
-            array=array,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -65,16 +65,16 @@ def to_arrow(
     """
     with ak._errors.OperationErrorContext(
         "ak.to_arrow",
-        dict(
-            array=array,
-            list_to32=list_to32,
-            string_to32=string_to32,
-            bytestring_to32=bytestring_to32,
-            emptyarray_to=emptyarray_to,
-            categorical_as_dictionary=categorical_as_dictionary,
-            extensionarray=extensionarray,
-            count_nulls=count_nulls,
-        ),
+        {
+            "array": array,
+            "list_to32": list_to32,
+            "string_to32": string_to32,
+            "bytestring_to32": bytestring_to32,
+            "emptyarray_to": emptyarray_to,
+            "categorical_as_dictionary": categorical_as_dictionary,
+            "extensionarray": extensionarray,
+            "count_nulls": count_nulls,
+        },
     ):
         return _impl(
             array,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -66,16 +66,16 @@ def to_arrow_table(
     """
     with ak._errors.OperationErrorContext(
         "ak.to_arrow_table",
-        dict(
-            array=array,
-            list_to32=list_to32,
-            string_to32=string_to32,
-            bytestring_to32=bytestring_to32,
-            emptyarray_to=emptyarray_to,
-            categorical_as_dictionary=categorical_as_dictionary,
-            extensionarray=extensionarray,
-            count_nulls=count_nulls,
-        ),
+        {
+            "array": array,
+            "list_to32": list_to32,
+            "string_to32": string_to32,
+            "bytestring_to32": bytestring_to32,
+            "emptyarray_to": emptyarray_to,
+            "categorical_as_dictionary": categorical_as_dictionary,
+            "extensionarray": extensionarray,
+            "count_nulls": count_nulls,
+        },
     ):
         return _impl(
             array,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -47,7 +47,12 @@ def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_backend",
-        dict(array=array, backend=backend, highlevel=highlevel, behavior=behavior),
+        {
+            "array": array,
+            "backend": backend,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, backend, highlevel, behavior)
 

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -119,15 +119,15 @@ def to_buffers(
     """
     with ak._errors.OperationErrorContext(
         "ak.to_buffers",
-        dict(
-            array=array,
-            container=container,
-            buffer_key=buffer_key,
-            form_key=form_key,
-            id_start=id_start,
-            backend=backend,
-            byteorder=byteorder,
-        ),
+        {
+            "array": array,
+            "container": container,
+            "buffer_key": buffer_key,
+            "form_key": form_key,
+            "id_start": id_start,
+            "backend": backend,
+            "byteorder": byteorder,
+        },
     ):
         return _impl(
             array, container, buffer_key, form_key, id_start, backend, byteorder

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -81,7 +81,7 @@ def to_categorical(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_categorical",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -22,7 +22,7 @@ def to_cupy(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_cupy",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -123,12 +123,12 @@ def to_dataframe(
     """
     with ak._errors.OperationErrorContext(
         "ak.to_dataframe",
-        dict(
-            array=array,
-            how=how,
-            levelname=levelname,
-            anonymous=anonymous,
-        ),
+        {
+            "array": array,
+            "how": how,
+            "levelname": levelname,
+            "anonymous": anonymous,
+        },
     ):
         return _impl(array, how, levelname, anonymous)
 

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -22,7 +22,7 @@ def to_jax(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_jax",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -112,19 +112,19 @@ def to_json(
     """
     with ak._errors.OperationErrorContext(
         "ak.to_json",
-        dict(
-            array=array,
-            file=file,
-            line_delimited=line_delimited,
-            num_indent_spaces=num_indent_spaces,
-            num_readability_spaces=num_readability_spaces,
-            nan_string=nan_string,
-            posinf_string=posinf_string,
-            neginf_string=neginf_string,
-            complex_record_fields=complex_record_fields,
-            convert_bytes=convert_bytes,
-            convert_other=convert_other,
-        ),
+        {
+            "array": array,
+            "file": file,
+            "line_delimited": line_delimited,
+            "num_indent_spaces": num_indent_spaces,
+            "num_readability_spaces": num_readability_spaces,
+            "nan_string": nan_string,
+            "posinf_string": posinf_string,
+            "neginf_string": neginf_string,
+            "complex_record_fields": complex_record_fields,
+            "convert_bytes": convert_bytes,
+            "convert_other": convert_other,
+        },
     ):
         return _impl(
             array,

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -41,12 +41,12 @@ def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True)
     """
     with _errors.OperationErrorContext(
         "ak.to_layout",
-        dict(
-            array=array,
-            allow_record=allow_record,
-            allow_other=allow_other,
-            regulararray=regulararray,
-        ),
+        {
+            "array": array,
+            "allow_record": allow_record,
+            "allow_other": allow_other,
+            "regulararray": regulararray,
+        },
     ):
         return _impl(array, allow_record, allow_other, regulararray=regulararray)
 

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -39,7 +39,7 @@ def to_list(array):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_list",
-        dict(array=array),
+        {"array": array},
     ):
         return _impl(array)
 

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -36,7 +36,7 @@ def to_numpy(array, *, allow_missing=True):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_numpy",
-        dict(array=array, allow_missing=allow_missing),
+        {"array": array, "allow_missing": allow_missing},
     ):
         return _impl(array, allow_missing)
 

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -66,7 +66,7 @@ def to_packed(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_packed",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -39,7 +39,7 @@ def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_rdataframe",
-        dict(arrays=arrays),
+        {"arrays": arrays},
     ):
         return _impl(
             arrays,

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -49,7 +49,7 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.to_regular",
-        dict(array=array, axis=axis, highlevel=highlevel, behavior=behavior),
+        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -407,22 +407,22 @@ def transform(
     """
     with ak._errors.OperationErrorContext(
         "ak.transform",
-        dict(
-            transformation=transformation,
-            array=array,
-            more_arrays=more_arrays,
-            depth_context=depth_context,
-            lateral_context=lateral_context,
-            allow_records=allow_records,
-            broadcast_parameters_rule=broadcast_parameters_rule,
-            left_broadcast=left_broadcast,
-            right_broadcast=right_broadcast,
-            numpy_to_regular=numpy_to_regular,
-            regular_to_jagged=regular_to_jagged,
-            return_value=return_value,
-            behavior=behavior,
-            highlevel=highlevel,
-        ),
+        {
+            "transformation": transformation,
+            "array": array,
+            "more_arrays": more_arrays,
+            "depth_context": depth_context,
+            "lateral_context": lateral_context,
+            "allow_records": allow_records,
+            "broadcast_parameters_rule": broadcast_parameters_rule,
+            "left_broadcast": left_broadcast,
+            "right_broadcast": right_broadcast,
+            "numpy_to_regular": numpy_to_regular,
+            "regular_to_jagged": regular_to_jagged,
+            "return_value": return_value,
+            "behavior": behavior,
+            "highlevel": highlevel,
+        },
     ):
         return _impl(
             transformation,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -74,7 +74,7 @@ def type(array, *, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.type",
-        dict(array=array, behavior=behavior),
+        {"array": array, "behavior": behavior},
     ):
         return _impl(array, behavior)
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -73,13 +73,13 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.unflatten",
-        dict(
-            array=array,
-            counts=counts,
-            axis=axis,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "counts": counts,
+            "axis": axis,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, counts, axis, highlevel, behavior)
 

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -34,7 +34,7 @@ def unzip(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.unzip",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -20,7 +20,7 @@ def validity_error(array, *, exception=False):
     """
     with ak._errors.OperationErrorContext(
         "ak.validity_error",
-        dict(array=array, exception=exception),
+        {"array": array, "exception": exception},
     ):
         return _impl(array, exception)
 

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -50,7 +50,7 @@ def values_astype(array, to, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.values_astype",
-        dict(array=array, to=to, highlevel=highlevel, behavior=behavior),
+        {"array": array, "to": to, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, to, highlevel, behavior)
 

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -69,14 +69,14 @@ def var(
     """
     with ak._errors.OperationErrorContext(
         "ak.var",
-        dict(
-            x=x,
-            weight=weight,
-            ddof=ddof,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "ddof": ddof,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (
@@ -137,14 +137,14 @@ def nanvar(
     """
     with ak._errors.OperationErrorContext(
         "ak.nanvar",
-        dict(
-            x=x,
-            weight=weight,
-            ddof=ddof,
-            axis=axis,
-            keepdims=keepdims,
-            mask_identity=mask_identity,
-        ),
+        {
+            "x": x,
+            "weight": weight,
+            "ddof": ddof,
+            "axis": axis,
+            "keepdims": keepdims,
+            "mask_identity": mask_identity,
+        },
     ):
         if flatten_records is not unset:
             message = (

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -42,7 +42,7 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     if len(args) == 0:
         with ak._errors.OperationErrorContext(
             "ak.where",
-            dict(condition=condition, mergebool=mergebool, highlevel=highlevel),
+            {"condition": condition, "mergebool": mergebool, "highlevel": highlevel},
         ):
             return _impl1(condition, mergebool, highlevel, behavior)
 
@@ -55,9 +55,13 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
         x, y = args
         with ak._errors.OperationErrorContext(
             "ak.where",
-            dict(
-                condition=condition, x=x, y=y, mergebool=mergebool, highlevel=highlevel
-            ),
+            {
+                "condition": condition,
+                "x": x,
+                "y": y,
+                "mergebool": mergebool,
+                "highlevel": highlevel,
+            },
         ):
             return _impl3(condition, x, y, mergebool, highlevel, behavior)
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -33,9 +33,13 @@ def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.with_field",
-        dict(
-            array=array, what=what, where=where, highlevel=highlevel, behavior=behavior
-        ),
+        {
+            "array": array,
+            "what": what,
+            "where": where,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, what, where, highlevel, behavior)
 

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -31,7 +31,7 @@ def with_name(array, name, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.with_name",
-        dict(array=array, name=name, highlevel=highlevel, behavior=behavior),
+        {"array": array, "name": name, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, name, highlevel, behavior)
 

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -28,13 +28,13 @@ def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.with_parameter",
-        dict(
-            array=array,
-            parameter=parameter,
-            value=value,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "array": array,
+            "parameter": parameter,
+            "value": value,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(array, parameter, value, highlevel, behavior)
 

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -31,7 +31,7 @@ def without_field(array, where, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.without_field",
-        dict(array=array, where=where, highlevel=highlevel, behavior=behavior),
+        {"array": array, "where": where, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, where, highlevel, behavior)
 

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -23,7 +23,7 @@ def without_parameters(array, *, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.without_parameters",
-        dict(array=array, highlevel=highlevel, behavior=behavior),
+        {"array": array, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior)
 

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -29,7 +29,7 @@ def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.zeros_like",
-        dict(array=array, dtype=dtype, highlevel=highlevel, behavior=behavior),
+        {"array": array, "dtype": dtype, "highlevel": highlevel, "behavior": behavior},
     ):
         return _impl(array, highlevel, behavior, dtype)
 

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -131,16 +131,16 @@ def zip(
     """
     with ak._errors.OperationErrorContext(
         "ak.zip",
-        dict(
-            arrays=arrays,
-            depth_limit=depth_limit,
-            parameters=parameters,
-            with_name=with_name,
-            right_broadcast=right_broadcast,
-            optiontype_outside_record=optiontype_outside_record,
-            highlevel=highlevel,
-            behavior=behavior,
-        ),
+        {
+            "arrays": arrays,
+            "depth_limit": depth_limit,
+            "parameters": parameters,
+            "with_name": with_name,
+            "right_broadcast": right_broadcast,
+            "optiontype_outside_record": optiontype_outside_record,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
         return _impl(
             arrays,


### PR DESCRIPTION
The built-in syntax is preferable to passing keywords to the dict constructor, which wastes a function call. Besides being more consistent and recognisable, it is also faster:

```pycon
Python 3.11.1 (main, Dec 23 2022, 09:39:26) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import timeit
>>> timeit.timeit("dict(a=1, b=2)")
0.09944732999429107
>>> timeit.timeit("{'a': 1, 'b': 2}")
0.07909351703710854
```

This removes the ignoring of `"C408"`.