### PR TITLE
feat: add `ak.broadcast_fields`

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -7,7 +7,7 @@ import numbers
 import os
 import re
 import sys
-from collections.abc import Iterable, Mapping, Sequence, Sized
+from collections.abc import Collection, Iterable, Mapping, Sequence, Sized
 
 import packaging.version
 
@@ -16,6 +16,7 @@ from awkward._nplikes import nplike_of, ufuncs
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward.typing import TypeVar
 
 np = NumpyMetadata.instance()
 
@@ -808,3 +809,17 @@ except AttributeError:
             __pos__ = _unary_method(um.positive, "pos")
         __abs__ = _unary_method(um.absolute, "abs")
         __invert__ = _unary_method(um.invert, "invert")
+
+
+T = TypeVar("T")
+
+
+def unique_list(items: Collection[T]) -> list[T]:
+    seen = set()
+    result = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -411,6 +411,17 @@ class RecordArray(Content):
         else:
             return out[: self._length]
 
+    def maybe_content(self, index_or_field) -> Content:
+        if self.has_field(index_or_field):
+            return self.content(index_or_field)
+        else:
+            return ak.contents.IndexedOptionArray(
+                ak.index.Index64(
+                    self._backend.index_nplike.full(self.length, -1, dtype=np.int64)
+                ),
+                ak.contents.EmptyArray(),
+            )
+
     def _getitem_nothing(self) -> Content:
         return self._getitem_range(0, 0)
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -220,8 +220,8 @@ class UnionForm(Form):
 
     @property
     def fields(self):
-        fieldslists = [cont.fields for cont in self._contents]
-        return list(set.intersection(*[set(x) for x in fieldslists]))
+        all_fields = [f for cont in self._contents for f in cont.fields]
+        return ak._util.unique_list(all_fields)
 
     @property
     def is_tuple(self):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -1,5 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+from collections import Counter
 from collections.abc import Iterable
 
 import awkward as ak
@@ -220,8 +221,8 @@ class UnionForm(Form):
 
     @property
     def fields(self):
-        all_fields = [f for cont in self._contents for f in cont.fields]
-        return ak._util.unique_list(all_fields)
+        field_counts = Counter([f for c in self._contents for f in c.fields])
+        return [f for f, n in field_counts.items() if n == len(self._contents)]
 
     @property
     def is_tuple(self):

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -10,6 +10,7 @@ from awkward.operations.ak_argmin import argmin, nanargmin
 from awkward.operations.ak_argsort import argsort
 from awkward.operations.ak_backend import backend
 from awkward.operations.ak_broadcast_arrays import broadcast_arrays
+from awkward.operations.ak_broadcast_fields import broadcast_fields
 from awkward.operations.ak_cartesian import cartesian
 from awkward.operations.ak_categories import categories
 from awkward.operations.ak_combinations import combinations

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -1,0 +1,105 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
+
+np = NumpyMetadata.instance()
+
+
+def broadcast_fields(
+    *arrays,
+    highlevel=True,
+    behavior=None,
+):
+    """
+    Args:
+        arrays: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Return a list of arrays whose types contain the same number of fields. Unlike
+    #ak.broadcast_arrays, this function does not require record types to occur at the
+    same depths. Where fields are missing from a record ...
+    """
+    with ak._errors.OperationErrorContext(
+        "ak.broadcast_fields",
+        {
+            "arrays": arrays,
+            "highlevel": highlevel,
+            "behavior": behavior,
+        },
+    ):
+        return _impl(arrays, highlevel, behavior)
+
+
+def _impl(arrays, highlevel, behavior):
+    def descend_to_record(layout):
+        if layout.is_list:
+            return layout.copy(content=descend_to_record(layout.content))
+        elif layout.is_record:
+            return layout
+        elif layout.is_option:
+            return layout.copy(content=descend_to_record(layout.content))
+        elif layout.is_indexed:
+            return layout.copy(content=descend_to_record(layout.content))
+        elif layout.is_leaf:
+            return layout
+        elif layout.is_union:
+            raise ak._errors.wrap_error(TypeError("encountered union"))
+        else:
+            raise ak._errors.wrap_error(AssertionError("unexpected content type"))
+
+    def recurse(inputs):
+        records = [descend_to_record(x) for x in inputs]
+
+        if not all(layout.is_record for layout in records):
+            return records
+
+        fields = ak._util.unique_list([f for layout in records for f in layout.fields])
+
+        # For each field, build a union over the zero-length arrays of all layouts
+        field_unions = []
+        for field in fields:
+            field_contents = []
+            for layout in records:
+                field_content = layout.maybe_content(field)
+                field_contents.append(
+                    field_content.form.length_zero_array(
+                        backend=field_content.backend, highlevel=False
+                    )
+                )
+            field_unions.append(ak._do.merge_as_union(field_contents))
+
+        # For each layout, build a record built from unions. Each union is formed over
+        # the full-length field layout and the zero-length field union
+        next_layouts = []
+        for layout in records:
+            if layout.fields == fields:
+                next_layouts.append(layout)
+            else:
+                index_nplike = layout.backend.index_nplike
+                tags = ak.index.Index8(index_nplike.zeros(layout.length, dtype=np.int8))
+                index = ak.index.Index64(
+                    index_nplike.arange(layout.length, dtype=np.int64)
+                )
+                next_layout = layout.copy(
+                    fields=fields,
+                    contents=[
+                        ak.contents.UnionArray.simplified(
+                            tags=tags,
+                            index=index,
+                            contents=[layout.maybe_content(field), field_union],
+                        )
+                        for field, field_union in zip(fields, field_unions)
+                    ],
+                )
+                next_layouts.append(next_layout)
+        return next_layouts
+
+    layouts = [ak.to_layout(x) for x in arrays]
+    return [
+        ak._util.wrap(x, highlevel=highlevel, behavior=behavior)
+        for x in recurse(layouts)
+    ]

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -18,7 +18,31 @@ def broadcast_fields(
 
     Return a list of arrays whose types contain the same number of fields. Unlike
     #ak.broadcast_arrays, this function does not require record types to occur at the
-    same depths. Where fields are missing from a record ...
+    same depths. Where fields are missing from one record, they are inserted at the same
+    position with an `option[unknown]` type. This type is easily erased by ufunc and
+    concatenation operations.
+
+        >>> x, y = ak.broadcast_fields(
+        ...     [{"x": {"y": 1, "z": 2, "w": [1]}}],
+        ...     [{"x": [{"y": 1}]}],
+        ... )
+        >>> x.type.show()
+        1 * {
+            x: {
+                y: int64,
+                z: int64,
+                w: var * int64
+            }
+        }
+        >>> y.type.show()
+        1 * {
+            x: var * {
+                y: int64,
+                z: ?unknown,
+                w: ?unknown
+            }
+        }
+
     """
     with ak._errors.OperationErrorContext(
         "ak.broadcast_fields",

--- a/tests/test_2267_broadcast_fields.py
+++ b/tests/test_2267_broadcast_fields.py
@@ -1,0 +1,29 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    a, b, c = ak.broadcast_fields(
+        [{"x": 1, "c": 4}],
+        [{"y": 2, "c": 5}],
+        [{"z": 3, "c": 6}],
+    )
+    assert ak.almost_equal(a, [{"x": 1, "c": 4, "y": None, "z": None}])
+    assert ak.almost_equal(b, [{"x": None, "c": 5, "y": 2, "z": None}])
+    assert ak.almost_equal(c, [{"x": None, "c": 6, "y": None, "z": 3}])
+
+
+def test_nested():
+    a, b, c = ak.broadcast_fields(
+        [{"x": 1, "z": {"a": 2, "b": 3}}],
+        [{"y": 2}],
+        [{"y": 3, "z": {"c": 9}}],
+    )
+    assert ak.almost_equal(a, [{"x": 1, "z": {"a": 2, "b": 3, "c": None}, "y": None}])
+    assert ak.almost_equal(b, [{"x": None, "z": None, "y": 2}])
+    assert ak.almost_equal(
+        c, [{"x": None, "z": {"a": None, "b": None, "c": 9}, "y": 3}]
+    )


### PR DESCRIPTION
This implementation of `ak.broadcast_fields` is just a starting point for discussion. It creates union-types for missing fields, though it does not descend through unions or attempt to coerce any other types.

Fixes #2211 through the new `ak.broadcast_fields` function, which can be used in conjunction with `ak.concatenate`