### PR TITLE
ci: fix parsing of docs version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -314,7 +314,7 @@ jobs:
         id: sync-stable
         run: |
           # Take only leading version
-          version=$(echo "${GITHUB_REF_NAME}" | sed -n -E "s/([0-9]+\.[0-9]+)\.[0-9]+/\1/p")
+          version=$(echo "${GITHUB_REF_NAME}" | sed -n -E "s/v?([0-9]+\.[0-9]+)\.[0-9]+/\1/p")
           aws s3 cp docs/switcher.json "s3://${S3_BUCKET}/doc/"
           aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/$version/"
           aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/stable/"


### PR DESCRIPTION
The [2.1 docs deployment](https://github.com/scikit-hep/awkward/actions/runs/4359154751/jobs/7620722224) pushed the docs to the `/doc/v2.1/` subdirectory instead of `/doc/2.1/`. This PR fixes the version parsing logic to correct this for future major/minor releases.