### PR TITLE
fix: set dtype in `full_like`

### DIFF
--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -102,7 +102,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
         if layout.is_numpy:
             original = nplike.asarray(layout.data)
 
-            if fill_value is _ZEROS or (ensure_known_scalar(fill_value == 0, False)):
+            if fill_value is _ZEROS or ensure_known_scalar(fill_value == 0, False):
                 return ak.contents.NumpyArray(
                     nplike.zeros_like(original, dtype=dtype),
                     parameters=layout.parameters,
@@ -182,14 +182,16 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
                     ak.contents.NumpyArray(asbytes, parameters={"__array__": "char"}),
                     parameters={"__array__": "string"},
                 )
-            # Interpret strings as numeric/bool types
-            result = ak.operations.strings_astype(
-                result, dtype, highlevel=highlevel, behavior=behavior
-            )
-            # Convert dtype
-            return ak.operations.values_astype(
-                result, dtype, highlevel=False, behavior=behavior
-            )
+            if dtype is not None:
+                # Interpret strings as numeric/bool types
+                result = ak.operations.strings_astype(
+                    result, dtype, highlevel=highlevel, behavior=behavior
+                )
+                # Convert dtype
+                result = ak.operations.values_astype(
+                    result, dtype, highlevel=False, behavior=behavior
+                )
+            return result
         else:
             return None
 

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -115,7 +115,10 @@ def _impl(array, fill_value, highlevel, behavior, dtype):
                     nplike=index_nplike,
                 ),
                 ak.contents.NumpyArray(
-                    asbytes, parameters="byte" if name == "bytestring" else "char"
+                    asbytes,
+                    parameters={
+                        "__array__": "byte" if name == "bytestring" else "char"
+                    },
                 ),
                 parameters={"__array__": name},
             )

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -7,11 +7,16 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
+def ones_like(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         dtype (None or NumPy dtype): Overrides the data type of the result.
+        including_unknown (bool): If True, the `unknown` type is considered
+            a value type and is converted to a zero-length array of the
+            specified dtype; if False, `unknown` will remain `unknown`.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -26,13 +31,21 @@ def ones_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.ones_like",
-        {"array": array, "dtype": dtype, "highlevel": highlevel, "behavior": behavior},
+        {
+            "array": array,
+            "dtype": dtype,
+            "including_unknown": including_unknown,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
-        return _impl(array, highlevel, behavior, dtype)
+        return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 
-def _impl(array, highlevel, behavior, dtype):
-    return ak.operations.ak_full_like._impl(array, 1, highlevel, behavior, dtype)
+def _impl(array, highlevel, behavior, dtype, including_unknown):
+    return ak.operations.ak_full_like._impl(
+        array, 1, highlevel, behavior, dtype, including_unknown
+    )
 
 
 @ak._connect.numpy.implements("ones_like")

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -10,11 +10,16 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
-def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
+def zeros_like(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         dtype (None or NumPy dtype): Overrides the data type of the result.
+        including_unknown (bool): If True, the `unknown` type is considered
+            a value type and is converted to a zero-length array of the
+            specified dtype; if False, `unknown` will remain `unknown`.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -29,15 +34,25 @@ def zeros_like(array, *, dtype=None, highlevel=True, behavior=None):
     """
     with ak._errors.OperationErrorContext(
         "ak.zeros_like",
-        {"array": array, "dtype": dtype, "highlevel": highlevel, "behavior": behavior},
+        {
+            "array": array,
+            "dtype": dtype,
+            "including_unknown": including_unknown,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
     ):
-        return _impl(array, highlevel, behavior, dtype)
+        return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 
-def _impl(array, highlevel, behavior, dtype):
+def _impl(array, highlevel, behavior, dtype, including_unknown):
     if dtype is not None:
-        return ak.operations.ak_full_like._impl(array, 0, highlevel, behavior, dtype)
-    return ak.operations.ak_full_like._impl(array, _ZEROS, highlevel, behavior, dtype)
+        return ak.operations.ak_full_like._impl(
+            array, 0, highlevel, behavior, dtype, including_unknown
+        )
+    return ak.operations.ak_full_like._impl(
+        array, _ZEROS, highlevel, behavior, dtype, including_unknown
+    )
 
 
 @ak._connect.numpy.implements("zeros_like")

--- a/tests/test_2250_full_like_bool.py
+++ b/tests/test_2250_full_like_bool.py
@@ -1,0 +1,16 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_bool():
+    result = ak.full_like([True], 2, dtype=np.int64)
+    assert ak.almost_equal(result, np.asarray([2], dtype=np.int64))
+
+
+def test_complex128():
+    result = ak.full_like([1, 2], 4j, dtype=np.complex128)
+    assert ak.almost_equal(result, np.asarray([0 + 4j, 0 + 4j], dtype=np.complex128))

--- a/tests/test_2250_full_like_bool.py
+++ b/tests/test_2250_full_like_bool.py
@@ -11,6 +11,14 @@ def test_bool():
     assert ak.almost_equal(result, np.asarray([2], dtype=np.int64))
 
 
+def test_empty():
+    result = ak.full_like([], 2, dtype=np.int64)
+    assert result.layout.is_unknown
+    result = ak.full_like([], 2, dtype=np.int64, including_unknown=True)
+    assert result.layout.is_numpy
+    assert result.layout.dtype == np.dtype(np.int64)
+
+
 def test_complex128():
     result = ak.full_like([1, 2], 4j, dtype=np.complex128)
     assert ak.almost_equal(result, np.asarray([0 + 4j, 0 + 4j], dtype=np.complex128))


### PR DESCRIPTION
This PR directly sets `dtype` in the `nplike.full_like` call, which I think is all we need to do here.

Fixes #2250 