### PR TITLE
fix: jupyterlite dependency changes

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ myst-nb
 sphinx-external-toc
 jupyterlite-sphinx
 ipyleaflet
-jupyterlite>=0.1.0b12,==0.1.0b16
+jupyterlite-core==0.1.0b19
 
 numpy>=1.13.1
 numba>=0.50.0


### PR DESCRIPTION
`jupyterlite` partitioned into `jupyterlite-core` and `jupyterlite`. We pin `jupyterlite`, but now we need to pin the root package.