### PR TITLE
docs: fix pyodide (again!)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,10 +9,9 @@ sphinx-sitemap
 pydata-sphinx-theme
 myst-nb
 sphinx-external-toc
-jupyterlite-sphinx
+jupyterlite-sphinx==0.7.3
 ipyleaflet
-jupyterlite-core==0.1.0b19
-jupyterlite-pyodide-kernel==0.0.5
+jupyterlite==0.1.0b16
 
 numpy>=1.13.1
 numba>=0.50.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ sphinx-external-toc
 jupyterlite-sphinx
 ipyleaflet
 jupyterlite-core==0.1.0b19
+jupyterlite-pyodide-kernel==0.0.5
 
 numpy>=1.13.1
 numba>=0.50.0


### PR DESCRIPTION
This PR reworks the fix in #2318. That fix was valid, but we need to wait until we can build for pyodide 0.22.0, which is given by #2062.


I usually use the docs release to rapidly test "in-the-wild" Awkward Array. I noticed that the build is currently broken.