### PR TITLE
fix: simplify depth limit test to support bigger-than-depth values

### DIFF
--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -216,10 +216,7 @@ def _impl(
         inputs.append(y.to_backend(backend))
 
     def action(inputs, depth, **kwargs):
-        if depth == depth_limit or (
-            depth_limit is None
-            and all(isinstance(x, ak.contents.NumpyArray) for x in inputs)
-        ):
+        if depth == depth_limit or all(x.is_numpy for x in inputs):
             return tuple(inputs)
         else:
             return None

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -217,16 +217,13 @@ def _impl(
         parameters["__record__"] = with_name
 
     def action(inputs, depth, **ignore):
-        if depth_limit == depth or (
-            depth_limit is None
-            and all(
-                x.purelist_depth == 1
-                or (
-                    x.purelist_depth == 2
-                    and x.purelist_parameter("__array__") in ("string", "bytestring")
-                )
-                for x in inputs
+        if depth_limit == depth or all(
+            x.purelist_depth == 1
+            or (
+                x.purelist_depth == 2
+                and x.purelist_parameter("__array__") in ("string", "bytestring")
             )
+            for x in inputs
         ):
             # If we want to zip after option types at this depth
             if optiontype_outside_record and any(x.is_option for x in inputs):

--- a/tests/test_2346_broadcast_depth_limit.py
+++ b/tests/test_2346_broadcast_depth_limit.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    left = ak.Array([0, 4, 5])
+    right = ak.Array([[0, 1, 2, 3], [5, 6, 7, 2], [9, 8, 2, 0]])
+
+    left_result, right_result = ak.broadcast_arrays(left, right, depth_limit=4)
+    assert left_result.to_list() == [[0, 0, 0, 0], [4, 4, 4, 4], [5, 5, 5, 5]]
+    assert right_result.to_list() == [[0, 1, 2, 3], [5, 6, 7, 2], [9, 8, 2, 0]]


### PR DESCRIPTION
Fixes #2346 by loosening the depth-limit test.