### PR TITLE
chore: bump NumPy version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,13 +192,12 @@ jobs:
           - "numpy"
         include:
           - python-version: '3.7'
-            numpy-package: "numpy==1.14.5"
+            numpy-package: "numpy==1.17.0"
 
     runs-on: ubuntu-20.04
 
     env:
       PIP_ONLY_BINARY: cmake
-      NUMPY_VERSION: '${{ matrix.numpy-version }}'
 
     steps:
       - uses: actions/checkout@v3

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "10"
 dependencies = [
-    "numpy>=1.14.5"
+    "numpy>=1.17.0"
 ]
 readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==10",
     "importlib_resources;python_version < \"3.9\"",
-    "numpy>=1.14.5",
+    "numpy>=1.17.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\""
 ]


### PR DESCRIPTION
This PR bumps the minimum NumPy version to 1.17.0, in line with #2143 

@jpivarski can you remind me why we settled on 1.17 instead of aligning with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)? I know we made this decision, but can't recall why.