### PR TITLE
fix: boolean slicing with non-packed arrays

### DIFF
--- a/tests/test_2246_slice_not_packed.py
+++ b/tests/test_2246_slice_not_packed.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    index = ak.Array(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 3, 5]),
+            ak.contents.NumpyArray(
+                np.array([True, False, False, True, True, False, False], dtype=np.bool_)
+            ),
+        )
+    )
+    array = ak.Array([[0, 1, 2], [3, 4]])
+    result = array[index]
+    assert result.tolist() == [[0], [3, 4]]


### PR DESCRIPTION
In fixing #2214, I missed the fact that `to_ListOffsetArray64(True)` provides no guarantee about the _length_ of the content. This PR fixes that oversight, by using `ak._do.flatten` which ensures the length of the result is correct.
