### PR TITLE
fix: common backend in functions accepting multiple arrays

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -771,7 +771,15 @@ class TypeTracer(NumpyLike):
     ) -> list[TypeTracerArray]:
         for x in arrays:
             try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+
+            assert x.ndim == 1
+
+        shape = tuple([x.size for x in arrays])
+        if indexing == "xy":
+            shape[:2] = shape[1], shape[0]
+
+        dtype = numpy.result_type(*arrays)
+        return [TypeTracerArray._new(dtype, shape=shape) for _ in arrays]
 
     ############################ testing
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -774,7 +774,7 @@ class TypeTracer(NumpyLike):
 
             assert x.ndim == 1
 
-        shape = tuple([x.size for x in arrays])
+        shape = tuple(x.size for x in arrays)
         if indexing == "xy":
             shape[:2] = shape[1], shape[0]
 

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
+cpu = ak._backends.NumpyBackend.instance()
 
 
 def argcartesian(
@@ -101,7 +102,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
 
     if isinstance(arrays, dict):
-        backend = ak._backends.backend_of(*arrays.values(), default=None)
+        backend = ak._backends.backend_of(*arrays.values(), default=cpu)
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         layouts = {
             n: ak._do.local_index(
@@ -112,7 +113,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         }
     else:
         arrays = list(arrays)
-        backend = ak._backends.backend_of(*arrays, default=None)
+        backend = ak._backends.backend_of(*arrays, default=cpu)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
         layouts = [
             ak._do.local_index(

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -99,23 +99,26 @@ def argcartesian(
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
+
     if isinstance(arrays, dict):
+        backend = ak._backends.backend_of(*arrays.values(), default=None)
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         layouts = {
             n: ak._do.local_index(
                 ak.operations.to_layout(x, allow_record=False, allow_other=False),
                 axis,
-            )
+            ).to_backend(backend)
             for n, x in arrays.items()
         }
     else:
         arrays = list(arrays)
+        backend = ak._backends.backend_of(*arrays, default=None)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
         layouts = [
             ak._do.local_index(
                 ak.operations.to_layout(x, allow_record=False, allow_other=False),
                 axis,
-            )
+            ).to_backend(backend)
             for x in arrays
         ]
 

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -204,12 +204,14 @@ def _impl(
     highlevel,
     behavior,
 ):
+    backend = ak._backends.backend_of(*arrays, default=None)
+
     inputs = []
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
             y = ak.contents.NumpyArray(nplike_of(*arrays).asarray([y]))
-        inputs.append(y)
+        inputs.append(y.to_backend(backend))
 
     def action(inputs, depth, **kwargs):
         if depth == depth_limit or (

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -6,6 +6,7 @@ from awkward._nplikes import nplike_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
+cpu = ak._backends.NumpyBackend.instance()
 
 
 def broadcast_arrays(
@@ -204,7 +205,7 @@ def _impl(
     highlevel,
     behavior,
 ):
-    backend = ak._backends.backend_of(*arrays, default=None)
+    backend = ak._backends.backend_of(*arrays, default=cpu)
 
     inputs = []
     for x in arrays:

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -56,7 +56,8 @@ def broadcast_fields(
 
 
 def _impl(arrays, highlevel, behavior):
-    layouts = [ak.to_layout(x) for x in arrays]
+    backend = ak._backends.backend_of(*arrays, default=None)
+    layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
 
     def identity(content):

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -2,6 +2,8 @@
 
 import awkward as ak
 
+cpu = ak._backends.NumpyBackend.instance()
+
 
 def broadcast_fields(
     *arrays,
@@ -56,7 +58,7 @@ def broadcast_fields(
 
 
 def _impl(arrays, highlevel, behavior):
-    backend = ak._backends.backend_of(*arrays, default=None)
+    backend = ak._backends.backend_of(*arrays, default=cpu)
     layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
 

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -4,7 +4,6 @@ import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
-cpu = ak._backends.NumpyBackend.instance()
 
 
 def cartesian(
@@ -207,8 +206,8 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
     if isinstance(arrays, dict):
+        backend = ak._backends.backend_of(*arrays.values(), default=None)
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
-        backend = ak._backends.backend_of(*arrays.values(), default=cpu)
         new_arrays = {}
         for n, x in arrays.items():
             new_arrays[n] = ak.operations.to_layout(
@@ -217,8 +216,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
     else:
         arrays = list(arrays)
+        backend = ak._backends.backend_of(*arrays, default=None)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
-        backend = ak._backends.backend_of(*arrays, default=cpu)
         new_arrays = []
         for x in arrays:
             new_arrays.append(

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
+cpu = ak._backends.NumpyBackend.instance()
 
 
 def cartesian(
@@ -206,22 +207,24 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
     if isinstance(arrays, dict):
-        backend = ak._backends.backend_of(*arrays.values(), default=None)
+        backend = ak._backends.backend_of(*arrays.values(), default=cpu)
         behavior = ak._util.behavior_of(*arrays.values(), behavior=behavior)
         new_arrays = {}
         for n, x in arrays.items():
             new_arrays[n] = ak.operations.to_layout(
                 x, allow_record=False, allow_other=False
-            )
+            ).to_backend(backend)
 
     else:
         arrays = list(arrays)
-        backend = ak._backends.backend_of(*arrays, default=None)
+        backend = ak._backends.backend_of(*arrays, default=cpu)
         behavior = ak._util.behavior_of(*arrays, behavior=behavior)
         new_arrays = []
         for x in arrays:
             new_arrays.append(
-                ak.operations.to_layout(x, allow_record=False, allow_other=False)
+                ak.operations.to_layout(
+                    x, allow_record=False, allow_other=False
+                ).to_backend(backend)
             )
 
     if with_name is not None:

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -48,7 +48,7 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
 def _impl(arrays, axis, mergebool, highlevel, behavior):
     axis = ak._util.regularize_axis(axis)
     # Simple single-array, axis=0 fast-path
-    backend = ak._backends.backend_of(*arrays, default=None)
+    backend = ak._backends.backend_of(*arrays, default=cpu)
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
     if (
         # Is an Awkward Content

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 
 import awkward as ak
 
+cpu = ak._backends.NumpyBackend.instance()
+
 
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
@@ -73,7 +75,7 @@ def _impl(
     for name, array in arrays.items():
         layouts[name] = ak.operations.ak_to_layout._impl(
             array, allow_record=False, allow_other=False, regulararray=True
-        )
+        ).to_backend(cpu)
         if length is None:
             length = layouts[name].length
         elif length != layouts[name].length:

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -458,18 +458,17 @@ def _impl(
     behavior,
     highlevel,
 ):
-    behavior = ak._util.behavior_of(*((array, *more_arrays)), behavior=behavior)
-
+    behavior = ak._util.behavior_of(array, *more_arrays, behavior=behavior)
+    backend = ak._backends.backend_of(array, *more_arrays, default=cpu)
     layout = ak.operations.ak_to_layout._impl(
         array, allow_record=False, allow_other=False, regulararray=True
-    )
+    ).to_backend(backend)
     more_layouts = [
         ak.operations.ak_to_layout._impl(
             x, allow_record=False, allow_other=False, regulararray=True
-        )
+        ).to_backend(backend)
         for x in more_arrays
     ]
-    backend = ak._backends.backend_of(layout, *more_layouts, default=cpu)
 
     options = {
         "allow_records": allow_records,

--- a/tests/test_2297_common_backend.py
+++ b/tests/test_2297_common_backend.py
@@ -1,0 +1,62 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+jax = pytest.importorskip("jax")
+ak.jax.register_and_check()
+
+left = ak.Array([1, 2, 3], backend="jax")
+right = ak.Array([100, 200, 300.0], backend="cpu")
+typetracer = ak.Array([44, 55, 66], backend="typetracer")
+
+
+def test_concatenate():
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible array libraries"
+    ):
+        ak.concatenate((left, right))
+
+    result = ak.concatenate((left, typetracer))
+    assert ak.backend(result) == "typetracer"
+
+
+def test_broadcast_arrays():
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible array libraries"
+    ):
+        ak.broadcast_arrays(left, right)
+
+    result = ak.broadcast_arrays(left, typetracer)
+    assert all(ak.backend(x) == "typetracer" for x in result)
+
+
+def test_broadcast_fields():
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible array libraries"
+    ):
+        ak.broadcast_fields(left, right)
+
+    result = ak.broadcast_fields(left, typetracer)
+    assert all(ak.backend(x) == "typetracer" for x in result)
+
+
+def test_cartesian():
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible array libraries"
+    ):
+        ak.cartesian((left, right), axis=0)
+
+    result = ak.cartesian((left, typetracer), axis=0)
+    assert ak.backend(result) == "typetracer"
+
+
+def test_to_rdataframe():
+    pytest.importorskip("ROOT")
+    array = ak.Array([100, 200, 300.0], backend="typetracer")
+    with pytest.raises(
+        TypeError,
+        match="Converting a TypeTracer nplike to an nplike with `known_data=True`",
+    ):
+        ak.to_rdataframe({"array": array})

--- a/tests/test_2297_common_backend.py
+++ b/tests/test_2297_common_backend.py
@@ -60,3 +60,18 @@ def test_to_rdataframe():
         match="Converting a TypeTracer nplike to an nplike with `known_data=True`",
     ):
         ak.to_rdataframe({"array": array})
+
+
+def test_transform():
+    def apply(layouts, backend, **kwargs):
+        if not all(x.is_numpy for x in layouts):
+            return
+        return tuple(x.copy(data=backend.nplike.asarray(x) * 2) for x in layouts)
+
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible array libraries"
+    ):
+        ak.transform(apply, left, right)
+
+    result = ak.transform(apply, left, typetracer)
+    assert all(ak.backend(x) == "typetracer" for x in result)


### PR DESCRIPTION
Similarly to #2175, we want to coerce arguments of functions that accept multiple arrays to the same backend. This should only succeed if the coercion is zero copy, i.e. typetracer + backend, or backend + backend.