### PR TITLE
fix: uneccessary use of `nplike_of`

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -9,7 +9,6 @@ import itertools
 from collections.abc import Sequence
 
 import awkward as ak
-from awkward._nplikes import nplike_of
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -60,11 +59,10 @@ def length_of_broadcast(inputs: Sequence) -> int | type[unknown_length]:
 
 def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
     maxlen = length_of_broadcast(inputs)
-
     nextinputs = []
     for x in inputs:
         if isinstance(x, Record):
-            index = nplike_of(*inputs).full(maxlen, x.at, dtype=np.int64)
+            index = x.backend.index_nplike.full(maxlen, x.at, dtype=np.int64)
             nextinputs.append(RegularArray(x.array[index], maxlen, 1))
             isscalar.append(True)
         elif isinstance(x, Content):

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -138,13 +138,7 @@ def _array_ufunc_adjust(custom, inputs, kwargs, behavior):
 
 
 def _array_ufunc_adjust_apply(apply_ufunc, ufunc, method, inputs, kwargs, behavior):
-    nextinputs = [
-        ak._util.wrap(x, behavior)
-        if isinstance(x, (ak.contents.Content, ak.record.Record))
-        else x
-        for x in inputs
-    ]
-
+    nextinputs = [ak._util.wrap(x, behavior, allow_other=True) for x in inputs]
     out = apply_ufunc(ufunc, method, nextinputs, kwargs)
 
     if out is NotImplemented:

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -5,7 +5,6 @@ import threading
 import warnings
 from collections.abc import Mapping, Sequence
 
-from awkward._nplikes import nplike_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -128,7 +127,12 @@ class OperationErrorContext(ErrorContext):
     _width = 80 - 8
 
     def __init__(self, name, arguments):
-        if self.primary() is not None or all(nplike_of(x).is_eager for x in arguments):
+        from awkward._backends import NumpyBackend, backend_of
+
+        numpy_backend = NumpyBackend.instance()
+        if self.primary() is not None or all(
+            backend_of(x, default=numpy_backend).nplike.is_eager for x in arguments
+        ):
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays
             # --> in either case, delay string generation
@@ -184,7 +188,12 @@ class SlicingErrorContext(ErrorContext):
     _width = 80 - 4
 
     def __init__(self, array, where):
-        if self.primary() is not None or nplike_of(array, where).is_eager:
+        from awkward._backends import NumpyBackend, backend_of
+
+        numpy_backend = NumpyBackend.instance()
+        if self.primary() is not None or all(
+            backend_of(x, default=numpy_backend).nplike.is_eager for x in (array, where)
+        ):
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays
             # --> in either case, delay string generation

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -603,10 +603,9 @@ def from_arraylib(array, regulararray, recordarray, highlevel, behavior):
     np = NumpyMetadata.instance()
     # overshadows global NumPy import for nplike-safety
     numpy = Numpy.instance()
+    nplike = nplike_of(array)
 
     def recurse(array, mask=None):
-        nplike = nplike_of(array)
-
         if Jax.is_tracer(array):
             raise ak._errors.wrap_error(
                 TypeError("Jax tracers cannot be used with `ak.from_arraylib`")

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -487,8 +487,6 @@ def wrap(content, behavior=None, highlevel=True, like=None, allow_other=False):
 
 
 def union_to_record(unionarray, anonymous):
-    nplike = nplike_of(unionarray)
-
     contents = []
     for layout in unionarray.contents:
         if layout.is_indexed and not layout.is_option:
@@ -525,7 +523,11 @@ def union_to_record(unionarray, anonymous):
                     all_names.append(anonymous)
 
         missingarray = ak.contents.IndexedOptionArray(
-            ak.index.Index64(nplike.full(len(unionarray), -1, dtype=np.int64)),
+            ak.index.Index64(
+                unionarray.backend.index_nplike.full(
+                    unionarray.length, -1, dtype=np.int64
+                )
+            ),
             ak.contents.EmptyArray(),
         )
 

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._nplikes import nplike_of, ufuncs
+from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward.highlevel import Array
 
@@ -111,13 +111,13 @@ class StringBehavior(Array):
 
 
 def _string_equal(one, two):
-    nplike = nplike_of(one, two)
     behavior = ak._util.behavior_of(one, two)
 
     one, two = (
         ak.operations.without_parameters(one).layout,
         ak.operations.without_parameters(two).layout,
     )
+    nplike = one.backend.nplike
 
     # first condition: string lengths must be the same
     counts1 = nplike.asarray(

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -12,7 +12,7 @@ class ByteBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = nplike_of(self.layout).asarray(self.layout)
+        tmp = self.layout.backend.nplike.asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -57,7 +57,7 @@ class CharBehavior(Array):
     __name__ = "Array"
 
     def __bytes__(self):
-        tmp = nplike_of(self.layout).asarray(self.layout)
+        tmp = self.layout.backend.nplike.asarray(self.layout)
         if hasattr(tmp, "tobytes"):
             return tmp.tobytes()
         else:
@@ -151,16 +151,16 @@ def _string_notequal(one, two):
 
 
 def _string_broadcast(layout, offsets):
-    nplike = nplike_of(offsets)
-    assert nplike is layout.backend.index_nplike
-
-    offsets = nplike.asarray(offsets)
+    index_nplike = layout.backend.index_nplike
+    offsets = index_nplike.asarray(offsets)
     counts = offsets[1:] - offsets[:-1]
     if ak._util.win or ak._util.bits32:
-        counts = nplike.astype(counts, dtype=np.int32)
-    parents = nplike.repeat(nplike.arange(len(counts), dtype=counts.dtype), counts)
+        counts = index_nplike.astype(counts, dtype=np.int32)
+    parents = index_nplike.repeat(
+        index_nplike.arange(counts.size, dtype=counts.dtype), counts
+    )
     return ak.contents.IndexedArray(
-        ak.index.Index64(parents, nplike=nplike), layout
+        ak.index.Index64(parents, nplike=index_nplike), layout
     ).project()
 
 

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -2,7 +2,6 @@
 
 import awkward as ak
 from awkward._connect.numpy import unsupported
-from awkward._nplikes import nplike_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -211,7 +210,7 @@ def _impl(
     for x in arrays:
         y = ak.operations.to_layout(x, allow_record=True, allow_other=True)
         if not isinstance(y, (ak.contents.Content, ak.Record)):
-            y = ak.contents.NumpyArray(nplike_of(*arrays).asarray([y]))
+            y = ak.contents.NumpyArray(backend.nplike.asarray([y]))
         inputs.append(y.to_backend(backend))
 
     def action(inputs, depth, **kwargs):

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._nplikes import nplike_of
+from awkward._backends import NumpyBackend, backend_of
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward.operations.ak_fill_none import fill_none
 
 np = NumpyMetadata.instance()
-cpu = ak._backends.NumpyBackend.instance()
+cpu = NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("concatenate")
@@ -51,10 +51,9 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
     backend = ak._backends.backend_of(*arrays, default=cpu)
     behavior = ak._util.behavior_of(*arrays, behavior=behavior)
     if (
-        # Is an Awkward Content
-        isinstance(arrays, ak.contents.Content)
-        # Is an array with a known NumpyLike
-        or nplike_of(arrays, default=None) is not None
+        # Is an array with a known backend
+        backend_of(arrays, default=None)
+        is not None
     ):
         # Convert the array to a layout object
         content = ak.operations.to_layout(arrays, allow_record=False, allow_other=False)

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -2,7 +2,8 @@
 
 
 import awkward as ak
-from awkward._nplikes import nplike_of, ufuncs
+from awkward._backends import backend_of
+from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._util import unset
 
@@ -105,7 +106,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        nplike = nplike_of(x, y, weight)
+        backend = backend_of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x,
@@ -213,7 +214,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            intercept = ak.contents.NumpyArray(nplike.asarray([intercept]))
+            intercept = ak.contents.NumpyArray(backend.nplike.asarray([intercept]))
             scalar = True
         if not isinstance(
             slope,
@@ -222,7 +223,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            slope = ak.contents.NumpyArray(nplike.asarray([slope]))
+            slope = ak.contents.NumpyArray(backend.nplike.asarray([slope]))
             scalar = True
         if not isinstance(
             intercept_error,
@@ -231,7 +232,9 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            intercept_error = ak.contents.NumpyArray(nplike.asarray([intercept_error]))
+            intercept_error = ak.contents.NumpyArray(
+                backend.nplike.asarray([intercept_error])
+            )
             scalar = True
         if not isinstance(
             slope_error,
@@ -240,7 +243,7 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
                 ak.record.Record,
             ),
         ):
-            slope_error = ak.contents.NumpyArray(nplike.asarray([slope_error]))
+            slope_error = ak.contents.NumpyArray(backend.nplike.asarray([slope_error]))
             scalar = True
 
         out = ak.contents.RecordArray(
@@ -251,7 +254,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
         if scalar:
             out = out[0]
 
-        if isinstance(out, (ak.contents.Content, ak.record.Record)):
-            return ak._util.wrap(out, ak._util.behavior_of(x, y))
-        else:
-            return out
+        return ak._util.wrap(out, highlevel=True, behavior=behavior)

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -254,4 +254,4 @@ def _impl(x, y, weight, axis, keepdims, mask_identity):
         if scalar:
             out = out[0]
 
-        return ak._util.wrap(out, highlevel=True, behavior=behavior)
+        return ak._util.wrap(out, highlevel=True, behavior=behavior, allow_other=scalar)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._nplikes import nplike_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -101,10 +100,10 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 
 
 def _impl(array, mask, valid_when, highlevel, behavior):
-    def action(inputs, **kwargs):
+    def action(inputs, backend, **kwargs):
         layoutarray, layoutmask = inputs
         if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = nplike_of(layoutmask).asarray(layoutmask)
+            m = backend.nplike.asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ak._errors.wrap_error(
                     ValueError(f"mask must have boolean type, not {repr(m.dtype)}")

--- a/tests/test_0395_complex_type_arrays.py
+++ b/tests/test_0395_complex_type_arrays.py
@@ -238,11 +238,7 @@ def test_astype_complex():
         (4.5 + 0j),
         (5.5 + 0j),
     ]
-    assert to_list(
-        ak._nplikes.nplike_of(array_complex64).asarray(
-            ak.highlevel.Array(array_complex64)
-        )
-    ) == [
+    assert to_list(array_complex64) == [
         (0.25 + 0.0j),
         (0.5 + 0.0j),
         (3.5 + 0.0j),


### PR DESCRIPTION
In preparation for a simplification of `nplike` identification, this PR eliminates redundant `nplike_of` usages, and/or replaces them with `backend_of`.

In future, `nplike_of` will only accept array objects (not layouts, etc).

