### PR TITLE
fix: keep `EmptyArray` in `remove_structure`

### DIFF
--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -318,7 +318,7 @@ class EmptyArray(Content):
         return backend.nplike.empty(0, dtype=np.float64)
 
     def _remove_structure(self, backend, options):
-        return []
+        return [self]
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -168,7 +168,7 @@ def _impl(array, axis, highlevel, behavior):
     if axis is None:
         out = ak._do.remove_structure(layout, function_name="ak.flatten")
         assert isinstance(out, tuple) and all(
-            isinstance(x, ak.contents.NumpyArray) for x in out
+            isinstance(x, ak.contents.Content) for x in out
         )
 
         result = ak._do.mergemany(out)

--- a/tests/test_2219_flatten_empty.py
+++ b/tests/test_2219_flatten_empty.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array([[[], [], []], []])
+    flattened = ak.flatten(array, axis=None)
+    assert isinstance(flattened.layout, ak.contents.EmptyArray)
+    assert len(flattened) == 0


### PR DESCRIPTION
Fixes #2207 by preserving `EmptyArray` in `ak._do.remove_structure`. This means that code that previously did not handle `EmptyArray` would now be expected to. I don't think there are many places where this is actually a problem; `EmptyArray` already handles reduction, and flattening almost immediately returns the result.