### PR TITLE
fix: only convert NEP18 arguments to layouts if required

### DIFF
--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection
+from collections.abc import Iterable
 
 import awkward_cpp
 
@@ -215,7 +215,7 @@ def _backend_for_nplike(nplike: NumpyLike) -> Backend:
         raise ak._errors.wrap_error(ValueError("unrecognised nplike", nplike))
 
 
-def common_backend(backends: Collection[Backend]) -> Backend:
+def common_backend(backends: Iterable[Backend]) -> Backend:
     unique_backends = frozenset(backends)
     # Either we have one nplike, or one + typetracer
     if len(unique_backends) == 1:
@@ -226,12 +226,19 @@ def common_backend(backends: Collection[Backend]) -> Backend:
             if not backend.nplike.known_data:
                 return backend
 
-        raise ak._errors.wrap_error(
-            ValueError(
-                "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
-                "to the same backend"
+        if len(unique_backends) > 1:
+            raise ak._errors.wrap_error(
+                ValueError(
+                    "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
+                    "to the same backend"
+                )
             )
-        )
+        else:
+            raise ak._errors.wrap_error(
+                ValueError(
+                    "no backends were given in order to determine a common backend."
+                )
+            )
 
 
 _UNSET = object()

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -36,10 +36,16 @@ implemented = {}
 
 
 def _to_rectilinear(arg):
+    # Is this object something we already associate with a backend?
     backend = ak._backends.backend_of(arg, default=None)
-    # We have some array-like object that our backend mechanism understands
     if backend is not None:
-        return ak.operations.to_numpy(arg)
+        # Is this argument already in a backend-supported form?
+        if backend.nplike.is_own_array(arg):
+            return arg
+        # Otherwise, cast to layout and convert
+        else:
+            layout = ak.to_layout(arg, allow_record=False, allow_other=False)
+            return layout.to_backend_array(allow_missing=True)
     elif isinstance(arg, tuple):
         return tuple(_to_rectilinear(x) for x in arg)
     elif isinstance(arg, list):

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -49,6 +49,8 @@ def nplike_of(*arrays, default: D = _UNSET) -> NumpyLike | D:
     iterable of arrays. If no known array types are found, return `default`
     if it is set, otherwise `Numpy.instance()`.
     """
+    from awkward_cpp.lib import _ext
+
     from awkward._nplikes.cupy import Cupy
     from awkward._nplikes.jax import Jax
     from awkward._nplikes.numpy import Numpy
@@ -73,6 +75,10 @@ def nplike_of(*arrays, default: D = _UNSET) -> NumpyLike | D:
                 if cls.is_own_array(array):
                     nplikes.add(cls.instance())
                     break
+            else:
+                # Explicitly test non-layout ArrayBuilder types
+                if isinstance(array, (_ext.ArrayBuilder, ak.highlevel.ArrayBuilder)):
+                    nplikes.add(Numpy.instance())
 
     if nplikes == set():
         if default is _UNSET:

--- a/tests/test_2305_nep_18_lazy_conversion.py
+++ b/tests/test_2305_nep_18_lazy_conversion.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_binary():
+    ak_array = ak.Array(np.arange(10, dtype="<u4"))
+    np_array = np.arange(10, dtype=">u4")
+    assert np.array_equal(ak_array, np_array)
+
+
+def test_different_backend():
+    pytest.importorskip("jax")
+    ak.jax.register_and_check()
+
+    left = ak.Array([0, 1, 2], backend="jax")
+    right = ak.Array([0, 1, 2], backend="cpu")
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible backends"
+    ):
+        assert np.array_equal(left, right)


### PR DESCRIPTION
Issue #2303 raises a couple of important points;
- We don't need to build a layout only to immediately convert it to a backend array
- We should not convert to NumPy eagerly; it's possible to use NEP18 on cuda `cp.ndarray,` the same should hold for `ak.Array` with `backend="cuda"`.

This PR fixes #2303 by 
- Only converting to layouts if we identify a backend, and the object is not a backend array
- Convert all arguments to a common backend

