### PR TITLE
refactor: drop `NumpyLike.known_shape`

### DIFF
--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -223,7 +223,7 @@ def common_backend(backends: Collection[Backend]) -> Backend:
     else:
         # We allow typetracers to mix with other nplikes, and take precedence
         for backend in unique_backends:
-            if not (backend.nplike.known_data and backend.nplike.known_shape):
+            if not backend.nplike.known_data:
                 return backend
 
         raise ak._errors.wrap_error(

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -71,7 +71,7 @@ def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
             nextinputs.append(
                 RegularArray(
                     x,
-                    x.length if x.backend.nplike.known_shape else 1,
+                    x.length if x.backend.nplike.known_data else 1,
                     1,
                     parameters=None,
                 )
@@ -86,12 +86,12 @@ def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
 
 def broadcast_unpack(x, isscalar: list[bool], backend: ak._backends.Backend):
     if all(isscalar):
-        if not backend.nplike.known_shape or x.length == 0:
+        if not backend.nplike.known_data or x.length == 0:
             return x._getitem_nothing()._getitem_nothing()
         else:
             return x[0][0]
     else:
-        if not backend.nplike.known_shape or x.length == 0:
+        if not backend.nplike.known_data or x.length == 0:
             return x._getitem_nothing()
         else:
             return x[0]
@@ -412,7 +412,7 @@ def apply_step(
                 )
 
     # Now all lengths must agree.
-    if backend.nplike.known_shape:
+    if backend.nplike.known_data:
         checklength([x for x in inputs if isinstance(x, Content)], options)
     else:
         for x in inputs:
@@ -695,7 +695,7 @@ def apply_step(
                     if isinstance(x, Content):
                         if length is unset:
                             length = x.length
-                        elif backend.nplike.known_shape:
+                        elif backend.nplike.known_data:
                             assert length == x.length
                 assert length is not unset
 
@@ -770,7 +770,7 @@ def apply_step(
                     for x, p in zip(outcontent, parameters)
                 )
 
-            elif not backend.nplike.known_data or not backend.nplike.known_shape:
+            elif not backend.nplike.known_data or not backend.nplike.known_data:
                 offsets = None
                 nextinputs = []
                 for x in inputs:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -770,7 +770,7 @@ def apply_step(
                     for x, p in zip(outcontent, parameters)
                 )
 
-            elif not backend.nplike.known_data or not backend.nplike.known_data:
+            elif not backend.nplike.known_data:
                 offsets = None
                 nextinputs = []
                 for x in inputs:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -28,7 +28,7 @@ def common_nplike(nplikes: Collection[NumpyLike]) -> NumpyLike:
     else:
         # We allow typetracers to mix with other nplikes, and take precedence
         for nplike in nplikes:
-            if not (nplike.known_data and nplike.known_shape):
+            if not (nplike.known_data and nplike.known_data):
                 return nplike
 
         raise ak._errors.wrap_error(

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -28,7 +28,7 @@ def common_nplike(nplikes: Collection[NumpyLike]) -> NumpyLike:
     else:
         # We allow typetracers to mix with other nplikes, and take precedence
         for nplike in nplikes:
-            if not (nplike.known_data and nplike.known_data):
+            if not nplike.known_data:
                 return nplike
 
         raise ak._errors.wrap_error(

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -12,7 +12,6 @@ np = NumpyMetadata.instance()
 
 class ArrayModuleNumpyLike(NumpyLike):
     known_data: Final = True
-    known_shape: Final = True
 
     ############################ array creation
 

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -179,11 +179,6 @@ class NumpyLike(Singleton, Protocol):
 
     @property
     @abstractmethod
-    def known_shape(self) -> bool:
-        ...
-
-    @property
-    @abstractmethod
     def is_eager(self) -> bool:
         ...
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -586,7 +586,6 @@ def try_touch_shape(array):
 
 class TypeTracer(NumpyLike):
     known_data: Final = False
-    known_shape: Final = False
     is_eager: Final = True
 
     def _apply_ufunc(self, ufunc, *inputs):

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -93,7 +93,7 @@ def custom_str(current):
 def valuestr_horiz(data, limit_cols):
     if isinstance(data, (ak.highlevel.Array, ak.highlevel.Record)) and (
         not data.layout.backend.nplike.known_data
-        or not data.layout.backend.nplike.known_shape
+        or not data.layout.backend.nplike.known_data
     ):
         if isinstance(data, ak.highlevel.Array):
             return 5, "[...]"
@@ -232,7 +232,7 @@ def valuestr_horiz(data, limit_cols):
 def valuestr(data, limit_rows, limit_cols):
     if isinstance(data, (ak.highlevel.Array, ak.highlevel.Record)) and (
         not data.layout.backend.nplike.known_data
-        or not data.layout.backend.nplike.known_shape
+        or not data.layout.backend.nplike.known_data
     ):
         data.layout._touch_data(recursive=True)
         if isinstance(data, ak.highlevel.Array):

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -93,7 +93,6 @@ def custom_str(current):
 def valuestr_horiz(data, limit_cols):
     if isinstance(data, (ak.highlevel.Array, ak.highlevel.Record)) and (
         not data.layout.backend.nplike.known_data
-        or not data.layout.backend.nplike.known_data
     ):
         if isinstance(data, ak.highlevel.Array):
             return 5, "[...]"
@@ -232,7 +231,6 @@ def valuestr_horiz(data, limit_cols):
 def valuestr(data, limit_rows, limit_cols):
     if isinstance(data, (ak.highlevel.Array, ak.highlevel.Record)) and (
         not data.layout.backend.nplike.known_data
-        or not data.layout.backend.nplike.known_data
     ):
         data.layout._touch_data(recursive=True)
         if isinstance(data, ak.highlevel.Array):

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -439,7 +439,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         and isinstance(item.content, NumpyArray)
         and np.issubdtype(item.content.dtype, np.bool_)
     ):
-        if item_backend.nplike.known_data or item_backend.nplike.known_data:
+        if item_backend.nplike.known_data:
             item = item.to_ListOffsetArray64(True)
             localindex = ak._do.local_index(item, axis=1)
             nextcontent = localindex.content.data[item.content.data]
@@ -469,7 +469,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         and isinstance(item.content.content, NumpyArray)
         and np.issubdtype(item.content.content.dtype, np.bool_)
     ):
-        if item_backend.nplike.known_data or item_backend.nplike.known_data:
+        if item_backend.nplike.known_data:
             if isinstance(item_backend.nplike, Jax):
                 raise wrap_error("This slice is not supported for JAX differentiation.")
             # missing values as any integer other than -1 are extremely rare
@@ -537,7 +537,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         if isinstance(item.content, NumpyArray) and issubclass(
             item.content.dtype.type, (bool, np.bool_)
         ):
-            if item_backend.nplike.known_data or item_backend.nplike.known_data:
+            if item_backend.nplike.known_data:
                 if isinstance(item_backend.nplike, Jax):
                     raise wrap_error(
                         TypeError(

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -439,7 +439,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         and isinstance(item.content, NumpyArray)
         and np.issubdtype(item.content.dtype, np.bool_)
     ):
-        if item_backend.nplike.known_data or item_backend.nplike.known_shape:
+        if item_backend.nplike.known_data or item_backend.nplike.known_data:
             item = item.to_ListOffsetArray64(True)
             localindex = ak._do.local_index(item, axis=1)
             nextcontent = localindex.content.data[item.content.data]
@@ -469,7 +469,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         and isinstance(item.content.content, NumpyArray)
         and np.issubdtype(item.content.content.dtype, np.bool_)
     ):
-        if item_backend.nplike.known_data or item_backend.nplike.known_shape:
+        if item_backend.nplike.known_data or item_backend.nplike.known_data:
             if isinstance(item_backend.nplike, Jax):
                 raise wrap_error("This slice is not supported for JAX differentiation.")
             # missing values as any integer other than -1 are extremely rare
@@ -537,7 +537,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         if isinstance(item.content, NumpyArray) and issubclass(
             item.content.dtype.type, (bool, np.bool_)
         ):
-            if item_backend.nplike.known_data or item_backend.nplike.known_shape:
+            if item_backend.nplike.known_data or item_backend.nplike.known_data:
                 if isinstance(item_backend.nplike, Jax):
                     raise wrap_error(
                         TypeError(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -236,7 +236,7 @@ class BitMaskedArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._mask.data.touch_shape()
         if recursive:
             self._content._touch_shape(recursive)
@@ -388,7 +388,7 @@ class BitMaskedArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._backend.nplike.known_shape:
+        if not (0 <= where < self.length) and self._backend.nplike.known_data:
             raise ak._errors.index_error(self, where)
         if self._lsb_order:
             bit = bool(self._mask[where // 8] & (1 << (where % 8)))
@@ -607,7 +607,7 @@ class BitMaskedArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._backend.nplike.known_shape:
+        if self._backend.nplike.known_data:
             content = self._content[0 : self._length]
         else:
             content = self._content

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -178,7 +178,7 @@ class ByteMaskedArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._mask.data.touch_shape()
         if recursive:
             self._content._touch_shape(recursive)
@@ -259,7 +259,7 @@ class ByteMaskedArray(Content):
     def to_BitMaskedArray(self, valid_when, lsb_order):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)
-            if self._backend.nplike.known_shape:
+            if self._backend.nplike.known_data:
                 excess_length = int(math.ceil(self.length / 8.0))
             else:
                 excess_length = None
@@ -307,7 +307,7 @@ class ByteMaskedArray(Content):
 
         if where < 0:
             where += self.length
-        if self._backend.nplike.known_shape and not 0 <= where < self.length:
+        if self._backend.nplike.known_data and not 0 <= where < self.length:
             raise ak._errors.index_error(self, where)
         if self._mask[where] == self._valid_when:
             return self._content._getitem_at(where)
@@ -315,7 +315,7 @@ class ByteMaskedArray(Content):
             return None
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -413,8 +413,8 @@ class ByteMaskedArray(Content):
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
         if (
-            slicestarts.nplike.known_shape
-            and self._backend.nplike.known_shape
+            slicestarts.nplike.known_data
+            and self._backend.nplike.known_data
             and slicestarts.length != self.length
         ):
             raise ak._errors.index_error(
@@ -520,7 +520,7 @@ class ByteMaskedArray(Content):
         numnull = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
 
         if mask is not None:
-            if self._backend.nplike.known_shape and mask_length != mask.length:
+            if self._backend.nplike.known_data and mask_length != mask.length:
                 raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
@@ -930,7 +930,7 @@ class ByteMaskedArray(Content):
             return ak.contents.ListOffsetArray(outoffsets, tmp, parameters=None)
 
     def _validity_error(self, path):
-        if self._backend.nplike.known_shape and self._content.length < self.mask.length:
+        if self._backend.nplike.known_data and self._content.length < self.mask.length:
             return f"at {path} ({type(self)!r}): len(content) < len(mask)"
         else:
             return self._content._validity_error(path + ".content")
@@ -1001,7 +1001,7 @@ class ByteMaskedArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._backend.nplike.known_shape:
+        if self._backend.nplike.known_data:
             content = self._content[0 : self._mask.length]
         else:
             content = self._content

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -411,7 +411,7 @@ class Content:
 
         index = Index64(head._index, nplike=self._backend.index_nplike)
         content = that._getitem_at(0)
-        if self._backend.nplike.known_shape and content.length < index.length:
+        if self._backend.nplike.known_data and content.length < index.length:
             raise ak._errors.index_error(
                 self,
                 head,
@@ -474,7 +474,7 @@ class Content:
             )
 
         if isinstance(head.content, ak.contents.ListOffsetArray):
-            if self._backend.nplike.known_shape and self.length != 1:
+            if self._backend.nplike.known_data and self.length != 1:
                 raise ak._errors.wrap_error(
                     NotImplementedError("reached a not-well-considered code path")
                 )
@@ -903,7 +903,7 @@ class Content:
                 ak.contents.IndexedArray.simplified(ptr, self, parameters=None)
             )
             length = contents[-1].length
-        assert not (length is ak._util.unset and self._backend.nplike.known_shape)
+        assert not (length is ak._util.unset and self._backend.nplike.known_data)
         return ak.contents.RecordArray(
             contents, recordlookup, length, parameters=parameters, backend=self._backend
         )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -137,7 +137,7 @@ class EmptyArray(Content):
     def _carry(self, carry: Index, allow_lazy: bool) -> EmptyArray:
         assert isinstance(carry, ak.index.Index)
 
-        if not carry.nplike.known_shape or carry.length == 0:
+        if not carry.nplike.known_data or carry.length == 0:
             return self
         else:
             raise ak._errors.index_error(self, carry.data, "array is empty")
@@ -179,7 +179,7 @@ class EmptyArray(Content):
             return self._getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
-            if not head.nplike.known_shape or head.length == 0:
+            if not head.nplike.known_data or head.length == 0:
                 return self
             else:
                 raise ak._errors.index_error(self, head.data, "array is empty")

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1009,10 +1009,7 @@ class IndexedArray(Content):
             )
             content = self._content[indexmin : npindex.max() + 1]
         else:
-            if (
-                not self._backend.nplike.known_data
-                or not self._backend.nplike.known_data
-            ):
+            if not self._backend.nplike.known_data:
                 self._touch_data(recursive=False)
             index, content = self._index, self._content
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -177,7 +177,7 @@ class IndexedArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._index.data.touch_shape()
         if recursive:
             self._content._touch_shape(recursive)
@@ -222,12 +222,12 @@ class IndexedArray(Content):
 
         if where < 0:
             where += self.length
-        if self._backend.nplike.known_shape and not 0 <= where < self.length:
+        if self._backend.nplike.known_data and not 0 <= where < self.length:
             raise ak._errors.index_error(self, where)
         return self._content._getitem_at(self._index[where])
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -266,7 +266,7 @@ class IndexedArray(Content):
         return IndexedArray(nextindex, self._content, parameters=self._parameters)
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
-        if self._backend.nplike.known_shape and slicestarts.length != self.length:
+        if self._backend.nplike.known_data and slicestarts.length != self.length:
             raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
@@ -362,7 +362,7 @@ class IndexedArray(Content):
 
     def project(self, mask=None):
         if mask is not None:
-            if self._backend.nplike.known_shape and self._index.length != mask.length:
+            if self._backend.nplike.known_data and self._index.length != mask.length:
                 raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
@@ -627,7 +627,7 @@ class IndexedArray(Content):
             return reversed._mergemany(tail[1:])
 
     def _fill_none(self, value: Content) -> Content:
-        if value.backend.nplike.known_shape and value.length != 1:
+        if value.backend.nplike.known_data and value.length != 1:
             raise ak._errors.wrap_error(
                 ValueError(f"fill_none value length ({value.length}) is not equal to 1")
             )
@@ -998,7 +998,7 @@ class IndexedArray(Content):
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
-            self._backend.nplike.known_shape
+            self._backend.nplike.known_data
             and self._backend.nplike.known_data
             and self._index.length != 0
         ):
@@ -1010,7 +1010,7 @@ class IndexedArray(Content):
             content = self._content[indexmin : npindex.max() + 1]
         else:
             if (
-                not self._backend.nplike.known_shape
+                not self._backend.nplike.known_data
                 or not self._backend.nplike.known_data
             ):
                 self._touch_data(recursive=False)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1586,10 +1586,7 @@ class IndexedOptionArray(Content):
             else:
                 index, content = self._index, self._content
         else:
-            if (
-                not self._backend.nplike.known_data
-                or not self._backend.nplike.known_data
-            ):
+            if not self._backend.nplike.known_data:
                 self._touch_data(recursive=False)
             index, content = self._index, self._content
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -164,7 +164,7 @@ class IndexedOptionArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._index.data.touch_shape()
         if recursive:
             self._content._touch_shape(recursive)
@@ -242,7 +242,7 @@ class IndexedOptionArray(Content):
 
         if where < 0:
             where += self.length
-        if self._backend.nplike.known_shape and not 0 <= where < self.length:
+        if self._backend.nplike.known_data and not 0 <= where < self.length:
             raise ak._errors.index_error(self, where)
         if self._index[where] < 0:
             return None
@@ -250,7 +250,7 @@ class IndexedOptionArray(Content):
             return self._content._getitem_at(self._index[where])
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -342,7 +342,7 @@ class IndexedOptionArray(Content):
         slicestarts = slicestarts.to_nplike(self._backend.index_nplike)
         slicestops = slicestops.to_nplike(self._backend.index_nplike)
 
-        if self._backend.nplike.known_shape and slicestarts.length != self.length:
+        if self._backend.nplike.known_data and slicestarts.length != self.length:
             raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
@@ -442,7 +442,7 @@ class IndexedOptionArray(Content):
 
     def project(self, mask=None):
         if mask is not None:
-            if self._backend.nplike.known_shape and self._index.length != mask.length:
+            if self._backend.nplike.known_data and self._index.length != mask.length:
                 raise ak._errors.wrap_error(
                     ValueError(
                         "mask length ({}) is not equal to {} length ({})".format(
@@ -769,7 +769,7 @@ class IndexedOptionArray(Content):
             return reversed._mergemany(tail[1:])
 
     def _fill_none(self, value: Content) -> Content:
-        if value.backend.nplike.known_shape and value.length != 1:
+        if value.backend.nplike.known_data and value.length != 1:
             raise ak._errors.wrap_error(
                 ValueError(f"fill_none value length ({value.length}) is not equal to 1")
             )
@@ -1571,7 +1571,7 @@ class IndexedOptionArray(Content):
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
-            self._backend.nplike.known_shape
+            self._backend.nplike.known_data
             and self._backend.nplike.known_data
             and self._index.length != 0
         ):
@@ -1587,7 +1587,7 @@ class IndexedOptionArray(Content):
                 index, content = self._index, self._content
         else:
             if (
-                not self._backend.nplike.known_shape
+                not self._backend.nplike.known_data
                 or not self._backend.nplike.known_data
             ):
                 self._touch_data(recursive=False)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -54,8 +54,8 @@ class ListArray(Content):
                 )
             )
         if (
-            starts.nplike.known_shape
-            and stops.nplike.known_shape
+            starts.nplike.known_data
+            and stops.nplike.known_data
             and starts.length > stops.length
         ):
             raise ak._errors.wrap_error(
@@ -170,7 +170,7 @@ class ListArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._starts.data.touch_shape()
             self._stops.data.touch_shape()
         if recursive:
@@ -242,13 +242,13 @@ class ListArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._backend.nplike.known_shape:
+        if not (0 <= where < self.length) and self._backend.nplike.known_data:
             raise ak._errors.index_error(self, where)
         start, stop = self._starts[where], self._stops[where]
         return self._content._getitem_range(slice(start, stop))
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -326,7 +326,7 @@ class ListArray(Content):
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):
         slicestarts = slicestarts.to_nplike(self._backend.index_nplike)
         slicestops = slicestops.to_nplike(self._backend.index_nplike)
-        if self._backend.nplike.known_shape and slicestarts.length != self.length:
+        if self._backend.nplike.known_data and slicestarts.length != self.length:
             raise ak._errors.index_error(
                 self,
                 ak.contents.ListArray(
@@ -454,7 +454,7 @@ class ListArray(Content):
 
         elif isinstance(slicecontent, ak.contents.IndexedOptionArray):
             if (
-                self._backend.nplike.known_shape
+                self._backend.nplike.known_data
                 and self._starts.length < slicestarts.length
             ):
                 raise ak._errors.index_error(
@@ -637,7 +637,7 @@ class ListArray(Content):
             start = ak._util.kSliceNone if start is None else start
             stop = ak._util.kSliceNone if stop is None else stop
 
-            if self._backend.nplike.known_shape:
+            if self._backend.nplike.known_data:
                 carrylength = ak.index.Index64.empty(1, self._backend.index_nplike)
                 assert (
                     carrylength.nplike is self._backend.index_nplike
@@ -719,7 +719,7 @@ class ListArray(Content):
                     parameters=self._parameters,
                 )
             else:
-                if self._backend.nplike.known_shape:
+                if self._backend.nplike.known_data:
                     total = ak.index.Index64.empty(1, self._backend.index_nplike)
                     assert (
                         total.nplike is self._backend.index_nplike
@@ -1237,7 +1237,7 @@ class ListArray(Content):
         )
 
     def _validity_error(self, path):
-        if self._backend.nplike.known_shape and self.stops.length < self.starts.length:
+        if self._backend.nplike.known_data and self.stops.length < self.starts.length:
             return f"at {path} ({type(self)!r}): len(stops) < len(starts)"
         assert (
             self.starts.nplike is self._backend.index_nplike
@@ -1403,7 +1403,7 @@ class ListArray(Content):
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
         if (
-            self._backend.nplike.known_shape
+            self._backend.nplike.known_data
             and self._backend.nplike.known_data
             and self._starts.length != 0
         ):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -150,7 +150,7 @@ class ListOffsetArray(Content):
             self._content._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._offsets.data.touch_shape()
         if recursive:
             self._content._touch_shape(recursive)
@@ -239,13 +239,13 @@ class ListOffsetArray(Content):
 
         if where < 0:
             where += self.length
-        if not (0 <= where < self.length) and self._backend.nplike.known_shape:
+        if not (0 <= where < self.length) and self._backend.nplike.known_data:
             raise ak._errors.index_error(self, where)
         start, stop = self._offsets[where], self._offsets[where + 1]
         return self._content._getitem_range(slice(start, stop))
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -315,7 +315,7 @@ class ListOffsetArray(Content):
                 )
             )
 
-        if offsets.nplike.known_shape and offsets.length - 1 != self.length:
+        if offsets.nplike.known_data and offsets.length - 1 != self.length:
             raise ak._errors.wrap_error(
                 AssertionError(
                     "cannot broadcast {} of length {} to length {}".format(
@@ -887,7 +887,7 @@ class ListOffsetArray(Content):
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
-            if self._backend.nplike.known_shape and parents.nplike.known_shape:
+            if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
 
             (
@@ -1038,7 +1038,7 @@ class ListOffsetArray(Content):
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
-            if self._backend.nplike.known_shape and parents.nplike.known_shape:
+            if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
 
             (
@@ -1225,7 +1225,7 @@ class ListOffsetArray(Content):
                     np.AxisError("array with strings can only be sorted with axis=-1")
                 )
 
-            if self._backend.nplike.known_shape and parents.nplike.known_shape:
+            if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
 
             (
@@ -2032,7 +2032,7 @@ class ListOffsetArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._backend.nplike.known_shape and self._backend.nplike.known_data:
+        if self._backend.nplike.known_data:
             offsetsmin = self._offsets[0]
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.index_nplike

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -141,7 +141,7 @@ class NumpyArray(Content):
             self._data.touch_data()
 
     def _touch_shape(self, recursive):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._data.touch_shape()
 
     @property
@@ -234,7 +234,7 @@ class NumpyArray(Content):
             return out
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -78,7 +78,7 @@ class RecordArray(Content):
             backend = ak._backends.NumpyBackend.instance()
 
         # TODO: remove me in future version
-        if length is None and backend.nplike.known_shape:
+        if length is None and backend.nplike.known_data:
             length = unset
 
         if length is unset:
@@ -91,7 +91,7 @@ class RecordArray(Content):
                     )
                 )
 
-            if backend.nplike.known_shape:
+            if backend.nplike.known_data:
                 for content in contents:
                     assert content.length is not None
                     # First time we're setting length, and content.length is not None
@@ -328,7 +328,7 @@ class RecordArray(Content):
         return self._getitem_range(slice(0, 0))
 
     def _getitem_at(self, where: SupportsIndex):
-        if self._backend.nplike.known_shape and where < 0:
+        if self._backend.nplike.known_data and where < 0:
             where += self.length
 
         if not (self._length is None or (0 <= where < self._length)):
@@ -336,7 +336,7 @@ class RecordArray(Content):
         return Record(self, where)
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -521,7 +521,7 @@ class RecordArray(Content):
             for content in self._contents:
                 trimmed = content._getitem_range(slice(0, self.length))
                 offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
-                if self._backend.nplike.known_shape and offsets.length != 0:
+                if self._backend.nplike.known_data and offsets.length != 0:
                     raise ak._errors.wrap_error(
                         AssertionError(
                             "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -956,7 +956,7 @@ class RecordArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._backend.nplike.known_shape:
+        if self._backend.nplike.known_data:
             contents = [x[: self._length] for x in self._contents]
         else:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -35,7 +35,7 @@ class RegularArray(Content):
                 )
             )
         if size is None:
-            if content.backend.index_nplike.known_shape:
+            if content.backend.index_nplike.known_data:
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'size' must be a non-negative integer for backends with known shapes, not None".format(
@@ -54,7 +54,7 @@ class RegularArray(Content):
                 )
 
         if zeros_length is None:
-            if content.backend.index_nplike.known_shape:
+            if content.backend.index_nplike.known_data:
                 raise ak._errors.wrap_error(
                     TypeError(
                         "{} 'zeros_length' must be a non-negative integer for backends with known shapes, not None".format(
@@ -219,7 +219,7 @@ class RegularArray(Content):
         return self._content._getitem_range(slice(0, 0))
 
     def _getitem_at(self, where: SupportsIndex):
-        if self._backend.nplike.known_shape and where < 0:
+        if self._backend.nplike.known_data and where < 0:
             where += self._length
 
         if not (self._length is None or 0 <= where < self._length):
@@ -228,7 +228,7 @@ class RegularArray(Content):
         return self._content._getitem_range(slice(start, stop))
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -338,7 +338,7 @@ class RegularArray(Content):
                 )
             )
 
-        if offsets.nplike.known_shape and offsets.length - 1 != self._length:
+        if offsets.nplike.known_data and offsets.length - 1 != self._length:
             raise ak._errors.wrap_error(
                 AssertionError(
                     "cannot broadcast RegularArray of length {} to length {}".format(
@@ -610,7 +610,7 @@ class RegularArray(Content):
                     "cannot mix jagged slice with NumPy-style advanced indexing",
                 )
 
-            if self._backend.nplike.known_shape and head.length != self._size:
+            if self._backend.nplike.known_data and head.length != self._size:
                 raise ak._errors.index_error(
                     self,
                     head,
@@ -1181,16 +1181,14 @@ class RegularArray(Content):
         # ShapeItem is a defined type, but some nplikes don't map onto the entire space; e.g.
         # NumPy never has `None` shape items. We require that if a shape-item is used between nplikes
         # they both be the same "known-shape-ness".
-        assert (
-            self._backend.index_nplike.known_shape == self._backend.nplike.known_shape
-        )
+        assert self._backend.index_nplike.known_data == self._backend.nplike.known_data
         length = self._backend.index_nplike.mul_shape_item(self._length, self._size)
         return self._backend.nplike.reshape(
             out[: self._backend.nplike.shape_item_as_scalar(length)], shape
         )
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        assert self._backend.nplike.known_data and self._backend.nplike.known_shape
+        assert self._backend.nplike.known_data
 
         if self.parameter("__array__") == "string":
             return self.to_ListOffsetArray64(False)._to_arrow(
@@ -1276,7 +1274,7 @@ class RegularArray(Content):
                 action, behavior, depth, depth_context, lateral_context, options
             )
 
-        if self._backend.nplike.known_shape:
+        if self._backend.nplike.known_data:
             content = self._content[: self._length * self._size]
         else:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -203,7 +203,7 @@ class UnionArray(Content):
                     )
                 )
 
-        if backend.nplike.known_shape and self_index.length < self_tags.length:
+        if backend.nplike.known_data and self_index.length < self_tags.length:
             raise ak._errors.wrap_error(
                 ValueError("invalid UnionArray: len(index) < len(tags)")
             )
@@ -423,7 +423,7 @@ class UnionArray(Content):
                 x._touch_data(recursive)
 
     def _touch_shape(self, recursive):
-        if not self._backend.index_nplike.known_shape:
+        if not self._backend.index_nplike.known_data:
             self._tags.data.touch_shape()
             self._index.data.touch_shape()
         if recursive:
@@ -465,13 +465,13 @@ class UnionArray(Content):
 
         if where < 0:
             where += self.length
-        if self._backend.nplike.known_shape and not 0 <= where < self.length:
+        if self._backend.nplike.known_data and not 0 <= where < self.length:
             raise ak._errors.index_error(self, where)
         tag, index = self._tags[where], self._index[where]
         return self._contents[tag]._getitem_at(index)
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
@@ -1298,16 +1298,13 @@ class UnionArray(Content):
 
     def _validity_error(self, path):
         for i in range(len(self.contents)):
-            if (
-                self._backend.nplike.known_shape
-                and self.index.length < self.tags.length
-            ):
+            if self._backend.nplike.known_data and self.index.length < self.tags.length:
                 return f"at {path} ({type(self)!r}): len(index) < len(tags)"
 
             lencontents = self._backend.index_nplike.empty(
                 len(self.contents), dtype=np.int64
             )
-            if self._backend.nplike.known_shape:
+            if self._backend.nplike.known_data:
                 for i in range(len(self.contents)):
                     lencontents[i] = self.contents[i].length
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -185,7 +185,7 @@ class UnmaskedArray(Content):
         return self._content._getitem_at(where)
 
     def _getitem_range(self, where):
-        if not self._backend.nplike.known_shape:
+        if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1193,7 +1193,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         typestr = repr(str(self.type))[1:-1]
         if (
-            self._layout.backend.nplike.known_shape
+            self._layout.backend.nplike.known_data
             and self._layout.backend.nplike.known_data
         ):
             valuestr = ""
@@ -1932,7 +1932,7 @@ class Record(NDArrayOperatorsMixin):
 
         typestr = repr(str(self.type))[1:-1]
         if (
-            self._layout.array.backend.nplike.known_shape
+            self._layout.array.backend.nplike.known_data
             and self._layout.array.backend.nplike.known_data
         ):
             valuestr = ""

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1928,10 +1928,7 @@ class Record(NDArrayOperatorsMixin):
         pytype = type(self).__name__
 
         typestr = repr(str(self.type))[1:-1]
-        if (
-            self._layout.array.backend.nplike.known_data
-            and self._layout.array.backend.nplike.known_data
-        ):
+        if self._layout.array.backend.nplike.known_data:
             valuestr = ""
         else:
             valuestr = "-typetracer"

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1192,10 +1192,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             pytype = type(self).__name__
 
         typestr = repr(str(self.type))[1:-1]
-        if (
-            self._layout.backend.nplike.known_data
-            and self._layout.backend.nplike.known_data
-        ):
+        if self._layout.backend.nplike.known_data:
             valuestr = ""
         else:
             valuestr = "-typetracer"


### PR DESCRIPTION
We've discussed this before; there is a distinction to be made between known shapes and known lengths, but there is currently no use for any variant besides `known_shape = known_data = True/False`. Given that we have no way to test the isolation of this logic, it's better that we remove it. 

Note that `known_shape` just means "this shape cannot contain unknown components`. `known_data`, meanwhile, used to mean "these data are totally unknown". 

Now `known_data` means "this shape might contain unknown components, and the data aren't known".