### PR TITLE
fix: `ak.full_like` with unknown arrays

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -17,7 +17,6 @@ from awkward._typing import (
     Literal,
     Self,
     SupportsIndex,
-    TypeVar,
 )
 
 np = NumpyMetadata.instance()
@@ -37,15 +36,6 @@ def is_unknown_integer(array: Any) -> bool:
 
 def is_unknown_array(array: Any) -> bool:
     return isinstance(array, TypeTracerArray) and array.ndim > 0
-
-
-T = TypeVar("T")
-S = TypeVar("S")
-
-
-def ensure_known_scalar(value: T, default: S) -> T | S:
-    assert not is_unknown_scalar(default)
-    return default if is_unknown_scalar(value) else value
 
 
 def _emptyarray(x):

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -5,7 +5,8 @@ from awkward._behavior import behavior_of
 from awkward._connect.numpy import unsupported
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._nplikes.typetracer import ensure_known_scalar
+from awkward._nplikes.typetracer import is_unknown_scalar
+from awkward._regularize import is_integer_like
 from awkward.operations.ak_zeros_like import _ZEROS
 
 np = NumpyMetadata.instance()
@@ -114,12 +115,20 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown):
         if layout.is_numpy:
             original = nplike.asarray(layout.data)
 
-            if fill_value is _ZEROS or ensure_known_scalar(fill_value == 0, False):
+            if fill_value is _ZEROS or (
+                is_integer_like(fill_value)
+                and not is_unknown_scalar(fill_value)
+                and fill_value == 0
+            ):
                 return ak.contents.NumpyArray(
                     nplike.zeros_like(original, dtype=dtype),
                     parameters=layout.parameters,
                 )
-            elif ensure_known_scalar(fill_value == 1, False):
+            elif (
+                is_integer_like(fill_value)
+                and not is_unknown_scalar(fill_value)
+                and fill_value == 1
+            ):
                 return ak.contents.NumpyArray(
                     nplike.ones_like(original, dtype=dtype),
                     parameters=layout.parameters,


### PR DESCRIPTION
We already test for unknown scalars, but unknown arrays slip through! In general, this logic should test for scalar fill values in addition to whether they're known.