### PR TITLE
fix: support unknown content length in `to_packed`

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2148,10 +2148,13 @@ class ListOffsetArray(Content):
     def to_packed(self) -> Self:
         next = self.to_ListOffsetArray64(True)
         content = next._content.to_packed()
+        packed_length = self._backend.index_nplike.index_as_shape_item(
+            next._offsets[-1]
+        )
         if (
             content.length is not unknown_length
-            and content.length
-            != self._backend.index_nplike.index_as_shape_item(next._offsets[-1])
+            and packed_length is not unknown_length
+            and content.length != packed_length
         ):
             content = content[: next._offsets[-1]]
         return ListOffsetArray(next._offsets, content, parameters=next._parameters)

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -147,5 +147,5 @@ def test_numpy_array():
 
 def test_typetracer():
     array = ak.Array([[[1, 2, 3]], [[5, 4]]], backend="typetracer")
-    with pytest.raises(TypeError):
+    with pytest.raises(NotImplementedError):
         ak.almost_equal(array, 2 * array)

--- a/tests/test_2263_to_packed_list.py
+++ b/tests/test_2263_to_packed_list.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._backends import TypeTracerBackend
+
+
+def test():
+    backend = TypeTracerBackend.instance()
+    layout = ak.contents.ListOffsetArray(
+        ak.index.Index64(
+            backend.index_nplike.asarray([0, 1, 3, 7], dtype=np.dtype("int64"))
+        ),
+        ak.contents.NumpyArray(backend.nplike.asarray([1, 2, 3, 4, 5, 6, 7])),
+    )
+    assert layout.to_packed().length == 3


### PR DESCRIPTION
Slowly we will find `.length == X` checks and guard them with `is unknown_length` cases.

Fixes #2261 