### PR TITLE
docs: add 1.10 legacy docs to `switcher.json`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,13 @@ Contributor's guide
 Spotted a typo in the documentation? Want to add to the codebase? The contributing guidelines will guide you through the process of improving Awkward Array.
 
 :::
+
+:::{grid-item-card} 
+:columns: 12
+:link: https://awkward-array.org/doc/1.10/
+:class-card: admonition warning
+
+{fas}`history` Need the documentation for version 1 of Awkward Array? Click this card.
+::::
     
 :::::
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ Spotted a typo in the documentation? Want to add to the codebase? The contributi
 
 :::{grid-item-card} 
 :columns: 12
-:link: https://awkward-array.org/doc/1.10/
+:link: https://awkward-array.org/doc/1.10/api-reference.html
 :class-card: admonition warning
 
 {fas}`history` Need the documentation for version 1 of Awkward Array? Click this card.

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -8,6 +8,10 @@
         "url": "https://awkward-array.org/doc/main/"
     },
     {
+        "version": "1.10",
+        "url": "https://awkward-array.org/doc/1.10/"
+    },
+    {
         "version": "2.0",
         "url": "https://awkward-array.org/doc/2.0/"
     }

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -8,10 +8,6 @@
         "url": "https://awkward-array.org/doc/main/"
     },
     {
-        "version": "1.10",
-        "url": "https://awkward-array.org/doc/1.10/"
-    },
-    {
         "version": "2.0",
         "url": "https://awkward-array.org/doc/2.0/"
     }


### PR DESCRIPTION
I've pushed a new build of the v1.10 docs to http://awkward-array.org/doc, using our new pydata-sphinx-theme template. It's not perfect, but it also doesn't need to be — it's just for existing v1 users. This path is set to be hidden from indexing, spidering, and analytics.

I've already pushed this to the website, but this change ensures that v1 can be selected from the version dropdown upon future releases, which will wipe the deployed contents of `switcher.json`