### PR TITLE
refactor: move `_parameters_XXX` functions into `_parameters` submodule

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -12,7 +12,11 @@ from awkward._behavior import find_custom_broadcast
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import parameters_are_empty, parameters_intersect
+from awkward._parameters import (
+    parameters_are_empty,
+    parameters_are_equal,
+    parameters_intersect,
+)
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
 from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
@@ -241,7 +245,7 @@ def all_or_nothing_parameters_factory(
         first_parameters = input_parameters[0]
         # Ensure all parameters match, or set parameters to None
         for other_parameters in input_parameters[1:]:
-            if not ak.forms.form._parameters_equal(first_parameters, other_parameters):
+            if not parameters_are_equal(first_parameters, other_parameters):
                 break
         else:
             parameters = first_parameters

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -12,6 +12,7 @@ from awkward._behavior import find_custom_broadcast
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
+from awkward._parameters import _parameters_intersect, _parameters_is_empty
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
 from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
@@ -278,14 +279,14 @@ def intersection_parameters_factory(
     # If we encounter None-parameters, then we stop early
     # as there can be no intersection.
     for parameters in input_parameters:
-        if ak.forms.form._parameters_is_empty(parameters):
+        if _parameters_is_empty(parameters):
             break
         else:
             parameters_to_intersect.append(parameters)
     # Otherwise, build the intersected parameter dict
     else:
         intersected_parameters = functools.reduce(
-            ak.forms.form._parameters_intersect, parameters_to_intersect
+            _parameters_intersect, parameters_to_intersect
         )
 
     def apply(n_outputs: int) -> list[dict[str, Any] | None]:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -12,7 +12,7 @@ from awkward._behavior import find_custom_broadcast
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import _parameters_intersect, _parameters_is_empty
+from awkward._parameters import parameters_intersect, parameters_is_empty
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
 from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
@@ -279,14 +279,14 @@ def intersection_parameters_factory(
     # If we encounter None-parameters, then we stop early
     # as there can be no intersection.
     for parameters in input_parameters:
-        if _parameters_is_empty(parameters):
+        if parameters_is_empty(parameters):
             break
         else:
             parameters_to_intersect.append(parameters)
     # Otherwise, build the intersected parameter dict
     else:
         intersected_parameters = functools.reduce(
-            _parameters_intersect, parameters_to_intersect
+            parameters_intersect, parameters_to_intersect
         )
 
     def apply(n_outputs: int) -> list[dict[str, Any] | None]:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -12,7 +12,7 @@ from awkward._behavior import find_custom_broadcast
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import parameters_intersect, parameters_is_empty
+from awkward._parameters import parameters_are_empty, parameters_intersect
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
 from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
@@ -279,7 +279,7 @@ def intersection_parameters_factory(
     # If we encounter None-parameters, then we stop early
     # as there can be no intersection.
     for parameters in input_parameters:
-        if parameters_is_empty(parameters):
+        if parameters_are_empty(parameters):
             break
         else:
             parameters_to_intersect.append(parameters)

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Sized
 import awkward as ak
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.forms.form import _parameters_union
+from awkward._parameters import parameters_union
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -407,7 +407,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 
         content = handle_arrow(paarray.dictionary, generate_bitmasks)
 
-        parameters = ak.forms.form._parameters_union(
+        parameters = parameters_union(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:
@@ -702,7 +702,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         a, b = to_awkwardarrow_storage_types(storage_type.value_type)
         content = form_popbuffers(a, b)
 
-        parameters = _parameters_union(
+        parameters = parameters_union(
             mask_parameters(awkwardarrow_type), node_parameters(awkwardarrow_type)
         )
         if parameters is None:

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -32,7 +32,7 @@ def type_parameters_equal(
         return True
 
 
-def parameters_equal(
+def parameters_are_equal(
     one: JSONMapping, two: JSONMapping, only_array_record=False
 ) -> bool:
     if one is None and two is None:
@@ -166,7 +166,7 @@ def parameters_union(
             return result
 
 
-def parameters_is_empty(parameters: JSONMapping | None) -> bool:
+def parameters_are_empty(parameters: JSONMapping | None) -> bool:
     """
     Args:
         parameters (dict or None): parameters dictionary, or None

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -5,7 +5,7 @@ from collections.abc import Collection
 from awkward._typing import JSONMapping, JSONSerializable
 
 
-def _type_parameters_equal(
+def type_parameters_equal(
     one: JSONMapping | None, two: JSONMapping | None, *, allow_missing: bool = False
 ) -> bool:
     if one is None and two is None:
@@ -32,7 +32,7 @@ def _type_parameters_equal(
         return True
 
 
-def _parameters_equal(
+def parameters_equal(
     one: JSONMapping, two: JSONMapping, only_array_record=False
 ) -> bool:
     if one is None and two is None:
@@ -74,7 +74,7 @@ def _parameters_equal(
         return True
 
 
-def _parameters_intersect(
+def parameters_intersect(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
@@ -122,7 +122,7 @@ def _parameters_intersect(
     return result
 
 
-def _parameters_union(
+def parameters_union(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
@@ -166,7 +166,7 @@ def _parameters_union(
             return result
 
 
-def _parameters_is_empty(parameters: JSONMapping | None) -> bool:
+def parameters_is_empty(parameters: JSONMapping | None) -> bool:
     """
     Args:
         parameters (dict or None): parameters dictionary, or None

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+
+from awkward._typing import JSONMapping, JSONSerializable
+
+
+def _type_parameters_equal(
+    one: JSONMapping | None, two: JSONMapping | None, *, allow_missing: bool = False
+) -> bool:
+    if one is None and two is None:
+        return True
+
+    elif one is None:
+        # NB: __categorical__ is currently a type-only parameter, but
+        # we check it here as types check this too.
+        for key in ("__array__", "__record__", "__categorical__"):
+            if two.get(key) is not None:
+                return allow_missing
+        return True
+
+    elif two is None:
+        for key in ("__array__", "__record__", "__categorical__"):
+            if one.get(key) is not None:
+                return allow_missing
+        return True
+
+    else:
+        for key in ("__array__", "__record__", "__categorical__"):
+            if one.get(key) != two.get(key):
+                return False
+        return True
+
+
+def _parameters_equal(
+    one: JSONMapping, two: JSONMapping, only_array_record=False
+) -> bool:
+    if one is None and two is None:
+        return True
+    elif one is None:
+        if only_array_record:
+            # NB: __categorical__ is currently a type-only parameter, but
+            # we check it here as types check this too.
+            for key in ("__array__", "__record__", "__categorical__"):
+                if two.get(key) is not None:
+                    return False
+            return True
+        else:
+            for value in two.values():
+                if value is not None:
+                    return False
+            return True
+
+    elif two is None:
+        if only_array_record:
+            for key in ("__array__", "__record__", "__categorical__"):
+                if one.get(key) is not None:
+                    return False
+            return True
+        else:
+            for value in one.values():
+                if value is not None:
+                    return False
+            return True
+
+    else:
+        if only_array_record:
+            keys = ("__array__", "__record__", "__categorical__")
+        else:
+            keys = set(one.keys()).union(two.keys())
+        for key in keys:
+            if one.get(key) != two.get(key):
+                return False
+        return True
+
+
+def _parameters_intersect(
+    left: JSONMapping | None,
+    right: JSONMapping | None,
+    *,
+    exclude: Collection[tuple[str, JSONSerializable]] = (),
+) -> JSONMapping | None:
+    """
+    Args:
+        left: first parameters mapping
+        right: second parameters mapping
+        exclude: collection of (key, value) items to exclude
+
+    Returns the intersected key-value pairs of `left` and `right` as a dictionary.
+    """
+    if left is None or right is None:
+        return None
+
+    common_keys = iter(left.keys() & right.keys())
+    has_no_exclusions = len(exclude) == 0
+
+    # Avoid creating `result` unless we have to
+    for key in common_keys:
+        left_value = left[key]
+        # Do our keys match?
+        if (
+            left_value is not None
+            and left_value == right[key]
+            and (has_no_exclusions or (key, left_value) not in exclude)
+        ):
+            # Exit, indicating that we want to create `result`
+            break
+    else:
+        return None
+
+    # We found a meaningful key, so create a result dict
+    result = {key: left_value}
+    for key in common_keys:
+        left_value = left[key]
+        if (
+            left_value is not None
+            and left_value == right[key]
+            and (has_no_exclusions or (key, left_value) not in exclude)
+        ):
+            result[key] = left_value
+
+    return result
+
+
+def _parameters_union(
+    left: JSONMapping | None,
+    right: JSONMapping | None,
+    *,
+    exclude: Collection[tuple[str, JSONSerializable]] = (),
+) -> JSONMapping | None:
+    """
+    Args:
+        left: first parameters mapping
+        right: second parameters mapping
+        exclude: collection of (key, value) items to exclude
+
+    Returns the merged key-value pairs of `left` and `right` as a dictionary.
+
+    """
+    has_no_exclusions = len(exclude) == 0
+    if left is None:
+        if right is None:
+            return None
+        else:
+            return {
+                k: v
+                for k, v in right.items()
+                if v is not None and (has_no_exclusions or (k, v) not in exclude)
+            }
+    else:
+        result = {
+            k: v
+            for k, v in left.items()
+            if v is not None and (has_no_exclusions or (k, v) not in exclude)
+        }
+        if right is None:
+            return result
+        else:
+            for key in right:
+                right_value = right[key]
+                if right_value is not None and (
+                    has_no_exclusions or (key, right_value) not in exclude
+                ):
+                    result[key] = right_value
+
+            return result
+
+
+def _parameters_is_empty(parameters: JSONMapping | None) -> bool:
+    """
+    Args:
+        parameters (dict or None): parameters dictionary, or None
+
+    Return True if the parameters dictionary is considered empty, either because it is
+    None, or because it does not have any meaningful (non-None) values; otherwise,
+    return False.
+    """
+    if parameters is None:
+        return True
+
+    for item in parameters.values():
+        if item is not None:
+            return False
+
+    return True

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -52,3 +52,9 @@ else:
         final,
         runtime_checkable,
     )
+
+
+JSONSerializable: TypeAlias = (
+    "str | int | float | bool | None | list | tuple | JSONMapping"
+)
+JSONMapping: TypeAlias = "dict[str, JSONSerializable]"

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -570,7 +570,7 @@ class BitMaskedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _type_parameters_equal(self._parameters, other._parameters)
+            ) and type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,6 +10,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -17,7 +18,6 @@ from awkward._util import unset
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
-from awkward.forms.form import _type_parameters_equal
 from awkward.index import Index
 
 if TYPE_CHECKING:

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,7 +10,9 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,13 +11,13 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
-from awkward.forms.form import _type_parameters_equal
 from awkward.index import Index
 
 if TYPE_CHECKING:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -707,7 +707,7 @@ class ByteMaskedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _type_parameters_equal(self._parameters, other._parameters)
+            ) and type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,7 +11,10 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -731,9 +734,7 @@ class ByteMaskedArray(Content):
             length = 0
             for x in others:
                 length_scalar = self._backend.index_nplike.shape_item_as_index(x.length)
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, x._parameters
-                )
+                parameters = parameters_intersect(parameters, x._parameters)
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])
                 length += x.length

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like, is_sized_iterable
 from awkward._slicing import normalize_slice
 from awkward._typing import (
@@ -1335,7 +1335,7 @@ class Content:
         return (
             self.__class__ is other.__class__
             and len(self) == len(other)
-            and _type_parameters_equal(self.parameters, other.parameters)
+            and type_parameters_equal(self.parameters, other.parameters)
             and self._is_equal_to(other, index_dtype, numpyarray)
         )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -15,7 +15,9 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like, is_sized_iterable
 from awkward._slicing import normalize_slice
 from awkward._typing import (

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -15,12 +15,14 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like, is_sized_iterable
 from awkward._slicing import normalize_slice
 from awkward._typing import (
     TYPE_CHECKING,
     Any,
     AxisMaybeNone,
+    JSONMapping,
     Literal,
     Self,
     SupportsIndex,
@@ -28,7 +30,7 @@ from awkward._typing import (
     TypedDict,
 )
 from awkward._util import unset
-from awkward.forms.form import Form, JSONMapping, _type_parameters_equal
+from awkward.forms.form import Form
 from awkward.index import Index, Index64
 
 if TYPE_CHECKING:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,12 +8,12 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,7 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -490,7 +490,7 @@ class IndexedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _type_parameters_equal(self._parameters, other._parameters)
+            ) and type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,7 +8,11 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    parameters_union,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -151,9 +155,7 @@ class IndexedArray(Content):
 
         if content.is_union and not is_cat:
             return content._carry(index, allow_lazy=False).copy(
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                )
+                parameters=parameters_union(content._parameters, parameters)
             )
 
         elif content.is_indexed or content.is_option:
@@ -182,17 +184,13 @@ class IndexedArray(Content):
                 return ak.contents.IndexedArray(
                     result,
                     content.content,
-                    parameters=ak.forms.form._parameters_union(
-                        content._parameters, parameters
-                    ),
+                    parameters=parameters_union(content._parameters, parameters),
                 )
             else:
                 return ak.contents.IndexedOptionArray(
                     result,
                     content.content,
-                    parameters=ak.forms.form._parameters_union(
-                        content._parameters, parameters
-                    ),
+                    parameters=parameters_union(content._parameters, parameters),
                 )
 
         else:
@@ -467,7 +465,7 @@ class IndexedArray(Content):
             )
             next = self._content._carry(nextcarry, False)
             return next.copy(
-                parameters=ak.forms.form._parameters_union(
+                parameters=parameters_union(
                     next._parameters,
                     self._parameters,
                     exclude=(("__array__", "categorical"),),
@@ -567,9 +565,7 @@ class IndexedArray(Content):
         )
         # We can directly merge with other options and indexed types, but we must merge parameters
         if other.is_option or other.is_indexed:
-            parameters = ak.forms.form._parameters_union(
-                self._parameters, other._parameters
-            )
+            parameters = parameters_union(self._parameters, other._parameters)
         # Otherwise, this option parameters win out
         else:
             parameters = self._parameters
@@ -613,9 +609,7 @@ class IndexedArray(Content):
             if isinstance(
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, array._parameters
-                )
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 contents.append(array.content)
                 array_index = array.index
@@ -1033,9 +1027,7 @@ class IndexedArray(Content):
                 next = self._content._carry(ak.index.Index(index), False)
 
             next2 = next.copy(
-                parameters=ak.forms.form._parameters_union(
-                    next._parameters, self._parameters
-                )
+                parameters=parameters_union(next._parameters, self._parameters)
             )
             return next2._to_arrow(pyarrow, mask_node, validbytes, length, options)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -620,7 +620,7 @@ class IndexedOptionArray(Content):
         elif other.is_option or other.is_indexed:
             return self._content._mergeable_next(
                 other.content, mergebool
-            ) and _type_parameters_equal(self._parameters, other._parameters)
+            ) and type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,12 +9,12 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -9,7 +9,11 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    parameters_union,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -175,9 +179,7 @@ class IndexedOptionArray(Content):
             return IndexedOptionArray(
                 result,
                 content.content,
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=parameters_union(content._parameters, parameters),
             )
 
         else:
@@ -706,9 +708,7 @@ class IndexedOptionArray(Content):
         )
         # We can directly merge with other options, but we must merge parameters
         if other.is_option:
-            parameters = ak.forms.form._parameters_union(
-                self._parameters, other._parameters
-            )
+            parameters = parameters_union(self._parameters, other._parameters)
         # Otherwise, this option parameters win out
         else:
             parameters = self._parameters
@@ -751,9 +751,7 @@ class IndexedOptionArray(Content):
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
                 # If we're merging an option, then merge parameters before pulling out `content`
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, array._parameters
-                )
+                parameters = parameters_intersect(parameters, array._parameters)
                 contents.append(array.content)
                 array_index = array.index
                 assert (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,7 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -1033,7 +1033,7 @@ class ListArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not _type_parameters_equal(self._parameters, other._parameters):
+        elif not type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,7 +8,10 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -1067,9 +1070,7 @@ class ListArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._parameters_intersect(
-                parameters, array._parameters
-            )
+            parameters = parameters_intersect(parameters, array._parameters)
             if isinstance(
                 array,
                 (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,13 +8,13 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.listform import ListForm
 from awkward.index import Index
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,7 +9,9 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,12 +9,12 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -792,7 +792,7 @@ class ListOffsetArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not _type_parameters_equal(self._parameters, other._parameters):
+        elif not type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,7 +10,10 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -481,9 +484,7 @@ class NumpyArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._parameters_intersect(
-                parameters, array._parameters
-            )
+            parameters = parameters_intersect(parameters, array._parameters)
             if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)
             else:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,12 +10,12 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.numpyform import NumpyForm
 from awkward.index import Index
 from awkward.types.numpytype import primitive_to_dtype

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,7 +10,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracerArray
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -424,7 +424,7 @@ class NumpyArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not _type_parameters_equal(self._parameters, other._parameters):
+        elif not type_parameters_equal(self._parameters, other._parameters):
             return False
         # Simplify *this* branch to be 1D self
         elif len(self.shape) > 1:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,7 +11,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -652,7 +652,7 @@ class RecordArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not _type_parameters_equal(self._parameters, other._parameters):
+        elif not type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,7 +11,10 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -699,9 +702,7 @@ class RecordArray(Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, array._parameters
-                )
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
@@ -734,9 +735,7 @@ class RecordArray(Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, array._parameters
-                )
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,12 +11,12 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.recordform import RecordForm
 from awkward.index import Index
 from awkward.record import Record

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,7 +8,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -729,7 +729,7 @@ class RegularArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
-        elif not _type_parameters_equal(self._parameters, other._parameters):
+        elif not type_parameters_equal(self._parameters, other._parameters):
             return False
         elif isinstance(
             other,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,7 +8,11 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    parameters_union,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -280,9 +284,7 @@ class RegularArray(Content):
             shape = (self._length, self._size) + content.data.shape[1:]
             return ak.contents.NumpyArray(
                 self._backend.nplike.reshape(content.data, shape),
-                parameters=ak.forms.form._parameters_union(
-                    self._parameters, content.parameters
-                ),
+                parameters=parameters_union(self._parameters, content.parameters),
                 backend=content.backend,
             )
         else:
@@ -763,9 +765,7 @@ class RegularArray(Content):
             tail_contents = []
             zeros_length = self._length
             for x in others:
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, x._parameters
-                )
+                parameters = parameters_intersect(parameters, x._parameters)
                 tail_contents.append(x._content[: x._length * x._size])
                 zeros_length += x._length
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,12 +8,12 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.regularform import RegularForm
 from awkward.index import Index
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -13,6 +13,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
+from awkward._parameters import parameters_intersect, parameters_union
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -264,9 +265,7 @@ class UnionArray(Content):
                 innercontents = self_cont._contents
 
                 # Update outermost parameters with this union's parameters
-                parameters = ak.forms.form._parameters_union(
-                    self_cont._parameters, parameters
-                )
+                parameters = parameters_union(self_cont._parameters, parameters)
 
                 # For each inner union content
                 for j, inner_cont in enumerate(innercontents):
@@ -408,9 +407,7 @@ class UnionArray(Content):
 
         if len(contents) == 1:
             next = contents[0]._carry(index, True)
-            return next.copy(
-                parameters=ak.forms.form._parameters_union(next._parameters, parameters)
-            )
+            return next.copy(parameters=parameters_union(next._parameters, parameters))
 
         else:
             return cls(
@@ -633,7 +630,7 @@ class UnionArray(Content):
             ak.index.Index(nexttags),
             ak.index.Index(nextindex),
             contents,
-            parameters=ak.forms.form._parameters_union(self._parameters, parameters),
+            parameters=parameters_union(self._parameters, parameters),
         )
 
     def project(self, index):
@@ -1085,9 +1082,7 @@ class UnionArray(Content):
             if isinstance(array, ak.contents.EmptyArray):
                 continue
 
-            parameters = ak.forms.form._parameters_intersect(
-                parameters, array._parameters
-            )
+            parameters = parameters_intersect(parameters, array._parameters)
             if isinstance(array, ak.contents.UnionArray):
                 union_tags = ak.index.Index(array.tags)
                 union_index = ak.index.Index(array.index)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,12 +9,12 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
 from awkward._util import unset
 from awkward.contents.content import Content
-from awkward.forms.form import _type_parameters_equal
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.index import Index
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,7 +9,11 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import (
+    parameters_intersect,
+    parameters_union,
+    type_parameters_equal,
+)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -107,15 +111,11 @@ class UnmaskedArray(Content):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=parameters_union(content._parameters, parameters),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                )
+                parameters=parameters_union(content._parameters, parameters)
             )
         else:
             return cls(content, parameters=parameters)
@@ -337,9 +337,7 @@ class UnmaskedArray(Content):
             parameters = self._parameters
             tail_contents = []
             for x in others:
-                parameters = ak.forms.form._parameters_intersect(
-                    parameters, x._parameters
-                )
+                parameters = parameters_intersect(parameters, x._parameters)
                 tail_contents.append(x._content)
 
             return UnmaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,7 +9,7 @@ from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.typetracer import MaybeNone
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
@@ -322,7 +322,7 @@ class UnmaskedArray(Content):
         elif other.is_option or other.is_indexed:
             return self._mergeable_next(
                 other.content, mergebool
-            ) and _type_parameters_equal(self._parameters, other._parameters)
+            ) and type_parameters_equal(self._parameters, other._parameters)
         else:
             return self._content._mergeable_next(other, mergebool)
 

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -164,7 +164,7 @@ class BitMaskedForm(Form):
                 and self._mask == other._mask
                 and self._valid_when == other._valid_when
                 and self._lsb_order == other._lsb_order
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -139,7 +139,7 @@ class ByteMaskedForm(Form):
                 self._form_key == other._form_key
                 and self._mask == other._mask
                 and self._valid_when == other._valid_when
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -4,22 +4,17 @@ from __future__ import annotations
 import itertools
 import json
 import re
-from collections.abc import Collection, Mapping
+from collections.abc import Mapping
 
 import awkward as ak
 from awkward import _errors
 from awkward._behavior import find_typestrs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
-from awkward._typing import Final, TypeAlias
+from awkward._typing import Final, JSONMapping, JSONSerializable
 
 np = NumpyMetadata.instance()
 numpy_backend = ak._backends.NumpyBackend.instance()
-
-JSONSerialisable: TypeAlias = (
-    "str | int | float | bool | None | list | tuple | JSONMapping"
-)
-JSONMapping: TypeAlias = "dict[str, JSONSerialisable]"
 
 
 reserved_nominal_parameters: Final = frozenset(
@@ -192,186 +187,6 @@ def from_json(input: str) -> Form:
     return from_dict(json.loads(input))
 
 
-def _type_parameters_equal(
-    one: JSONMapping | None, two: JSONMapping | None, *, allow_missing: bool = False
-) -> bool:
-    if one is None and two is None:
-        return True
-
-    elif one is None:
-        # NB: __categorical__ is currently a type-only parameter, but
-        # we check it here as types check this too.
-        for key in ("__array__", "__record__", "__categorical__"):
-            if two.get(key) is not None:
-                return allow_missing
-        return True
-
-    elif two is None:
-        for key in ("__array__", "__record__", "__categorical__"):
-            if one.get(key) is not None:
-                return allow_missing
-        return True
-
-    else:
-        for key in ("__array__", "__record__", "__categorical__"):
-            if one.get(key) != two.get(key):
-                return False
-        return True
-
-
-def _parameters_equal(
-    one: JSONMapping, two: JSONMapping, only_array_record=False
-) -> bool:
-    if one is None and two is None:
-        return True
-    elif one is None:
-        if only_array_record:
-            # NB: __categorical__ is currently a type-only parameter, but
-            # we check it here as types check this too.
-            for key in ("__array__", "__record__", "__categorical__"):
-                if two.get(key) is not None:
-                    return False
-            return True
-        else:
-            for value in two.values():
-                if value is not None:
-                    return False
-            return True
-
-    elif two is None:
-        if only_array_record:
-            for key in ("__array__", "__record__", "__categorical__"):
-                if one.get(key) is not None:
-                    return False
-            return True
-        else:
-            for value in one.values():
-                if value is not None:
-                    return False
-            return True
-
-    else:
-        if only_array_record:
-            keys = ("__array__", "__record__", "__categorical__")
-        else:
-            keys = set(one.keys()).union(two.keys())
-        for key in keys:
-            if one.get(key) != two.get(key):
-                return False
-        return True
-
-
-def _parameters_intersect(
-    left: JSONMapping | None,
-    right: JSONMapping | None,
-    *,
-    exclude: Collection[tuple[str, JSONSerialisable]] = (),
-) -> JSONMapping | None:
-    """
-    Args:
-        left: first parameters mapping
-        right: second parameters mapping
-        exclude: collection of (key, value) items to exclude
-
-    Returns the intersected key-value pairs of `left` and `right` as a dictionary.
-    """
-    if left is None or right is None:
-        return None
-
-    common_keys = iter(left.keys() & right.keys())
-    has_no_exclusions = len(exclude) == 0
-
-    # Avoid creating `result` unless we have to
-    for key in common_keys:
-        left_value = left[key]
-        # Do our keys match?
-        if (
-            left_value is not None
-            and left_value == right[key]
-            and (has_no_exclusions or (key, left_value) not in exclude)
-        ):
-            # Exit, indicating that we want to create `result`
-            break
-    else:
-        return None
-
-    # We found a meaningful key, so create a result dict
-    result = {key: left_value}
-    for key in common_keys:
-        left_value = left[key]
-        if (
-            left_value is not None
-            and left_value == right[key]
-            and (has_no_exclusions or (key, left_value) not in exclude)
-        ):
-            result[key] = left_value
-
-    return result
-
-
-def _parameters_union(
-    left: JSONMapping | None,
-    right: JSONMapping | None,
-    *,
-    exclude: Collection[tuple[str, JSONSerialisable]] = (),
-) -> JSONMapping | None:
-    """
-    Args:
-        left: first parameters mapping
-        right: second parameters mapping
-        exclude: collection of (key, value) items to exclude
-
-    Returns the merged key-value pairs of `left` and `right` as a dictionary.
-
-    """
-    has_no_exclusions = len(exclude) == 0
-    if left is None:
-        if right is None:
-            return None
-        else:
-            return {
-                k: v
-                for k, v in right.items()
-                if v is not None and (has_no_exclusions or (k, v) not in exclude)
-            }
-    else:
-        result = {
-            k: v
-            for k, v in left.items()
-            if v is not None and (has_no_exclusions or (k, v) not in exclude)
-        }
-        if right is None:
-            return result
-        else:
-            for key in right:
-                right_value = right[key]
-                if right_value is not None and (
-                    has_no_exclusions or (key, right_value) not in exclude
-                ):
-                    result[key] = right_value
-
-            return result
-
-
-def _parameters_is_empty(parameters: JSONMapping | None) -> bool:
-    """
-    Args:
-        parameters (dict or None): parameters dictionary, or None
-
-    Return True if the parameters dictionary is considered empty, either because it is
-    None, or because it does not have any meaningful (non-None) values; otherwise,
-    return False.
-    """
-    if parameters is None:
-        return True
-
-    for item in parameters.values():
-        if item is not None:
-            return False
-
-    return True
-
-
 def _expand_braces(text, seen=None):
     if seen is None:
         seen = set()
@@ -434,13 +249,13 @@ class Form:
         """Return True if the content or its non-list descendents are an identity"""
         raise _errors.wrap_error(NotImplementedError)
 
-    def parameter(self, key: str) -> JSONSerialisable:
+    def parameter(self, key: str) -> JSONSerializable:
         if self._parameters is None:
             return None
         else:
             return self._parameters.get(key)
 
-    def purelist_parameter(self, key: str) -> JSONSerialisable:
+    def purelist_parameter(self, key: str) -> JSONSerializable:
         raise _errors.wrap_error(NotImplementedError)
 
     @property

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import _parameters_union, _type_parameters_equal
+from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -76,21 +76,21 @@ class IndexedForm(Form):
 
         if content.is_union and not is_cat:
             return content.copy(
-                parameters=_parameters_union(content._parameters, parameters)
+                parameters=parameters_union(content._parameters, parameters)
             )
 
         elif content.is_option:
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=_parameters_union(content._parameters, parameters),
+                parameters=parameters_union(content._parameters, parameters),
             )
 
         elif content.is_indexed:
             return IndexedForm(
                 "i64",
                 content.content,
-                parameters=_parameters_union(content._parameters, parameters),
+                parameters=parameters_union(content._parameters, parameters),
             )
 
         else:
@@ -117,7 +117,7 @@ class IndexedForm(Form):
             if out._parameters is None:
                 out._parameters = self._parameters
             else:
-                out._parameters = _parameters_union(out._parameters, self._parameters)
+                out._parameters = parameters_union(out._parameters, self._parameters)
 
             if self._parameters.get("__array__") == "categorical":
                 if out._parameters is self._parameters:
@@ -138,7 +138,7 @@ class IndexedForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._index == other._index
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._parameters import _parameters_union, _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _parameters_union, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final
@@ -75,27 +76,21 @@ class IndexedForm(Form):
 
         if content.is_union and not is_cat:
             return content.copy(
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                )
+                parameters=_parameters_union(content._parameters, parameters)
             )
 
         elif content.is_option:
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=_parameters_union(content._parameters, parameters),
             )
 
         elif content.is_indexed:
             return IndexedForm(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=_parameters_union(content._parameters, parameters),
             )
 
         else:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _parameters_union, _type_parameters_equal
+from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -82,7 +82,7 @@ class IndexedOptionForm(Form):
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=_parameters_union(content._parameters, parameters),
+                parameters=parameters_union(content._parameters, parameters),
             )
 
         else:
@@ -121,7 +121,7 @@ class IndexedOptionForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._index == other._index
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _parameters_union, _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final
@@ -81,9 +82,7 @@ class IndexedOptionForm(Form):
             return ak.forms.IndexedOptionForm.simplified(
                 "i64",
                 content.content,
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=_parameters_union(content._parameters, parameters),
             )
 
         else:

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -124,7 +124,7 @@ class ListForm(Form):
                 self._form_key == other._form_key
                 and self._starts == other._starts
                 and self._stops == other._stops
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -78,7 +78,7 @@ class ListOffsetForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._offsets == other._offsets
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -148,7 +148,7 @@ class NumpyForm(Form):
                 self._form_key == other._form_key
                 and self._primitive == other._primitive
                 and self._inner_shape == other._inner_shape
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
             )
         else:
             return False

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -4,9 +4,10 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -4,10 +4,11 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward._util import unset
@@ -191,7 +191,7 @@ class RecordForm(Form):
                 self._form_key == other._form_key
                 and self.is_tuple == other.is_tuple
                 and len(self._contents) == len(other._contents)
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
             ):
                 if self.is_tuple:
                     return self._contents == other._contents

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -2,7 +2,7 @@
 import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward._util import unset
@@ -83,7 +83,7 @@ class RegularForm(Form):
             return (
                 self._form_key == other._form_key
                 and self._size == other._size
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -2,10 +2,11 @@
 import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._nplikes.shape import unknown_length
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -4,9 +4,10 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -155,7 +155,7 @@ class UnionForm(Form):
             and self._tags == other._tags
             and self._index == other._index
             and len(self._contents) == len(other._contents)
-            and _type_parameters_equal(self._parameters, other._parameters)
+            and type_parameters_equal(self._parameters, other._parameters)
         ):
             return self._contents == other._contents
 

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
+from awkward._parameters import _parameters_union, _type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
-from awkward.forms.form import Form, _type_parameters_equal
+from awkward.forms.form import Form
 
 
 @final
@@ -57,15 +58,11 @@ class UnmaskedForm(Form):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                ),
+                parameters=_parameters_union(content._parameters, parameters),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=ak.forms.form._parameters_union(
-                    content._parameters, parameters
-                )
+                parameters=_parameters_union(content._parameters, parameters)
             )
         else:
             return cls(content, parameters=parameters, form_key=form_key)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import find_typestr
-from awkward._parameters import _parameters_union, _type_parameters_equal
+from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
 from awkward.forms.form import Form
@@ -58,11 +58,11 @@ class UnmaskedForm(Form):
         if content.is_union:
             return content.copy(
                 contents=[cls.simplified(x) for x in content.contents],
-                parameters=_parameters_union(content._parameters, parameters),
+                parameters=parameters_union(content._parameters, parameters),
             )
         elif content.is_indexed or content.is_option:
             return content.copy(
-                parameters=_parameters_union(content._parameters, parameters)
+                parameters=parameters_union(content._parameters, parameters)
             )
         else:
             return cls(content, parameters=parameters, form_key=form_key)
@@ -91,7 +91,7 @@ class UnmaskedForm(Form):
         if isinstance(other, UnmaskedForm):
             return (
                 self._form_key == other._form_key
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -8,7 +8,7 @@ from awkward._backends import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.forms.form import _parameters_equal
+from awkward._parameters import _parameters_equal
 from awkward.operations.ak_to_layout import to_layout
 
 np = NumpyMetadata.instance()

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -8,7 +8,7 @@ from awkward._backends import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._parameters import _parameters_equal
+from awkward._parameters import parameters_equal
 from awkward.operations.ak_to_layout import to_layout
 
 np = NumpyMetadata.instance()
@@ -86,9 +86,7 @@ def almost_equal(
         if left.length != right.length:
             return False
 
-        if check_parameters and not _parameters_equal(
-            left.parameters, right.parameters
-        ):
+        if check_parameters and not parameters_equal(left.parameters, right.parameters):
             return False
 
         # Require that the arrays have the same evaluated types

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -8,7 +8,7 @@ from awkward._backends import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._parameters import parameters_equal
+from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
 
 np = NumpyMetadata.instance()
@@ -86,7 +86,9 @@ def almost_equal(
         if left.length != right.length:
             return False
 
-        if check_parameters and not parameters_equal(left.parameters, right.parameters):
+        if check_parameters and not parameters_are_equal(
+            left.parameters, right.parameters
+        ):
             return False
 
         # Require that the arrays have the same evaluated types

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,8 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -69,7 +69,7 @@ class ListType(Type):
     def __eq__(self, other):
         if isinstance(other, ListType):
             return (
-                _type_parameters_equal(self._parameters, other._parameters)
+                type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -5,8 +5,8 @@ import re
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 np = NumpyMetadata.instance()

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -5,7 +5,7 @@ import re
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -163,7 +163,7 @@ class NumpyType(Type):
 
     def __eq__(self, other):
         if isinstance(other, NumpyType):
-            return self._primitive == other._primitive and _type_parameters_equal(
+            return self._primitive == other._primitive and type_parameters_equal(
                 self._parameters, other._parameters
             )
         else:

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
@@ -84,7 +84,7 @@ class OptionType(Type):
     def __eq__(self, other):
         if isinstance(other, OptionType):
             return (
-                _type_parameters_equal(self._parameters, other._parameters)
+                type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,8 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
 from awkward.types.type import Type

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
@@ -101,7 +101,7 @@ class OptionType(Type):
                     contents.append(
                         OptionType(
                             content.content,
-                            parameters=ak.forms.form._parameters_union(
+                            parameters=parameters_union(
                                 self._parameters, content._parameters
                             ),
                             typestr=typestr,

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -5,8 +5,8 @@ from collections.abc import Iterable
 
 import awkward as ak
 import awkward._prettyprint
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 import awkward._prettyprint
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -185,7 +185,7 @@ class RecordType(Type):
 
     def __eq__(self, other):
         if isinstance(other, RecordType):
-            if not _type_parameters_equal(self._parameters, other._parameters):
+            if not type_parameters_equal(self._parameters, other._parameters):
                 return False
 
             if self._fields is None and other._fields is None:

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._nplikes.shape import unknown_length
+from awkward._parameters import _type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward.types.type import Type
@@ -88,7 +88,7 @@ class RegularType(Type):
         if isinstance(other, RegularType):
             return (
                 self._size == other._size
-                and _type_parameters_equal(self._parameters, other._parameters)
+                and type_parameters_equal(self._parameters, other._parameters)
                 and self._content == other._content
             )
         else:

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -95,7 +95,7 @@ class UnionType(Type):
     def __eq__(self, other):
         if isinstance(other, UnionType):
             return (
-                _type_parameters_equal(self._parameters, other._parameters)
+                type_parameters_equal(self._parameters, other._parameters)
                 and self._contents == other._contents
             )
         else:

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -3,8 +3,8 @@
 from collections.abc import Iterable
 
 import awkward as ak
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -2,8 +2,8 @@
 
 import awkward as ak
 from awkward._errors import deprecate
+from awkward._parameters import _type_parameters_equal
 from awkward._typing import final
-from awkward.forms.form import _type_parameters_equal
 from awkward.types.type import Type
 
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._errors import deprecate
-from awkward._parameters import _type_parameters_equal
+from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -52,6 +52,6 @@ class UnknownType(Type):
 
     def __eq__(self, other):
         if isinstance(other, UnknownType):
-            return _type_parameters_equal(self._parameters, other._parameters)
+            return type_parameters_equal(self._parameters, other._parameters)
         else:
             return False


### PR DESCRIPTION
> **Warning**
> For ease, depends upon #2324, which should be merged first.

The same rationale applies here as for other renames: the `_parameters` functions are L3, and should existing in an L3 submodule rather than L3 names in an L2 submodule.

There is, in my mind, a stronger reason to create a new submodule under `awkward` than `awkward.forms`, but I would easily be moved on this.
