### PR TITLE
fix: support length-zero outer arrays in almost_equal

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -165,11 +165,6 @@ class ArrayModuleNumpyLike(NumpyLike):
         slice_length = math.ceil((stop - start) / step)
         return start, stop, step, slice_length
 
-    def shape_equals(
-        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> bool:
-        return shape1 == shape2
-
     def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
         return self._module.nonzero(x)
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -99,8 +99,10 @@ class ArrayModuleNumpyLike(NumpyLike):
 
     def array_equal(
         self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
-    ) -> bool:
-        return self._module.array_equal(x1, x2, equal_nan=equal_nan)
+    ) -> ArrayLike:
+        return self._module.asarray(
+            self._module.array_equal(x1, x2, equal_nan=equal_nan)
+        )
 
     def searchsorted(
         self,
@@ -118,7 +120,7 @@ class ArrayModuleNumpyLike(NumpyLike):
         return self._module.broadcast_arrays(*arrays)
 
     def reshape(
-        self, x: ArrayLike, shape: tuple[int, ...], *, copy: bool | None = None
+        self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
     ) -> ArrayLike:
         if copy is False:
             raise ak._errors.wrap_error(
@@ -162,6 +164,11 @@ class ArrayModuleNumpyLike(NumpyLike):
         start, stop, step = slice_.indices(length)
         slice_length = math.ceil((stop - start) / step)
         return start, stop, step, slice_length
+
+    def shape_equals(
+        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
+    ) -> bool:
+        return shape1 == shape2
 
     def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
         return self._module.nonzero(x)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -165,6 +165,11 @@ class ArrayModuleNumpyLike(NumpyLike):
         slice_length = math.ceil((stop - start) / step)
         return start, stop, step, slice_length
 
+    def shape_equals(
+        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
+    ) -> bool:
+        return shape1 == shape2
+
     def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
         return self._module.nonzero(x)
 

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -11,6 +11,7 @@ from awkward.typing import (
     Literal,
     Protocol,
     Self,
+    SupportsBool,
     SupportsIndex,
     TypeAlias,
     overload,
@@ -101,6 +102,59 @@ class ArrayLike(Protocol):
 
     @abstractmethod
     def view(self, dtype: dtype) -> Self:
+        ...
+
+    # Scalar UFUNCS
+    @abstractmethod
+    def __add__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __sub__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __mul__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __truediv__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __floordiv__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __gt__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __lt__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __ge__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __le__(self, other: int | complex | float | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __eq__(self, other: int | complex | float | bool | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __and__(self, other: int | bool | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __or__(self, other: int | bool | Self) -> Self:
+        ...
+
+    @abstractmethod
+    def __invert__(self) -> Self:
         ...
 
 
@@ -330,7 +384,7 @@ class NumpyLike(Singleton, Protocol):
     @abstractmethod
     def shape_equals(
         self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> bool | None:
+    ) -> SupportsBool:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -328,12 +328,6 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
-    def shape_equals(
-        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> bool | None:
-        ...
-
-    @abstractmethod
     def reshape(
         self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
     ) -> ArrayLike:

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -11,7 +11,6 @@ from awkward.typing import (
     Literal,
     Protocol,
     Self,
-    SupportsBool,
     SupportsIndex,
     TypeAlias,
     overload,
@@ -379,12 +378,6 @@ class NumpyLike(Singleton, Protocol):
     def derive_slice_for_length(
         self, slice_: slice, length: ShapeItem
     ) -> tuple[IndexType, IndexType, IndexType, ShapeItem]:
-        ...
-
-    @abstractmethod
-    def shape_equals(
-        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> SupportsBool:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -328,6 +328,12 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
+    def shape_equals(
+        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
+    ) -> bool | None:
+        ...
+
+    @abstractmethod
     def reshape(
         self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
     ) -> ArrayLike:

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -208,26 +208,35 @@ class NumpyLike(Singleton, Protocol):
 
     @abstractmethod
     def zeros(
-        self, shape: int | tuple[int, ...], *, dtype: numpy.dtype | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: numpy.dtype | None = None,
     ) -> ArrayLike:
         ...
 
     @abstractmethod
     def ones(
-        self, shape: int | tuple[int, ...], *, dtype: numpy.dtype | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: numpy.dtype | None = None,
     ) -> ArrayLike:
         ...
 
     @abstractmethod
     def empty(
-        self, shape: int | tuple[int, ...], *, dtype: numpy.dtype | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: numpy.dtype | None = None,
     ) -> ArrayLike:
         ...
 
     @abstractmethod
     def full(
         self,
-        shape: int | tuple[int, ...],
+        shape: ShapeItem | tuple[ShapeItem, ...],
         fill_value,
         *,
         dtype: numpy.dtype | None = None,
@@ -272,7 +281,7 @@ class NumpyLike(Singleton, Protocol):
     @abstractmethod
     def array_equal(
         self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
-    ) -> bool:
+    ) -> ArrayLike:
         ...
 
     @abstractmethod
@@ -319,8 +328,14 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
+    def shape_equals(
+        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
+    ) -> bool | None:
+        ...
+
+    @abstractmethod
     def reshape(
-        self, x: ArrayLike, shape: tuple[int, ...], *, copy: bool | None = None
+        self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
     ) -> ArrayLike:
         ...
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -15,7 +15,6 @@ from awkward.typing import (
     Final,
     Literal,
     Self,
-    SupportsBool,
     SupportsIndex,
     TypeVar,
 )
@@ -887,25 +886,6 @@ class TypeTracer(NumpyLike):
                 slice_length = max(0, slice_length)
 
             return start, stop, step, self.index_as_shape_item(slice_length)
-
-    def shape_equals(
-        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> SupportsBool:
-        if len(shape1) != len(shape2):
-            return False
-
-        result_is_known = True
-        for x, y in zip(shape1, shape2):
-            if x is unknown_length or y is unknown_length:
-                result_is_known = False
-                continue
-            elif x != y:
-                return False
-
-        if result_is_known:
-            return True
-        else:
-            return TypeTracerArray._new(np.bool_, shape=())
 
     def broadcast_shapes(self, *shapes: tuple[ShapeItem, ...]) -> tuple[ShapeItem, ...]:
         ndim = max([len(s) for s in shapes], default=0)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -880,20 +880,6 @@ class TypeTracer(NumpyLike):
 
             return start, stop, step, self.index_as_shape_item(slice_length)
 
-    def shape_equals(
-        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
-    ) -> bool:
-        if len(shape1) != len(shape2):
-            return False
-
-        for x, y in zip(shape1, shape2):
-            if x is unknown_length or y is unknown_length:
-                continue
-            elif x != y:
-                return False
-
-        return True
-
     def broadcast_shapes(self, *shapes: tuple[ShapeItem, ...]) -> tuple[ShapeItem, ...]:
         ndim = max([len(s) for s in shapes], default=0)
         result: list[ShapeItem] = [1] * ndim

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -880,6 +880,20 @@ class TypeTracer(NumpyLike):
 
             return start, stop, step, self.index_as_shape_item(slice_length)
 
+    def shape_equals(
+        self, shape1: tuple[ShapeItem, ...], shape2: tuple[ShapeItem, ...]
+    ) -> bool:
+        if len(shape1) != len(shape2):
+            return False
+
+        for x, y in zip(shape1, shape2):
+            if x is unknown_length or y is unknown_length:
+                continue
+            elif x != y:
+                return False
+
+        return True
+
     def broadcast_shapes(self, *shapes: tuple[ShapeItem, ...]) -> tuple[ShapeItem, ...]:
         ndim = max([len(s) for s in shapes], default=0)
         result: list[ShapeItem] = [1] * ndim

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -112,7 +112,7 @@ def almost_equal(
                         left.data, right.data, rtol=rtol, atol=atol, equal_nan=False
                     )
                 )
-                and left.shape == right.shape
+                and backend.nplike.shape_equals(left.shape, right.shape)
             )
 
         elif left.is_option:

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -112,7 +112,7 @@ def almost_equal(
                         left.data, right.data, rtol=rtol, atol=atol, equal_nan=False
                     )
                 )
-                and backend.nplike.shape_equals(left.shape, right.shape)
+                and left.shape == right.shape
             )
 
         elif left.is_option:

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -40,6 +40,9 @@ def almost_equal(
     The relative difference (`rtol * abs(b)`) and the absolute difference `atol`
     are added together to compare against the absolute difference between `left`
     and `right`.
+
+    TypeTracer arrays are not supported, as there is very little information to
+    be compared.
     """
     left_behavior = behavior_of(left)
     right_behavior = behavior_of(right)
@@ -48,6 +51,12 @@ def almost_equal(
     right = to_layout(right, allow_record=False).to_packed()
 
     backend = backend_of(left, right)
+    if not backend.nplike.known_data:
+        raise wrap_error(
+            TypeError(
+                "Awkward Arrays with typetracer backends cannot be compared with `ak.almost_equal`."
+            )
+        )
 
     def is_approx_dtype(left, right) -> bool:
         if not dtype_exact:
@@ -88,21 +97,24 @@ def almost_equal(
             return False
 
         if left.is_list:
-            return (
-                backend.index_nplike.array_equal(left.starts, right.starts)
-                and backend.index_nplike.array_equal(left.stops, right.stops)
-                and visitor(
-                    left.content[: left.stops[-1]], right.content[: right.stops[-1]]
-                )
+            return backend.index_nplike.array_equal(
+                left.offsets, right.offsets
+            ) and visitor(
+                left.content[: left.offsets[-1]], right.content[: right.offsets[-1]]
             )
         elif left.is_regular:
             return (left.size == right.size) and visitor(left.content, right.content)
         elif left.is_numpy:
-            return is_approx_dtype(left.dtype, right.dtype) and backend.nplike.all(
-                backend.nplike.isclose(
-                    left.data, right.data, rtol=rtol, atol=atol, equal_nan=False
+            return (
+                is_approx_dtype(left.dtype, right.dtype)
+                and backend.nplike.all(
+                    backend.nplike.isclose(
+                        left.data, right.data, rtol=rtol, atol=atol, equal_nan=False
+                    )
                 )
+                and backend.nplike.shape_equals(left.shape, right.shape)
             )
+
         elif left.is_option:
             return backend.index_nplike.array_equal(
                 left.index.data < 0, right.index.data < 0

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -118,7 +118,7 @@ def almost_equal(
         elif left.is_option:
             return backend.index_nplike.array_equal(
                 left.index.data < 0, right.index.data < 0
-            ) and visitor(left.project(), right.project())
+            ) and visitor(left.project().to_packed(), right.project().to_packed())
         elif left.is_union:
             return (len(left.contents) == len(right.contents)) and all(
                 [

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -53,8 +53,8 @@ def almost_equal(
     backend = backend_of(left, right)
     if not backend.nplike.known_data:
         raise wrap_error(
-            TypeError(
-                "Awkward Arrays with typetracer backends cannot be compared with `ak.almost_equal`."
+            NotImplementedError(
+                "Awkward Arrays with typetracer backends cannot yet be compared with `ak.almost_equal`."
             )
         )
 

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -52,3 +52,8 @@ else:
         final,
         runtime_checkable,
     )
+
+
+class SupportsBool(Protocol):
+    def __bool__(self) -> bool:
+        ...

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -135,3 +135,10 @@ def test_empty_outer_ragged():
     array = ak.Array([[1]])[0:0]
     assert not ak.almost_equal(array, [])
     assert ak.almost_equal(array, array)
+
+
+def test_numpy_array():
+    left = np.arange(2 * 3 * 4, dtype=np.int64).reshape(4, 3, 2)
+    right = np.arange(2 * 3 * 4, dtype=np.int64).reshape(2, 3, 4)
+    assert not ak.almost_equal(left, right)
+    assert ak.almost_equal(left, left)

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np  # noqa: F401
+import pytest
 
 import awkward as ak
 
@@ -142,3 +143,9 @@ def test_numpy_array():
     right = np.arange(2 * 3 * 4, dtype=np.int64).reshape(2, 3, 4)
     assert not ak.almost_equal(left, right)
     assert ak.almost_equal(left, left)
+
+
+def test_typetracer():
+    array = ak.Array([[[1, 2, 3]], [[5, 4]]], backend="typetracer")
+    with pytest.raises(TypeError):
+        ak.almost_equal(array, 2 * array)

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -129,3 +129,9 @@ def test_behavior():
     another_array = ak.Array([1, 2, 3], behavior=behavior)
     assert not ak.almost_equal(array, another_array)
     assert not ak.almost_equal(other_array, another_array)
+
+
+def test_empty_outer_ragged():
+    array = ak.Array([[1]])[0:0]
+    assert not ak.almost_equal(array, [])
+    assert ak.almost_equal(array, array)


### PR DESCRIPTION
- Fixes #2209 
- Adds `shapes_equal` to nplike with `None` return result for unknown shape items.