### PR TITLE
docs: update version switcher (#2299)Co-authored-by: Jim Pivarski <jpivarski@users.noreply.github.com>

### DIFF
--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -2,7 +2,7 @@
     {
         "name": "stable",
         "url": "https://awkward-array.org/doc/stable/"
-    },    
+    },
     {
         "name": "main",
         "url": "https://awkward-array.org/doc/main/"

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -2,11 +2,15 @@
     {
         "name": "stable",
         "url": "https://awkward-array.org/doc/stable/"
-    },
+    },    
     {
         "name": "main",
         "url": "https://awkward-array.org/doc/main/"
     },
+    {
+        "version": "2.1",
+        "url": "https://awkward-array.org/doc/2.1/"
+    }
     {
         "version": "2.0",
         "url": "https://awkward-array.org/doc/2.0/"


### PR DESCRIPTION
This PR enables 2.1 in the documentation version switcher. We have to do this manually, and I forgot!