### PR TITLE
fix: use of size in `to_RegularArray`

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -207,25 +207,26 @@ class ListOffsetArray(Content):
     def to_RegularArray(self):
         start, stop = self._offsets[0], self._offsets[self._offsets.length - 1]
         content = self._content._getitem_range(slice(start, stop))
-        size = ak.index.Index64.empty(1, self._backend.index_nplike)
+        _size = ak.index.Index64.empty(1, self._backend.index_nplike)
         assert (
-            size.nplike is self._backend.index_nplike
+            _size.nplike is self._backend.index_nplike
             and self._offsets.nplike is self._backend.index_nplike
         )
         self._handle_error(
             self._backend[
                 "awkward_ListOffsetArray_toRegularArray",
-                size.dtype.type,
+                _size.dtype.type,
                 self._offsets.dtype.type,
             ](
-                size.data,
+                _size.data,
                 self._offsets.data,
                 self._offsets.length,
             )
         )
-
+        size = self._backend.index_nplike.scalar_as_shape_item(_size[0])
+        length = self._backend.index_nplike.sub_shape_item(self._offsets.length, 1)
         return ak.contents.RegularArray(
-            content, size[0], self._offsets.length - 1, parameters=self._parameters
+            content, size, length, parameters=self._parameters
         )
 
     def _getitem_nothing(self):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -34,7 +34,16 @@ class RegularArray(Content):
                     )
                 )
             )
-        if size is not None:
+        if size is None:
+            if content.backend.index_nplike.known_shape:
+                raise ak._errors.wrap_error(
+                    TypeError(
+                        "{} 'size' must be a non-negative integer for backends with known shapes, not None".format(
+                            type(self).__name__
+                        )
+                    )
+                )
+        else:
             if not (ak._util.is_integer(size) and size >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(
@@ -43,9 +52,17 @@ class RegularArray(Content):
                         )
                     )
                 )
-            else:
-                size = int(size)
-        if zeros_length is not None:
+
+        if zeros_length is None:
+            if content.backend.index_nplike.known_shape:
+                raise ak._errors.wrap_error(
+                    TypeError(
+                        "{} 'zeros_length' must be a non-negative integer for backends with known shapes, not None".format(
+                            type(self).__name__
+                        )
+                    )
+                )
+        else:
             if not (ak._util.is_integer(zeros_length) and zeros_length >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -20,17 +20,17 @@ class RegularForm(Form):
                     )
                 )
             )
-        if not ak._util.is_integer(size):
+        if not ((ak._util.is_integer(size) and size >= 0) or size is None):
             raise ak._errors.wrap_error(
                 TypeError(
-                    "{} 'size' must be of type int, not {}".format(
+                    "{} 'size' must be a non-negative int or None, not {}".format(
                         type(self).__name__, repr(size)
                     )
                 )
             )
 
         self._content = content
-        self._size = int(size)
+        self._size = size
         self._init(parameters=parameters, form_key=form_key)
 
     @property

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -66,11 +66,16 @@ class RegularType(Type):
 
         else:
             params = self._str_parameters()
+            if self._size is None:
+                size_str = "##"
+            else:
+                size_str = str(self._size)
+
             if params is None:
-                out = [str(self._size), " * "] + self._content._str(indent, compact)
+                out = [size_str, " * "] + self._content._str(indent, compact)
             else:
                 out = (
-                    ["[", str(self._size), " * "]
+                    ["[", size_str, " * "]
                     + self._content._str(indent, compact)
                     + [", ", params, "]"]
                 )

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -17,10 +17,10 @@ class RegularType(Type):
                     )
                 )
             )
-        if not ak._util.is_integer(size) or size < 0:
+        if not ((ak._util.is_integer(size) and size >= 0) or size is None):
             raise ak._errors.wrap_error(
                 ValueError(
-                    "{} 'size' must be of a positive integer, not {}".format(
+                    "{} 'size' must be a non-negative int or None, not {}".format(
                         type(self).__name__, repr(size)
                     )
                 )

--- a/tests/test_2226_slice_regulararray_typetracer.py
+++ b/tests/test_2226_slice_regulararray_typetracer.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    x = ak.to_regular(
+        ak.Array([[[-1, 1.0], [-2, 2], [-3, 3]], [[-4, 4]], []], backend="typetracer"),
+        axis=-1,
+    )
+    result = x[:, :-1]
+    assert ak.backend(result) == "typetracer"
+    layout = ak.to_layout(result)
+    assert layout.length == 3
+    assert layout.content.length is None
+    assert layout.content.content.length is None
+    assert layout.content.content.dtype == np.dtype(np.float64)


### PR DESCRIPTION
Anywhere that we compute lengths in kernels, we should be casting the results to lengths using `index_nplike.scalar_as_shape_item(scalar)`, This allows conversion from unknown typetracer scalars to `None` lengths.