### PR TITLE
fix: don't raise `NotImplementedError` when reading empty array from Parquet

### DIFF
--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -1001,8 +1001,13 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
     elif isinstance(obj, pyarrow.lib.Table):
         batches = obj.combine_chunks().to_batches()
         if len(batches) == 0:
-            # FIXME: create a zero-length array with the right type
-            raise ak._errors.wrap_error(NotImplementedError)
+            # create a RecordBatch of empty arrays following the schema
+            return handle_arrow(
+                pyarrow.lib.RecordBatch.from_arrays(
+                    [[] for _ in obj.schema.names],
+                    schema=obj.schema,
+                )
+            )
         elif len(batches) == 1:
             return handle_arrow(batches[0], generate_bitmasks, pass_empty_field)
         else:

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -1001,13 +1001,11 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
     elif isinstance(obj, pyarrow.lib.Table):
         batches = obj.combine_chunks().to_batches()
         if len(batches) == 0:
-            # create a RecordBatch of empty arrays following the schema
-            return handle_arrow(
-                pyarrow.lib.RecordBatch.from_arrays(
-                    [[] for _ in obj.schema.names],
-                    schema=obj.schema,
-                )
-            )
+            # create an empty array following the input schema
+            return form_handle_arrow(
+                obj.schema,
+                pass_empty_field=pass_empty_field,
+            ).length_zero_array(highlevel=False)
         elif len(batches) == 1:
             return handle_arrow(batches[0], generate_bitmasks, pass_empty_field)
         else:

--- a/tests/test_1125_to_arrow_from_arrow.py
+++ b/tests/test_1125_to_arrow_from_arrow.py
@@ -695,3 +695,11 @@ def test_unionarray(tmp_path, extensionarray):
     )
     paarray = akarray.to_arrow(extensionarray=extensionarray)
     arrow_round_trip(akarray, paarray, extensionarray)
+
+
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_empty_arrow(tmp_path, extensionarray):
+    akarray = ak.Array([{"x": 1, "y": 2.2}])[0:0]
+    paarray = ak.to_arrow_table(akarray, extensionarray=extensionarray)
+    arrow_round_trip(akarray, paarray, extensionarray)
+    parquet_round_trip(akarray, paarray, extensionarray, tmp_path)


### PR DESCRIPTION
This PR proposes an implementation for reading an zero-length `ak.RecordArray` / Arrow `Table` from Parquet.

Since for zero-length there are no batches to use for conversion, an empty `RecordBatch` is created matching the input schema, and is propagated through the `handle_arrow` function. 

There might be better ways to do this (maybe avoiding the list-of-empty lists?), so let me know.

Closes #2193.