### PR TITLE
feat: new nplike finding mechanism

### DIFF
--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -5,10 +5,12 @@ import numpy
 
 import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
+from awkward._nplikes.finder import register_nplike
 from awkward._nplikes.numpylike import ArrayLike
 from awkward.typing import Final
 
 
+@register_nplike
 class Cupy(ArrayModuleNumpyLike):
     is_eager: Final = False
 
@@ -146,15 +148,15 @@ class Cupy(ArrayModuleNumpyLike):
         return self._module.array_str(array, max_line_width, precision, suppress_small)
 
     @classmethod
-    def is_own_array(cls, obj) -> bool:
+    def is_own_array_type(cls, type_: type) -> bool:
         """
         Args:
-            obj: object to test
+            type_: object to test
 
-        Return `True` if the given object is a cupy buffer, otherwise `False`.
+        Return `True` if the given object type is a cupy ndarray subclass, otherwise `False`.
 
         """
-        module, _, suffix = type(obj).__module__.partition(".")
+        module, _, suffix = type_.__module__.partition(".")
         return module == "cupy"
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:

--- a/src/awkward/_nplikes/finder.py
+++ b/src/awkward/_nplikes/finder.py
@@ -24,7 +24,7 @@ def register_nplike_finder_factory(finder: NumpyLikeFinderFactory):
     return finder
 
 
-N = TypeVar("N", bound=type[NumpyLike])
+N = TypeVar("N", bound="type[NumpyLike]")
 
 
 def register_nplike(cls: N) -> N:

--- a/src/awkward/_nplikes/finder.py
+++ b/src/awkward/_nplikes/finder.py
@@ -1,0 +1,69 @@
+from awkward.typing import Callable, TypeAlias, TypeVar
+
+from .numpylike import NumpyLike
+
+T = TypeVar("T")
+NumpyLikeFinder: TypeAlias = "Callable[[T], NumpyLike]"
+NumpyLikeFinderFactory: TypeAlias = "Callable[[type[T]], NumpyLikeFinder[T] | None]"
+
+_type_finders: dict[type, NumpyLikeFinder] = {}
+_finder_factories = []
+
+
+def register_nplike_finder_factory(finder: NumpyLikeFinderFactory):
+    """
+    Args:
+        finder: nplike finder callable
+
+    Returns the given finder, after registering it in a list of nplike finders.
+
+    """
+    _finder_factories.append(finder)
+    return finder
+
+
+N = TypeVar("N", bound=type[NumpyLike])
+
+
+def register_nplike(cls: N) -> N:
+    """
+    Args:
+        cls: nplike class
+
+    Returns the given class, after registering `cls.is_own_array` as an nplike
+    finder.
+    """
+
+    def nplike_finder_factory(type_):
+        if cls.is_own_array_type(type_):
+
+            def primitive_finder(_):
+                return cls.instance()
+
+            return primitive_finder
+
+    register_nplike_finder_factory(nplike_finder_factory)
+    return cls
+
+
+def find_nplike_for(obj) -> NumpyLike | None:
+    """
+    Args:
+        obj: object for which to find an nplike
+
+    Return the first nplike for which a finder returns a non-None result.
+    """
+    cls = type(obj)
+    try:
+        finder = _type_finders[cls]
+    except KeyError:
+        for factory in _finder_factories:
+            maybe_finder = factory(cls)
+            if maybe_finder is not None:
+                break
+        else:
+            return None
+        _type_finders[cls] = maybe_finder
+        return maybe_finder(obj)
+    else:
+        return finder(obj)

--- a/src/awkward/_nplikes/finder.py
+++ b/src/awkward/_nplikes/finder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from awkward.typing import Callable, TypeAlias, TypeVar
 
 from .numpylike import NumpyLike

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -49,7 +49,7 @@ class Jax(ArrayModuleNumpyLike):
         Return `True` if the given object is a jax buffer, otherwise `False`.
 
         """
-        return cls.is_array(type_) or cls.is_tracer(type_)
+        return cls.is_array_type(type_) or cls.is_tracer_type(type_)
 
     @classmethod
     def is_array_type(cls, type_: type) -> bool:

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -5,10 +5,12 @@ import numpy
 
 import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
+from awkward._nplikes.finder import register_nplike
 from awkward._nplikes.numpylike import ArrayLike
 from awkward.typing import Final
 
 
+@register_nplike
 class Jax(ArrayModuleNumpyLike):
     is_eager: Final = True
 
@@ -39,39 +41,47 @@ class Jax(ArrayModuleNumpyLike):
         return self._module.ndarray
 
     @classmethod
-    def is_own_array(cls, obj) -> bool:
+    def is_own_array_type(cls, type_: type) -> bool:
         """
         Args:
-            obj: object to test
+            type_: class to test
 
         Return `True` if the given object is a jax buffer, otherwise `False`.
 
         """
-        return cls.is_array(obj) or cls.is_tracer(obj)
+        return cls.is_array(type_) or cls.is_tracer(type_)
 
     @classmethod
-    def is_array(cls, obj) -> bool:
+    def is_array_type(cls, type_: type) -> bool:
         """
         Args:
-            obj: object to test
+            type_: class to test
 
-        Return `True` if the given object is a jax buffer, otherwise `False`.
+        Return `True` if the given object is a jax buffer subclass, otherwise `False`.
 
         """
-        module, _, suffix = type(obj).__module__.partition(".")
+        module, _, suffix = type_.__module__.partition(".")
         return module == "jaxlib"
 
     @classmethod
-    def is_tracer(cls, obj) -> bool:
+    def is_array(cls, obj):
+        return cls.is_array_type(type(obj))
+
+    @classmethod
+    def is_tracer_type(cls, type_: type) -> bool:
         """
         Args:
-            obj: object to test
+            type_: class to test
 
-        Return `True` if the given object is a jax tracer, otherwise `False`.
+        Return `True` if the given object is a jax tracer subclass, otherwise `False`.
 
         """
-        module, _, suffix = type(obj).__module__.partition(".")
+        module, _, suffix = type_.__module__.partition(".")
         return module == "jax"
+
+    @classmethod
+    def is_tracer(cls, obj):
+        return cls.is_tracer_type(type(obj))
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:
         return True

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -5,12 +5,14 @@ import numpy
 
 import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
+from awkward._nplikes.finder import register_nplike
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward.typing import Final, Literal
 
 np = NumpyMetadata.instance()
 
 
+@register_nplike
 class Numpy(ArrayModuleNumpyLike):
     is_eager: Final = True
 
@@ -30,15 +32,15 @@ class Numpy(ArrayModuleNumpyLike):
         return self._module.ndarray
 
     @classmethod
-    def is_own_array(cls, obj) -> bool:
+    def is_own_array_type(cls, type_: type) -> bool:
         """
         Args:
             obj: object to test
 
-        Return `True` if the given object is a numpy buffer, otherwise `False`.
+        Return `True` if the given object is a numpy ndarray subclass, otherwise `False`.
 
         """
-        return isinstance(obj, numpy.ndarray)
+        return issubclass(type_, numpy.ndarray)
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:
         return x.flags["C_CONTIGUOUS"]

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -616,5 +616,9 @@ class NumpyLike(Singleton, Protocol):
 
     @classmethod
     @abstractmethod
-    def is_own_array(cls, obj) -> bool:
+    def is_own_array_type(cls, type_: type) -> bool:
         ...
+
+    @classmethod
+    def is_own_array(cls, obj) -> bool:
+        return cls.is_own_array_type(type(obj))

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -8,6 +8,7 @@ from numpy.lib.mixins import NDArrayOperatorsMixin
 
 import awkward as ak
 from awkward._errors import wrap_error
+from awkward._nplikes.finder import register_nplike
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._regularize import is_integer, is_non_string_like_sequence
@@ -582,6 +583,7 @@ def try_touch_shape(array):
         array.touch_shape()
 
 
+@register_nplike
 class TypeTracer(NumpyLike):
     known_data: Final = False
     is_eager: Final = True
@@ -1310,8 +1312,8 @@ class TypeTracer(NumpyLike):
         return numpy.can_cast(from_, to, casting="same_kind")
 
     @classmethod
-    def is_own_array(cls, obj) -> bool:
-        return isinstance(obj, TypeTracerArray)
+    def is_own_array_type(cls, type_: type) -> bool:
+        return issubclass(type_, TypeTracerArray)
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:
         return True

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -11,6 +11,7 @@ from awkward._backends import Backend
 from awkward._behavior import get_array_class, get_record_class
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
+from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
@@ -1343,3 +1344,13 @@ class Content:
 
     def copy(self, *, parameters: JSONMapping | None = unset) -> Self:
         raise ak._errors.wrap_error(NotImplementedError)
+
+
+@register_nplike_finder_factory
+def _content_nplike_finder_factory(cls: type) -> NumpyLikeFinder:
+    if issubclass(cls, Content):
+
+        def finder(obj: cls) -> NumpyLike:
+            return obj.backend.nplike
+
+        return finder

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -17,9 +17,9 @@ from numpy.lib.mixins import NDArrayOperatorsMixin  # noqa: TID251
 
 import awkward as ak
 import awkward._connect.hist
-from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._layout import wrap_layout
+from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_non_string_like_iterable

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1,4 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
 __all__ = ("Array", "ArrayBuilder", "Record")
 
 import copy
@@ -15,6 +17,7 @@ from numpy.lib.mixins import NDArrayOperatorsMixin  # noqa: TID251
 
 import awkward as ak
 import awkward._connect.hist
+from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
@@ -2791,3 +2794,21 @@ class ArrayBuilder(Sized):
 def ignore_in_to_list(getitem_function):
     getitem_function.ignore_in_to_list = True
     return getitem_function
+
+
+@register_nplike_finder_factory
+def _highlevel_nplike_finder(cls) -> NumpyLikeFinder | None:
+    if issubclass(cls, (Array, Record)):
+
+        def finder(obj):
+            return obj.layout.backend.nplike
+
+    elif issubclass(cls, (ArrayBuilder, _ext.ArrayBuilder)):
+
+        def finder(_):
+            return Numpy.instance()
+
+    else:
+        return None
+
+    return finder

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -6,6 +6,7 @@ import copy
 import awkward as ak
 from awkward._nplikes import nplike_of, to_nplike
 from awkward._nplikes.cupy import Cupy
+from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
@@ -137,7 +138,7 @@ class Index:
 
     def forget_length(self):
         tt = TypeTracer.instance()
-        if isinstance(self._nplike, type(tt)):
+        if isinstance(self._nplike, TypeTracer):
             data = self._data
         else:
             data = self.raw(tt)
@@ -252,3 +253,13 @@ class IndexU32(Index):
 
 class Index64(Index):
     _expected_dtype = np.dtype(np.int64)
+
+
+@register_nplike_finder_factory
+def _index_nplike_finder_factory(cls) -> NumpyLikeFinder:
+    if issubclass(cls, Index):
+
+        def finder(index: Index) -> NumpyLike:
+            return index.nplike
+
+        return finder

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -7,7 +7,8 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._behavior import get_record_class
 from awkward._layout import wrap_layout
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.finder import NumpyLikeFinder, register_nplike_finder_factory
+from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer
 from awkward._util import unset
@@ -257,3 +258,13 @@ class Record:
         return Record(
             self._array if array is unset else array, self._at if at is unset else at
         )
+
+
+@register_nplike_finder_factory
+def _record_nplike_finder_factory(cls: type) -> NumpyLikeFinder:
+    if issubclass(cls, Record):
+
+        def finder(obj: cls) -> NumpyLike:
+            return obj.array.backend.nplike
+
+        return finder


### PR DESCRIPTION
## TL;DR
This PR replaces a hard-coded loop-based search with a faster per-type lookup for each nplike.

## TL
### Context
We have an `nplike_of` L3 function in Awkward so that we can determine the most suitable array library among a set of complex input objects. This mechanism needs to extend beyond identifying the array library for the array type to layouts, builders, and potentially other objects.

Our existing mechanism for finding the appropriate nplike for a given object is flawed, due to the following points:
1. Our L1 API should not expose `backend` or `nplike`
2. Our L2 APIs cannot all be made homogeneous, e.g. `_ext.ArrayBuilder` should not have a backend (it has no concept of such a thing)
3. Each call to `nplike_for` performs a non-cached lookup of several attributes. For array types, it loops over each nplike
4. The set of nplikes is hard-coded

Extending `nplike_for` to include `ArrayBuilder` would require more customisation of this logic. At the same time, PRs like #2305 would benefit from the search for an nplike being as fast as possible.

### Details
In general, we can do better by generalising the search mechanism. This PR makes such a change, by introducing a type-cached "finder" system, that allows us to register direct nplike lookups for each type. When there is a cache miss, the system walks over the list of finders until a suitable finder is found, and memoizes the result under the type of the object.

There is now a `register_nplike_finder_factory` function that lets the caller register a finder factory that returns a `NumpyLikeFinder`:
```python
@register_nplike_finder_factory
def finder(cls) -> NumpyLikeFinder:
    if issubclass(cls, SomeType):
        return finder_for_SomeType
```
The `NumpyLikeFinder` is responsible for taking an instance of the registered type and returning its associated nplike:
```python
def finder_for_SomeType(obj: SomeType) -> NumpyLike:
    return Numpy.instance()
```
