### PR TITLE
docs: add Gitter badge

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,12 @@ html_theme_options = {
         {
             "name": "PyPI",
             "url": "https://pypi.org/project/awkward",
-            "icon": "fab fa-python",
+            "icon": "fa-brands fa-python",
+        },
+        {
+            "name": "Gitter",
+            "url": "https://gitter.im/Scikit-HEP/awkward-array",
+            "icon": "fa-brands fa-gitter"
         }
     ],
     "use_edit_page_button": True,


### PR DESCRIPTION
This PR adds a Gitter badge to the documentation header:
![image](https://user-images.githubusercontent.com/1248413/224164822-a5eadf01-e724-4872-ac71-b288973bddd4.png)

