### PR TITLE
fix: indexing into `RegularArray` with typetracer

### DIFF
--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -319,6 +319,12 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
+    def regularize_index_for_length(
+        self, index: IndexType, length: ShapeItem
+    ) -> IndexType:
+        ...
+
+    @abstractmethod
     def reshape(
         self, x: ArrayLike, shape: tuple[int, ...], *, copy: bool | None = None
     ) -> ArrayLike:

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -808,6 +808,36 @@ class TypeTracer(NumpyLike):
         else:
             return int(x1)
 
+    def regularize_index_for_length(
+        self, index: IndexType, length: ShapeItem
+    ) -> IndexType:
+        """
+        Args:
+            index: index value
+            length: length of array
+
+        Returns regularized index that is guaranteed to be in-bounds.
+        """
+        # Unknown indices are already regularized
+        if is_unknown_scalar(index):
+            return index
+
+        # Without a known length the result must be unknown, as we cannot regularize the index
+        length_scalar = self.shape_item_as_index(length)
+        if length is unknown_length:
+            return length_scalar
+
+        # We have known length and index
+        if index < 0:
+            index = index + length
+
+        if 0 <= index < length:
+            return index
+        else:
+            raise wrap_error(
+                IndexError(f"index value out of bounds (0, {length}): {index}")
+            )
+
     def derive_slice_for_length(
         self, slice_: slice, length: ShapeItem
     ) -> tuple[IndexType, IndexType, IndexType, ShapeItem]:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -50,7 +50,7 @@ def regularize_index(
         return index
     else:
         raise wrap_error(
-            ValueError(f"index value out of bounds (0, {length}): {index}")
+            IndexError(f"index value out of bounds (0, {length}): {index}")
         )
 
 

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -35,14 +35,16 @@ def regularize_index(
 
     Returns regularized index that is guaranteed to be in-bounds.
     """
+    # Unknown indices are already regularized
     if is_unknown_scalar(index):
         return index
 
-    # Without a known length, the result is unbounded
+    # Without a known length the result must be unknown, as we cannot regularize the index
     length_scalar = backend.index_nplike.shape_item_as_scalar(length)
     if length is None:
         return length_scalar
 
+    # We have known length and index
     if index < 0:
         index = index + length
 

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -11,49 +11,16 @@ from awkward._nplikes import nplike_of, to_nplike
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._nplikes.typetracer import is_unknown_scalar
 from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias
 
 if TYPE_CHECKING:
-    from awkward._nplikes.numpylike import ArrayLike, ShapeItem  # noqa: F401
+    from awkward._nplikes.numpylike import ArrayLike
     from awkward.contents.content import Content
 
 np = NumpyMetadata.instance()
 
 
 SliceItem: TypeAlias = "int | slice | str | None | Ellipsis | ArrayLike | Content"
-
-
-def regularize_index(
-    index: int | ArrayLike, length: ShapeItem, *, backend: Backend
-) -> int | ArrayLike:
-    """
-    Args:
-        index: index value
-        length: length of array
-        backend: backend of array
-
-    Returns regularized index that is guaranteed to be in-bounds.
-    """
-    # Unknown indices are already regularized
-    if is_unknown_scalar(index):
-        return index
-
-    # Without a known length the result must be unknown, as we cannot regularize the index
-    length_scalar = backend.index_nplike.shape_item_as_scalar(length)
-    if length is None:
-        return length_scalar
-
-    # We have known length and index
-    if index < 0:
-        index = index + length
-
-    if 0 <= index < length:
-        return index
-    else:
-        raise wrap_error(
-            IndexError(f"index value out of bounds (0, {length}): {index}")
-        )
 
 
 def normalize_slice_item(item, *, backend: Backend):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -222,14 +222,11 @@ class RegularArray(Content):
 
     def _getitem_at(self, where: IndexType):
         index_nplike = self._backend.index_nplike
-        if index_nplike.known_data and where < 0:
-            where += self._length
-
-        if not (self._length is unknown_length or 0 <= where < self._length):
-            raise ak._errors.index_error(self, where)
-        start, stop = where * index_nplike.shape_item_as_index(self._size), (
+        where = ak._slicing.regularize_index(where, self._length, backend=self._backend)
+        size_scalar = index_nplike.shape_item_as_index(self._size)
+        start, stop = where * size_scalar, (
             where + 1
-        ) * index_nplike.shape_item_as_index(self._size)
+        ) * size_scalar
         return self._content._getitem_range(start, stop)
 
     def _getitem_range(self, start: SupportsIndex, stop: IndexType) -> Content:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -221,7 +221,7 @@ class RegularArray(Content):
 
     def _getitem_at(self, where: IndexType):
         index_nplike = self._backend.index_nplike
-        where = ak._slicing.regularize_index(where, self._length, backend=self._backend)
+        where = index_nplike.regularize_index_for_length(where, self._length)
         size_scalar = index_nplike.shape_item_as_index(self._size)
         start, stop = where * size_scalar, (where + 1) * size_scalar
         return self._content._getitem_range(start, stop)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -7,7 +7,6 @@ import awkward as ak
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._nplikes.typetracer import is_unknown_scalar
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -224,9 +223,7 @@ class RegularArray(Content):
         index_nplike = self._backend.index_nplike
         where = ak._slicing.regularize_index(where, self._length, backend=self._backend)
         size_scalar = index_nplike.shape_item_as_index(self._size)
-        start, stop = where * size_scalar, (
-            where + 1
-        ) * size_scalar
+        start, stop = where * size_scalar, (where + 1) * size_scalar
         return self._content._getitem_range(start, stop)
 
     def _getitem_range(self, start: SupportsIndex, stop: IndexType) -> Content:
@@ -428,26 +425,6 @@ class RegularArray(Content):
             start, stop, step, nextsize = index_nplike.derive_slice_for_length(
                 head, length=self._size
             )
-
-            if (
-                is_unknown_scalar(start)
-                or is_unknown_scalar(stop)
-                or is_unknown_scalar(step)
-            ):
-                nextsize = unknown_length
-            else:
-                if step > 0 and stop > start:
-                    diff = stop - start
-                    nextsize = diff // step
-                    if diff % step != 0:
-                        nextsize += 1
-                elif step < 0 and stop < start:
-                    diff = start - stop
-                    nextsize = diff // (step * -1)
-                    if diff % step != 0:
-                        nextsize += 1
-                else:
-                    nextsize = 0
 
             nextcarry = ak.index.Index64.empty(self._length * nextsize, index_nplike)
             assert nextcarry.nplike is index_nplike


### PR DESCRIPTION
## TL;DR
This PR 
- fixes #2222 by handling unknown lengths in `RegularArray` for `_getitem_at`. 
- introduces helper to regularize an index given an array length

## DR
This latter point (regularisation of indices) is infectious; if a length is not known, or the index is unknown, the result is unknown.

This PR is taking a step towards allowing `int` as indices alongside the scalar arrays belong to `backend.index_nplike`. We need this if we want concrete slices (`array[2:4]`) to preserve more information than unknown slices (`array[x:y]`). 


