### PR TITLE
docs: reintroduce Content documentation from v1 reST files.

### DIFF
--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -161,7 +161,7 @@ def dosig(node):
 
 def dodoc(docstring, qualname, names):
     out = docstring.replace("`", "``")
-    out = re.sub(r"<<([^>]*)>>", r"`\1`_", out)
+    out = re.sub(r"<<<([^>]*)>>>", r"`\1`_", out)
     out = re.sub(r"#(ak\.[A-Za-z0-9_\.]*[A-Za-z0-9_])", r":py:obj:`\1`", out)
     for x in names:
         out = out.replace("#" + x, ":py:meth:`{1} <{0}.{1}>`".format(qualname, x))

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -74,6 +74,8 @@ class BitMaskedArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     if self.lsb_order:
                         bit = bool(self.mask[where // 8] & (1 << (where % 8)))
@@ -83,6 +85,7 @@ class BitMaskedArray(Content):
                         return self.content[where]
                     else:
                         return None
+
                 elif isinstance(where, slice) and where.step is None:
                     # In general, slices must convert BitMaskedArray to ByteMaskedArray.
                     bytemask = np.unpackbits(
@@ -93,6 +96,7 @@ class BitMaskedArray(Content):
                         self.content[where.start : where.stop],
                         valid_when=self.valid_when,
                     )
+
                 elif isinstance(where, str):
                     return BitMaskedArray(
                         self.mask,
@@ -101,6 +105,7 @@ class BitMaskedArray(Content):
                         length=self.length,
                         lsb_order=self.lsb_order,
                     )
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -27,6 +27,79 @@ numpy = Numpy.instance()
 
 @final
 class BitMaskedArray(Content):
+    """
+    Like #ak.contents.ByteMaskedArray, BitMaskedArray implements an
+    #ak.types.OptionType with two buffers, `mask` and `content`.
+    However, the boolean `mask` values are packed into a bitmap.
+
+    BitMaskedArray has an additional parameter, `lsb_order`; if True,
+    the position of each bit is in
+    [Least-Significant Bit order](https://en.wikipedia.org/wiki/Bit_numbering)
+    (LSB):
+
+        is_valid[j] = bool(mask[j // 8] & (1 << (j % 8))) == valid_when
+
+    If False, the position of each bit is in Most-Significant Bit order
+    (MSB):
+
+        is_valid[j] = bool(mask[j // 8] & (128 >> (j % 8))) == valid_when
+
+    If the logical size of the buffer is not a multiple of 8, the `mask`
+    has to be padded. Thus, an explicit `length` is also part of the
+    class's definition.
+
+    This is equivalent to *all* of Apache Arrow's array types because they all
+    [use bitmaps](https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps)
+    to mask their data, with `valid_when=True` and `lsb_order=True`.
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class BitMaskedArray(Content):
+            def __init__(self, mask, content, valid_when, length, lsb_order):
+                assert isinstance(mask, IndexU8)
+                assert isinstance(content, Content)
+                assert isinstance(valid_when, bool)
+                assert isinstance(length, int) and length >= 0
+                assert isinstance(lsb_order, bool)
+                assert len(mask) <= len(content)
+                self.mask = mask
+                self.content = content
+                self.valid_when = valid_when
+                self.length = length
+                self.lsb_order = lsb_order
+
+            def __len__(self):
+                return self.length
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert 0 <= where < len(self)
+                    if self.lsb_order:
+                        bit = bool(self.mask[where // 8] & (1 << (where % 8)))
+                    else:
+                        bit = bool(self.mask[where // 8] & (128 >> (where % 8)))
+                    if bit == self.valid_when:
+                        return self.content[where]
+                    else:
+                        return None
+                elif isinstance(where, slice) and where.step is None:
+                    # In general, slices must convert BitMaskedArray to ByteMaskedArray.
+                    bytemask = np.unpackbits(self.mask,
+                                   bitorder=("little" if self.lsb_order else "big")).view(bool)
+                    return ByteMaskedArray(bytemask[where.start:where.stop],
+                                           self.content[where.start:where.stop],
+                                           valid_when=self.valid_when)
+                elif isinstance(where, str):
+                    return BitMaskedArray(self.mask,
+                                          self.content[where],
+                                          valid_when=self.valid_when,
+                                          length=self.length,
+                                          lsb_order=self.lsb_order)
+                else:
+                    raise AssertionError(where)
+    """
+
     is_option = True
 
     def __init__(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -85,17 +85,22 @@ class BitMaskedArray(Content):
                         return None
                 elif isinstance(where, slice) and where.step is None:
                     # In general, slices must convert BitMaskedArray to ByteMaskedArray.
-                    bytemask = np.unpackbits(self.mask,
-                                   bitorder=("little" if self.lsb_order else "big")).view(bool)
-                    return ByteMaskedArray(bytemask[where.start:where.stop],
-                                           self.content[where.start:where.stop],
-                                           valid_when=self.valid_when)
+                    bytemask = np.unpackbits(
+                        self.mask, bitorder=("little" if self.lsb_order else "big")
+                    ).view(bool)
+                    return ByteMaskedArray(
+                        bytemask[where.start : where.stop],
+                        self.content[where.start : where.stop],
+                        valid_when=self.valid_when,
+                    )
                 elif isinstance(where, str):
-                    return BitMaskedArray(self.mask,
-                                          self.content[where],
-                                          valid_when=self.valid_when,
-                                          length=self.length,
-                                          lsb_order=self.lsb_order)
+                    return BitMaskedArray(
+                        self.mask,
+                        self.content[where],
+                        valid_when=self.valid_when,
+                        length=self.length,
+                        lsb_order=self.lsb_order,
+                    )
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -57,21 +57,26 @@ class ByteMaskedArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     if self.mask[where] == self.valid_when:
                         return self.content[where]
                     else:
                         return None
+
                 elif isinstance(where, slice) and where.step is None:
                     return ByteMaskedArray(
                         self.mask[where.start : where.stop],
                         self.content[where.start : where.stop],
                         valid_when=self.valid_when,
                     )
+
                 elif isinstance(where, str):
                     return ByteMaskedArray(
                         self.mask, self.content[where], valid_when=self.valid_when
                     )
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -63,11 +63,15 @@ class ByteMaskedArray(Content):
                     else:
                         return None
                 elif isinstance(where, slice) and where.step is None:
-                    return ByteMaskedArray(self.mask[where.start:where.stop],
-                                           self.content[where.start:where.stop],
-                                           valid_when=self.valid_when)
+                    return ByteMaskedArray(
+                        self.mask[where.start : where.stop],
+                        self.content[where.start : where.stop],
+                        valid_when=self.valid_when,
+                    )
                 elif isinstance(where, str):
-                    return ByteMaskedArray(self.mask, self.content[where], valid_when=self.valid_when)
+                    return ByteMaskedArray(
+                        self.mask, self.content[where], valid_when=self.valid_when
+                    )
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -134,11 +134,26 @@ class Content:
 
     @property
     def parameters(self) -> dict[str, Any]:
+        """
+        Free-form parameters associated with every array node as a dict from parameter
+        name to its JSON-like value. Some parameters are special and are used to assign
+        behaviors to the data.
+
+        Note that the dict returned by this property is a *view* of the array node's
+        parameters. *Changing the dict will change the array!*
+
+        See #ak.behavior.
+        """
         if self._parameters is None:
             self._parameters = {}
         return self._parameters
 
     def parameter(self, key: str):
+        """
+        Returns a parameter's value or None.
+
+        (No distinction is ever made between unset parameters and parameters set to None.)
+        """
         if self._parameters is None:
             return None
         else:
@@ -936,6 +951,13 @@ class Content:
         return self._nbytes_part()
 
     def purelist_parameter(self, key: str):
+        """
+        Return the value of the outermost parameter matching `key` in a sequence
+        of nested lists, stopping at the first record or tuple layer.
+
+        If a layer has #ak.types.UnionType, the value is only returned if all
+        possibilities have the same value.
+        """
         return self.form_cls.purelist_parameter(self, key)
 
     def _is_unique(
@@ -962,10 +984,23 @@ class Content:
 
     @property
     def purelist_isregular(self) -> bool:
+        """
+        Returns True if all dimensions down to the first record or tuple layer have
+        #ak.types.RegularType; False otherwise.
+        """
         return self.form_cls.purelist_isregular.__get__(self)
 
     @property
     def purelist_depth(self) -> int:
+        """
+        Number of dimensions of nested lists, not counting anything deeper than the
+        first record or tuple layer, if any. The depth of a one-dimensional array is
+        `1`.
+
+        If the array contains #ak.types.UnionType data and its contents have
+        equal depths, the return value is that depth. If they do not have equal
+        depths, the return value is `-1`.
+        """
         return self.form_cls.purelist_depth.__get__(self)
 
     @property

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -27,7 +27,7 @@ class EmptyArray(Content):
     (such as data from #ak.ArrayBuilder without enough sample points to resolve the
     type).
 
-    EmptyArray has no equivalent in Apache Arrow.
+    EmptyArray has no equivalent in Apache Arrow. It also cannot contain any parameters.
 
     To illustrate how the constructor arguments are interpreted, the following is a
     simplified implementation of `__init__`, `__len__`, and `__getitem__`:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -27,7 +27,10 @@ class EmptyArray(Content):
     (such as data from #ak.ArrayBuilder without enough sample points to resolve the
     type).
 
-    EmptyArray has no equivalent in Apache Arrow. It also cannot contain any parameters.
+    Unlike all other Content subclasses, EmptyArray cannot contain any parameters
+    (parameter values are always None).
+
+    EmptyArray has no equivalent in Apache Arrow.
 
     To illustrate how the constructor arguments are interpreted, the following is a
     simplified implementation of `__init__`, `__len__`, and `__getitem__`:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -42,10 +42,13 @@ class EmptyArray(Content):
             def __getitem__(self, where):
                 if isinstance(where, int):
                     assert False
+
                 elif isinstance(where, slice) and where.step is None:
                     return EmptyArray()
+
                 elif isinstance(where, str):
                     raise ValueError("field " + repr(where) + " not found")
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -22,6 +22,34 @@ numpy = Numpy.instance()
 
 @final
 class EmptyArray(Content):
+    """
+    An EmptyArray is used whenever an array's type is not known because it is empty
+    (such as data from #ak.ArrayBuilder without enough sample points to resolve the
+    type).
+
+    EmptyArray has no equivalent in Apache Arrow.
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class EmptyArray(Content):
+            def __init__(self):
+                pass
+
+            def __len__(self):
+                return 0
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert False
+                elif isinstance(where, slice) and where.step is None:
+                    return EmptyArray()
+                elif isinstance(where, str):
+                    raise ValueError("field " + repr(where) + " not found")
+                else:
+                    raise AssertionError(where)
+    """
+
     is_unknown = True
     is_leaf = True
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -56,14 +56,19 @@ class IndexedArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     return self.content[self.index[where]]
+
                 elif isinstance(where, slice) and where.step is None:
                     return IndexedArray(
                         self.index[where.start : where.stop], self.content
                     )
+
                 elif isinstance(where, str):
                     return IndexedArray(self.index, self.content[where])
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -31,9 +31,9 @@ class IndexedArray(Content):
 
     It has many uses:
 
-       * representing a lazily applied slice.
-       * simulating pointers into another collection.
-       * emulating the dictionary encoding of Apache Arrow and Parquet.
+    * representing a lazily applied slice.
+    * simulating pointers into another collection.
+    * emulating the dictionary encoding of Apache Arrow and Parquet.
 
     If the `__array__` parameter is `"categorical"`, the contents must be unique.
     Some operations are optimized (for instance, `==` only compares `index` integers)
@@ -47,7 +47,7 @@ class IndexedArray(Content):
                 assert isinstance(index, (Index32, IndexU32, Index64))
                 assert isinstance(content, Content)
                 for x in index:
-                    assert 0 <= x < len(content)   # index[i] must not be negative
+                    assert 0 <= x < len(content)  # index[i] must not be negative
                 self.index = index
                 self.content = content
 
@@ -59,7 +59,9 @@ class IndexedArray(Content):
                     assert 0 <= where < len(self)
                     return self.content[self.index[where]]
                 elif isinstance(where, slice) and where.step is None:
-                    return IndexedArray(self.index[where.start:where.stop], self.content)
+                    return IndexedArray(
+                        self.index[where.start : where.stop], self.content
+                    )
                 elif isinstance(where, str):
                     return IndexedArray(self.index, self.content[where])
                 else:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -23,6 +23,49 @@ numpy = Numpy.instance()
 
 @final
 class IndexedArray(Content):
+    """
+    IndexedArray is a general-purpose tool for *lazily* changing the order of
+    and/or duplicating some `content` with a
+    [np.take](https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html)
+    over the integer buffer `index.
+
+    It has many uses:
+
+       * representing a lazily applied slice.
+       * simulating pointers into another collection.
+       * emulating the dictionary encoding of Apache Arrow and Parquet.
+
+    If the `__array__` parameter is `"categorical"`, the contents must be unique.
+    Some operations are optimized (for instance, `==` only compares `index` integers)
+    and the array can be converted to and from Arrow/Parquet's dictionary encoding.
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class IndexedArray(Content):
+            def __init__(self, index, content):
+                assert isinstance(index, (Index32, IndexU32, Index64))
+                assert isinstance(content, Content)
+                for x in index:
+                    assert 0 <= x < len(content)   # index[i] must not be negative
+                self.index = index
+                self.content = content
+
+            def __len__(self):
+                return len(self.index)
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert 0 <= where < len(self)
+                    return self.content[self.index[where]]
+                elif isinstance(where, slice) and where.step is None:
+                    return IndexedArray(self.index[where.start:where.stop], self.content)
+                elif isinstance(where, str):
+                    return IndexedArray(self.index, self.content[where])
+                else:
+                    raise AssertionError(where)
+    """
+
     is_indexed = True
 
     def __init__(self, index, content, *, parameters=None):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -51,17 +51,22 @@ class IndexedOptionArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     if self.index[where] < 0:
                         return None
                     else:
                         return self.content[self.index[where]]
+
                 elif isinstance(where, slice) and where.step is None:
                     return IndexedOptionArray(
                         self.index[where.start : where.stop], self.content
                     )
+
                 elif isinstance(where, str):
                     return IndexedOptionArray(self.index, self.content[where])
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -42,7 +42,7 @@ class IndexedOptionArray(Content):
                 assert isinstance(index, (Index32, Index64))
                 assert isinstance(content, Content)
                 for x in index:
-                    assert x < len(content)   # index[i] may be negative
+                    assert x < len(content)  # index[i] may be negative
                 self.index = index
                 self.content = content
 
@@ -57,7 +57,9 @@ class IndexedOptionArray(Content):
                     else:
                         return self.content[self.index[where]]
                 elif isinstance(where, slice) and where.step is None:
-                    return IndexedOptionArray(self.index[where.start:where.stop], self.content)
+                    return IndexedOptionArray(
+                        self.index[where.start : where.stop], self.content
+                    )
                 elif isinstance(where, str):
                     return IndexedOptionArray(self.index, self.content[where])
                 else:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -24,6 +24,46 @@ numpy = Numpy.instance()
 
 @final
 class IndexedOptionArray(Content):
+    """
+    IndexedOptionArray is an #ak.contents.IndexedArray for which
+    negative values in the index are interpreted as missing. It represents
+    #ak.types.OptionType data like #ak.contents.ByteMaskedArray,
+    #ak.contents.BitMaskedArray, and #ak.contents.UnmaskedArray, but
+    the flexibility of the arbitrary `index` makes it a common output of
+    many operations.
+
+    IndexedOptionArray doesn't have a direct equivalent in Apache Arrow.
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class IndexedOptionArray(Content):
+            def __init__(self, index, content):
+                assert isinstance(index, (Index32, Index64))
+                assert isinstance(content, Content)
+                for x in index:
+                    assert x < len(content)   # index[i] may be negative
+                self.index = index
+                self.content = content
+
+            def __len__(self):
+                return len(self.index)
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert 0 <= where < len(self)
+                    if self.index[where] < 0:
+                        return None
+                    else:
+                        return self.content[self.index[where]]
+                elif isinstance(where, slice) and where.step is None:
+                    return IndexedOptionArray(self.index[where.start:where.stop], self.content)
+                elif isinstance(where, str):
+                    return IndexedOptionArray(self.index, self.content[where])
+                else:
+                    raise AssertionError(where)
+    """
+
     is_option = True
     is_indexed = True
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -29,8 +29,8 @@ class ListArray(Content):
     have unreachable elements between lists. Instead of a single `offsets` buffer,
     ListArray has
 
-       * `starts`: The starting index of each list.
-       * `stops`: The stopping index of each list.
+    * `starts`: The starting index of each list.
+    * `stops`: The stopping index of each list.
 
     #ak.contents.ListOffsetArray `offsets` may be related to `starts` and
     `stops` by
@@ -60,12 +60,12 @@ class ListArray(Content):
                 assert isinstance(starts, (Index32, IndexU32, Index64))
                 assert isinstance(stops, type(starts))
                 assert isinstance(content, Content)
-                assert len(stops) >= len(starts)   # usually equal
+                assert len(stops) >= len(starts)  # usually equal
                 for i in range(len(starts)):
                     start = starts[i]
                     stop = stops[i]
                     if start != stop:
-                        assert start < stop   # i.e. start <= stop
+                        assert start < stop  # i.e. start <= stop
                         assert start >= 0
                         assert stop <= len(content)
                 self.starts = starts
@@ -78,10 +78,10 @@ class ListArray(Content):
             def __getitem__(self, where):
                 if isinstance(where, int):
                     assert 0 <= where < len(self)
-                    return self.content[self.starts[where]:self.stops[where]]
+                    return self.content[self.starts[where] : self.stops[where]]
                 elif isinstance(where, slice) and where.step is None:
-                    starts = self.starts[where.start:where.stop]
-                    stops = self.stops[where.start:where.stop]
+                    starts = self.starts[where.start : where.stop]
+                    stops = self.stops[where.start : where.stop]
                     return ListArray(starts, stops, self.content)
                 elif isinstance(where, str):
                     return ListArray(self.starts, self.stops, self.content[where])

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -77,14 +77,19 @@ class ListArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     return self.content[self.starts[where] : self.stops[where]]
+
                 elif isinstance(where, slice) and where.step is None:
                     starts = self.starts[where.start : where.stop]
                     stops = self.stops[where.start : where.stop]
                     return ListArray(starts, stops, self.content)
+
                 elif isinstance(where, str):
                     return ListArray(self.starts, self.stops, self.content[where])
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -58,7 +58,7 @@ class ListOffsetArray(Content):
                     start = offsets[i]
                     stop = offsets[i + 1]
                     if start != stop:
-                        assert start < stop   # i.e. start <= stop
+                        assert start < stop  # i.e. start <= stop
                         assert start >= 0
                         assert stop <= len(content)
                 self.offsets = offsets
@@ -70,7 +70,7 @@ class ListOffsetArray(Content):
             def __getitem__(self, where):
                 if isinstance(where, int):
                     assert 0 <= where < len(self)
-                    return self.content[self.offsets[where]:self.offsets[where + 1]]
+                    return self.content[self.offsets[where] : self.offsets[where + 1]]
                 elif isinstance(where, slice) and where.step is None:
                     offsets = self.offsets[where.start : where.stop + 1]
                     if len(offsets) == 0:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -35,7 +35,7 @@ class ListOffsetArray(Content):
     but it need not start with `0` or include all of the `content`. Just as
     #ak.contents.RegularArray can have unreachable `content` if it is not
     an integer multiple of `size`, a ListOffsetArray can have unreachable
-    content before the first list and after the last list.
+    content before the start of the first list and after the end of the last list.
 
     Like #ak.contents.RegularArray and #ak.contents.ListArray, a ListOffsetArray can
     represent strings if its `__array__` parameter is `"string"` (UTF-8 assumed) or

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -24,6 +24,64 @@ numpy = Numpy.instance()
 
 @final
 class ListOffsetArray(Content):
+    """
+    ListOffsetArray describes unequal-length lists (often called a
+    "jagged" or "ragged" array). Like #ak.contents.RegularArray, the
+    underlying data for all lists are in a contiguous `content`. It is
+    subdivided into lists according to an `offsets` buffer, which specifies
+    the starting and stopping index of each list.
+
+    The `offsets` must have at least length 1 (corresponding to an empty array),
+    but it need not start with `0` or include all of the `content`. Just as
+    #ak.contents.RegularArray can have unreachable `content` if it is not
+    an integer multiple of `size`, a ListOffsetArray can have unreachable
+    content before the first list and after the last list.
+
+    Like #ak.contents.RegularArray and #ak.contents.ListArray, a ListOffsetArray can
+    represent strings if its `__array__` parameter is `"string"` (UTF-8 assumed) or
+    `"bytestring"` (no encoding assumed) and it contains an #ak.contents.NumpyArray
+    of `dtype=np.uint8` whose `__array__` parameter is `"char"` (UTF-8 assumed) or
+    `"byte"` (no encoding assumed).
+
+    ListOffsetArray corresponds to Apache Arrow
+    [List type](https://arrow.apache.org/docs/format/Columnar.html#variable-size-list-layout).
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class ListOffsetArray(Content):
+            def __init__(self, offsets, content):
+                assert isinstance(offsets, (Index32, IndexU32, Index64))
+                assert isinstance(content, Content)
+                assert len(offsets) != 0
+                for i in range(len(offsets) - 1):
+                    start = offsets[i]
+                    stop = offsets[i + 1]
+                    if start != stop:
+                        assert start < stop   # i.e. start <= stop
+                        assert start >= 0
+                        assert stop <= len(content)
+                self.offsets = offsets
+                self.content = content
+
+            def __len__(self):
+                return len(self.offsets) - 1
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert 0 <= where < len(self)
+                    return self.content[self.offsets[where]:self.offsets[where + 1]]
+                elif isinstance(where, slice) and where.step is None:
+                    offsets = self.offsets[where.start : where.stop + 1]
+                    if len(offsets) == 0:
+                        offsets = [0]
+                    return ListOffsetArray(offsets, self.content)
+                elif isinstance(where, str):
+                    return ListOffsetArray(self.offsets, self.content[where])
+                else:
+                    raise AssertionError(where)
+    """
+
     is_list = True
 
     def __init__(self, offsets, content, *, parameters=None):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -69,15 +69,20 @@ class ListOffsetArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     return self.content[self.offsets[where] : self.offsets[where + 1]]
+
                 elif isinstance(where, slice) and where.step is None:
                     offsets = self.offsets[where.start : where.stop + 1]
                     if len(offsets) == 0:
                         offsets = [0]
                     return ListOffsetArray(offsets, self.content)
+
                 elif isinstance(where, str):
                     return ListOffsetArray(self.offsets, self.content[where])
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -26,6 +26,60 @@ numpy = Numpy.instance()
 
 @final
 class NumpyArray(Content):
+    """
+    A NumpyArray describes 1-dimensional or rectilinear data using a NumPy
+    `np.ndarray`, a CuPy `cp.ndarray`, etc., depending on the backend.
+
+    This class is aware of the rectilinear array's `shape` and `strides`, and
+    allows for arbitrary `strides`, such as Fortran-ordered data. However, many
+    operations require C-contiguous data, so derivatives of Fortran-ordered
+    arrays may not be Fortran-ordered.
+
+    Only a subset of `dtype` values are allowed, and only for your system's
+    native endianness:
+
+      * `bool`: boolean, like NumPy's `np.bool_` (considered distinct from integers)
+      * `int8`: signed 8-bit
+      * `uint8`: unsigned 8-bit
+      * `int16`: signed 16-bit
+      * `uint16`: unsigned 16-bit
+      * `int32`: signed 32-bit
+      * `uint32`: unsigned 32-bit
+      * `int64`: signed 64-bit
+      * `uint64`: unsigned 64-bit
+      * `float16`: floating point 16-bit, if your system's NumPy supports it
+      * `float32`: floating point 32-bit
+      * `float64`: floating point 64-bit
+      * `float128`: floating point 128-bit, if your system's NumPy supports it
+      * `complex64`: floating complex numbers composed of 32-bit real/imag parts
+      * `complex128`: floating complex numbers composed of 64-bit real/imag parts
+      * `complex256`: floating complex numbers composed of 128-bit real/imag parts, if your system's NumPy supports it
+      * `datetime64`: date/time, origin is midnight on January 1, 1970, in any units NumPy supports
+      * `timedelta64`: time difference, in any units NumPy supports
+
+    If the `shape` is one-dimensional, a NumpyArray corresponds to an Apache
+    Arrow [Primitive array](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout).
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class NumpyArray(Content):
+            def __init__(self, data):
+                assert isinstance(data, numpy_like_array)
+                assert data.dtype in allowed_dtypes
+                self.data = data
+
+            def __len__(self):
+                return len(self.data)
+
+            def __getitem__(self, where):
+                result = self.data[where]
+                if isinstance(result, numpy_like_array):
+                    return NumpyArray(result)
+                else:
+                    return result
+    """
+
     is_numpy = True
     is_leaf = True
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,24 +38,24 @@ class NumpyArray(Content):
     Only a subset of `dtype` values are allowed, and only for your system's
     native endianness:
 
-      * `bool`: boolean, like NumPy's `np.bool_` (considered distinct from integers)
-      * `int8`: signed 8-bit
-      * `uint8`: unsigned 8-bit
-      * `int16`: signed 16-bit
-      * `uint16`: unsigned 16-bit
-      * `int32`: signed 32-bit
-      * `uint32`: unsigned 32-bit
-      * `int64`: signed 64-bit
-      * `uint64`: unsigned 64-bit
-      * `float16`: floating point 16-bit, if your system's NumPy supports it
-      * `float32`: floating point 32-bit
-      * `float64`: floating point 64-bit
-      * `float128`: floating point 128-bit, if your system's NumPy supports it
-      * `complex64`: floating complex numbers composed of 32-bit real/imag parts
-      * `complex128`: floating complex numbers composed of 64-bit real/imag parts
-      * `complex256`: floating complex numbers composed of 128-bit real/imag parts, if your system's NumPy supports it
-      * `datetime64`: date/time, origin is midnight on January 1, 1970, in any units NumPy supports
-      * `timedelta64`: time difference, in any units NumPy supports
+    * `bool`: boolean, like NumPy's `np.bool_` (considered distinct from integers)
+    * `int8`: signed 8-bit
+    * `uint8`: unsigned 8-bit
+    * `int16`: signed 16-bit
+    * `uint16`: unsigned 16-bit
+    * `int32`: signed 32-bit
+    * `uint32`: unsigned 32-bit
+    * `int64`: signed 64-bit
+    * `uint64`: unsigned 64-bit
+    * `float16`: floating point 16-bit, if your system's NumPy supports it
+    * `float32`: floating point 32-bit
+    * `float64`: floating point 64-bit
+    * `float128`: floating point 128-bit, if your system's NumPy supports it
+    * `complex64`: floating complex numbers composed of 32-bit real/imag parts
+    * `complex128`: floating complex numbers composed of 64-bit real/imag parts
+    * `complex256`: floating complex numbers composed of 128-bit real/imag parts, if your system's NumPy supports it
+    * `datetime64`: date/time, origin is midnight on January 1, 1970, in any units NumPy supports
+    * `timedelta64`: time difference, in any units NumPy supports
 
     If the `shape` is one-dimensional, a NumpyArray corresponds to an Apache
     Arrow [Primitive array](https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout).

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -66,12 +66,15 @@ class RecordArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     record = [x[where] for x in self.contents]
                     if self.fields is None:
                         return tuple(record)
                     else:
                         return dict(zip(self.fields, record))
+
                 elif isinstance(where, slice) and where.step is None:
                     if len(self.contents) == 0:
                         start = min(max(where.start, 0), self.length)
@@ -85,6 +88,7 @@ class RecordArray(Content):
                             self.fields,
                             where.stop - where.start,
                         )
+
                 elif isinstance(where, str):
                     if self.fields is None:
                         try:
@@ -102,6 +106,7 @@ class RecordArray(Content):
                         else:
                             return self.contents[i][0 : len(self)]
                     raise ValueError("field " + repr(where) + " not found")
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -30,10 +30,9 @@ class RecordArray(Content):
     RecordArray represents an array of tuples or records, all with the
     same type. Its `contents` is an ordered list of arrays.
 
-       * If `fields` is None, the data are tuples, indexed only by
-         their order.
-       * Otherwise, `fields` is an ordered list of names with the same length as
-         the `contents`, associating a field name to every content.
+    * If `fields` is None, the data are tuples, indexed only by their order.
+    * Otherwise, `fields` is an ordered list of names with the same length as
+      the `contents`, associating a field name to every content.
 
     The length of the RecordArray, if not given, is the length of its shortest
     content; all are aligned element-by-element. If a RecordArray has zero contents,
@@ -81,8 +80,11 @@ class RecordArray(Content):
                             stop = start
                         return RecordArray([], self.fields, stop - start)
                     else:
-                        return RecordArray([x[where] for x in self.contents], self.fields,
-                                           where.stop - where.start)
+                        return RecordArray(
+                            [x[where] for x in self.contents],
+                            self.fields,
+                            where.stop - where.start,
+                        )
                 elif isinstance(where, str):
                     if self.fields is None:
                         try:
@@ -91,14 +93,14 @@ class RecordArray(Content):
                             pass
                         else:
                             if i < len(self.contents):
-                                return self.contents[i][0:len(self)]
+                                return self.contents[i][0 : len(self)]
                     else:
                         try:
                             i = self.fields.index(where)
                         except ValueError:
                             pass
                         else:
-                            return self.contents[i][0:len(self)]
+                            return self.contents[i][0 : len(self)]
                     raise ValueError("field " + repr(where) + " not found")
                 else:
                     raise AssertionError(where)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -72,8 +72,11 @@ class RegularArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     return self.content[(where) * self.size : (where + 1) * self.size]
+
                 elif isinstance(where, slice) and where.step is None:
                     start = where.start * self.size
                     stop = where.stop * self.size
@@ -81,8 +84,10 @@ class RegularArray(Content):
                     return RegularArray(
                         self.content[start:stop], self.size, zeros_length
                     )
+
                 elif isinstance(where, str):
                     return RegularArray(self.content[where], self.size, self.length)
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -59,7 +59,7 @@ class RegularArray(Content):
                 assert isinstance(zeros_length, int)
                 assert size >= 0
                 if size != 0:
-                    length = len(content) // size   # floor division
+                    length = len(content) // size  # floor division
                 else:
                     assert zeros_length >= 0
                     length = zeros_length
@@ -73,12 +73,14 @@ class RegularArray(Content):
             def __getitem__(self, where):
                 if isinstance(where, int):
                     assert 0 <= where < len(self)
-                    return self.content[(where) * self.size:(where + 1) * self.size]
+                    return self.content[(where) * self.size : (where + 1) * self.size]
                 elif isinstance(where, slice) and where.step is None:
                     start = where.start * self.size
                     stop = where.stop * self.size
                     zeros_length = where.stop - where.start
-                    return RegularArray(self.content[start:stop], self.size, zeros_length)
+                    return RegularArray(
+                        self.content[start:stop], self.size, zeros_length
+                    )
                 elif isinstance(where, str):
                     return RegularArray(self.content[where], self.size, self.length)
                 else:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -62,16 +62,21 @@ class UnionArray(Content):
 
             def __getitem__(self, where):
                 if isinstance(where, int):
+                    if where < 0:
+                        where += len(self)
                     assert 0 <= where < len(self)
                     return self.contents[self.tags[where]][self.index[where]]
+
                 elif isinstance(where, slice) and where.step is None:
                     return UnionArray(
                         self.tags[where], self.index[where], self.contents
                     )
+
                 elif isinstance(where, str):
                     return UnionArray(
                         self.tags, self.index, [x[where] for x in self.contents]
                     )
+
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -32,10 +32,8 @@ class UnionArray(Content):
     UnionArray represents data drawn from an ordered list of `contents`,
     which can have different types, using
 
-       * `tags`: buffer of integers indicating which content each array element
-         draws from.
-       * `index`: buffer of integers indicating which element from the content
-         to draw from.
+    * `tags`: buffer of integers indicating which content each array element draws from.
+    * `index`: buffer of integers indicating which element from the content to draw from.
 
     UnionArrays correspond to Apache Arrow's
     [dense union type](https://arrow.apache.org/docs/format/Columnar.html#dense-union).
@@ -50,7 +48,7 @@ class UnionArray(Content):
                 assert isinstance(tags, Index8)
                 assert isinstance(index, (Index32, IndexU32, Index64))
                 assert isinstance(contents, list)
-                assert len(index) >= len(tags)   # usually equal
+                assert len(index) >= len(tags)  # usually equal
                 for x in tags:
                     assert 0 <= x < len(contents)
                 for i, x in enumerate(tags):
@@ -67,9 +65,13 @@ class UnionArray(Content):
                     assert 0 <= where < len(self)
                     return self.contents[self.tags[where]][self.index[where]]
                 elif isinstance(where, slice) and where.step is None:
-                    return UnionArray(self.tags[where], self.index[where], self.contents)
+                    return UnionArray(
+                        self.tags[where], self.index[where], self.contents
+                    )
                 elif isinstance(where, str):
-                    return UnionArray(self.tags, self.index, [x[where] for x in self.contents])
+                    return UnionArray(
+                        self.tags, self.index, [x[where] for x in self.contents]
+                    )
                 else:
                     raise AssertionError(where)
     """

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -28,6 +28,52 @@ numpy = Numpy.instance()
 
 @final
 class UnionArray(Content):
+    """
+    UnionArray represents data drawn from an ordered list of `contents`,
+    which can have different types, using
+
+       * `tags`: buffer of integers indicating which content each array element
+         draws from.
+       * `index`: buffer of integers indicating which element from the content
+         to draw from.
+
+    UnionArrays correspond to Apache Arrow's
+    [dense union type](https://arrow.apache.org/docs/format/Columnar.html#dense-union).
+    Awkward Array has no direct equivalent for Apache Arrow's
+    [sparse union type](https://arrow.apache.org/docs/format/Columnar.html#sparse-union).
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class UnionArray(Content):
+            def __init__(self, tags, index, contents):
+                assert isinstance(tags, Index8)
+                assert isinstance(index, (Index32, IndexU32, Index64))
+                assert isinstance(contents, list)
+                assert len(index) >= len(tags)   # usually equal
+                for x in tags:
+                    assert 0 <= x < len(contents)
+                for i, x in enumerate(tags):
+                    assert 0 <= index[i] < len(contents[x])
+                self.tags = tags
+                self.index = index
+                self.contents = contents
+
+            def __len__(self):
+                return len(self.tags)
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    assert 0 <= where < len(self)
+                    return self.contents[self.tags[where]][self.index[where]]
+                elif isinstance(where, slice) and where.step is None:
+                    return UnionArray(self.tags[where], self.index[where], self.contents)
+                elif isinstance(where, str):
+                    return UnionArray(self.tags, self.index, [x[where] for x in self.contents])
+                else:
+                    raise AssertionError(where)
+    """
+
     is_union = True
 
     def __init__(self, tags, index, contents, *, parameters=None):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -24,6 +24,38 @@ numpy = Numpy.instance()
 
 @final
 class UnmaskedArray(Content):
+    """
+    UnmaskedArray implements an #ak.types.OptionType for which the values are
+    never, in fact, missing. It exists to satisfy systems that formally require this
+    high-level type without the overhead of generating an array of all True or all
+    False values.
+
+    This is like NumPy's
+    [masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.html)
+    with `mask=None`.
+
+    It is also like Apache Arrow's
+    [validity bitmaps](https://arrow.apache.org/docs/format/Columnar.html#validity-bitmaps)
+    because the bitmap can be omitted when all values are valid.
+
+    To illustrate how the constructor arguments are interpreted, the following is a
+    simplified implementation of `__init__`, `__len__`, and `__getitem__`:
+
+        class UnmaskedArray(Content):
+            def __init__(self, content):
+                assert isinstance(content, Content)
+                self.content = content
+
+            def __len__(self):
+                return len(self.content)
+
+            def __getitem__(self, where):
+                if isinstance(where, int):
+                    return self.content[where]
+                else:
+                    return UnmaskedArray(self.content[where])
+    """
+
     is_option = True
 
     def __init__(self, content, *, parameters=None):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -348,7 +348,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         can be used in mathematical expressions with the original `array`
         because they are still aligned.
 
-        See <<filtering>> and #ak.mask.
+        See <<<filtering>>> and #ak.mask.
         """
         return self.Mask(self)
 
@@ -555,7 +555,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
           like Python/NumPy.
         * **A string** selects a tuple or record field, even if its
           position in the tuple is to the left of the dimension where the
-          tuple/record is defined. (See <<projection>> below.) This is
+          tuple/record is defined. (See <<<projection>>> below.) This is
           similar to NumPy's
           [field access](https://numpy.org/doc/stable/user/basics.indexing.html#field-access),
           except that strings are allowed in the same tuple with other
@@ -591,12 +591,12 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
           to the output. This behavior matches pyarrow's
           [Array.take](https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.take)
           which also manages arrays with missing values. See
-          <<option indexing>> below.
+          <<<option indexing>>> below.
         * **An Array of nested lists**, ultimately containing booleans or
           integers and having the same lengths of lists at each level as
           the Array to which they're applied, selects by boolean or by
           integer at the deeply nested level. Missing items at any level
-          above the deepest level must broadcast. See <<nested indexing>> below.
+          above the deepest level must broadcast. See <<<nested indexing>>> below.
 
         A tuple of the above applies each slice item to a dimension of the
         data, which can be very expressive. More than one flat boolean/integer
@@ -630,7 +630,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             <Array [[[1], [], [3], [5]], [[7], [9]]] type='2 * var * var * int64'>
 
         In this example, the boolean array is itself nested (see
-        <<nested indexing>> below).
+        <<<nested indexing>>> below).
 
             >>> array % 2 == 1
             <Array [[[False, True, False], ..., [True]], ...] type='2 * var * var * bool'>
@@ -931,7 +931,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         Here, the `np.argmax` returns the integer position of the maximum
         element or None for empty arrays. It's a nice example of
-        <<option indexing>> with <<nested indexing>>.
+        <<<option indexing>>> with <<<nested indexing>>>.
 
         When applying a nested index with missing (None) entries at levels
         higher than the last level, the indexer must have the same dimension
@@ -1090,7 +1090,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             <Array [[[1], [2, 2], [3, 3, 3]], [], [...]] type='3 * var * var * int64'>
 
         which are equivalent to `array["x"]` and `array["y"]`. (See
-        <<projection>>.)
+        <<<projection>>>.)
 
         Fields can't be accessed as attributes when
 

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -15,6 +15,20 @@ np = NumpyMetadata.instance()
 
 
 class Record:
+    """
+    Represents a single value from a #ak.contents.RecordArray.
+
+    As this is a columnar representation, the Record contains a
+    #ak.layout.RecordArray, rather than the other way around.
+    Its two fields are
+
+    * `array`: the #ak.layout.RecordArray and
+    * `at`: the index posiion where this Record is found.
+
+    The Record shares a reference with its #ak.layout.RecordArray;
+    it is not a copy.
+    """
+
     def __init__(self, array, at):
         if not isinstance(array, ak.contents.RecordArray):
             raise ak._errors.wrap_error(


### PR DESCRIPTION
Specifically,

  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.Content.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.BitMaskedArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.ByteMaskedArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.EmptyArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.IndexedArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.IndexedOptionArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.ListArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.ListOffsetArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.NumpyArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.RecordArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.RegularArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.UnionArray.rst
  * https://raw.githubusercontent.com/scikit-hep/awkward/main-v1/docs-sphinx/ak.layout.UnmaskedArray.rst