### PR TITLE
feat: validate `axis` in L1

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -16,7 +16,7 @@ from awkward._nplikes import nplike_of, ufuncs
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.typing import TypeVar
+from awkward.typing import AxisMaybeNone, SupportsInt, TypeVar
 
 np = NumpyMetadata.instance()
 
@@ -823,3 +823,10 @@ def unique_list(items: Collection[T]) -> list[T]:
         seen.add(item)
         result.append(item)
     return result
+
+
+def regularize_axis(axis: SupportsInt | None) -> AxisMaybeNone:
+    if axis is None:
+        return None
+    else:
+        return int(axis)

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -75,6 +75,7 @@ def all(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.All()

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -75,7 +75,7 @@ def all(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.All()

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -75,6 +75,7 @@ def any(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Any()

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -75,7 +75,7 @@ def any(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Any()

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -99,7 +99,6 @@ def argcartesian(
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         layouts = {

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -98,6 +98,8 @@ def argcartesian(
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         layouts = {

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -98,7 +98,7 @@ def argcartesian(
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -83,7 +83,6 @@ def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
     axis = ak._util.regularize_axis(axis)
-
     if parameters is None:
         parameters = {}
     else:

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -82,6 +82,8 @@ def argcombinations(
 def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
+    axis = None if axis is None else int(axis)
+
     if parameters is None:
         parameters = {}
     else:

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -82,7 +82,7 @@ def argcombinations(
 def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     if parameters is None:
         parameters = {}

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -149,7 +149,6 @@ def nanargmax(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.ArgMax()

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -148,7 +148,7 @@ def nanargmax(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -148,6 +148,8 @@ def nanargmax(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.ArgMax()

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -148,7 +148,6 @@ def nanargmin(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.ArgMin()

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -147,7 +147,7 @@ def nanargmin(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -147,6 +147,8 @@ def nanargmin(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.ArgMin()

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -60,6 +60,8 @@ def argsort(
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.argsort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -60,7 +60,7 @@ def argsort(
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.argsort(layout, axis, ascending, stable)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -61,7 +61,6 @@ def argsort(
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.argsort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -206,7 +206,6 @@ def cartesian(
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         backend = ak._backends.backend_of(*arrays.values(), default=cpu)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -205,7 +205,7 @@ def cartesian(
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -205,6 +205,8 @@ def cartesian(
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     if isinstance(arrays, dict):
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         backend = ak._backends.backend_of(*arrays.values(), default=cpu)

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -203,6 +203,8 @@ def combinations(
 def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
+    axis = None if axis is None else int(axis)
+
     if parameters is None:
         parameters = {}
     else:

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -203,7 +203,7 @@ def combinations(
 def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     if parameters is None:
         parameters = {}

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -204,7 +204,6 @@ def _impl(
     array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior
 ):
     axis = ak._util.regularize_axis(axis)
-
     if parameters is None:
         parameters = {}
     else:

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -47,7 +47,6 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
 
 def _impl(arrays, axis, mergebool, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     # Simple single-array, axis=0 fast-path
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
     if (

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -46,6 +46,8 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
 
 
 def _impl(arrays, axis, mergebool, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     # Simple single-array, axis=0 fast-path
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
     if (

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -46,7 +46,7 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
 
 
 def _impl(arrays, axis, mergebool, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     # Simple single-array, axis=0 fast-path
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -83,7 +83,7 @@ def corr(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -84,7 +84,6 @@ def corr(
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -83,6 +83,8 @@ def corr(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -117,6 +117,8 @@ def count(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Count()

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -117,7 +117,7 @@ def count(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -118,7 +118,6 @@ def count(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Count()

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -76,6 +76,8 @@ def count_nonzero(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.CountNonzero()

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -76,7 +76,7 @@ def count_nonzero(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -77,7 +77,6 @@ def count_nonzero(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.CountNonzero()

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -79,6 +79,7 @@ def covar(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
+    axis = ak._util.regularize_axis(axis)
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -46,6 +46,8 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
     def drop_nones(layout, **kwargs):

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -46,7 +46,7 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -47,7 +47,6 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
     def drop_nones(layout, **kwargs):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -68,7 +68,6 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
 def _impl(array, value, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     behavior = ak._util.behavior_of(array, value, behavior=behavior)
     backend = ak._backends.backend_of(arraylayout, default=cpu)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -67,7 +67,7 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, value, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     behavior = ak._util.behavior_of(array, value, behavior=behavior)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -67,6 +67,8 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, value, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     arraylayout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     behavior = ak._util.behavior_of(array, value, behavior=behavior)
     backend = ak._backends.backend_of(arraylayout, default=cpu)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -46,7 +46,6 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -45,6 +45,8 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -45,7 +45,7 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -163,7 +163,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -163,6 +163,8 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
     if axis is None:

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -164,7 +164,6 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
     if axis is None:

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -42,6 +42,7 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = ak._util.regularize_axis(axis)
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -30,6 +30,8 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -30,7 +30,7 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -31,7 +31,6 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -88,7 +88,7 @@ def linear_fit(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -89,7 +89,6 @@ def linear_fit(
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -88,6 +88,8 @@ def linear_fit(
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x, y, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -79,7 +79,6 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     out = ak._do.local_index(layout, axis)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -78,7 +78,7 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     out = ak._do.local_index(layout, axis)

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -78,6 +78,8 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     out = ak._do.local_index(layout, axis)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -169,7 +169,6 @@ def nanmax(
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Max(initial)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -168,7 +168,7 @@ def nanmax(
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -168,6 +168,8 @@ def nanmax(
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Max(initial)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -171,7 +171,6 @@ def nanmean(
 
 def _impl(x, weight, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -170,7 +170,7 @@ def nanmean(
 
 
 def _impl(x, weight, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -170,6 +170,8 @@ def nanmean(
 
 
 def _impl(x, weight, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -38,7 +38,7 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -38,6 +38,8 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)
 

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -39,7 +39,6 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -48,7 +48,7 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -48,6 +48,8 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -49,7 +49,6 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array, allow_record=False)
 

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -166,6 +166,8 @@ def nanmin(
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Min(initial)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -167,7 +167,6 @@ def nanmin(
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Min(initial)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -166,7 +166,7 @@ def nanmin(
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -83,6 +83,7 @@ def moment(
 
 
 def _impl(x, n, weight, axis, keepdims, mask_identity):
+    axis = ak._util.regularize_axis(axis)
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -73,6 +73,8 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -74,7 +74,6 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -73,7 +73,7 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -108,6 +108,8 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
 
 
 def _impl(array, target, axis, clip, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.pad_none(layout, target, axis, clip=clip)
 

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -109,7 +109,6 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
 
 def _impl(array, target, axis, clip, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.pad_none(layout, target, axis, clip=clip)
 

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -108,7 +108,7 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
 
 
 def _impl(array, target, axis, clip, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.pad_none(layout, target, axis, clip=clip)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -138,7 +138,6 @@ def nanprod(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Prod()

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -137,7 +137,7 @@ def nanprod(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -137,6 +137,8 @@ def nanprod(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Prod()

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -79,7 +79,6 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
 
 def _impl(array, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(array)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -78,6 +78,8 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
 
 
 def _impl(array, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(array)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -78,7 +78,7 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
 
 
 def _impl(array, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(array)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -45,7 +45,7 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -45,6 +45,8 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -46,7 +46,6 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -67,7 +67,6 @@ def softmax(
 
 def _impl(x, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -66,7 +66,7 @@ def softmax(
 
 
 def _impl(x, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -66,6 +66,8 @@ def softmax(
 
 
 def _impl(x, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -47,7 +47,7 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.sort(layout, axis, ascending, stable)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -48,7 +48,6 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.sort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -47,6 +47,8 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.sort(layout, axis, ascending, stable)
     return ak._util.wrap(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -160,7 +160,6 @@ def nanstd(
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -159,7 +159,7 @@ def nanstd(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -159,6 +159,8 @@ def nanstd(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -285,6 +285,8 @@ def nansum(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Sum()

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -286,7 +286,6 @@ def nansum(
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)
     reducer = ak._reducers.Sum()

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -285,7 +285,7 @@ def nansum(
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     behavior = ak._util.behavior_of(array, behavior=behavior)

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -55,6 +55,7 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, axis, highlevel, behavior):
+    axis = ak._util.regularize_axis(axis)
     layout = ak.operations.to_layout(array)
     behavior = ak._util.behavior_of(array, behavior=behavior)
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -86,7 +86,6 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
 
 def _impl(array, counts, axis, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
-
     layout = ak.operations.to_layout(
         array, allow_record=False, allow_other=False
     ).to_packed()

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -85,6 +85,8 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, counts, axis, highlevel, behavior):
+    axis = None if axis is None else int(axis)
+
     layout = ak.operations.to_layout(
         array, allow_record=False, allow_other=False
     ).to_packed()

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -85,7 +85,7 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
 
 
 def _impl(array, counts, axis, highlevel, behavior):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     layout = ak.operations.to_layout(
         array, allow_record=False, allow_other=False

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -164,6 +164,8 @@ def nanvar(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
+    axis = None if axis is None else int(axis)
+
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -165,7 +165,6 @@ def nanvar(
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
     axis = ak._util.regularize_axis(axis)
-
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -164,7 +164,7 @@ def nanvar(
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):
-    axis = None if axis is None else int(axis)
+    axis = ak._util.regularize_axis(axis)
 
     behavior = ak._util.behavior_of(x, weight)
     x = ak.highlevel.Array(


### PR DESCRIPTION
Long-term, we want to take advantage of L2 being developer-focused to simplify the API signatures. This PR ensures that L1 checks that `axis` is `None` or int-like. 

In general, we don't need to validate every argument at L1 - some are validated in L2. But anywhere that we expect L2 to be stricter than L1, we should do this.

