### PR TITLE
fix: add `is_c_contiguous` method to Cupy

### DIFF
--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -159,3 +159,6 @@ class Cupy(ArrayModuleNumpyLike):
         """
         module, _, suffix = type(obj).__module__.partition(".")
         return module == "cupy"
+
+    def is_c_contiguous(self, x: ArrayLike) -> bool:
+        return x.flags["C_CONTIGUOUS"]

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1395,7 +1395,7 @@ class ListArray(Content):
             and self._backend.nplike.known_data
             and self._starts.length != 0
         ):
-            startsmin = self._backend.index_nplike.min(self._starts.data).item()
+            startsmin = self._backend.index_nplike.min(self._starts.data)
             starts = ak.index.Index(
                 self._starts.data - startsmin, nplike=self._backend.index_nplike
             )
@@ -1403,7 +1403,7 @@ class ListArray(Content):
                 self._stops.data - startsmin, nplike=self._backend.index_nplike
             )
             content = self._content[
-                startsmin : self._backend.index_nplike.max(self._stops.data).item()
+                startsmin : self._backend.index_nplike.max(self._stops.data)
             ]
         else:
             self._touch_data(recursive=False)

--- a/tests-cuda/test_1276-cupy-interop.py
+++ b/tests-cuda/test_1276-cupy-interop.py
@@ -5,11 +5,13 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._nplikes.cupy import Cupy
+from awkward._nplikes.numpy import Numpy
 
 
 def test_cupy_interop():
-    cupy = ak._nplikes.cupy.Cupy.instance()
-    numpy = ak._nplikes.numpy.Numpy.instance()
+    cupy = Cupy.instance()
+    numpy = Numpy.instance()
 
     cupy_index_arr = ak.index.Index64(cp.arange(10))
     assert cupy_index_arr.nplike is cupy

--- a/tests-cuda/test_1276-cupy-interop.py
+++ b/tests-cuda/test_1276-cupy-interop.py
@@ -8,8 +8,8 @@ import awkward as ak
 
 
 def test_cupy_interop():
-    cupy = ak._nplikes.Cupy.instance()
-    numpy = ak._nplikes.Numpy.instance()
+    cupy = ak._nplikes.cupy.Cupy.instance()
+    numpy = ak._nplikes.numpy.Numpy.instance()
 
     cupy_index_arr = ak.index.Index64(cp.arange(10))
     assert cupy_index_arr.nplike is cupy


### PR DESCRIPTION
- [x] implement an abstract `is_c_contiguous` method for Cupy class
- [x] update cuda tests