### PR TITLE
fix: support typetracer in `ak.unflatten`

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -16,7 +16,7 @@ from awkward._nplikes import nplike_of, ufuncs
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.typing import TypeVar
+from awkward.typing import SupportsInt, TypeVar
 
 np = NumpyMetadata.instance()
 
@@ -61,6 +61,22 @@ def is_sized_iterable(obj) -> bool:
 
 def is_integer(x) -> bool:
     return isinstance(x, numbers.Integral) and not isinstance(x, bool)
+
+
+def is_array_like(x) -> bool:
+    return hasattr(x, "shape") and hasattr(x, "dtype")
+
+
+def is_integer_like(x) -> bool:
+    # Integral types
+    if isinstance(x, numbers.Integral):
+        return not isinstance(x, bool)
+    # Scalar arrays
+    elif is_array_like(x):
+        return np.issubdtype(x.dtype, np.integer) and x.ndim == 0
+    # Other things that support integers
+    else:
+        return isinstance(x, SupportsInt)
 
 
 def is_non_string_like_iterable(obj) -> bool:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -16,7 +16,7 @@ from awkward._nplikes import nplike_of, ufuncs
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.typing import SupportsInt, TypeVar
+from awkward.typing import TypeVar
 
 np = NumpyMetadata.instance()
 
@@ -76,7 +76,7 @@ def is_integer_like(x) -> bool:
         return np.issubdtype(x.dtype, np.integer) and x.ndim == 0
     # Other things that support integers
     else:
-        return isinstance(x, SupportsInt)
+        return hasattr(x, "__int__")
 
 
 def is_non_string_like_iterable(obj) -> bool:

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -94,7 +94,7 @@ def _impl(array, counts, axis, highlevel, behavior):
 
     if ak._util.is_integer_like(counts):
         # Regularize unknown values to unknown lengths
-        if not backend.index_nplike.known_data:
+        if is_unknown_scalar(counts) or counts is unknown_length:
             counts = unknown_length
         else:
             counts = int(counts)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -95,6 +95,8 @@ def _impl(array, counts, axis, highlevel, behavior):
         # Regularize unknown values to unknown lengths
         if not backend.index_nplike.known_data:
             counts = unknown_length
+        else:
+            counts = int(counts)
         current_offsets = None
     else:
         counts = ak.operations.to_layout(counts, allow_record=False, allow_other=False)
@@ -129,7 +131,7 @@ def _impl(array, counts, axis, highlevel, behavior):
     def unflatten_this_layout(layout):
         nonlocal current_offsets
 
-        if ak._util.is_integer_like(counts):
+        if isinstance(counts, int) or counts is unknown_length:
             if (
                 counts is not unknown_length
                 and layout.length is not unknown_length

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -4,6 +4,7 @@
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
+from awkward._nplikes.typetracer import is_unknown_scalar
 
 np = NumpyMetadata.instance()
 
@@ -156,6 +157,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             if (
                 current_offsets.size is not unknown_length
                 and layout.length is not unknown_length
+                and not is_unknown_scalar(position)
                 and (
                     position >= current_offsets.size
                     or current_offsets[position] != layout.length

--- a/src/awkward/typing.py
+++ b/src/awkward/typing.py
@@ -52,8 +52,3 @@ else:
         final,
         runtime_checkable,
     )
-
-
-class SupportsBool(Protocol):
-    def __bool__(self) -> bool:
-        ...

--- a/tests/test_2293_unflatten_typetracer.py
+++ b/tests/test_2293_unflatten_typetracer.py
@@ -1,0 +1,42 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_array_with_length():
+    array = ak.Array(
+        [[100.0, 200.0, 22.0], [4.0, 5.0], [8.0, 9.0, 10.0, 11.0]], backend="typetracer"
+    )
+    counts = ak.Array([2, 1, 1, 1, 2, 2])
+    ak.unflatten(array, counts)
+
+
+def test_array_without_length():
+    array = ak.Array(
+        ak.to_layout(
+            [[100.0, 200.0, 22.0], [4.0, 5.0], [8.0, 9.0, 10.0, 11.0]]
+        ).to_typetracer(forget_length=True)
+    )
+    counts = ak.Array(
+        ak.to_layout([2, 1, 1, 1, 2, 2]).to_typetracer(forget_length=True)
+    )
+    ak.unflatten(array, counts)
+
+
+def test_scalar():
+    array = ak.Array(
+        [[100.0, 200.0, 22.0, 8.0], [4.0, 5.0, 5.0, 8.0], [8.0, 9.0, 10.0, 8.0]],
+        backend="typetracer",
+    )
+    ak.unflatten(array, 2)
+
+
+def test_unknown_scalar():
+    array = ak.Array(
+        ak.to_layout(
+            [[100.0, 200.0, 22.0], [4.0, 5.0, 5.0], [8.0, 9.0, 10.0]]
+        ).to_typetracer(forget_length=True)
+    )
+    ak.unflatten(array, array.layout.length)

--- a/tests/test_2293_unflatten_typetracer.py
+++ b/tests/test_2293_unflatten_typetracer.py
@@ -35,6 +35,15 @@ def test_scalar():
 
 def test_unknown_scalar():
     array = ak.Array(
+        ak.to_layout([[100, 200, 22], [4, 5, 5], [8, 9, 10]]).to_typetracer(
+            forget_length=True
+        )
+    )
+    ak.unflatten(array, array[0, 0])
+
+
+def test_unknown_length():
+    array = ak.Array(
         ak.to_layout(
             [[100.0, 200.0, 22.0], [4.0, 5.0, 5.0], [8.0, 9.0, 10.0]]
         ).to_typetracer(forget_length=True)


### PR DESCRIPTION
This PR fixes assumptions of length and known values that dask-awkward's test-suite fails.