### PR TITLE
fix: don't merge non-union parameters

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1064,14 +1064,8 @@ class UnionArray(Content):
                 AssertionError("FIXME: handle UnionArray with more than 127 contents")
             )
 
-        parameters = ak.forms.form._parameters_union(
-            self._parameters,
-            other._parameters,
-            exclude=ak.forms.form.reserved_nominal_parameters,
-        )
-
         return ak.contents.UnionArray.simplified(
-            tags, index, contents, parameters=parameters
+            tags, index, contents, parameters=self._parameters
         )
 
     def _mergemany(self, others):

--- a/tests/test_2240_merge_union_parameters.py
+++ b/tests/test_2240_merge_union_parameters.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    one = ak.with_parameter([1, 2, [], [3, 4]], "one", "one")
+    two = ak.with_parameter([100, 200, 300], "two", "two")
+    three = ak.with_parameter([{"x": 1}, {"x": 2}, 5, 6, 7], "two", "two")
+
+    # No parameter unions should occur here
+    result = ak.concatenate((two, one, three))
+    assert ak.parameters(result) == {}


### PR DESCRIPTION
## TL;DR
- Fix old parameter logic in `UnionArray._reverse_merge`

## TL


`UnionArray._reverse_merge` used to try and reconstruct parameters from the `other` layout. Now we just let the `.simplified` logic do this. We only want to take the union parameters in specific circumstances, and  parameters of the contents should only be merged with parameters of the union when they intersect. `UnionArray.simplified` already handles 