### PR TITLE
fix: test untested path in `ak.cartesian` & broadcasting

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -844,11 +844,7 @@ def apply_step(
                     elif isinstance(x, RegularArray):
                         nextinputs.append(x.content[: x.size * x.length])
                     else:
-                        raise ak._errors.wrap_error(
-                            AssertionError(
-                                "encountered non list-type despite all_same_offsets requiring lists"
-                            )
-                        )
+                        nextinputs.append(x)
 
                 outcontent = apply_step(
                     backend,

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -160,7 +160,7 @@ def all_same_offsets(backend: ak._backends.Backend, inputs: list) -> bool:
                 my_offsets = index_nplike.empty(0, dtype=np.int64)
             else:
                 my_offsets = index_nplike.arange(
-                    0, x.content.length, x.size, dtype=np.int64
+                    0, x.content.length + 1, x.size, dtype=np.int64
                 )
 
             if offsets is None:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -841,9 +841,14 @@ def apply_step(
                         else:
                             lencontent = backend.index_nplike.max(stops)
                             nextinputs.append(x.content[:lencontent])
-
+                    elif isinstance(x, RegularArray):
+                        nextinputs.append(x.content[: x.size * x.length])
                     else:
-                        nextinputs.append(x)
+                        raise ak._errors.wrap_error(
+                            AssertionError(
+                                "encountered non list-type despite all_same_offsets requiring lists"
+                            )
+                        )
 
                 outcontent = apply_step(
                     backend,

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -283,7 +283,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             ):
                 raise ak._errors.wrap_error(
                     ValueError(
-                        "the 'nested' prarmeter of cartesian must be integers in "
+                        "the 'nested' parameter of cartesian must be integers in "
                         "[0, len(arrays) - 1) for an iterable of arrays"
                     )
                 )

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -292,7 +292,13 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             for x in new_arrays:
                 layouts.append(x)
 
-        layouts = list(layouts)
+        if len(nested) >= len(layouts):
+            raise ak._errors.wrap_error(
+                ValueError(
+                    "the `nested` parameter of cartesian must contain "
+                    "fewer items than there are arrays"
+                )
+            )
 
         indexes = [
             ak.index.Index64(backend.index_nplike.reshape(x, (-1,)))

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -408,13 +408,6 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
         def apply_build_record(inputs, depth, **kwargs):
             if depth == posaxis + len(array_layouts):
-                if all(len(x) == 0 for x in inputs):
-                    inputs = [
-                        x.content
-                        if isinstance(x, ak.contents.RegularArray) and x.size == 1
-                        else x
-                        for x in inputs
-                    ]
                 return (ak.contents.RecordArray(inputs, fields, parameters=parameters),)
 
             else:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -177,10 +177,7 @@ def cartesian(
          [(4, 3.3, 'a'), (4, 3.3, 'b')]]
 
     The order of the output is fixed: it is always lexicographical in the
-    order that the `arrays` are written. (Before Python 3.6, the order of
-    keys in a dict were not guaranteed, so the dict interface is not
-    recommended for these versions of Python.) Thus, it is not possible to
-    group by `three` in the example above.
+    order that the `arrays` are written.
 
     To emulate an SQL or Pandas "group by" operation, put the keys that you
     wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -420,9 +420,9 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         result = out[0]
 
         # Remove surplus dimensions, iterating from smallest to greatest
-        for axis in axes_to_flatten:
+        for axis_to_flatten in axes_to_flatten:
             result = ak.operations.flatten(
-                result, axis=axis, highlevel=False, behavior=behavior
+                result, axis=axis_to_flatten, highlevel=False, behavior=behavior
             )
 
     return wrap_layout(result, behavior, highlevel)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -257,7 +257,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         if isinstance(new_arrays, dict):
             if nested is True:
                 nested = list(new_arrays.keys())  # last key is ignored below
-            if any(not (isinstance(n, str) and n in new_arrays) for x in nested):
+            if any(not (isinstance(x, str) and x in new_arrays) for x in nested):
                 raise ak._errors.wrap_error(
                     ValueError(
                         "the 'nested' parameter of cartesian must be dict keys "

--- a/tests/test_2329_cartesian_broadcasting_fixes.py
+++ b/tests/test_2329_cartesian_broadcasting_fixes.py
@@ -1,0 +1,66 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_nested_exis_0():
+    arrays = {"x": np.arange(4), "y": ["this", "that", "foo", "bar!"]}
+
+    result = ak.cartesian(arrays, nested=True, axis=0)
+    assert result.to_list() == [
+        [
+            {"x": 0, "y": "this"},
+            {"x": 0, "y": "that"},
+            {"x": 0, "y": "foo"},
+            {"x": 0, "y": "bar!"},
+        ],
+        [
+            {"x": 1, "y": "this"},
+            {"x": 1, "y": "that"},
+            {"x": 1, "y": "foo"},
+            {"x": 1, "y": "bar!"},
+        ],
+        [
+            {"x": 2, "y": "this"},
+            {"x": 2, "y": "that"},
+            {"x": 2, "y": "foo"},
+            {"x": 2, "y": "bar!"},
+        ],
+        [
+            {"x": 3, "y": "this"},
+            {"x": 3, "y": "that"},
+            {"x": 3, "y": "foo"},
+            {"x": 3, "y": "bar!"},
+        ],
+    ]
+
+    result = ak.cartesian(arrays, nested=["x"], axis=0)
+    assert result.to_list() == [
+        [
+            {"x": 0, "y": "this"},
+            {"x": 0, "y": "that"},
+            {"x": 0, "y": "foo"},
+            {"x": 0, "y": "bar!"},
+        ],
+        [
+            {"x": 1, "y": "this"},
+            {"x": 1, "y": "that"},
+            {"x": 1, "y": "foo"},
+            {"x": 1, "y": "bar!"},
+        ],
+        [
+            {"x": 2, "y": "this"},
+            {"x": 2, "y": "that"},
+            {"x": 2, "y": "foo"},
+            {"x": 2, "y": "bar!"},
+        ],
+        [
+            {"x": 3, "y": "this"},
+            {"x": 3, "y": "that"},
+            {"x": 3, "y": "foo"},
+            {"x": 3, "y": "bar!"},
+        ],
+    ]


### PR DESCRIPTION
This PR: 
- removes a special case for zero-length arrays from `ak.cartesian`
- fixes missing case in `broadcast_and_apply` that required this patch
- fixes and tests a set of inputs that was broken in `ak.cartesian`