### PR TITLE
fix: boolean indexing with non-zero starting offsets

### DIFF
--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -440,6 +440,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         and np.issubdtype(item.content.dtype, np.bool_)
     ):
         if item_backend.nplike.known_data or item_backend.nplike.known_shape:
+            item = item.to_ListOffsetArray64(True)
             localindex = ak._do.local_index(item, axis=1)
             nextcontent = localindex.content.data[item.content.data]
 

--- a/tests/test_2214_offset_bool_index.py
+++ b/tests/test_2214_offset_bool_index.py
@@ -1,0 +1,38 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    # fmt: off
+    layout = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index64(np.array([22, 36], dtype=np.int64)),
+                ak.contents.RecordArray(
+                    [
+                        ak.contents.NumpyArray(
+                            np.array([True, False, True, False, True, False, True, False, True, False, True, False, False, False,
+                             False, False, False, False, False, False, False, False, True, False, True, False, True,
+                             False, True, False, False, False, False, False, False, False], dtype=np.bool_)
+                        ),
+                        ak.contents.NumpyArray(
+                            np.array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6], dtype=np.int64)
+                        )
+                    ],
+                    ["part_of_iterative_splitting", "parent_splitting_index"],
+                ),
+            )
+        ],
+        ["subjets"],
+    )
+    # fmt: on
+
+    array = ak.Array(layout)
+    result = array.subjets.parent_splitting_index[
+        array.subjets.part_of_iterative_splitting
+    ]
+    assert ak.almost_equal(result, [[0, 1, 2, 3]])


### PR DESCRIPTION
Fixes #2214

The fix here is simplest if we start the `ListOffsetArray` at zero. This should not copy anything besides offsets for the list-of-NumPy case. There are other places in this region of the codebase that might also have this bug, but I'd prefer to wait for bug reports.