### PR TITLE
feat: implemented GrowableBuffer in Numba as a start toward LayoutBuilder

### DIFF
--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -158,6 +158,7 @@ for member in ("panels", "length_pos", "resize"):
 def GrowableBufferType_dtype(growablebuffer):
     def getter(growablebuffer):
         return growablebuffer._panel[0].dtype
+
     return getter
 
 
@@ -165,6 +166,7 @@ def GrowableBufferType_dtype(growablebuffer):
 def GrowableBufferType_length(growablebuffer):
     def getter(growablebuffer):
         return growablebuffer._length_pos[0]
+
     return getter
 
 
@@ -172,6 +174,7 @@ def GrowableBufferType_length(growablebuffer):
 def GrowableBufferType_pos(growablebuffer):
     def getter(growablebuffer):
         return growablebuffer._length_pos[1]
+
     return getter
 
 
@@ -204,15 +207,29 @@ def GrowableBufferType_box(typ, val, c):
     GrowableBuffer_obj = c.pyapi.unserialize(c.pyapi.serialize_object(GrowableBuffer))
     from_data_obj = c.pyapi.object_getattr_string(GrowableBuffer_obj, "_from_data")
 
-    growablebuffer = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
-    panels_obj = c.pyapi.from_native_value(typ.panels, growablebuffer.panels, c.env_manager)
-    length_pos_obj = c.pyapi.from_native_value(typ.length_pos, growablebuffer.length_pos, c.env_manager)
-    resize_obj = c.pyapi.from_native_value(typ.resize, growablebuffer.resize, c.env_manager)
+    growablebuffer = numba.core.cgutils.create_struct_proxy(typ)(
+        c.context, c.builder, value=val
+    )
+    panels_obj = c.pyapi.from_native_value(
+        typ.panels, growablebuffer.panels, c.env_manager
+    )
+    length_pos_obj = c.pyapi.from_native_value(
+        typ.length_pos, growablebuffer.length_pos, c.env_manager
+    )
+    resize_obj = c.pyapi.from_native_value(
+        typ.resize, growablebuffer.resize, c.env_manager
+    )
 
-    out = c.pyapi.call_function_objargs(from_data_obj, (panels_obj, length_pos_obj, resize_obj))
+    out = c.pyapi.call_function_objargs(
+        from_data_obj, (panels_obj, length_pos_obj, resize_obj)
+    )
 
     # decref PyObjects
     c.pyapi.decref(GrowableBuffer_obj)
     c.pyapi.decref(from_data_obj)
+
+    c.pyapi.decref(panels_obj)
+    c.pyapi.decref(length_pos_obj)
+    c.pyapi.decref(resize_obj)
 
     return out

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -1,0 +1,80 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numba
+import numba.core.typing
+import numba.core.typing.ctypes_utils
+import numpy
+
+
+class GrowableBuffer:
+    def __init__(self, dtype, *, initial=1024, resize=10.0):
+        self._panels = [numpy.zeros((initial,), dtype=dtype)]
+        self._last_panel = self._panels[-1]
+        self._length = 0
+        self._last_panel_length = 0
+        self._resize = resize
+
+    def __repr__(self):
+        return f"<GrowableBuffer({self._last_panel.dtype!r}) len {self._length}>"
+
+    def __len__(self):
+        return self._length
+
+    def append(self, datum):
+        if self._last_panel_length == len(self._last_panel):
+            self._add_panel()
+
+        self._last_panel[self._last_panel_length] = datum
+        self._last_panel_length += 1
+        self._length += 1
+
+    def extend(self, data):
+        panel_index = len(self._panels) - 1
+        pos = self._last_panel_length
+
+        available = len(self._last_panel) - self._last_panel_length
+        while len(data) > available:
+            self._add_panel()
+            available += len(self._last_panel)
+
+        remaining = len(data)
+        while remaining > 0:
+            panel = self._panels[panel_index]
+            available_in_panel = len(panel) - pos
+            to_write = min(remaining, available_in_panel)
+
+            start = len(data) - remaining
+            panel[pos : pos + to_write] = data[start : start + to_write]
+
+            if panel_index == len(self._panels) - 1:
+                self._last_panel_length += to_write
+            remaining -= to_write
+            pos = 0
+            panel_index += 1
+
+        self._length += len(data)
+
+    def _add_panel(self):
+        panel_length = len(self._last_panel)
+        if len(self._panels) == 1:
+            # only resize the first time, and by a large factor (C++ should do this, too!)
+            panel_length = int(numpy.ceil(panel_length * self._resize))
+
+        self._last_panel = numpy.zeros((panel_length,), dtype=self._last_panel.dtype)
+        self._panels.append(self._last_panel)
+        self._last_panel_length = 0
+
+    def snapshot(self):
+        out = numpy.zeros((self._length,), dtype=self._last_panel.dtype)
+
+        start = 0
+        stop = 0
+        for panel in self._panels[:-1]:  # full panels, not including the last
+            stop += len(panel)
+            out[start:stop] = panel
+            start = stop
+
+        stop += self._last_panel_length
+        out[start:stop] = self._last_panel[:self._last_panel_length]
+
+        return out

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -277,7 +277,7 @@ def GrowableBuffer_from_data_impl(context, builder, sig, args):
 
 
 @numba.extending.overload(GrowableBuffer)
-def GrowableBuffer_ctor(dtype):
+def GrowableBuffer_ctor(dtype, initial=1024, resize=10.0):
     if isinstance(dtype, numba.types.StringLiteral):
         dt = numpy.dtype(dtype.literal_value)
 
@@ -287,10 +287,9 @@ def GrowableBuffer_ctor(dtype):
     else:
         return
 
-    def ctor_impl(dtype):
-        panels = numba.typed.List([numpy.empty((1024,), dt)])
+    def ctor_impl(dtype, initial=1024, resize=10.0):
+        panels = numba.typed.List([numpy.empty((initial,), dt)])
         length_pos = numpy.zeros((2,), dtype=numpy.int64)
-        resize = 10.0
         return _from_data(panels, length_pos, resize)
 
     return ctor_impl

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -1,27 +1,33 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import numba
+import numba.core.typing
+import numba.core.typing.ctypes_utils
 import numpy
 
 
 class GrowableBuffer:
     def __init__(self, dtype, *, initial=1024, resize=10.0):
         self._panels = [numpy.zeros((initial,), dtype=dtype)]
-        self._last_panel = self._panels[-1]
         self._length = 0
         self._last_panel_length = 0
         self._resize = resize
 
+    @property
+    def dtype(self):
+        return self._panels[0].dtype
+
     def __repr__(self):
-        return f"<GrowableBuffer({self._last_panel.dtype!r}) len {self._length}>"
+        return f"<GrowableBuffer({self.dtype!r}) len {self._length}>"
 
     def __len__(self):
         return self._length
 
     def append(self, datum):
-        if self._last_panel_length == len(self._last_panel):
+        if self._last_panel_length == len(self._panels[-1]):
             self._add_panel()
 
-        self._last_panel[self._last_panel_length] = datum
+        self._panels[-1][self._last_panel_length] = datum
         self._last_panel_length += 1
         self._length += 1
 
@@ -29,10 +35,10 @@ class GrowableBuffer:
         panel_index = len(self._panels) - 1
         pos = self._last_panel_length
 
-        available = len(self._last_panel) - self._last_panel_length
+        available = len(self._panels[-1]) - self._last_panel_length
         while len(data) > available:
             self._add_panel()
-            available += len(self._last_panel)
+            available += len(self._panels[-1])
 
         remaining = len(data)
         while remaining > 0:
@@ -52,17 +58,16 @@ class GrowableBuffer:
         self._length += len(data)
 
     def _add_panel(self):
-        panel_length = len(self._last_panel)
+        panel_length = len(self._panels[-1])
         if len(self._panels) == 1:
             # only resize the first time, and by a large factor (C++ should do this, too!)
             panel_length = int(numpy.ceil(panel_length * self._resize))
 
-        self._last_panel = numpy.zeros((panel_length,), dtype=self._last_panel.dtype)
-        self._panels.append(self._last_panel)
+        self._panels.append(numpy.zeros((panel_length,), dtype=self.dtype))
         self._last_panel_length = 0
 
     def snapshot(self):
-        out = numpy.zeros((self._length,), dtype=self._last_panel.dtype)
+        out = numpy.zeros((self._length,), dtype=self.dtype)
 
         start = 0
         stop = 0
@@ -72,6 +77,78 @@ class GrowableBuffer:
             start = stop
 
         stop += self._last_panel_length
-        out[start:stop] = self._last_panel[: self._last_panel_length]
+        out[start:stop] = self._panels[-1][: self._last_panel_length]
 
         return out
+
+
+class GrowableBufferType(numba.types.Type):
+    def __init__(self, dtype):
+        super().__init__(name=f"ak.GrowableBuffer({dtype})")
+        self._dtype = dtype
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def arraytype(self):
+        return numba.types.Array(self.dtype, 1, "C")
+
+    @property
+    def listtype(self):
+        return numba.types.List(self.arraytype)
+
+
+@numba.extending.typeof_impl.register(GrowableBuffer)
+def typeof_GrowableBuffer(val, c):
+    return GrowableBufferType(numba.from_dtype(val.dtype))
+
+
+@numba.extending.register_model(GrowableBufferType)
+class GrowableBufferModel(numba.extending.models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("_panels", fe_type.listtype),
+            ("_length", numba.types.int64),
+            ("_last_panel_length", numba.types.int64),
+            ("_resize", numba.types.float64),
+        ]
+        super().__init__(dmm, fe_type, members)
+
+
+for member in ("_panels", "_length", "_last_panel_length", "_resize"):
+    numba.extending.make_attribute_wrapper(GrowableBufferType, member, member)
+
+
+@numba.extending.overload_attribute(GrowableBufferType, "dtype")
+def GrowableBufferType_dtype(growablebuffer):
+    def getter(growablebuffer):
+        return growablebuffer._panel[0].dtype
+    return getter
+
+
+@numba.extending.unbox(GrowableBufferType)
+def GrowableBufferType_unbox(typ, obj, c):
+    print("compile-time")
+    numba.core.cgutils.printf(c.builder, "runtime\n")
+
+    # get PyObjects
+    panels_obj = c.pyapi.object_getattr_string(obj, "_panels")
+    length_obj = c.pyapi.object_getattr_string(obj, "_length")
+    last_panel_length_obj = c.pyapi.object_getattr_string(obj, "_last_panel_length")
+    resize_obj = c.pyapi.object_getattr_string(obj, "_resize")
+
+    out = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder)
+    out._panels = c.pyapi.to_native_value(typ.listtype, panels_obj).value
+    out._length = c.pyapi.to_native_value(numba.types.int64, length_obj).value
+    out._last_panel_length = c.pyapi.to_native_value(numba.types.int64, last_panel_length_obj).value
+    out._resize = c.pyapi.to_native_value(numba.types.float64, resize_obj).value
+
+    c.pyapi.decref(panels_obj)
+    c.pyapi.decref(length_obj)
+    c.pyapi.decref(last_panel_length_obj)
+    c.pyapi.decref(resize_obj)
+
+    is_error = numba.core.cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
+    return numba.extending.NativeValue(out._getvalue(), is_error=is_error)

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -161,6 +161,7 @@ def GrowableBufferType_unbox(typ, obj, c):
     cres = c.context.compile_subroutine(c.builder, _get_last, sig)
     last_val = c.context.call_internal_no_propagate(c.builder, cres.fndesc, sig, args)[1]
 
+
     # fill the lowered model
     out = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder)
     out.panels = panels_val

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -1,8 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import numba
-import numba.core.typing
-import numba.core.typing.ctypes_utils
 import numpy
 
 
@@ -75,6 +72,6 @@ class GrowableBuffer:
             start = stop
 
         stop += self._last_panel_length
-        out[start:stop] = self._last_panel[:self._last_panel_length]
+        out[start:stop] = self._last_panel[: self._last_panel_length]
 
         return out

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -161,22 +161,6 @@ def GrowableBufferType_dtype(growablebuffer):
     return getter
 
 
-@numba.extending.overload_attribute(GrowableBufferType, "_length")
-def GrowableBufferType_length(growablebuffer):
-    def getter(growablebuffer):
-        return growablebuffer._length_pos[0]
-
-    return getter
-
-
-@numba.extending.overload_attribute(GrowableBufferType, "_pos")
-def GrowableBufferType_pos(growablebuffer):
-    def getter(growablebuffer):
-        return growablebuffer._length_pos[1]
-
-    return getter
-
-
 @numba.extending.unbox(GrowableBufferType)
 def GrowableBufferType_unbox(typ, obj, c):
     # get PyObjects
@@ -234,16 +218,6 @@ def GrowableBufferType_box(typ, val, c):
     return out
 
 
-@numba.extending.overload(len)
-def GrowableBufferType_len(growablebuffer):
-    if isinstance(growablebuffer, GrowableBufferType):
-
-        def len_impl(growablebuffer):
-            return growablebuffer._length
-
-        return len_impl
-
-
 def _from_data():
     ...
 
@@ -293,3 +267,61 @@ def GrowableBuffer_ctor(dtype, initial=1024, resize=10.0):
         return _from_data(panels, length_pos, resize)
 
     return ctor_impl
+
+
+@numba.extending.overload_method(GrowableBufferType, "_length_get", inline="always")
+def GrowableBuffer_length_get(growablebuffer):
+    def getter(growablebuffer):
+        return growablebuffer._length_pos[0]
+
+    return getter
+
+
+@numba.extending.overload_method(GrowableBufferType, "_pos_get", inline="always")
+def GrowableBuffer_pos_get(growablebuffer):
+    def getter(growablebuffer):
+        return growablebuffer._length_pos[1]
+
+    return getter
+
+
+@numba.extending.overload_method(GrowableBufferType, "_length_set", inline="always")
+def GrowableBuffer_length_set(growablebuffer, value):
+    def setter(growablebuffer, value):
+        growablebuffer._length_pos[0] = value
+
+    return setter
+
+
+@numba.extending.overload_method(GrowableBufferType, "_pos_set", inline="always")
+def GrowableBuffer_pos_set(growablebuffer, value):
+    def setter(growablebuffer, value):
+        growablebuffer._length_pos[1] = value
+
+    return setter
+
+
+@numba.extending.overload_method(GrowableBufferType, "_length_inc", inline="always")
+def GrowableBuffer_length_inc(growablebuffer, value):
+    def inccer(growablebuffer, value):
+        growablebuffer._length_pos[0] += value
+
+    return inccer
+
+
+@numba.extending.overload_method(GrowableBufferType, "_pos_inc", inline="always")
+def GrowableBuffer_pos_inc(growablebuffer, value):
+    def inccer(growablebuffer, value):
+        growablebuffer._length_pos[1] += value
+
+    return inccer
+
+
+@numba.extending.overload(len)
+def GrowableBufferType_len(growablebuffer):
+    if isinstance(growablebuffer, GrowableBufferType):
+
+        def len_impl(growablebuffer):
+            return growablebuffer._length_get()
+
+        return len_impl

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -6,7 +6,7 @@ import numpy
 
 
 class GrowableBuffer:
-    def __init__(self, dtype, *, initial=1024, resize=10.0):
+    def __init__(self, dtype, *, initial=1024, resize=8.0):
         # all mutable data are in arrays that can be in-place shared with Numba
         self._panels = numba.typed.List([numpy.empty((initial,), dtype=dtype)])
         self._length_pos = numpy.zeros((2,), dtype=numpy.int64)
@@ -251,7 +251,7 @@ def GrowableBuffer_from_data_impl(context, builder, sig, args):
 
 
 @numba.extending.overload(GrowableBuffer)
-def GrowableBuffer_ctor(dtype, initial=1024, resize=10.0):
+def GrowableBuffer_ctor(dtype, initial=1024, resize=8.0):
     if isinstance(dtype, numba.types.StringLiteral):
         dt = numpy.dtype(dtype.literal_value)
 
@@ -261,7 +261,7 @@ def GrowableBuffer_ctor(dtype, initial=1024, resize=10.0):
     else:
         return
 
-    def ctor_impl(dtype, initial=1024, resize=10.0):
+    def ctor_impl(dtype, initial=1024, resize=8.0):
         panels = numba.typed.List([numpy.empty((initial,), dt)])
         length_pos = numpy.zeros((2,), dtype=numpy.int64)
         return _from_data(panels, length_pos, resize)

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -10,8 +10,21 @@ class GrowableBuffer:
     def __init__(self, dtype, *, initial=1024, resize=10.0):
         self._panels = [numpy.zeros((initial,), dtype=dtype)]
         self._length = 0
-        self._last_panel_length = 0
+        self._pos = 0
         self._resize = resize
+
+    @classmethod
+    def _from_data(cls, panels, length, pos, resize):
+        out = cls.__new__(cls)
+        out._panels = panels
+        out._length = length
+        out._pos = pos
+        out._resize = resize
+        return out
+
+    @property
+    def _numba_panels(self):
+        return numba.typed.List(self._panels)
 
     @property
     def dtype(self):
@@ -24,18 +37,18 @@ class GrowableBuffer:
         return self._length
 
     def append(self, datum):
-        if self._last_panel_length == len(self._panels[-1]):
+        if self._pos == len(self._panels[-1]):
             self._add_panel()
 
-        self._panels[-1][self._last_panel_length] = datum
-        self._last_panel_length += 1
+        self._panels[-1][self._pos] = datum
+        self._pos += 1
         self._length += 1
 
     def extend(self, data):
         panel_index = len(self._panels) - 1
-        pos = self._last_panel_length
+        pos = self._pos
 
-        available = len(self._panels[-1]) - self._last_panel_length
+        available = len(self._panels[-1]) - self._pos
         while len(data) > available:
             self._add_panel()
             available += len(self._panels[-1])
@@ -50,7 +63,7 @@ class GrowableBuffer:
             panel[pos : pos + to_write] = data[start : start + to_write]
 
             if panel_index == len(self._panels) - 1:
-                self._last_panel_length += to_write
+                self._pos += to_write
             remaining -= to_write
             pos = 0
             panel_index += 1
@@ -64,7 +77,7 @@ class GrowableBuffer:
             panel_length = int(numpy.ceil(panel_length * self._resize))
 
         self._panels.append(numpy.zeros((panel_length,), dtype=self.dtype))
-        self._last_panel_length = 0
+        self._pos = 0
 
     def snapshot(self):
         out = numpy.zeros((self._length,), dtype=self.dtype)
@@ -76,8 +89,8 @@ class GrowableBuffer:
             out[start:stop] = panel
             start = stop
 
-        stop += self._last_panel_length
-        out[start:stop] = self._panels[-1][: self._last_panel_length]
+        stop += self._pos
+        out[start:stop] = self._panels[-1][: self._pos]
 
         return out
 
@@ -97,7 +110,7 @@ class GrowableBufferType(numba.types.Type):
 
     @property
     def listtype(self):
-        return numba.types.List(self.arraytype)
+        return numba.types.ListType(self.arraytype)
 
 
 @numba.extending.typeof_impl.register(GrowableBuffer)
@@ -109,16 +122,17 @@ def typeof_GrowableBuffer(val, c):
 class GrowableBufferModel(numba.extending.models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
-            ("_panels", fe_type.listtype),
-            ("_length", numba.types.int64),
-            ("_last_panel_length", numba.types.int64),
-            ("_resize", numba.types.float64),
+            ("panels", fe_type.listtype),
+#            ("last", fe_type.arraytype),
+            ("length", numba.types.intp),
+            ("pos", numba.types.intp),
+            ("resize", numba.types.float64),
         ]
         super().__init__(dmm, fe_type, members)
 
 
-for member in ("_panels", "_length", "_last_panel_length", "_resize"):
-    numba.extending.make_attribute_wrapper(GrowableBufferType, member, member)
+for member in ("panels", "length", "pos", "resize"):
+    numba.extending.make_attribute_wrapper(GrowableBufferType, member, "_" + member)
 
 
 @numba.extending.overload_attribute(GrowableBufferType, "dtype")
@@ -128,27 +142,66 @@ def GrowableBufferType_dtype(growablebuffer):
     return getter
 
 
+def _get_last(lst):
+    return lst[-1]
+
+
 @numba.extending.unbox(GrowableBufferType)
 def GrowableBufferType_unbox(typ, obj, c):
+    # get PyObjects
+    panels_obj = c.pyapi.object_getattr_string(obj, "_numba_panels")
+    length_obj = c.pyapi.object_getattr_string(obj, "_length")
+    pos_obj = c.pyapi.object_getattr_string(obj, "_pos")
+    resize_obj = c.pyapi.object_getattr_string(obj, "_resize")
+
+    # lower _get_last and use it to extract the last array from panels
+    panels_val = c.pyapi.to_native_value(typ.listtype, panels_obj).value
+    args = (panels_val,)
+    sig = typ.arraytype(typ.listtype)
+    cres = c.context.compile_subroutine(c.builder, _get_last, sig)
+    last_val = c.context.call_internal_no_propagate(c.builder, cres.fndesc, sig, args)[1]
+
+    # fill the lowered model
+    out = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder)
+    out.panels = panels_val
+    # out.last = last_val
+    out.length = c.pyapi.number_as_ssize_t(length_obj)
+    out.pos = c.pyapi.number_as_ssize_t(pos_obj)
+    out.resize = c.pyapi.float_as_double(resize_obj)
+
+    # decref PyObjects
+    c.pyapi.decref(panels_obj)
+    c.pyapi.decref(length_obj)
+    c.pyapi.decref(pos_obj)
+    c.pyapi.decref(resize_obj)
+
+    # if c.context.enable_nrt:
+    #     c.context.nrt.decref(c.builder, typ.arraytype, last_val)
+
+    # return it or the exception
+    is_error = numba.core.cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
+    return numba.extending.NativeValue(out._getvalue(), is_error=is_error)
+
+
+@numba.extending.box(GrowableBufferType)
+def GrowableBufferType_box(typ, val, c):
     print("compile-time")
     numba.core.cgutils.printf(c.builder, "runtime\n")
 
-    # get PyObjects
-    panels_obj = c.pyapi.object_getattr_string(obj, "_panels")
-    length_obj = c.pyapi.object_getattr_string(obj, "_length")
-    last_panel_length_obj = c.pyapi.object_getattr_string(obj, "_last_panel_length")
-    resize_obj = c.pyapi.object_getattr_string(obj, "_resize")
+    # get PyObject of the GrowableBuffer class and _from_data constructor
+    GrowableBuffer_obj = c.pyapi.unserialize(c.pyapi.serialize_object(GrowableBuffer))
+    from_data_obj = c.pyapi.object_getattr_string(GrowableBuffer_obj, "_from_data")
 
-    out = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder)
-    out._panels = c.pyapi.to_native_value(typ.listtype, panels_obj).value
-    out._length = c.pyapi.to_native_value(numba.types.int64, length_obj).value
-    out._last_panel_length = c.pyapi.to_native_value(numba.types.int64, last_panel_length_obj).value
-    out._resize = c.pyapi.to_native_value(numba.types.float64, resize_obj).value
+    growablebuffer = numba.core.cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
+    panels_obj = c.pyapi.from_native_value(typ.listtype, growablebuffer.panels, c.env_manager)
+    length_obj = c.pyapi.long_from_ssize_t(growablebuffer.length)
+    pos_obj = c.pyapi.long_from_ssize_t(growablebuffer.pos)
+    resize_obj = c.pyapi.float_from_double(growablebuffer.resize)
 
-    c.pyapi.decref(panels_obj)
-    c.pyapi.decref(length_obj)
-    c.pyapi.decref(last_panel_length_obj)
-    c.pyapi.decref(resize_obj)
+    out = c.pyapi.call_function_objargs(from_data_obj, (panels_obj, length_obj, pos_obj, resize_obj))
 
-    is_error = numba.core.cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
-    return numba.extending.NativeValue(out._getvalue(), is_error=is_error)
+    # decref PyObjects
+    c.pyapi.decref(GrowableBuffer_obj)
+    c.pyapi.decref(from_data_obj)
+
+    return out

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -126,3 +126,35 @@ def test_unbox():
 
     growablebuffer = GrowableBuffer(np.int32)
     f1(growablebuffer)
+
+
+def test_box():
+    @numba.njit
+    def f2(x):
+        return x
+
+    growablebuffer = GrowableBuffer(np.int32, initial=10)
+
+    out1 = f1(growablebuffer)
+    assert len(out1._panels) == len(growablebuffer._panels)
+    assert out1._panels[0] is growablebuffer._panels[0]
+    assert out1._length == growablebuffer._length
+    assert out1._pos == growablebuffer._pos
+    assert out1._resize == growablebuffer._resize
+
+    for x in range(15):
+        growablebuffer.append(x)
+
+    out2 = f1(growablebuffer)
+    assert len(out2._panels) == len(growablebuffer._panels)
+    assert out2._panels[0] is growablebuffer._panels[0]
+    assert out2._panels[1] is growablebuffer._panels[1]
+    assert out2._length == growablebuffer._length
+    assert out2._pos == growablebuffer._pos
+    assert out2._resize == growablebuffer._resize
+
+    assert len(out1._panels) == 1 != len(growablebuffer._panels)
+    assert out1._panels[0] is growablebuffer._panels[0]
+    assert out1._length == 0 != growablebuffer._length
+    assert out1._pos == 0 != growablebuffer._pos
+    assert out1._resize == growablebuffer._resize

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import sys
 
 import numpy as np
 import pytest

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -135,7 +135,7 @@ def test_box():
 
     growablebuffer = GrowableBuffer(np.int32, initial=10)
 
-    out1 = f1(growablebuffer)
+    out1 = f2(growablebuffer)
     assert len(out1._panels) == len(growablebuffer._panels)
     assert out1._panels[0] is growablebuffer._panels[0]
     assert out1._length == growablebuffer._length
@@ -145,7 +145,7 @@ def test_box():
     for x in range(15):
         growablebuffer.append(x)
 
-    out2 = f1(growablebuffer)
+    out2 = f2(growablebuffer)
     assert len(out2._panels) == len(growablebuffer._panels)
     assert out2._panels[0] is growablebuffer._panels[0]
     assert out2._panels[1] is growablebuffer._panels[1]

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import sys
+
 import numpy as np
 import pytest
 
 from awkward._connect.numba.growablebuffer import GrowableBuffer
-
-numba = pytest.importorskip("numba")
 
 
 def test_python_append():
@@ -113,3 +113,16 @@ def test_python_extend():
     growablebuffer.extend(np.array(range(250, 1000)))
     assert growablebuffer.snapshot().tolist() == list(range(1000))
     assert len(growablebuffer._panels) == 51
+
+
+numba = pytest.importorskip("numba")
+
+
+def test_unbox():
+    @numba.njit
+    def f1(x):
+        x
+        return 3.14
+
+    growablebuffer = GrowableBuffer(np.int32)
+    f1(growablebuffer)

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -1,0 +1,116 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward._connect.numba.growablebuffer import GrowableBuffer
+
+numba = pytest.importorskip("numba")
+
+
+def test_python_append():
+    # small 'initial' and 'resize' for testing
+    growablebuffer = GrowableBuffer(np.int32, initial=10, resize=2.0)
+    assert growablebuffer.snapshot().tolist() == []
+    assert len(growablebuffer._panels) == 1
+
+    # within the first panel
+    for x in range(0, 5):
+        growablebuffer.append(x)
+    assert growablebuffer.snapshot().tolist() == list(range(5))
+    assert len(growablebuffer._panels) == 1
+
+    # reaching the end of the first panel (10)
+    for x in range(5, 9):
+        growablebuffer.append(x)
+    assert growablebuffer.snapshot().tolist() == list(range(9))
+    assert len(growablebuffer._panels) == 1
+
+    # at the end
+    growablebuffer.append(9)
+    assert growablebuffer.snapshot().tolist() == list(range(10))
+    assert len(growablebuffer._panels) == 1
+
+    # beyond the end; onto the second panel
+    growablebuffer.append(10)
+    assert growablebuffer.snapshot().tolist() == list(range(11))
+    assert len(growablebuffer._panels) == 2
+
+    # continuing into the second panel
+    growablebuffer.append(11)
+    assert growablebuffer.snapshot().tolist() == list(range(12))
+    assert len(growablebuffer._panels) == 2
+
+    # to the end of the second panel (30)
+    for x in range(12, 30):
+        growablebuffer.append(x)
+    assert growablebuffer.snapshot().tolist() == list(range(30))
+    assert len(growablebuffer._panels) == 2
+
+    # continuing into the third panel
+    growablebuffer.append(30)
+    assert growablebuffer.snapshot().tolist() == list(range(31))
+    assert len(growablebuffer._panels) == 3
+
+
+def test_python_extend():
+    # small 'initial' and 'resize' for testing
+    growablebuffer = GrowableBuffer(np.int32, initial=10, resize=2.0)
+    assert growablebuffer.snapshot().tolist() == []
+    assert len(growablebuffer._panels) == 1
+
+    # within the first panel
+    growablebuffer.extend(np.array(range(0, 5)))
+    assert growablebuffer.snapshot().tolist() == list(range(5))
+    assert len(growablebuffer._panels) == 1
+
+    # up to (and touching) the end of the first panel (10)
+    growablebuffer.extend(np.array(range(5, 10)))
+    assert growablebuffer.snapshot().tolist() == list(range(10))
+    assert len(growablebuffer._panels) == 1
+
+    # within the second panel (which ends at 30)
+    growablebuffer.extend(np.array(range(10, 20)))
+    assert growablebuffer.snapshot().tolist() == list(range(20))
+    assert len(growablebuffer._panels) == 2
+
+    # touching the end of the second panel
+    growablebuffer.extend(np.array(range(20, 30)))
+    assert growablebuffer.snapshot().tolist() == list(range(30))
+    assert len(growablebuffer._panels) == 2
+
+    # fill one whole panel exactly (start to end)
+    growablebuffer.extend(np.array(range(30, 50)))
+    assert growablebuffer.snapshot().tolist() == list(range(50))
+    assert len(growablebuffer._panels) == 3
+
+    # fill more than one panel, starting at a threshold
+    growablebuffer.extend(np.array(range(50, 80)))
+    assert growablebuffer.snapshot().tolist() == list(range(80))
+    assert len(growablebuffer._panels) == 5
+
+    # fill more than one panel, not starting at a threshold, but ending on one
+    growablebuffer.extend(np.array(range(80, 110)))
+    assert growablebuffer.snapshot().tolist() == list(range(110))
+    assert len(growablebuffer._panels) == 6
+
+    # fill lots of panels, starting at a threshold
+    growablebuffer.extend(np.array(range(110, 160)))
+    assert growablebuffer.snapshot().tolist() == list(range(160))
+    assert len(growablebuffer._panels) == 9
+
+    # fill lots of panels, not starting at a threshold or ending on one
+    growablebuffer.extend(np.array(range(160, 200)))
+    assert growablebuffer.snapshot().tolist() == list(range(200))
+    assert len(growablebuffer._panels) == 11
+
+    # fill lots of panels, not starting at a threshold, but ending on one
+    growablebuffer.extend(np.array(range(200, 250)))
+    assert growablebuffer.snapshot().tolist() == list(range(250))
+    assert len(growablebuffer._panels) == 13
+
+    # fill a whole lot of panels, just for fun
+    growablebuffer.extend(np.array(range(250, 1000)))
+    assert growablebuffer.snapshot().tolist() == list(range(1000))
+    assert len(growablebuffer._panels) == 51

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pytest
 
-from awkward._connect.numba.growablebuffer import GrowableBuffer
+from awkward._connect.numba.growablebuffer import GrowableBuffer, _from_data
 
 
 def test_python_append():
@@ -158,3 +158,45 @@ def test_box():
     assert out1._length == growablebuffer._length
     assert out1._pos == growablebuffer._pos
     assert out1._resize == growablebuffer._resize
+
+
+def test_len():
+    @numba.njit
+    def f3(x):
+        return len(x)
+
+    growablebuffer = GrowableBuffer(np.int32)
+
+    assert f3(growablebuffer) == 0
+
+    growablebuffer.append(123)
+
+    assert f3(growablebuffer) == 1
+
+
+def test_from_data():
+    @numba.njit
+    def f4():
+        return _from_data(
+            numba.typed.List([np.array([3.12], np.float32)]), np.array([1, 0]), 1.23
+        )
+
+    out = f4()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype(np.float32)
+    assert len(out) == 1
+    assert out._pos == 0
+    assert out._resize == 1.23
+
+
+def test_ctor():
+    @numba.njit
+    def f5():
+        return GrowableBuffer("f4")
+
+    out = f5()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype("f4")
+    assert len(out) == 0
+    assert out._pos == 0
+    assert out._resize == 10.0

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -153,8 +153,9 @@ def test_box():
     assert out2._pos == growablebuffer._pos
     assert out2._resize == growablebuffer._resize
 
-    assert len(out1._panels) == 1 != len(growablebuffer._panels)
+    assert len(out1._panels) == len(growablebuffer._panels)
     assert out1._panels[0] is growablebuffer._panels[0]
-    assert out1._length == 0 != growablebuffer._length
-    assert out1._pos == 0 != growablebuffer._pos
+    assert out1._panels[1] is growablebuffer._panels[1]
+    assert out1._length == growablebuffer._length
+    assert out1._pos == growablebuffer._pos
     assert out1._resize == growablebuffer._resize

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -179,7 +179,9 @@ def test_from_data():
     @numba.njit
     def f4():
         return _from_data(
-            numba.typed.List([np.array([3.12], np.float32)]), np.array([1, 0]), 1.23
+            numba.typed.List([np.array([3.12], np.float32)]),
+            np.array([1, 0], np.int64),
+            1.23,
         )
 
     out = f4()

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-import awkward as ak
 from awkward._connect.numba.growablebuffer import GrowableBuffer
 
 numba = pytest.importorskip("numba")

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
 import numpy as np
 import pytest
 
-from awkward._connect.numba.growablebuffer import GrowableBuffer, _from_data
+numba = pytest.importorskip("numba")
+
+from awkward._connect.numba.growablebuffer import (  # noqa: E402
+    GrowableBuffer,
+    _from_data,
+)
 
 
 def test_python_append():
@@ -114,9 +118,6 @@ def test_python_extend():
     assert len(growablebuffer._panels) == 51
 
 
-numba = pytest.importorskip("numba")
-
-
 def test_unbox():
     @numba.njit
     def f1(x):
@@ -198,5 +199,72 @@ def test_ctor():
     assert isinstance(out, GrowableBuffer)
     assert out.dtype == np.dtype("f4")
     assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 1024
+    assert out._pos == 0
+    assert out._resize == 10.0
+
+    @numba.njit
+    def f6():
+        return GrowableBuffer("f4", initial=10)
+
+    out = f6()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype("f4")
+    assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 10
+    assert out._pos == 0
+    assert out._resize == 10.0
+
+    @numba.njit
+    def f7():
+        return GrowableBuffer("f4", resize=2.0)
+
+    out = f7()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype("f4")
+    assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 1024
+    assert out._pos == 0
+    assert out._resize == 2.0
+
+    @numba.njit
+    def f8():
+        return GrowableBuffer("f4", resize=2.0, initial=10)
+
+    out = f8()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype("f4")
+    assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 10
+    assert out._pos == 0
+    assert out._resize == 2.0
+
+    @numba.njit
+    def f9():
+        return GrowableBuffer(np.float32)
+
+    out = f9()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype(np.float32)
+    assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 1024
+    assert out._pos == 0
+    assert out._resize == 10.0
+
+    @numba.njit
+    def f10():
+        return GrowableBuffer(np.dtype(np.float32))
+
+    out = f10()
+    assert isinstance(out, GrowableBuffer)
+    assert out.dtype == np.dtype(np.float32)
+    assert len(out) == 0
+    assert len(out._panels) == 1
+    assert len(out._panels[0]) == 1024
     assert out._pos == 0
     assert out._resize == 10.0

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -204,7 +204,7 @@ def test_ctor():
     assert len(out._panels) == 1
     assert len(out._panels[0]) == 1024
     assert out._pos == 0
-    assert out._resize == 10.0
+    assert out._resize == 8.0
 
     @numba.njit
     def f6():
@@ -217,7 +217,7 @@ def test_ctor():
     assert len(out._panels) == 1
     assert len(out._panels[0]) == 10
     assert out._pos == 0
-    assert out._resize == 10.0
+    assert out._resize == 8.0
 
     @numba.njit
     def f7():
@@ -256,7 +256,7 @@ def test_ctor():
     assert len(out._panels) == 1
     assert len(out._panels[0]) == 1024
     assert out._pos == 0
-    assert out._resize == 10.0
+    assert out._resize == 8.0
 
     @numba.njit
     def f10():
@@ -269,7 +269,7 @@ def test_ctor():
     assert len(out._panels) == 1
     assert len(out._panels[0]) == 1024
     assert out._pos == 0
-    assert out._resize == 10.0
+    assert out._resize == 8.0
 
 
 def test_length_and_pos():

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -268,3 +268,35 @@ def test_ctor():
     assert len(out._panels[0]) == 1024
     assert out._pos == 0
     assert out._resize == 10.0
+
+
+def test_length_and_pos():
+    @numba.njit
+    def f11(growablebuffer):
+        return growablebuffer._length_get(), growablebuffer._pos_get()
+
+    @numba.njit
+    def f12(growablebuffer):
+        growablebuffer._length_set(1)
+        growablebuffer._pos_set(2)
+
+    @numba.njit
+    def f13(growablebuffer):
+        growablebuffer._length_inc(10)
+        growablebuffer._pos_inc(10)
+
+    growablebuffer = GrowableBuffer(np.float32)
+    growablebuffer._length = 123
+    growablebuffer._pos = 99
+
+    assert f11(growablebuffer) == (123, 99)
+
+    f12(growablebuffer)
+
+    assert growablebuffer._length == 1
+    assert growablebuffer._pos == 2
+
+    f13(growablebuffer)
+
+    assert growablebuffer._length == 11
+    assert growablebuffer._pos == 12


### PR DESCRIPTION
@ianna, this is a complete implementation of GrowableBuffer (with `dtype`, `append`, `extend`, `snapshot` public methods) in Numba. It's also a good example to follow, instead of the ArrayView iterators, for a mutable Numba object like (future) LayoutBuilder.

The public API doesn't exactly follow the one in C++ because we can provide more high-level conveniences here. The C++ ArrayBuilder has a multi-step process to provide a length to Python, let Python allocate arrays of the right length, and then fill them, but all of that can be a single `snapshot` method here because Numba can ensure that Python owns the output arrays.

The lowered `GrowableBuffer` object is actually immutable and passed by value (`StructModel`). In order to ensure identity among all the objects created from one `GrowableBuffer` by assignment, all of the mutable data are in NumPy arrays and a `numba.typed.List`. Numba maintains the reference counts and referential identity of these objects; we take advantage of the fact that they do so. This way, if you

```python
>>> @nb.njit
>>> def f(x):
...     return x, x
...
>>> growablebuffer1 = GrowableBuffer(np.float32)
>>> growablebuffer2, growablebuffer3 = f(growablebuffer1)
```

then all three `growablebuffer1`, `growablebuffer2`, `growablebuffer3` share the same state: appending to any one of them appends to all of them.

In order to do this, I had to put two attributes, `_length` and `_pos`, into a 2-element NumPy array. If it weren't for trying to avoid confusions about mutability, they would have been simple attributes.

The `numba.typed.List` for a growable list of NumPy array `_panels` is also essential. This Python implementation of `GrowableBuffer` can't be used without Numba. I didn't like that conclusion, but the _only_ reason we'd have a pure Python version of these things is to provide an outside-of-Numba playground for practicing before moving things to Numba, so I guess it's not that bad.

The Numba implementations of `_add_panel`, `append`, `extend`, and `snapshot` (the only "substantial" functions) are all implemented in Numba's high-level extension API. I used the high-level API as much as possible. Quite a few underscored/hidden attributes and methods also exist in Numba, some of them implemented with the low-level API, and they're not all the same as the ones in Python. For instance, we have `_length_get()` in Numba and `_length` in Python.

The interpretation of the `resize` parameter might be different from how it is in C++. If so, it's because we never finished updating that. Now that we have panels, it no longer makes sense to grow an array exponentially with `resize` close to the golden ratio (we approximated with `1.5`); it would be much better for `resize` to only change the size once:

  * the first panel has size `initial` (1024 items)
  * _all subsequent panels_ (2nd, 3rd, 4th, ...) all have the same size `initial*resize` (8192 items)

because (1) many buffers are never going to exceed their first panel and (2) having a bunch of same-sized chunks in memory space is less likely to get fragmented. If the C++ `GrowableBuffer` doesn't have this behavior yet, it should—not having that was an oversight.

I checked all of the reference-counting and they're correct. I couldn't do it in the test because pytest seemed to be changing the reference counts—could it be that it's holding onto objects so that it can prepare a richer error message?