### PR TITLE
fix: view for unknown scalar

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -326,14 +326,18 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return len(self._shape)
 
     def view(self, dtype: np.dtype) -> Self:
-        if self.itemsize != np.dtype(dtype).itemsize and self._shape[-1] is not None:
+        dtype = np.dtype(dtype)
+        if (
+            self.itemsize != dtype.itemsize
+            and self.ndim >= 1
+            and self._shape[-1] is not None
+        ):
             last = int(
                 round(self._shape[-1] * self.itemsize / np.dtype(dtype).itemsize)
             )
             shape = self._shape[:-1] + (last,)
         else:
             shape = self._shape
-        dtype = np.dtype(dtype)
         return self._new(
             dtype, shape=shape, form_key=self._form_key, report=self._report
         )

--- a/tests/test_2294_view_unknown_scalar.py
+++ b/tests/test_2294_view_unknown_scalar.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test():
+    scalar = ak.Array(np.arange(5, dtype=np.int64), backend="typetracer")[0]
+    result = scalar.view(np.float64)
+    assert result.dtype == np.dtype(np.float64)
+    assert result.ndim == 0
+    with pytest.raises(RuntimeError):
+        int(result)


### PR DESCRIPTION
This small PR fixes the assumption in `TypeTracerArray.view` that an array's shape always contains at least one element.