### PR TITLE
feat!: re-introduce `unknown-length`

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -11,7 +11,8 @@ from collections.abc import Sequence
 import awkward as ak
 from awkward._nplikes import nplike_of
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
 from awkward.contents.bytemaskedarray import ByteMaskedArray

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -275,11 +275,11 @@ def merge_as_union(one: Content, two: Content) -> ak.contents.UnionArray:
     mylength = one.length
     theirlength = two.length
     tags = ak.index.Index8.empty(
-        one.backend.index_nplike.add_shape_item(mylength, theirlength),
+        mylength + theirlength,
         one.backend.index_nplike,
     )
     index = ak.index.Index64.empty(
-        one.backend.index_nplike.add_shape_item(mylength, theirlength),
+        mylength + theirlength,
         one.backend.index_nplike,
     )
     contents = [one, two]

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 import numpy
 
 import awkward as ak
-from awkward._nplikes.numpylike import ArrayLike, NumpyLike, NumpyMetadata, ShapeItem
+from awkward._nplikes.numpylike import (
+    ArrayLike,
+    NumpyLike,
+    NumpyMetadata,
+    ShapeItem,
+    unknown_length,
+)
 from awkward.typing import Final, Literal, SupportsInt
 
 np = NumpyMetadata.instance()
@@ -129,8 +135,8 @@ class ArrayModuleNumpyLike(NumpyLike):
         else:
             return result
 
-    def shape_item_as_scalar(self, x1: ShapeItem):
-        if x1 is None:
+    def shape_item_as_index(self, x1: ShapeItem) -> int | ArrayLike:
+        if x1 is unknown_length:
             raise ak._errors.wrap_error(
                 TypeError("array module nplikes do not support unknown lengths")
             )
@@ -141,11 +147,8 @@ class ArrayModuleNumpyLike(NumpyLike):
                 TypeError(f"expected None or int type, received {x1}")
             )
 
-    def scalar_as_shape_item(self, x1) -> ShapeItem:
-        if x1 is None:
-            return None
-        else:
-            return int(x1)
+    def index_as_shape_item(self, x1: int | ArrayLike) -> ShapeItem:
+        return int(x1)
 
     def add_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
         assert x1 >= 0

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -8,9 +8,8 @@ from awkward._nplikes.numpylike import (
     ArrayLike,
     NumpyLike,
     NumpyMetadata,
-    ShapeItem,
-    unknown_length,
 )
+from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward.typing import Final, Literal, SupportsInt
 
 np = NumpyMetadata.instance()

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -150,30 +150,6 @@ class ArrayModuleNumpyLike(NumpyLike):
     def index_as_shape_item(self, x1: int | ArrayLike) -> ShapeItem:
         return int(x1)
 
-    def add_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        assert x1 >= 0
-        assert x2 >= 0
-        return x1 + x2
-
-    def sub_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 - x2
-        assert result >= 0
-        return result
-
-    def mul_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        assert x1 >= 0
-        assert x2 >= 0
-        return x1 * x2
-
-    def div_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 // x2
-        assert result * x2 == x1
-        return result
-
     def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
         return self._module.nonzero(x)
 

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -5,118 +5,16 @@ from abc import abstractmethod
 
 import numpy
 
+from awkward._nplikes.shape import ShapeItem
 from awkward._singleton import Singleton
 from awkward.typing import (
     Literal,
     Protocol,
     Self,
     SupportsIndex,
-    SupportsInt,  # noqa: F401
-    TypeAlias,
+    # noqa: F401
     overload,
 )
-
-ShapeItem: TypeAlias = "SupportsInt | _UnknownLength"
-
-
-class _UnknownLength:
-    _name: str
-
-    @classmethod
-    def _new(cls, name: str):
-        self = super().__new__(cls)
-        self._name = name
-        return self
-
-    def __new__(cls, *args, **kwargs):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError(
-                "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
-            )
-        )
-
-    def __add__(self, other) -> Self | NotImplemented:
-        if isinstance(other, int) or other is self:
-            return self
-        else:
-            return NotImplemented
-
-    __radd__ = __add__
-    __iadd__ = __add__
-
-    def __sub__(self, other) -> Self | NotImplemented:
-        if isinstance(other, int) or other is self:
-            return self
-        else:
-            return NotImplemented
-
-    __rsub__ = __sub__
-    __isub__ = __sub__
-
-    def __mul__(self, other) -> Self | NotImplemented:
-        if isinstance(other, int) or other is self:
-            return self
-        else:
-            return NotImplemented
-
-    __rmul__ = __mul__
-    __imul__ = __mul__
-
-    def __floordiv__(self, other) -> Self | NotImplemented:
-        if isinstance(other, int) or other is self:
-            return self
-        else:
-            return NotImplemented
-
-    __rfloordiv__ = __floordiv__
-    __ifloordiv__ = __floordiv__
-
-    def __str__(self) -> str:
-        return "##"
-
-    def __repr__(self):
-        return f"{__name__}.{self._name}"
-
-    def __eq__(self, other):
-        from awkward._errors import wrap_error
-
-        if other is self:
-            return True
-        else:
-            raise wrap_error(
-                TypeError("cannot compare unknown lengths against known values")
-            )
-
-    def __gt__(self, other):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(TypeError("cannot order unknown lengths"))
-
-    def __index__(self):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError("cannot interpret unknown lengths as concrete index values")
-        )
-
-    def __int__(self):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError("cannot interpret unknown lengths as concrete values")
-        )
-
-    __bool__ = __int__
-    __float__ = __int__
-
-    __ge__ = __gt__
-    __le__ = __gt__
-    __lt__ = __gt__
-
-
-unknown_length = _UnknownLength._new("unknown_length")
 
 
 class ArrayLike(Protocol):

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -16,7 +16,107 @@ from awkward.typing import (
     overload,
 )
 
-ShapeItem: TypeAlias = "SupportsInt | None"
+ShapeItem: TypeAlias = "SupportsInt | _UnknownLength"
+
+
+class _UnknownLength:
+    _name: str
+
+    @classmethod
+    def _new(cls, name: str):
+        self = super().__new__(cls)
+        self._name = name
+        return self
+
+    def __new__(cls, *args, **kwargs):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError(
+                "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
+            )
+        )
+
+    def __add__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __radd__ = __add__
+    __iadd__ = __add__
+
+    def __sub__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rsub__ = __sub__
+    __isub__ = __sub__
+
+    def __mul__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rmul__ = __mul__
+    __imul__ = __mul__
+
+    def __floordiv__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rfloordiv__ = __floordiv__
+    __ifloordiv__ = __floordiv__
+
+    def __str__(self) -> str:
+        return "##"
+
+    def __repr__(self):
+        return f"{__name__}.{self._name}"
+
+    def __eq__(self, other):
+        from awkward._errors import wrap_error
+
+        if other is self:
+            return True
+        else:
+            raise wrap_error(
+                TypeError("cannot compare unknown lengths against known values")
+            )
+
+    def __gt__(self, other):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(TypeError("cannot order unknown lengths"))
+
+    def __index__(self):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError("cannot interpret unknown lengths as concrete index values")
+        )
+
+    def __int__(self):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError("cannot interpret unknown lengths as concrete values")
+        )
+
+    __bool__ = __int__
+    __float__ = __int__
+
+    __ge__ = __gt__
+    __le__ = __gt__
+    __lt__ = __gt__
+
+
+unknown_length = _UnknownLength._new("unknown_length")
 
 
 class ArrayLike(Protocol):
@@ -297,11 +397,11 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
-    def shape_item_as_scalar(self, x1: ShapeItem):
+    def shape_item_as_index(self, x1: ShapeItem):
         ...
 
     @abstractmethod
-    def scalar_as_shape_item(self, x1) -> ShapeItem:
+    def index_as_shape_item(self, x1) -> ShapeItem:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -405,22 +405,6 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
-    def sub_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        ...
-
-    @abstractmethod
-    def add_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        ...
-
-    @abstractmethod
-    def mul_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        ...
-
-    @abstractmethod
-    def div_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        ...
-
-    @abstractmethod
     def reshape(
         self, x: ArrayLike, shape: tuple[int, ...], *, copy: bool | None = None
     ) -> ArrayLike:

--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -85,7 +85,7 @@ class _UnknownLength:
 
         raise wrap_error(TypeError("cannot order unknown lengths"))
 
-    def __index__(self):
+    def __index__(self):  # pylint: disable=invalid-index-returned
         from awkward._errors import wrap_error
 
         raise wrap_error(

--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -1,0 +1,110 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+from awkward.typing import (
+    Self,
+    SupportsInt,  # noqa: F401
+    TypeAlias,
+)
+
+ShapeItem: TypeAlias = "SupportsInt | _UnknownLength"
+
+
+class _UnknownLength:
+    _name: str
+
+    @classmethod
+    def _new(cls, name: str) -> Self:
+        self = super().__new__(cls)
+        self._name = name
+        return self
+
+    def __new__(cls, *args, **kwargs):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError(
+                "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
+            )
+        )
+
+    def __add__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __radd__ = __add__
+    __iadd__ = __add__
+
+    def __sub__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rsub__ = __sub__
+    __isub__ = __sub__
+
+    def __mul__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rmul__ = __mul__
+    __imul__ = __mul__
+
+    def __floordiv__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rfloordiv__ = __floordiv__
+    __ifloordiv__ = __floordiv__
+
+    def __str__(self) -> str:
+        return "##"
+
+    def __repr__(self):
+        return f"{__name__}.{self._name}"
+
+    def __eq__(self, other) -> bool:
+        from awkward._errors import wrap_error
+
+        if other is self:
+            return True
+        else:
+            raise wrap_error(
+                TypeError("cannot compare unknown lengths against known values")
+            )
+
+    def __gt__(self, other):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(TypeError("cannot order unknown lengths"))
+
+    def __index__(self):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError("cannot interpret unknown lengths as concrete index values")
+        )
+
+    def __int__(self):
+        from awkward._errors import wrap_error
+
+        raise wrap_error(
+            TypeError("cannot interpret unknown lengths as concrete values")
+        )
+
+    __bool__ = __int__
+    __float__ = __int__
+
+    __ge__ = __gt__
+    __le__ = __gt__
+    __lt__ = __gt__
+
+
+unknown_length = _UnknownLength._new("unknown_length")

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -7,7 +7,13 @@ import numpy
 
 import awkward as ak
 from awkward._errors import wrap_error
-from awkward._nplikes.numpylike import ArrayLike, NumpyLike, NumpyMetadata, ShapeItem
+from awkward._nplikes.numpylike import (
+    ArrayLike,
+    NumpyLike,
+    NumpyMetadata,
+    ShapeItem,
+    unknown_length,
+)
 from awkward._util import NDArrayOperatorsMixin, is_non_string_like_sequence
 from awkward.typing import (
     Any,
@@ -23,7 +29,7 @@ np = NumpyMetadata.instance()
 
 
 def is_unknown_length(array: Any) -> bool:
-    return array is None
+    return array is unknown_length
 
 
 def is_unknown_scalar(array: Any) -> bool:
@@ -280,7 +286,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
             if ak._util.is_integer(item):
                 size *= item
             else:
-                return None
+                return unknown_length
         return size
 
     @property
@@ -351,7 +357,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     def forget_length(self) -> Self:
         return self._new(
             self._dtype,
-            (None,) + self._shape[1:],
+            (unknown_length,) + self._shape[1:],
             self._form_key,
             self._report,
         )
@@ -389,12 +395,12 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     def _resolve_slice_length(self, length, slice_):
-        if length is None:
-            return None
+        if length is unknown_length:
+            return unknown_length
         elif any(
             is_unknown_scalar(x) for x in (slice_.start, slice_.stop, slice_.step)
         ):
-            return None
+            return unknown_length
         else:
             start, stop, step = slice_.indices(length)
             return min((stop - start) // step, length)
@@ -764,7 +770,7 @@ class TypeTracer(NumpyLike):
         ):
             length = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
         else:
-            length = None
+            length = unknown_length
 
         default_int_type = np.int64 if (ak._util.win or ak._util.bits32) else np.int32
         return TypeTracerArray._new(dtype or default_int_type, (length,))
@@ -810,27 +816,25 @@ class TypeTracer(NumpyLike):
         else:
             raise wrap_error(TypeError(f"expected scalar type, received {obj}"))
 
-    def shape_item_as_scalar(self, x1: ShapeItem) -> TypeTracerArray:
-        if x1 is None:
+    def shape_item_as_index(self, x1: ShapeItem) -> int | TypeTracerArray:
+        if x1 is unknown_length:
             return TypeTracerArray._new(np.int64, shape=())
         elif isinstance(x1, int):
-            return TypeTracerArray._new(np.int64, shape=())
+            return x1
         else:
             raise wrap_error(TypeError(f"expected None or int type, received {x1}"))
 
-    def scalar_as_shape_item(self, x1) -> ShapeItem:
-        if x1 is None:
-            return None
-        elif is_unknown_scalar(x1) and np.issubdtype(x1.dtype, np.integer):
-            return None
+    def index_as_shape_item(self, x1: int | ArrayLike) -> ShapeItem:
+        if is_unknown_scalar(x1) and np.issubdtype(x1.dtype, np.integer):
+            return unknown_length
         else:
             return int(x1)
 
     def sub_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is None:
-            return None
-        if x2 is None:
-            return None
+        if x1 is unknown_length:
+            return unknown_length
+        if x2 is unknown_length:
+            return unknown_length
         assert x1 >= 0
         assert x2 >= 0
         result = x1 - x2
@@ -838,30 +842,30 @@ class TypeTracer(NumpyLike):
         return result
 
     def add_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is None:
-            return None
-        if x2 is None:
-            return None
+        if x1 is unknown_length:
+            return unknown_length
+        if x2 is unknown_length:
+            return unknown_length
         assert x1 >= 0
         assert x2 >= 0
         result = x1 + x2
         return result
 
     def mul_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is None:
-            return None
-        if x2 is None:
-            return None
+        if x1 is unknown_length:
+            return unknown_length
+        if x2 is unknown_length:
+            return unknown_length
         assert x1 >= 0
         assert x2 >= 0
         result = x1 * x2
         return result
 
     def div_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is None:
-            return None
-        if x2 is None:
-            return None
+        if x1 is unknown_length:
+            return unknown_length
+        if x2 is unknown_length:
+            return unknown_length
         assert x1 >= 0
         assert x2 >= 0
         result = x1 // x2
@@ -884,10 +888,10 @@ class TypeTracer(NumpyLike):
             # Fail if we absolutely know the shapes aren't compatible
             for i, item in enumerate(shape):
                 # Item is unknown, take it
-                if is_unknown_scalar(item):
+                if is_unknown_length(item):
                     result[i] = item
                 # Existing item is unknown, keep it
-                elif is_unknown_scalar(result[i]):
+                elif is_unknown_length(result[i]):
                     continue
                 # Items match, continue
                 elif result[i] == item:
@@ -940,9 +944,9 @@ class TypeTracer(NumpyLike):
         n_placeholders = 0
         new_size = 1
         for item in shape:
-            if item is None:
+            if item is unknown_length:
                 # Size is no longer defined
-                new_size = None
+                new_size = unknown_length
             elif not ak._util.is_integer(item):
                 raise wrap_error(
                     ValueError(
@@ -958,13 +962,13 @@ class TypeTracer(NumpyLike):
             elif item == 0:
                 raise wrap_error(ValueError("shape items cannot be zero"))
             else:
-                new_size = self.mul_shape_item(new_size, item)
+                new_size *= item
 
         # Populate placeholders
         new_shape = [*shape]
         for i, item in enumerate(shape):
             if item == -1:
-                new_shape[i] = self.div_shape_item(size, new_size)
+                new_shape[i] = size // new_size
                 break
 
         return TypeTracerArray._new(x.dtype, tuple(new_shape), x.form_key, x.report)
@@ -982,7 +986,7 @@ class TypeTracer(NumpyLike):
     def nonzero(self, x: ArrayLike) -> tuple[TypeTracerArray, ...]:
         # array
         try_touch_data(x)
-        return (TypeTracerArray._new(np.int64, (None,)),) * len(x.shape)
+        return (TypeTracerArray._new(np.int64, (unknown_length,)),) * len(x.shape)
 
     def unique_values(self, x: ArrayLike) -> TypeTracerArray:
         try_touch_data(x)
@@ -1017,7 +1021,7 @@ class TypeTracer(NumpyLike):
             )
 
         return TypeTracerArray._new(
-            numpy.concatenate(emptyarrays).dtype, (None,) + inner_shape
+            numpy.concatenate(emptyarrays).dtype, (unknown_length,) + inner_shape
         )
 
     def repeat(

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -830,48 +830,6 @@ class TypeTracer(NumpyLike):
         else:
             return int(x1)
 
-    def sub_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is unknown_length:
-            return unknown_length
-        if x2 is unknown_length:
-            return unknown_length
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 - x2
-        assert result >= 0
-        return result
-
-    def add_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is unknown_length:
-            return unknown_length
-        if x2 is unknown_length:
-            return unknown_length
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 + x2
-        return result
-
-    def mul_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is unknown_length:
-            return unknown_length
-        if x2 is unknown_length:
-            return unknown_length
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 * x2
-        return result
-
-    def div_shape_item(self, x1: ShapeItem, x2: ShapeItem) -> ShapeItem:
-        if x1 is unknown_length:
-            return unknown_length
-        if x2 is unknown_length:
-            return unknown_length
-        assert x1 >= 0
-        assert x2 >= 0
-        result = x1 // x2
-        assert result * x2 == x1
-        return result
-
     def broadcast_shapes(
         self, *shapes: tuple[SupportsInt, ...]
     ) -> tuple[SupportsInt, ...]:

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -7,13 +7,8 @@ import numpy
 
 import awkward as ak
 from awkward._errors import wrap_error
-from awkward._nplikes.numpylike import (
-    ArrayLike,
-    NumpyLike,
-    NumpyMetadata,
-    ShapeItem,
-    unknown_length,
-)
+from awkward._nplikes.numpylike import ArrayLike, NumpyLike, NumpyMetadata
+from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._util import NDArrayOperatorsMixin, is_non_string_like_sequence
 from awkward.typing import (
     Any,

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -7,7 +7,8 @@ from awkward._backends import Backend
 from awkward._errors import wrap_error
 from awkward._nplikes import nplike_of, to_nplike
 from awkward._nplikes.jax import Jax
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias
 
 if TYPE_CHECKING:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -7,7 +7,7 @@ from awkward._backends import Backend
 from awkward._errors import wrap_error
 from awkward._nplikes import nplike_of, to_nplike
 from awkward._nplikes.jax import Jax
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias
 
 if TYPE_CHECKING:
@@ -456,7 +456,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
         else:
             item._touch_data(recursive=False)
             nextoffsets = item.offsets
-            nextcontent = item_backend.nplike.empty(None, dtype=np.int64)
+            nextcontent = item_backend.nplike.empty(unknown_length, dtype=np.int64)
 
         return ListOffsetArray(
             ak.index.Index64(nextoffsets),
@@ -513,7 +513,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
             item._touch_data(recursive=False)
             nextoffsets = item.offsets
             outindex = item.content.index
-            nextcontent = item_backend.nplike.empty(None, dtype=np.int64)
+            nextcontent = item_backend.nplike.empty(unknown_length, dtype=np.int64)
 
         return ListOffsetArray(
             ak.index.Index64(nextoffsets, nplike=item_backend.index_nplike),
@@ -583,7 +583,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
             else:
                 item._touch_data(recursive=False)
                 outindex = item.index
-                nextcontent = item_backend.nplike.empty(None, dtype=np.int64)
+                nextcontent = item_backend.nplike.empty(unknown_length, dtype=np.int64)
 
             return IndexedOptionArray(
                 ak.index.Index(outindex, nplike=item_backend.index_nplike),

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -7,7 +7,7 @@ import math
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
@@ -63,7 +63,7 @@ class BitMaskedArray(Content):
                     )
                 )
             )
-        if length is not None:
+        if length is not unknown_length:
             if not (ak._util.is_integer(length) and length >= 0):
                 raise ak._errors.wrap_error(
                     TypeError(
@@ -80,7 +80,10 @@ class BitMaskedArray(Content):
                     )
                 )
             )
-        if not (length is None or mask.length is None) and length > mask.length * 8:
+        if (
+            not (length is unknown_length or mask.length is unknown_length)
+            and length > mask.length * 8
+        ):
             raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' ({}) must be <= len(mask) * 8 ({})".format(
@@ -89,7 +92,7 @@ class BitMaskedArray(Content):
                 )
             )
         if (
-            not (length is None or content.length is None)
+            not (length is unknown_length or content.length is unknown_length)
             and length > content.length * 8
         ):
             raise ak._errors.wrap_error(
@@ -224,7 +227,7 @@ class BitMaskedArray(Content):
             self._mask.to_nplike(tt),
             self._content._to_typetracer(False),
             self._valid_when,
-            None if forget_length else self.length,
+            unknown_length if forget_length else self.length,
             self._lsb_order,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -7,7 +7,8 @@ import math
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -7,7 +7,8 @@ import math
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -7,7 +7,7 @@ import math
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -60,7 +60,7 @@ class ByteMaskedArray(Content):
                 )
             )
         if (
-            not (mask.length is None or content.length is None)
+            not (mask.length is unknown_length or content.length is unknown_length)
             and mask.length > content.length
         ):
             raise ak._errors.wrap_error(
@@ -262,7 +262,7 @@ class ByteMaskedArray(Content):
             if self._backend.nplike.known_data:
                 excess_length = int(math.ceil(self.length / 8.0))
             else:
-                excess_length = None
+                excess_length = unknown_length
             return ak.contents.BitMaskedArray(
                 ak.index.IndexU8(
                     self._backend.nplike.empty(excess_length, dtype=np.uint8)
@@ -382,7 +382,7 @@ class ByteMaskedArray(Content):
                 self._valid_when,
             )
         )
-        numnull = self._backend.index_nplike.scalar_as_shape_item(_numnull[0])
+        numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
         nextcarry = ak.index.Index64.empty(
             self._backend.index_nplike.sub_shape_item(self.length, numnull),
             nplike=self._backend.index_nplike,
@@ -667,22 +667,20 @@ class ByteMaskedArray(Content):
             for x in others
         ):
             parameters = self._parameters
-            self_length_scalar = self._backend.index_nplike.shape_item_as_scalar(
+            self_length_scalar = self._backend.index_nplike.shape_item_as_index(
                 self.length
             )
             masks = [self._mask.data[:self_length_scalar]]
             tail_contents = []
             length = 0
             for x in others:
-                length_scalar = self._backend.index_nplike.shape_item_as_scalar(
-                    x.length
-                )
+                length_scalar = self._backend.index_nplike.shape_item_as_index(x.length)
                 parameters = ak.forms.form._parameters_intersect(
                     parameters, x._parameters
                 )
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])
-                length = self._backend.index_nplike.add_shape_item(length, x.length)
+                length += x.length
 
             return ByteMaskedArray(
                 ak.index.Index8(self._backend.nplike.concat(masks)),
@@ -794,7 +792,7 @@ class ByteMaskedArray(Content):
                 self._valid_when,
             )
         )
-        numnull = self._backend.index_nplike.scalar_as_shape_item(_numnull[0])
+        numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
 
         next_length = self._backend.index_nplike.sub_shape_item(mask_length, numnull)
         nextcarry = ak.index.Index64.empty(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -384,7 +384,7 @@ class ByteMaskedArray(Content):
         )
         numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
         nextcarry = ak.index.Index64.empty(
-            self._backend.index_nplike.sub_shape_item(self.length, numnull),
+            self.length - numnull,
             nplike=self._backend.index_nplike,
         )
         outindex = ak.index.Index64.empty(
@@ -430,11 +430,11 @@ class ByteMaskedArray(Content):
         numnull, nextcarry, outindex = self._nextcarry_outindex()
 
         reducedstarts = ak.index.Index64.empty(
-            self._backend.index_nplike.sub_shape_item(self.length, numnull),
+            self.length - numnull,
             nplike=self._backend.index_nplike,
         )
         reducedstops = ak.index.Index64.empty(
-            self._backend.index_nplike.sub_shape_item(self.length, numnull),
+            self.length - numnull,
             nplike=self._backend.index_nplike,
         )
 
@@ -794,7 +794,7 @@ class ByteMaskedArray(Content):
         )
         numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
 
-        next_length = self._backend.index_nplike.sub_shape_item(mask_length, numnull)
+        next_length = mask_length - numnull
         nextcarry = ak.index.Index64.empty(
             next_length, nplike=self._backend.index_nplike
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -10,12 +10,8 @@ import awkward as ak
 from awkward._backends import Backend
 from awkward._nplikes import to_nplike
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import (
-    NumpyLike,
-    NumpyMetadata,
-    ShapeItem,
-    unknown_length,
-)
+from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
+from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.forms.form import Form, JSONMapping, _type_parameters_equal

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -10,7 +10,12 @@ import awkward as ak
 from awkward._backends import Backend
 from awkward._nplikes import to_nplike
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata, ShapeItem
+from awkward._nplikes.numpylike import (
+    NumpyLike,
+    NumpyMetadata,
+    ShapeItem,
+    unknown_length,
+)
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.forms.form import Form, JSONMapping, _type_parameters_equal
@@ -370,12 +375,12 @@ class Content:
         length: int,
     ):
         # if this is in a tuple-slice and really should be 0, it will be trimmed later
-        length = 1 if length is not None and length == 0 else length
+        length = 1 if length is not unknown_length and length == 0 else length
         index = Index64(head.index, nplike=self._backend.index_nplike)
         indexlength = index.length
         index = index.to_nplike(self._backend.index_nplike)
         outindex = Index64.empty(
-            self._backend.index_nplike.mul_shape_item(index.length, length),
+            index.length * length,
             self._backend.index_nplike,
         )
 
@@ -567,7 +572,7 @@ class Content:
 
             out = next._getitem_next(nextwhere[0], nextwhere[1:], None)
 
-            if out.length is not None and out.length == 0:
+            if out.length is not unknown_length and out.length == 0:
                 return out._getitem_nothing()
             else:
                 return out._getitem_at(0)
@@ -628,7 +633,7 @@ class Content:
             out = ak._slicing.getitem_next_array_wrap(
                 self._carry(carry, allow_lazy), where.shape
             )
-            if out.length is not None and out.length == 0:
+            if out.length is not unknown_length and out.length == 0:
                 return out._getitem_nothing()
             else:
                 return out._getitem_at(0)
@@ -988,7 +993,7 @@ class Content:
         return self.form_cls.dimension_optiontype.__get__(self)
 
     def _pad_none_axis0(self, target: int, clip: bool) -> Content:
-        if not clip and (self.length is None or (target < self.length)):
+        if not clip and (self.length is unknown_length or (target < self.length)):
             index = Index64(
                 self._backend.index_nplike.arange(self.length, dtype=np.int64),
                 nplike=self._backend.index_nplike,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -5,7 +5,8 @@ import copy
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -307,7 +307,7 @@ class IndexedOptionArray(Content):
         )
         numnull = index_nplike.index_as_shape_item(_numnull[0])
         nextcarry = ak.index.Index64.empty(
-            index_nplike.sub_shape_item(self._index.length, numnull),
+            self._index.length - numnull,
             index_nplike,
         )
         outindex = ak.index.Index.empty(
@@ -356,11 +356,11 @@ class IndexedOptionArray(Content):
         numnull, nextcarry, outindex = self._nextcarry_outindex()
 
         reducedstarts = ak.index.Index64.empty(
-            self._backend.index_nplike.sub_shape_item(self.length, numnull),
+            self.length - numnull,
             nplike=self._backend.index_nplike,
         )
         reducedstops = ak.index.Index64.empty(
-            self._backend.index_nplike.sub_shape_item(self.length, numnull),
+            self.length - numnull,
             nplike=self._backend.index_nplike,
         )
         assert (
@@ -494,7 +494,7 @@ class IndexedOptionArray(Content):
             )
             numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
             nextcarry = ak.index.Index64.empty(
-                self._backend.index_nplike.sub_shape_item(self.length, numnull),
+                self.length - numnull,
                 self._backend.index_nplike,
             )
 
@@ -960,10 +960,8 @@ class IndexedOptionArray(Content):
             )
 
             newindex = ak.index.Index64.empty(
-                self._backend.index_nplike.add_shape_item(
-                    self._backend.index_nplike.index_as_shape_item(out._offsets[-1]),
-                    len_newnulls,
-                ),
+                self._backend.index_nplike.index_as_shape_item(out._offsets[-1])
+                + len_newnulls,
                 self._backend.index_nplike,
             )
             newoffsets = ak.index.Index64.empty(
@@ -1094,7 +1092,7 @@ class IndexedOptionArray(Content):
         )
         numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
 
-        next_length = self._backend.index_nplike.sub_shape_item(index_length, numnull)
+        next_length = index_length - numnull
         nextparents = ak.index.Index64.empty(next_length, self._backend.index_nplike)
         nextcarry = ak.index.Index64.empty(next_length, self._backend.index_nplike)
         outindex = ak.index.Index64.empty(index_length, self._backend.index_nplike)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import copy
 
 import awkward as ak
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import copy
 
 import awkward as ak
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -297,7 +297,7 @@ class ListArray(Content):
     def _compact_offsets64(self, start_at_zero):
         starts_len = self._starts.length
         out = ak.index.Index64.empty(
-            self._backend.index_nplike.add_shape_item(starts_len, 1),
+            starts_len + 1,
             self._backend.index_nplike,
         )
         assert (
@@ -339,7 +339,7 @@ class ListArray(Content):
 
         if isinstance(slicecontent, ak.contents.ListOffsetArray):
             outoffsets = ak.index.Index64.empty(
-                self._backend.index_nplike.add_shape_item(slicestarts.length, 1),
+                slicestarts.length + 1,
                 self._backend.index_nplike,
             )
             assert (
@@ -404,11 +404,11 @@ class ListArray(Content):
                 ),
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
-            carrylen = self._backend.index_nplike.scalar_as_shape_item(_carrylen[0])
+            carrylen = self._backend.index_nplike.index_as_shape_item(_carrylen[0])
 
             sliceindex = ak.index.Index64(slicecontent._data)
             outoffsets = ak.index.Index64.empty(
-                self._backend.index_nplike.add_shape_item(slicestarts.length, 1),
+                slicestarts.length + 1,
                 self._backend.index_nplike,
             )
             nextcarry = ak.index.Index64.empty(carrylen, self._backend.index_nplike)
@@ -490,16 +490,16 @@ class ListArray(Content):
                 ),
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
-            numvalid = self._backend.index_nplike.scalar_as_shape_item(_numvalid[0])
+            numvalid = self._backend.index_nplike.index_as_shape_item(_numvalid[0])
 
             nextcarry = ak.index.Index64.empty(numvalid, self._backend.index_nplike)
 
             smalloffsets = ak.index.Index64.empty(
-                self._backend.index_nplike.add_shape_item(slicestarts.length, 1),
+                slicestarts.length + 1,
                 self._backend.index_nplike,
             )
             largeoffsets = ak.index.Index64.empty(
-                self._backend.index_nplike.add_shape_item(slicestarts.length, 1),
+                slicestarts.length + 1,
                 self._backend.index_nplike,
             )
 
@@ -666,9 +666,11 @@ class ListArray(Content):
                 )
             else:
                 self._touch_data(recursive=False)
-                nextcarry = ak.index.Index64.empty(None, self._backend.index_nplike)
+                nextcarry = ak.index.Index64.empty(
+                    unknown_length, self._backend.index_nplike
+                )
 
-            lennextoffsets = self._backend.index_nplike.add_shape_item(lenstarts, 1)
+            lennextoffsets = lenstarts + 1
             if self._starts.dtype == "int64":
                 nextoffsets = ak.index.Index64.empty(
                     lennextoffsets, self._backend.index_nplike
@@ -711,7 +713,7 @@ class ListArray(Content):
             nextcontent = self._content._carry(nextcarry, True)
 
             if advanced is None or (
-                advanced.length is not None and advanced.length == 0
+                advanced.length is not unknown_length and advanced.length == 0
             ):
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
@@ -743,7 +745,7 @@ class ListArray(Content):
                 else:
                     self._touch_data(recursive=False)
                     nextadvanced = ak.index.Index64.empty(
-                        None, self._backend.index_nplike
+                        unknown_length, self._backend.index_nplike
                     )
                 advanced = advanced.to_nplike(self._backend.index_nplike)
                 assert (
@@ -794,18 +796,14 @@ class ListArray(Content):
                 flathead, nplike=self._backend.index_nplike
             )
             if advanced is None or (
-                advanced.length is not None and advanced.length == 0
+                advanced.length is not unknown_length and advanced.length == 0
             ):
                 nextcarry = ak.index.Index64.empty(
-                    self._backend.index_nplike.mul_shape_item(
-                        lenstarts, flathead.shape[0]
-                    ),
+                    lenstarts * flathead.shape[0],
                     self._backend.index_nplike,
                 )
                 nextadvanced = ak.index.Index64.empty(
-                    self._backend.index_nplike.mul_shape_item(
-                        lenstarts, flathead.shape[0]
-                    ),
+                    lenstarts * flathead.shape[0],
                     self._backend.index_nplike,
                 )
                 assert (
@@ -987,9 +985,7 @@ class ListArray(Content):
 
         total_length = 0
         for array in head:
-            total_length = self._backend.index_nplike.add_shape_item(
-                total_length, array.length
-            )
+            total_length += array.length
 
         contents = []
 
@@ -1066,12 +1062,9 @@ class ListArray(Content):
                         contentlength_so_far,
                     )
                 )
-                contentlength_so_far = self._backend.index_nplike.add_shape_item(
-                    contentlength_so_far, array.content.length
-                )
-                length_so_far = self._backend.index_nplike.add_shape_item(
-                    length_so_far, array.length
-                )
+                contentlength_so_far += array.content.length
+
+                length_so_far += array.length
 
             elif isinstance(array, ak.contents.RegularArray):
                 listoffsetarray = array.to_ListOffsetArray64(True)
@@ -1103,12 +1096,9 @@ class ListArray(Content):
                         contentlength_so_far,
                     )
                 )
-                contentlength_so_far = self._backend.index_nplike.add_shape_item(
-                    contentlength_so_far, array.content.length
-                )
-                length_so_far = self._backend.index_nplike.add_shape_item(
-                    length_so_far, array.length
-                )
+                contentlength_so_far += array.content.length
+
+                length_so_far += array.length
 
             elif isinstance(array, ak.contents.EmptyArray):
                 pass
@@ -1140,7 +1130,7 @@ class ListArray(Content):
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
-            innerlength = self._backend.index_nplike.scalar_as_shape_item(
+            innerlength = self._backend.index_nplike.index_as_shape_item(
                 offsets[-1]
             )  # todo: removed touch_data?
             localindex = ak.index.Index64.empty(innerlength, self._backend.index_nplike)
@@ -1178,7 +1168,7 @@ class ListArray(Content):
         )
 
     def _is_unique(self, negaxis, starts, parents, outlength):
-        if self._starts.length is not None and self._starts.length == 0:
+        if self._starts.length is not unknown_length and self._starts.length == 0:
             return True
 
         return self.to_ListOffsetArray64(True)._is_unique(
@@ -1186,7 +1176,7 @@ class ListArray(Content):
         )
 
     def _unique(self, negaxis, starts, parents, outlength):
-        if self._starts.length is not None and self._starts.length == 0:
+        if self._starts.length is not unknown_length and self._starts.length == 0:
             return self
 
         return self.to_ListOffsetArray64(True)._unique(
@@ -1297,10 +1287,10 @@ class ListArray(Content):
                         self._starts.length,
                     )
                 )
-                min_ = self._backend.index_nplike.scalar_as_shape_item(_min[0])
+                min_ = self._backend.index_nplike.index_as_shape_item(_min[0])
                 # TODO: Replace the kernel call with below code once typtracer supports '-'
                 # min_ = self._backend.nplike.min(self._stops.data - self._starts.data)
-                if min_ is not None and target < min_:
+                if min_ is not unknown_length and target < min_:
                     return self
                 else:
                     _tolength = ak.index.Index64.empty(1, self._backend.index_nplike)
@@ -1323,7 +1313,7 @@ class ListArray(Content):
                             self._starts.length,
                         )
                     )
-                    tolength = self._backend.index_nplike.scalar_as_shape_item(
+                    tolength = self._backend.index_nplike.index_as_shape_item(
                         _tolength[0]
                     )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1146,7 +1146,7 @@ class ListArray(Content):
                 ](
                     localindex.data,
                     offsets.data,
-                    self._backend.index_nplike.sub_shape_item(offsets.length, 1),
+                    offsets.length - 1,
                 )
             )
             return ak.contents.ListOffsetArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -157,7 +157,7 @@ class ListOffsetArray(Content):
 
     @property
     def length(self):
-        return self._backend.index_nplike.sub_shape_item(self._offsets.length, 1)
+        return self._offsets.length - 1
 
     def __repr__(self):
         return self._repr("", "", "")
@@ -224,7 +224,7 @@ class ListOffsetArray(Content):
             )
         )
         size = self._backend.index_nplike.index_as_shape_item(_size[0])
-        length = self._backend.index_nplike.sub_shape_item(self._offsets.length, 1)
+        length = self._offsets.length - 1
         return ak.contents.RegularArray(
             content, size, length, parameters=self._parameters
         )
@@ -290,7 +290,7 @@ class ListOffsetArray(Content):
         )
 
     def _compact_offsets64(self, start_at_zero):
-        offsets_len = self._backend.index_nplike.sub_shape_item(self._offsets.length, 1)
+        offsets_len = self._offsets.length - 1
         out = ak.index.Index64.empty(self._offsets.length, self._backend.index_nplike)
         assert (
             out.nplike is self._backend.index_nplike
@@ -1148,7 +1148,7 @@ class ListOffsetArray(Content):
                 ](
                     nextparents.data,
                     self._offsets.data,
-                    self._backend.index_nplike.sub_shape_item(self._offsets.length, 1),
+                    self._offsets.length - 1,
                 )
             )
 
@@ -1185,7 +1185,7 @@ class ListOffsetArray(Content):
 
             if isinstance(self._content, ak.contents.NumpyArray):
                 nextcarry = ak.index.Index64.empty(
-                    index_nplike.sub_shape_item(self._offsets.length, 1), index_nplike
+                    self._offsets.length - 1, index_nplike
                 )
 
                 starts, stops = self._offsets[:-1], self._offsets[1:]
@@ -1449,7 +1449,7 @@ class ListOffsetArray(Content):
             )
 
         branch, depth = self.branch_depth
-        globalstarts_length = index_nplike.sub_shape_item(self._offsets.length, 1)
+        globalstarts_length = self._offsets.length - 1
 
         if not branch and negaxis == depth:
             (
@@ -1619,7 +1619,7 @@ class ListOffsetArray(Content):
     def _rearrange_prepare_next(self, outlength, parents):
         index_nplike = self._backend.index_nplike
         nextlen = index_nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
-        lenstarts = index_nplike.sub_shape_item(self._offsets.length, 1)
+        lenstarts = self._offsets.length - 1
         _maxcount = ak.index.Index64.empty(1, index_nplike)
         offsetscopy = ak.index.Index64.empty(self.offsets.length, index_nplike)
         assert (
@@ -1761,7 +1761,7 @@ class ListOffsetArray(Content):
                     ](
                         offsets_.data,
                         self._offsets.data,
-                        index_nplike.sub_shape_item(self._offsets.length, 1),
+                        self._offsets.length - 1,
                         target,
                         _tolength.data,
                     )
@@ -1780,7 +1780,7 @@ class ListOffsetArray(Content):
                     ](
                         outindex.data,
                         self._offsets.data,
-                        index_nplike.sub_shape_item(self._offsets.length, 1),
+                        self._offsets.length - 1,
                         target,
                     )
                 )
@@ -1792,11 +1792,11 @@ class ListOffsetArray(Content):
                 )
             else:
                 starts_ = ak.index.Index64.empty(
-                    index_nplike.sub_shape_item(self._offsets.length, 1),
+                    self._offsets.length - 1,
                     index_nplike,
                 )
                 stops_ = ak.index.Index64.empty(
-                    index_nplike.sub_shape_item(self._offsets.length, 1),
+                    self._offsets.length - 1,
                     index_nplike,
                 )
                 assert starts_.nplike is index_nplike and stops_.nplike is index_nplike
@@ -1814,9 +1814,7 @@ class ListOffsetArray(Content):
                 )
 
                 outindex = ak.index.Index64.empty(
-                    index_nplike.mul_shape_item(
-                        target, (index_nplike.sub_shape_item(self._offsets.length, 1))
-                    ),
+                    target * (self._offsets.length - 1),
                     index_nplike,
                 )
                 assert (
@@ -1831,7 +1829,7 @@ class ListOffsetArray(Content):
                     ](
                         outindex.data,
                         self._offsets.data,
-                        index_nplike.sub_shape_item(self._offsets.length, 1),
+                        self._offsets.length - 1,
                         target,
                     )
                 )

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -5,7 +5,8 @@ import copy
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -189,7 +189,7 @@ class NumpyArray(Content):
         shape = self._data.shape
         zeroslen = [1]
         for x in shape:
-            zeroslen.append(self._backend.index_nplike.mul_shape_item(zeroslen[-1], x))
+            zeroslen.append(zeroslen[-1] * x)
 
         out = NumpyArray(
             self._backend.nplike.reshape(self._data, (-1,)),
@@ -861,7 +861,7 @@ class NumpyArray(Content):
                     parents_length,
                 )
             )
-            offsets_length = self._backend.index_nplike.scalar_as_shape_item(
+            offsets_length = self._backend.index_nplike.index_as_shape_item(
                 _offsets_length[0]
             )
 
@@ -973,7 +973,7 @@ class NumpyArray(Content):
                     parents_length,
                 )
             )
-            offsets_length = self._backend.index_nplike.scalar_as_shape_item(
+            offsets_length = self._backend.index_nplike.index_as_shape_item(
                 _offsets_length[0]
             )
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -7,7 +7,8 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -36,7 +36,7 @@ class RecordArray(Content):
         self,
         contents: Iterable[Content],
         fields: Iterable[str] | None,
-        length: int | type[unknown_length] = unset,
+        length: int | type[unknown_length] | None = None,
         *,
         parameters=None,
         backend=None,
@@ -78,11 +78,7 @@ class RecordArray(Content):
         if backend is None:
             backend = ak._backends.NumpyBackend.instance()
 
-        # TODO: remove me in future version
-        if length is unknown_length and backend.nplike.known_data:
-            length = unset
-
-        if length is unset:
+        if length is None:
             if len(contents) == 0:
                 raise ak._errors.wrap_error(
                     TypeError(
@@ -96,7 +92,7 @@ class RecordArray(Content):
                 for content in contents:
                     assert content.length is not unknown_length
                     # First time we're setting length, and content.length is not unknown_length
-                    if length is unset:
+                    if length is None:
                         length = content.length
                     # length is not unknown_length, content.length is not unknown_length
                     else:
@@ -104,7 +100,7 @@ class RecordArray(Content):
             else:
                 for content in contents:
                     # First time we're setting length, and content.length is not unknown_length
-                    if length is unset:
+                    if length is None:
                         length = content.length
                         # Any unknown_length means all unknown_length
                         if length is unknown_length:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -35,7 +35,7 @@ class RecordArray(Content):
         self,
         contents: Iterable[Content],
         fields: Iterable[str] | None,
-        length: int | None = unset,
+        length: int | type[unknown_length] = unset,
         *,
         parameters=None,
         backend=None,
@@ -78,7 +78,7 @@ class RecordArray(Content):
             backend = ak._backends.NumpyBackend.instance()
 
         # TODO: remove me in future version
-        if length is None and backend.nplike.known_data:
+        if length is unknown_length and backend.nplike.known_data:
             length = unset
 
         if length is unset:
@@ -93,31 +93,31 @@ class RecordArray(Content):
 
             if backend.nplike.known_data:
                 for content in contents:
-                    assert content.length is not None
-                    # First time we're setting length, and content.length is not None
+                    assert content.length is not unknown_length
+                    # First time we're setting length, and content.length is not unknown_length
                     if length is unset:
                         length = content.length
-                    # length is not None, content.length is not None
+                    # length is not unknown_length, content.length is not unknown_length
                     else:
                         length = min(length, content.length)
             else:
                 for content in contents:
-                    # First time we're setting length, and content.length is not None
+                    # First time we're setting length, and content.length is not unknown_length
                     if length is unset:
                         length = content.length
-                        # Any None means all None
-                        if length is None:
+                        # Any unknown_length means all unknown_length
+                        if length is unknown_length:
                             break
-                    # `length` is set, can't be None
-                    elif content.length is None:
-                        length = None
+                    # `length` is set, can't be unknown_length
+                    elif content.length is unknown_length:
+                        length = unknown_length
                         break
-                    # `length` is set, can't be None
+                    # `length` is set, can't be unknown_length
                     else:
                         length = min(length, content.length)
-        elif length is not None:
+        elif length is not unknown_length:
             for content in contents:
-                if content.length is not None and content.length < length:
+                if content.length is not unknown_length and content.length < length:
                     raise ak._errors.wrap_error(
                         ValueError(
                             "{} len(content) ({}) must be >= length ({}) for all 'contents'".format(
@@ -257,7 +257,7 @@ class RecordArray(Content):
         return RecordArray(
             contents,
             self._fields,
-            None if forget_length else self._length,
+            unknown_length if forget_length else self._length,
             parameters=self._parameters,
             backend=backend,
         )
@@ -321,7 +321,7 @@ class RecordArray(Content):
         if out.length == self._length:
             return out
         else:
-            assert self._length is not None, "TODO: need to handle this"
+            assert self._length is not unknown_length, "TODO: need to handle this"
             return out[: self._length]
 
     def _getitem_nothing(self) -> Content:
@@ -331,7 +331,7 @@ class RecordArray(Content):
         if self._backend.nplike.known_data and where < 0:
             where += self.length
 
-        if not (self._length is None or (0 <= where < self._length)):
+        if not (self._length is unknown_length or (0 <= where < self._length)):
             raise ak._errors.index_error(self, where)
         return Record(self, where)
 
@@ -340,7 +340,7 @@ class RecordArray(Content):
             self._touch_shape(recursive=False)
             return self
 
-        if self._length is None:
+        if self._length is unknown_length:
             return self
         start, stop, step = where.indices(self.length)
         assert step == 1
@@ -680,17 +680,15 @@ class RecordArray(Content):
             nextcontents.append(merged)
 
             if minlength is ak._util.unset or (
-                not (merged.length is None or minlength is None)
+                not (merged.length is unknown_length or minlength is unknown_length)
                 and merged.length < minlength
             ):
                 minlength = merged.length
 
-        if minlength is None:
+        if minlength is unknown_length:
             minlength = self.length
             for x in others:
-                minlength = self._backend.index_nplike.add_shape_item(
-                    minlength, x.length
-                )
+                minlength += x.length
 
         next = RecordArray(
             nextcontents,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -5,7 +5,8 @@ import copy
 
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable, Sequence
 import awkward as ak
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -99,7 +99,7 @@ class UnionArray(Content):
                 )
 
         if (
-            not (tags.length is None or index.length is None)
+            not (tags.length is unknown_length or index.length is unknown_length)
             and tags.length > index.length
         ):
             raise ak._errors.wrap_error(
@@ -599,7 +599,7 @@ class UnionArray(Content):
     def project(self, index):
         lentags = self._tags.length
         assert (
-            self._index.length is None or lentags is None
+            self._index.length is unknown_length or lentags is unknown_length
         ) or self._index.length >= lentags
         lenout = ak.index.Index64.empty(1, self._backend.index_nplike)
         tmpcarry = ak.index.Index64.empty(lentags, self._backend.index_nplike)
@@ -655,7 +655,7 @@ class UnionArray(Content):
                 lentags,
             )
         )
-        size = backend.index_nplike.scalar_as_shape_item(_size[0])
+        size = backend.index_nplike.index_as_shape_item(_size[0])
         current = index_cls.empty(size, nplike=backend.index_nplike)
         outindex = index_cls.empty(lentags, nplike=backend.index_nplike)
         assert (
@@ -942,11 +942,11 @@ class UnionArray(Content):
         mylength = self.length
 
         tags = ak.index.Index8.empty(
-            self._backend.index_nplike.add_shape_item(theirlength, mylength),
+            theirlength + mylength,
             nplike=self._backend.index_nplike,
         )
         index = ak.index.Index64.empty(
-            self._backend.index_nplike.add_shape_item(theirlength, mylength),
+            theirlength + mylength,
             nplike=self._backend.index_nplike,
         )
 
@@ -1030,9 +1030,7 @@ class UnionArray(Content):
 
         total_length = 0
         for array in head:
-            total_length = self._backend.index_nplike.add_shape_item(
-                total_length, array.length
-            )
+            total_length += array.length
 
         nexttags = ak.index.Index8.empty(
             total_length, nplike=self._backend.index_nplike
@@ -1089,9 +1087,8 @@ class UnionArray(Content):
                         array.length,
                     )
                 )
-                length_so_far = self._backend.index_nplike.add_shape_item(
-                    length_so_far, array.length
-                )
+                length_so_far += array.length
+
                 nextcontents.extend(union_contents)
 
             else:
@@ -1115,9 +1112,8 @@ class UnionArray(Content):
                     ](nextindex.data, length_so_far, array.length)
                 )
 
-                length_so_far = self._backend.index_nplike.add_shape_item(
-                    length_so_far, array.length
-                )
+                length_so_far += array.length
+
                 nextcontents.append(array)
 
         if len(nextcontents) > 127:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -10,7 +10,8 @@ from collections.abc import Iterable, Sequence
 import awkward as ak
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
 from awkward._util import unset
 from awkward.contents.content import Content

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -7,6 +7,7 @@ from collections.abc import Collection, Mapping
 import awkward as ak
 from awkward import _errors
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward.typing import Final, TypeAlias
 
 np = NumpyMetadata.instance()
@@ -31,9 +32,7 @@ reserved_nominal_parameters: Final = frozenset(
 
 
 def from_dict(input: dict) -> Form:
-    if input is None:
-        return None
-
+    assert input is not None
     if isinstance(input, str):
         return ak.forms.NumpyForm(primitive=input)
 
@@ -54,7 +53,7 @@ def from_dict(input: dict) -> Form:
     elif input["class"] == "RegularArray":
         return ak.forms.RegularForm(
             content=from_dict(input["content"]),
-            size=input["size"],
+            size=unknown_length if input["size"] is None else input["size"],
             parameters=parameters,
             form_key=form_key,
         )

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._nplikes.numpylike import unknown_length
+from awkward._nplikes.shape import unknown_length
 from awkward._util import unset
 from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -62,7 +62,7 @@ class RegularForm(Form):
         return self._to_dict_extra(
             {
                 "class": "RegularArray",
-                "size": self._size,
+                "size": None if self._size is unknown_length else self._size,
                 "content": self._content._to_dict_part(verbose, toplevel=False),
             },
             verbose,

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._nplikes.numpylike import unknown_length
 from awkward._util import unset
 from awkward.forms.form import Form, _type_parameters_equal
 from awkward.typing import final
@@ -20,7 +21,7 @@ class RegularForm(Form):
                     )
                 )
             )
-        if not ((ak._util.is_integer(size) and size >= 0) or size is None):
+        if not (size is unknown_length or (ak._util.is_integer(size) and size >= 0)):
             raise ak._errors.wrap_error(
                 TypeError(
                     "{} 'size' must be a non-negative int or None, not {}".format(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -192,13 +192,13 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 fields.append(k)
                 contents.append(Array(v).layout)
                 if length is None:
-                    length = len(contents[-1])
-                elif length != len(contents[-1]):
+                    length = contents[-1].length
+                elif length != contents[-1].length:
                     raise ak._errors.wrap_error(
                         ValueError(
                             "dict of arrays in ak.Array constructor must have arrays "
                             "of equal length ({} vs {})".format(
-                                length, len(contents[-1])
+                                length, contents[-1].length
                             )
                         )
                     )

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -5,7 +5,7 @@ import copy
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.typing import Self
@@ -23,7 +23,7 @@ class Record:
             raise ak._errors.wrap_error(
                 TypeError(f"Record 'at' must be an integer, not {array!r}")
             )
-        if not (array.length is None or 0 <= at < array.length):
+        if not (array.length is unknown_length or 0 <= at < array.length):
             raise ak._errors.wrap_error(
                 ValueError(
                     f"Record 'at' must be >= 0 and < len(array) == {array.length}, not {at}"

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -5,7 +5,8 @@ import copy
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._nplikes.numpylike import NumpyMetadata, unknown_length
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.typing import Self

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -3,7 +3,7 @@
 import sys
 
 import awkward as ak
-from awkward._nplikes.numpylike import unknown_length
+from awkward._nplikes.shape import unknown_length
 
 
 class ArrayType:

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -3,6 +3,7 @@
 import sys
 
 import awkward as ak
+from awkward._nplikes.numpylike import unknown_length
 
 
 class ArrayType:
@@ -15,7 +16,9 @@ class ArrayType:
                     )
                 )
             )
-        if not ((ak._util.is_integer(length) and length >= 0) or length is None):
+        if not (
+            (ak._util.is_integer(length) and length >= 0) or length is unknown_length
+        ):
             raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'length' must be a non-negative integer or unknown length, not {}".format(
@@ -41,7 +44,7 @@ class ArrayType:
         stream.write("".join(self._str("", False) + ["\n"]))
 
     def _str(self, indent, compact):
-        length_str = "##" if self._length is None else str(self._length)
+        length_str = str(self._length)
         return [f"{length_str} * "] + self._content._str(indent, compact)
 
     def __repr__(self):
@@ -51,9 +54,9 @@ class ArrayType:
     def __eq__(self, other):
         if isinstance(other, ArrayType):
             return (
-                self._length == other._length
-                or other._length is None
-                or self._length is None
+                other._length is unknown_length
+                or self._length is unknown_length
+                or self._length == other._length
             ) and self._content == other._content
         else:
             return False

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._nplikes.numpylike import unknown_length
 from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final
@@ -17,7 +18,7 @@ class RegularType(Type):
                     )
                 )
             )
-        if not ((ak._util.is_integer(size) and size >= 0) or size is None):
+        if not (size is unknown_length or (ak._util.is_integer(size) and size >= 0)):
             raise ak._errors.wrap_error(
                 ValueError(
                     "{} 'size' must be a non-negative int or None, not {}".format(
@@ -66,7 +67,7 @@ class RegularType(Type):
 
         else:
             params = self._str_parameters()
-            if self._size is None:
+            if self._size is unknown_length:
                 size_str = "##"
             else:
                 size_str = str(self._size)

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._nplikes.numpylike import unknown_length
+from awkward._nplikes.shape import unknown_length
 from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 from awkward.typing import final

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -67,16 +67,12 @@ class RegularType(Type):
 
         else:
             params = self._str_parameters()
-            if self._size is unknown_length:
-                size_str = "##"
-            else:
-                size_str = str(self._size)
 
             if params is None:
-                out = [size_str, " * "] + self._content._str(indent, compact)
+                out = [str(self._size), " * "] + self._content._str(indent, compact)
             else:
                 out = (
-                    ["[", size_str, " * "]
+                    ["[", str(self._size), " * "]
                     + self._content._str(indent, compact)
                     + [", ", params, "]"]
                 )

--- a/tests/test_0111_jagged_and_masked_getitem.py
+++ b/tests/test_0111_jagged_and_masked_getitem.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import itertools
 
 import numpy as np
 import pytest
@@ -485,20 +486,11 @@ def test_bool_missing():
     expected = [m if m is None else x for x, m in zip(data, mask) if m is not False]
     array2 = ak.highlevel.Array(mask, check_valid=True).layout
 
-    for x1 in [True, False, None]:
-        for x2 in [True, False, None]:
-            for x3 in [True, False, None]:
-                for x4 in [True, False, None]:
-                    for x5 in [True, False, None]:
-                        mask = [x1, x2, x3, x4, x5]
-                        expected = [
-                            m if m is None else x
-                            for x, m in zip(data, mask)
-                            if m is not False
-                        ]
-                        array2 = ak.highlevel.Array(mask, check_valid=True).layout
-                        assert to_list(array[array2]) == expected
-                        assert array.to_typetracer()[array2].form == array[array2].form
+    for mask in itertools.repeat([True, False, None], 5):
+        expected = [m if m is None else x for x, m in zip(data, mask) if m is not False]
+        array2 = ak.highlevel.Array(mask, check_valid=True).layout
+        assert to_list(array[array2]) == expected
+        assert array.to_typetracer()[array2].form == array[array2].form
 
 
 def test_bool_missing2():

--- a/tests/test_2150_typetracer_high_level_ufunc.py
+++ b/tests/test_2150_typetracer_high_level_ufunc.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
-from awkward._nplikes.numpylike import unknown_length
+from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, is_unknown_scalar
 
 

--- a/tests/test_2150_typetracer_high_level_ufunc.py
+++ b/tests/test_2150_typetracer_high_level_ufunc.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._nplikes.numpylike import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, is_unknown_scalar
 
 
@@ -13,7 +14,7 @@ def test():
     typetracer_result = np.sqrt(typetracer_array)
 
     assert typetracer_result.type == ak.types.ArrayType(
-        ak.types.NumpyType("float64"), None
+        ak.types.NumpyType("float64"), unknown_length
     )
 
 
@@ -25,7 +26,7 @@ def test_add():
     typetracer_result = np.add(typetracer_left, typetracer_right)
 
     assert typetracer_result.type == ak.types.ArrayType(
-        ak.types.NumpyType("float64"), None
+        ak.types.NumpyType("float64"), unknown_length
     )
 
 
@@ -37,7 +38,7 @@ def test_add_scalar():
 
     typetracer_result = np.add(typetracer_array, other)
     assert typetracer_result.type == ak.types.ArrayType(
-        ak.types.NumpyType("int64"), None
+        ak.types.NumpyType("int64"), unknown_length
     )
 
 
@@ -50,5 +51,5 @@ def test_add_none_scalar():
 
     typetracer_result = np.add(typetracer_array, other)
     assert typetracer_result.type == ak.types.ArrayType(
-        ak.types.NumpyType("int64"), None
+        ak.types.NumpyType("int64"), unknown_length
     )

--- a/tests/test_2226_slice_regulararray_typetracer.py
+++ b/tests/test_2226_slice_regulararray_typetracer.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._nplikes.numpylike import unknown_length
 
 
 def test():
@@ -15,6 +16,6 @@ def test():
     assert ak.backend(result) == "typetracer"
     layout = ak.to_layout(result)
     assert layout.length == 3
-    assert layout.content.length is None
-    assert layout.content.content.length is None
+    assert layout.content.length is unknown_length
+    assert layout.content.content.length is unknown_length
     assert layout.content.content.dtype == np.dtype(np.float64)

--- a/tests/test_2226_slice_regulararray_typetracer.py
+++ b/tests/test_2226_slice_regulararray_typetracer.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
-from awkward._nplikes.numpylike import unknown_length
+from awkward._nplikes.shape import unknown_length
 
 
 def test():


### PR DESCRIPTION
## TL;DR
- Replace use of `None` as "unknown length" token with `unknown_length` singleton.
- Replace use of `nplike.add_shape_item(length, x)` with `length + x`

## TL
The rationale for using `None` as a token for an unknown length was weak, but was ultimately due to the following factors:
- Array API uses `None` for unknown dimension lengths
- `None` easily serialises to JSON
- `None` is a natural singleton

Some of this was discussed in https://github.com/scikit-hep/awkward/pull/2220#issuecomment-1422902819

However, a significant problem with using `None` is that it is also a meaningful index value, and we would be unable to disambiguate between `array[None]` and `array[array.layout.length]` for typetracer arrays. Whilst this would only affect L2 typetracer users, it's enough to change the balance.

Thereafter, there are arguments to be made in favour of using `nplike.XXX_shape_item` functions to operate upon lengths vs a rich object that implements magic methods. I preferred the former, due to explicitness and the ability to do e.g. validation on known lengths (such as ensuring that they are positive). However, code is less easy to read from an expression perspective. @jpivarski and I discussed this, and we settled on re-introducing the object-oriented API. 

We will maintain a strong distinction between an `index: int | ArrayLike` and a `length: int | type[unknown_length]`, to ensure that unknown values map correctly between spaces.

This reverts the inability to set `None` as length values in `RecordArray`.