### PR TITLE
fix: run-lengths with typetracer

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -787,7 +787,17 @@ class TypeTracer(NumpyLike):
         try_touch_data(x)
         try_touch_data(values)
         try_touch_data(sorter)
-        raise ak._errors.wrap_error(NotImplementedError)
+        if (
+            not (
+                is_unknown_length(x.size)
+                or sorter is None
+                or is_unknown_length(sorter.size)
+            )
+            and x.size != sorter.size
+        ):
+            raise wrap_error(ValueError("x.size should equal sorter.size"))
+
+        return TypeTracerArray._new(x.dtype, (values.size,))
 
     ############################ manipulation
 

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -96,7 +96,7 @@ def _impl(array, highlevel, behavior):
     backend = ak._backends.backend_of(array, default=cpu)
 
     def lengths_of(data, offsets):
-        if len(data) == 0:
+        if backend.nplike.known_data and data.size == 0:
             return backend.index_nplike.empty(0, dtype=np.int64), offsets
         else:
             diffs = data[1:] != data[:-1]
@@ -116,16 +116,17 @@ def _impl(array, highlevel, behavior):
                 # To consider only the interior boundaries, we ignore the start and end
                 # offset values. These can be repeated with empty sublists, so we mask them out.
                 is_interior = backend.nplike.logical_and(
-                    0 < offsets, offsets < len(data)
+                    0 < offsets,
+                    offsets < backend.index_nplike.shape_item_as_index(data.size),
                 )
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True
             positions = backend.index_nplike.nonzero(diffs)[0]
             full_positions = backend.index_nplike.empty(
-                len(positions) + 2, dtype=np.int64
+                positions.size + 2, dtype=np.int64
             )
             full_positions[0] = 0
-            full_positions[-1] = len(data)
+            full_positions[-1] = backend.index_nplike.shape_item_as_index(data.size)
             full_positions[1:-1] = positions + 1
 
             nextcontent = full_positions[1:] - full_positions[:-1]

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -2,6 +2,7 @@
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 
 np = NumpyMetadata.instance()
 cpu = ak._backends.NumpyBackend.instance()
@@ -96,13 +97,16 @@ def _impl(array, highlevel, behavior):
     backend = ak._backends.backend_of(array, default=cpu)
 
     def lengths_of(data, offsets):
-        if backend.nplike.known_data and data.size == 0:
+        if backend.nplike.is_own_array(data):
+            size = data.size
+        else:
+            layout = ak.to_layout(data)
+            size = layout.length
+
+        if size is not unknown_length and size == 0:
             return backend.index_nplike.empty(0, dtype=np.int64), offsets
         else:
-            diffs = data[1:] != data[:-1]
-
-            if isinstance(diffs, ak.highlevel.Array):
-                diffs = backend.nplike.asarray(diffs)
+            diffs = backend.nplike.asarray(data[1:] != data[:-1])
             # Do we have list boundaries to consider?
             if offsets is not None:
                 # When checking to see whether one element equals its following neighbour
@@ -117,7 +121,7 @@ def _impl(array, highlevel, behavior):
                 # offset values. These can be repeated with empty sublists, so we mask them out.
                 is_interior = backend.nplike.logical_and(
                     0 < offsets,
-                    offsets < backend.index_nplike.shape_item_as_index(data.size),
+                    offsets < backend.index_nplike.shape_item_as_index(size),
                 )
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True
@@ -126,7 +130,7 @@ def _impl(array, highlevel, behavior):
                 positions.size + 2, dtype=np.int64
             )
             full_positions[0] = 0
-            full_positions[-1] = backend.index_nplike.shape_item_as_index(data.size)
+            full_positions[-1] = backend.index_nplike.shape_item_as_index(size)
             full_positions[1:-1] = positions + 1
 
             nextcontent = full_positions[1:] - full_positions[:-1]

--- a/tests/test_2259_run_lengths_typetracer.py
+++ b/tests/test_2259_run_lengths_typetracer.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+
+def test():
+    array = ak.Array([2, 1, 1, 1, 2, 2, 3, 3, 4], backend="typetracer")
+    result = ak.run_lengths(array)
+    assert isinstance(result.layout, ak.contents.NumpyArray)
+    assert result.layout.length is unknown_length
+    assert result.layout.dtype == np.dtype("int64")


### PR DESCRIPTION
Fix `ak.run_lengths` use with typetracer arrays