### PR TITLE
fix: support unknown scalars in `__getitem__`

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -68,7 +68,6 @@ class NumpyKernel(BaseKernel):
     def _cast(cls, x, t):
         if issubclass(t, ctypes._Pointer):
             # Do we have a NumPy-owned array?
-            # TODO should kernels strip nplike wrapper? Probably
             if Numpy.is_own_array(x):
                 if x.ndim > 0:
                     return ctypes.cast(x.ctypes.data, t)

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -70,7 +70,10 @@ class NumpyKernel(BaseKernel):
             # Do we have a NumPy-owned array?
             # TODO should kernels strip nplike wrapper? Probably
             if Numpy.is_own_array(x):
-                return ctypes.cast(x.ctypes.data, t)
+                if x.ndim > 0:
+                    return ctypes.cast(x.ctypes.data, t)
+                else:
+                    return x
             # Or, do we have a ctypes type
             elif hasattr(x, "_b_base_"):
                 return ctypes.cast(x, t)

--- a/src/awkward/_regularize.py
+++ b/src/awkward/_regularize.py
@@ -27,7 +27,7 @@ def is_integer(x) -> bool:
 
 
 def is_array_like(x) -> bool:
-    return hasattr(x, "shape") and hasattr(x, "dtype")
+    return hasattr(x, "shape") and hasattr(x, "dtype") and hasattr(x, "T")
 
 
 def is_integer_like(x) -> bool:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -10,7 +10,7 @@ from awkward._nplikes import to_nplike
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._regularize import is_integer_like, is_sized_iterable
+from awkward._regularize import is_array_like, is_integer_like, is_sized_iterable
 from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
@@ -209,7 +209,7 @@ def prepare_advanced_indexing(items, backend: Backend):
 
 
 def normalize_integer_like(x) -> int | ArrayLike:
-    if ak._util.is_array_like(x):
+    if is_array_like(x):
         if np.issubdtype(x.dtype, np.integer) and x.ndim == 0:
             return x
         else:

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -11,7 +11,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer, is_sized_iterable
-from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias
+from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from awkward._nplikes.numpylike import ArrayLike
@@ -71,13 +71,23 @@ def normalize_slice(slice_: slice, *, backend: Backend) -> slice:
         return slice(start, stop, step)
 
 
-def headtail(
-    oldtail: tuple[SliceItem, ...]
-) -> tuple[SliceItem | tuple, tuple[SliceItem, ...]]:
-    if len(oldtail) == 0:
-        return (), ()
+T = TypeVar("T")
+
+
+class _NoHead:
+    def __repr__(self):
+        return f"{__name__}.NO_HEAD"
+
+
+NO_HEAD = _NoHead()
+S = TypeVar("S", bound=Sequence)
+
+
+def head_tail(sequence: S[T]) -> tuple[T | type(NO_HEAD), S[T]]:
+    if len(sequence) == 0:
+        return NO_HEAD, ()
     else:
-        return oldtail[0], oldtail[1:]
+        return sequence[0], sequence[1:]
 
 
 def prepare_advanced_indexing(items):

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -10,7 +10,7 @@ from awkward._nplikes import to_nplike
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._regularize import is_integer, is_sized_iterable
+from awkward._regularize import is_integer_like, is_sized_iterable
 from awkward.typing import TYPE_CHECKING, Sequence, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
@@ -219,8 +219,8 @@ def normalise_item(item, backend: Backend) -> SliceItem:
     of integers.
     """
     # Basic indices
-    if is_integer(item):
-        return int(item)
+    if is_integer_like(item):
+        return item
 
     elif isinstance(item, slice):
         return normalize_slice(item, backend=backend)
@@ -280,7 +280,9 @@ def normalise_item(item, backend: Backend) -> SliceItem:
             # Is it a scalar, not array?
             if len(item.shape) == 0:
                 raise wrap_error(
-                    NotImplementedError("scalar objects in slice normalisation")
+                    AssertionError(
+                        "scalar arrays should be handled by integer-like indexing"
+                    )
                 )
             else:
                 layout = ak.operations.ak_to_layout._impl(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._regularize import is_integer
+from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
@@ -533,8 +533,8 @@ class BitMaskedArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             return self.to_ByteMaskedArray()._getitem_next(head, tail, advanced)
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -11,6 +11,7 @@ from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._regularize import is_integer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
@@ -529,7 +530,7 @@ class BitMaskedArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,6 +11,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
@@ -538,15 +539,13 @@ class ByteMaskedArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(
             head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
-            nexthead, nexttail = ak._slicing.headtail(tail)
             _, nextcarry, outindex = self._nextcarry_outindex()
-
             next = self._content._carry(nextcarry, True)
             out = next._getitem_next(head, tail, advanced)
             return ak.contents.IndexedOptionArray.simplified(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,6 +11,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -542,8 +543,8 @@ class ByteMaskedArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             _, nextcarry, outindex = self._nextcarry_outindex()
             next = self._content._carry(nextcarry, True)

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -341,7 +341,7 @@ class Content:
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ):
-        nexthead, nexttail = ak._slicing.headtail(tail)
+        nexthead, nexttail = ak._slicing.head_tail(tail)
         return self._getitem_field(head)._getitem_next(nexthead, nexttail, advanced)
 
     def _getitem_next_fields(self, head, tail, advanced: Index | None) -> Content:
@@ -351,13 +351,13 @@ class Content:
                 only_fields.append(x)
             else:
                 not_fields.append(x)
-        nexthead, nexttail = ak._slicing.headtail(tuple(not_fields))
+        nexthead, nexttail = ak._slicing.head_tail(tuple(not_fields))
         return self._getitem_fields(head, tuple(only_fields))._getitem_next(
             nexthead, nexttail, advanced
         )
 
     def _getitem_next_newaxis(self, tail, advanced: Index | None):
-        nexthead, nexttail = ak._slicing.headtail(tail)
+        nexthead, nexttail = ak._slicing.head_tail(tail)
         return ak.contents.RegularArray(
             self._getitem_next(nexthead, nexttail, advanced), 1, 0, parameters=None
         )
@@ -368,7 +368,7 @@ class Content:
         dimlength = sum(1 if isinstance(x, (int, slice, Index64)) else 0 for x in tail)
 
         if len(tail) == 0 or mindepth - 1 == maxdepth - 1 == dimlength:
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             return self._getitem_next(nexthead, nexttail, advanced)
 
         elif dimlength in {mindepth - 1, maxdepth - 1}:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -555,7 +555,7 @@ class Content:
 
     def _getitem(self, where):
         if is_integer_like(where):
-            return self._getitem_at(where)
+            return self._getitem_at(ak._slicing.normalize_integer_like(where))
 
         elif isinstance(where, slice) and where.step is None:
             # Ensure that start, stop are non-negative!

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._regularize import is_integer, is_integer_like, is_sized_iterable
+from awkward._regularize import is_integer_like, is_sized_iterable
 from awkward._slicing import normalize_slice
 from awkward._util import unset
 from awkward.forms.form import Form, JSONMapping, _type_parameters_equal
@@ -554,7 +554,7 @@ class Content:
         return self._getitem(where)
 
     def _getitem(self, where):
-        if is_integer(where):
+        if is_integer_like(where):
             return self._getitem_at(where)
 
         elif isinstance(where, slice) and where.step is None:
@@ -691,13 +691,13 @@ class Content:
                 # Is it a scalar, not array?
                 if len(where.shape) == 0:
                     raise ak._errors.wrap_error(
-                        NotImplementedError(
-                            "scalar arrays in slices are not currently supported"
+                        AssertionError(
+                            "scalar arrays should be handled by integer-like indexing"
                         )
                     )
                 else:
                     layout = ak.operations.ak_to_layout._impl(
-                        where, allow_record=False, allow_other=True, regulararray=False
+                        where, allow_record=False, allow_other=False, regulararray=False
                     )
                     return self._getitem(layout)
 
@@ -714,7 +714,9 @@ class Content:
                 return self._getitem_fields(list(where))
 
             else:
-                layout = ak.operations.to_layout(where)
+                layout = ak.operations.ak_to_layout._impl(
+                    where, allow_record=False, allow_other=False, regulararray=False
+                )
                 return self._getitem(layout)
 
         else:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._regularize import is_integer, is_sized_iterable
+from awkward._regularize import is_integer, is_integer_like, is_sized_iterable
 from awkward._slicing import normalize_slice
 from awkward._util import unset
 from awkward.forms.form import Form, JSONMapping, _type_parameters_equal
@@ -365,7 +365,10 @@ class Content:
     def _getitem_next_ellipsis(self, tail, advanced: Index | None):
         mindepth, maxdepth = self.minmax_depth
 
-        dimlength = sum(1 if isinstance(x, (int, slice, Index64)) else 0 for x in tail)
+        dimlength = sum(
+            1 if is_integer_like(x) or isinstance(x, (slice, Index64)) else 0
+            for x in tail
+        )
 
         if len(tail) == 0 or mindepth - 1 == maxdepth - 1 == dimlength:
             nexthead, nexttail = ak._slicing.head_tail(tail)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -8,6 +8,7 @@ from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -196,7 +197,7 @@ class EmptyArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(head, int):
+        elif is_integer_like(head):
             raise ak._errors.index_error(self, head, "array is empty")
 
         elif isinstance(head, slice):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -8,6 +8,7 @@ from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
@@ -192,7 +193,7 @@ class EmptyArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, int):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,6 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -363,8 +364,8 @@ class IndexedArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             nexthead, nexttail = ak._slicing.head_tail(tail)
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,6 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -359,13 +360,13 @@ class IndexedArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(
             head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
 
             nextcarry = ak.index.Index64.empty(
                 self._index.length, self._backend.index_nplike

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -457,8 +458,8 @@ class IndexedOptionArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             nexthead, nexttail = ak._slicing.head_tail(tail)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -453,13 +454,13 @@ class IndexedOptionArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(
             head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
 
             numnull, nextcarry, outindex = self._nextcarry_outindex()
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,6 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
@@ -518,7 +519,7 @@ class ListArray(Content):
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
             nextcontent = self._content._carry(nextcarry, True)
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             outcontent = nextcontent._getitem_next(nexthead, nexttail, None)
 
             return ak.contents.ListOffsetArray(outoffsets, outcontent, parameters=None)
@@ -665,12 +666,12 @@ class ListArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, int):
             assert advanced is None
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             lenstarts = self._starts.length
             nextcarry = ak.index.Index64.empty(lenstarts, self._backend.index_nplike)
             assert (
@@ -699,7 +700,7 @@ class ListArray(Content):
         elif isinstance(head, slice):
             lenstarts = self._starts.length
 
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
 
             start, stop, step = head.start, head.stop, head.step
 
@@ -858,7 +859,7 @@ class ListArray(Content):
         elif isinstance(head, ak.index.Index64):
             lenstarts = self._starts.length
 
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             flathead = self._backend.index_nplike.reshape(
                 self._backend.index_nplike.asarray(head.data), (-1,)
             )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,6 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -669,7 +670,7 @@ class ListArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(head, int):
+        elif is_integer_like(head):
             assert advanced is None
             nexthead, nexttail = ak._slicing.head_tail(tail)
             lenstarts = self._starts.length
@@ -690,9 +691,9 @@ class ListArray(Content):
                     self._starts.data,
                     self._stops.data,
                     lenstarts,
-                    head,
+                    int(head) if self._backend.index_nplike.known_data else head,
                 ),
-                slicer=head,
+                slicer=int(head) if self._backend.index_nplike.known_data else head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -691,9 +691,9 @@ class ListArray(Content):
                     self._starts.data,
                     self._stops.data,
                     lenstarts,
-                    int(head) if self._backend.index_nplike.known_data else head,
+                    head,
                 ),
-                slicer=int(head) if self._backend.index_nplike.known_data else head,
+                slicer=head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -462,9 +462,9 @@ class ListOffsetArray(Content):
                     starts.data,
                     stops.data,
                     lenstarts,
-                    int(head) if self._backend.index_nplike.known_data else head,
+                    head,
                 ),
-                slicer=int(head) if self._backend.index_nplike.known_data else head,
+                slicer=head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -434,14 +435,14 @@ class ListOffsetArray(Content):
         advanced: Index | None,
     ) -> Content:
         advanced = advanced.to_nplike(self._backend.nplike)
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, int):
             assert advanced is None
             lenstarts = self._offsets.length - 1
             starts, stops = self.starts, self.stops
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             nextcarry = ak.index.Index64.empty(lenstarts, self._backend.index_nplike)
 
             assert (
@@ -468,7 +469,7 @@ class ListOffsetArray(Content):
             return nextcontent._getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             lenstarts = self._offsets.length - 1
             start, stop, step = head.start, head.stop, head.step
 
@@ -614,7 +615,7 @@ class ListOffsetArray(Content):
             return self._getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             flathead = self._backend.index_nplike.reshape(
                 self._backend.index_nplike.asarray(head.data), (-1,)
             )

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -438,7 +439,7 @@ class ListOffsetArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(head, int):
+        elif is_integer_like(head):
             assert advanced is None
             lenstarts = self._offsets.length - 1
             starts, stops = self.starts, self.stops
@@ -461,9 +462,9 @@ class ListOffsetArray(Content):
                     starts.data,
                     stops.data,
                     lenstarts,
-                    head,
+                    int(head) if self._backend.index_nplike.known_data else head,
                 ),
-                slicer=head,
+                slicer=int(head) if self._backend.index_nplike.known_data else head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,6 +10,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -341,7 +342,7 @@ class NumpyArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(head, int):
+        elif is_integer_like(head):
             where = (slice(None), head, *tail)
 
             try:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,6 +10,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -337,7 +338,7 @@ class NumpyArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, int):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,6 +11,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
+from awkward._slicing import NO_HEAD
 from awkward._regularize import is_integer
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -472,7 +473,7 @@ class RecordArray(Content):
             return self.content(where)
 
         else:
-            nexthead, nexttail = ak._slicing.headtail(only_fields)
+            nexthead, nexttail = ak._slicing.head_tail(only_fields)
             if isinstance(nexthead, str):
                 return self.content(where)._getitem_field(nexthead, nexttail)
             else:
@@ -490,7 +491,7 @@ class RecordArray(Content):
         if len(only_fields) == 0:
             contents = [self.content(i) for i in indexes]
         else:
-            nexthead, nexttail = ak._slicing.headtail(only_fields)
+            nexthead, nexttail = ak._slicing.head_tail(only_fields)
             if isinstance(nexthead, str):
                 contents = [
                     self.content(i)._getitem_field(nexthead, nexttail) for i in indexes
@@ -562,7 +563,7 @@ class RecordArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, str):
@@ -575,7 +576,7 @@ class RecordArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
 
             contents = []
             for i in range(len(self._contents)):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,8 +11,8 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._slicing import NO_HEAD
 from awkward._regularize import is_integer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -9,6 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -470,11 +471,11 @@ class RegularArray(Content):
     ) -> Content:
         index_nplike = self._backend.index_nplike
 
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(head, int):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             nextcarry = ak.index.Index64.empty(self._length, index_nplike)
             assert nextcarry.nplike is index_nplike
             self._handle_error(
@@ -492,7 +493,7 @@ class RegularArray(Content):
             return nextcontent._getitem_next(nexthead, nexttail, advanced)
 
         elif isinstance(head, slice):
-            nexthead, nexttail = ak._slicing.headtail(tail)
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             start, stop, step, nextsize = index_nplike.derive_slice_for_length(
                 head, length=self._size
             )
@@ -566,7 +567,6 @@ class RegularArray(Content):
 
         elif isinstance(head, ak.index.Index64):
             head = head.to_nplike(index_nplike)
-            nexthead, nexttail = ak._slicing.headtail(tail)
             flathead = index_nplike.reshape(index_nplike.asarray(head.data), (-1,))
             regular_flathead = ak.index.Index64.empty(flathead.shape[0], index_nplike)
             assert regular_flathead.nplike is index_nplike
@@ -584,6 +584,7 @@ class RegularArray(Content):
                 slicer=head,
             )
 
+            nexthead, nexttail = ak._slicing.head_tail(tail)
             if advanced is None or (
                 advanced.length is not unknown_length and advanced.length == 0
             ):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -483,11 +483,11 @@ class RegularArray(Content):
                     "awkward_RegularArray_getitem_next_at", nextcarry.dtype.type
                 ](
                     nextcarry.data,
-                    int(head) if index_nplike.known_data else head,
+                    head,
                     self._length,
                     self._size,
                 ),
-                slicer=int(head) if index_nplike.known_data else head,
+                slicer=head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,7 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._regularize import is_integer
+from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -474,7 +474,7 @@ class RegularArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(head, int):
+        elif is_integer_like(head):
             nexthead, nexttail = ak._slicing.head_tail(tail)
             nextcarry = ak.index.Index64.empty(self._length, index_nplike)
             assert nextcarry.nplike is index_nplike
@@ -483,11 +483,11 @@ class RegularArray(Content):
                     "awkward_RegularArray_getitem_next_at", nextcarry.dtype.type
                 ](
                     nextcarry.data,
-                    head,
+                    int(head) if index_nplike.known_data else head,
                     self._length,
                     self._size,
                 ),
-                slicer=head,
+                slicer=int(head) if index_nplike.known_data else head,
             )
             nextcontent = self._content._carry(nextcarry, True)
             return nextcontent._getitem_next(nexthead, nexttail, advanced)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -13,6 +13,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -804,8 +805,8 @@ class UnionArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             outcontents = []
             for i in range(len(self._contents)):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -13,6 +13,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.unionform import UnionForm
@@ -800,7 +801,7 @@ class UnionArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,6 +9,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
+from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.form import _type_parameters_equal
@@ -260,7 +261,7 @@ class UnmaskedArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        if head == ():
+        if head is NO_HEAD:
             return self
 
         elif isinstance(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,6 +9,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
+from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._util import unset
 from awkward.contents.content import Content
@@ -264,8 +265,8 @@ class UnmaskedArray(Content):
         if head is NO_HEAD:
             return self
 
-        elif isinstance(
-            head, (int, slice, ak.index.Index64, ak.contents.ListOffsetArray)
+        elif is_integer_like(head) or isinstance(
+            head, (slice, ak.index.Index64, ak.contents.ListOffsetArray)
         ):
             return UnmaskedArray.simplified(
                 self._content._getitem_next(head, tail, advanced),

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -310,11 +310,11 @@ def _parameters_intersect(
 
 
 def _parameters_union(
-    left: JSONMapping,
-    right: JSONMapping,
+    left: JSONMapping | None,
+    right: JSONMapping | None,
     *,
     exclude: Collection[tuple[str, JSONSerialisable]] = (),
-) -> JSONMapping:
+) -> JSONMapping | None:
     """
     Args:
         left: first parameters mapping

--- a/tests/test_0021_emptyarray.py
+++ b/tests/test_0021_emptyarray.py
@@ -161,7 +161,7 @@ def test_from_json_getitem():
     with pytest.raises(IndexError) as excinfo:
         a[2, 1][100:200, 0]
     assert (
-        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 0)\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
+        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 0)\n\nat inner EmptyArray of length 0, using sub-slice array(0).\n\nError details: array is empty."
         in str(excinfo.value)
     )
     with pytest.raises(IndexError) as excinfo:


### PR DESCRIPTION
## TL;DR
- Add support for 0D arrays as array index arguments
