### PR TITLE
fix: expose array interface for CUDA

### DIFF
--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -149,8 +149,13 @@ class Index:
     def __len__(self):
         return self.length
 
-    def __array__(self, dtype=None):
-        return self._nplike.asarray(self._data, dtype=dtype)
+    @property
+    def __cuda_array_interface__(self):
+        return self._data.__cuda_array_interface__
+
+    @property
+    def __array_interface__(self):
+        return self._data.__array_interface__
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/tests/test_2327_array_interface.py
+++ b/tests/test_2327_array_interface.py
@@ -1,0 +1,31 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_wrap_index_cupy():
+    cp = pytest.importorskip("cupy")
+    data = cp.arange(10, dtype=cp.int64)
+    index = ak.index.Index64(data)
+    other_index = ak.index.Index64(index)
+    other_data = cp.asarray(other_index)
+    assert cp.shares_memory(data, other_data)
+
+
+def test_wrap_index_numpy():
+    data = np.arange(10, dtype=np.int64)
+    index = ak.index.Index64(data)
+    other_index = ak.index.Index64(index)
+    other_data = np.asarray(other_index)
+    assert np.shares_memory(data, other_data)
+
+
+def test_wrap_bare_list():
+    data = [1, 2, 3, 4, 5]
+    index = ak.index.Index64(data)
+    other_index = ak.index.Index64(index)
+    other_data = np.asarray(other_index)
+    assert other_data.tolist() == data


### PR DESCRIPTION
`ak.index.Index(existing_index)` doesn't work for CuPy arrays. We rely on being able to do this in our internal layout logic.

I think what happens is that CuPy asks NumPy to read this array, which then fails as what's returned is _not_ a NumPy array.

We can generalise our index to expose the various array interfaces. In the longer term, we should also expose DLPack.
