### PR TITLE
docs: add missing entries to toctree

### DIFF
--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -228,6 +228,7 @@
     generated/ak.jax.assert_registered
     generated/ak.jax.import_jax
     generated/ak.jax.register_and_check
+    generated/ak.jax.register_behavior_class
 
 .. toctree::
     :caption: Array layout transformations
@@ -269,6 +270,7 @@
     generated/ak.types.from_datashape
     generated/ak.types.Type
     generated/ak.types.ArrayType
+    generated/ak.types.ScalarType
     generated/ak.types.ListType
     generated/ak.types.NumpyType
     generated/ak.types.OptionType


### PR DESCRIPTION
At some point we should try and catch more automatically, but for now it's just a case of checking the docs build output.