### PR TITLE
fix: use `simplified` in `ak._do.merge_as_union`

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -306,7 +306,7 @@ def merge_as_union(one: Content, two: Content) -> ak.contents.UnionArray:
         )
     )
 
-    return ak.contents.UnionArray(tags, index, contents, parameters=None)
+    return ak.contents.UnionArray.simplified(tags, index, contents, parameters=None)
 
 
 def mergemany(contents: list[Content]) -> Content:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -271,7 +271,9 @@ def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
     return one._mergeable_next(two, mergebool=mergebool)
 
 
-def merge_as_union(contents: Sequence[Content]) -> ak.contents.UnionArray:
+def merge_as_union(
+    contents: Sequence[Content], parameters=None
+) -> ak.contents.UnionArray:
     length = sum([c.length for c in contents])
     first = contents[0]
     tags = ak.index.Index8.empty(length, first.backend.index_nplike)
@@ -291,7 +293,7 @@ def merge_as_union(contents: Sequence[Content]) -> ak.contents.UnionArray:
         )
         offset += content.length
 
-    return ak.contents.UnionArray(tags, index, contents, parameters=None)
+    return ak.contents.UnionArray(tags, index, contents, parameters=parameters)
 
 
 def mergemany(contents: list[Content]) -> Content:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -293,7 +293,9 @@ def merge_as_union(
         )
         offset += content.length
 
-    return ak.contents.UnionArray(tags, index, contents, parameters=parameters)
+    return ak.contents.UnionArray.simplified(
+        tags, index, contents, parameters=parameters
+    )
 
 
 def mergemany(contents: list[Content]) -> Content:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 from numbers import Integral
 
 import awkward as ak
@@ -271,42 +271,27 @@ def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
     return one._mergeable_next(two, mergebool=mergebool)
 
 
-def merge_as_union(one: Content, two: Content) -> ak.contents.UnionArray:
-    mylength = one.length
-    theirlength = two.length
-    tags = ak.index.Index8.empty(
-        mylength + theirlength,
-        one.backend.index_nplike,
-    )
-    index = ak.index.Index64.empty(
-        mylength + theirlength,
-        one.backend.index_nplike,
-    )
-    contents = [one, two]
-    assert tags.nplike is one.backend.index_nplike
-    one._handle_error(
-        one.backend["awkward_UnionArray_filltags_const", tags.dtype.type](
-            tags.data, 0, mylength, 0
-        )
-    )
-    assert index.nplike is one.backend.index_nplike
-    one._handle_error(
-        one.backend["awkward_UnionArray_fillindex_count", index.dtype.type](
-            index.data, 0, mylength
-        )
-    )
-    one._handle_error(
-        one.backend["awkward_UnionArray_filltags_const", tags.dtype.type](
-            tags.data, mylength, theirlength, 1
-        )
-    )
-    one._handle_error(
-        one.backend["awkward_UnionArray_fillindex_count", index.dtype.type](
-            index.data, mylength, theirlength
-        )
-    )
+def merge_as_union(contents: Sequence[Content]) -> ak.contents.UnionArray:
+    length = sum([c.length for c in contents])
+    first = contents[0]
+    tags = ak.index.Index8.empty(length, first.backend.index_nplike)
+    index = ak.index.Index64.empty(length, first.backend.index_nplike)
 
-    return ak.contents.UnionArray.simplified(tags, index, contents, parameters=None)
+    offset = 0
+    for i, content in enumerate(contents):
+        content._handle_error(
+            content.backend["awkward_UnionArray_filltags_const", tags.dtype.type](
+                tags.data, offset, content.length, i
+            )
+        )
+        content._handle_error(
+            content.backend["awkward_UnionArray_fillindex_count", index.dtype.type](
+                index.data, offset, content.length
+            )
+        )
+        offset += content.length
+
+    return ak.contents.UnionArray(tags, index, contents, parameters=None)
 
 
 def mergemany(contents: list[Content]) -> Content:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1180,14 +1180,9 @@ class UnionArray(Content):
             parameters=parameters,
         )
 
-        if len(tail) == 0:
-            return next
-
-        reversed = tail[0]._reverse_merge(next)
-        if len(tail) == 1:
-            return reversed
-        else:
-            return reversed._mergemany(tail[1:])
+        # `tail` should always be empty for UnionArray's merging strategy
+        assert len(tail) == 0
+        return next
 
     def _fill_none(self, value: Content) -> Content:
         contents = []

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -111,7 +111,10 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                 batches.append([x])
 
         contents = [ak._do.mergemany(b) for b in batches]
-        out = ak._do.merge_as_union(contents)
+        if len(contents) > 1:
+            out = ak._do.merge_as_union(contents)
+        else:
+            out = contents[0]
 
         if isinstance(out, ak.contents.UnionArray):
             out = type(out).simplified(

--- a/tests/test_2240_simplify_merge_as_union.py
+++ b/tests/test_2240_simplify_merge_as_union.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 
-import numpy as np  # noqa: F401
+import numpy as np
 
 import awkward as ak
 

--- a/tests/test_2240_simplify_merge_as_union.py
+++ b/tests/test_2240_simplify_merge_as_union.py
@@ -1,0 +1,37 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import numpy as np  # noqa: F401
+
+import awkward as ak
+
+
+def test_many():
+    result = ak.concatenate(
+        [ak.Array(x) for x in [[{"a": 3}], [{"c": 3}], [{"d": 3}], [{"e": 3}]]]
+    )
+    assert result.tolist() == [{"a": 3}, {"c": 3}, {"d": 3}, {"e": 3}]
+
+
+def test_validity_error_simple():
+    layout = ak.contents.UnionArray(
+        ak.index.Index8(np.array([0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.int8)),
+        ak.index.Index64(np.array([0, 1, 2, 3, 0, 1, 2, 3, 4], dtype=np.int64)),
+        [ak.to_layout([1, 2, 3, 4]), ak.to_layout([5, 6, 7, 8, 9])],
+    )
+    assert layout.to_list() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert "content(1) is mergeable with content(0)" in ak.validity_error(layout)
+
+
+def test_validity_error_complex():
+    layout = ak.contents.UnionArray(
+        ak.index.Index8(np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2], dtype=np.int8)),
+        ak.index.Index64(np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2], dtype=np.int64)),
+        [
+            ak.to_layout([1, 2, 3, 4]),
+            ak.to_layout(["a", "b", "c", "d"]),
+            ak.to_layout([5, 6, 7]),
+        ],
+    )
+    assert layout.to_list() == [1, 2, 3, 4, "a", "b", "c", "d", 5, 6, 7]
+    assert "content(2) is mergeable with content(0)" in ak.validity_error(layout)


### PR DESCRIPTION
## TL;DR
- Remove untestable logic in `UnionArray._mergemany`
- Fix merging of multiple layouts that can be simplified
- Move mergeability check from `UnionArray.__init__` to `_validity_error`

## TL

`UnionArray._merge_strategy` always returns an empty sequence for `tail`. Therefore, any logic depending upon `tail` being non-empty can be removed, as it's more than just an implementation detail: unions always merge everything in one go.

We should use `simplified` to merge arrays that are not known to produce a canonical union. At present we could handle this explicitly; if the contents aren't unions and aren't mergeable, we can use `UnionArray(...)`, but in future this will become more complex if we absorb index arrays into unions as well.

Mergeable checks are "slow" as in the ideal case they must validate at every level of the tree. These should be done in the validity error checks instead.

Fixes #2239 