### PR TITLE
refactor: move `merge_as_union` to `ak_concatenate`

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping
 from numbers import Integral
 
 import awkward as ak
@@ -268,33 +268,6 @@ def num(layout, axis):
 
 def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
     return one._mergeable_next(two, mergebool=mergebool)
-
-
-def merge_as_union(
-    contents: Sequence[Content], parameters=None
-) -> ak.contents.UnionArray:
-    length = sum([c.length for c in contents])
-    first = contents[0]
-    tags = ak.index.Index8.empty(length, first.backend.index_nplike)
-    index = ak.index.Index64.empty(length, first.backend.index_nplike)
-
-    offset = 0
-    for i, content in enumerate(contents):
-        content._handle_error(
-            content.backend["awkward_UnionArray_filltags_const", tags.dtype.type](
-                tags.data, offset, content.length, i
-            )
-        )
-        content._handle_error(
-            content.backend["awkward_UnionArray_fillindex_count", index.dtype.type](
-                index.data, offset, content.length
-            )
-        )
-        offset += content.length
-
-    return ak.contents.UnionArray.simplified(
-        tags, index, contents, parameters=parameters
-    )
 
 
 def mergemany(contents: list[Content]) -> Content:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -768,15 +768,6 @@ class UnionArray(Content):
             )
         return (tags, index)
 
-    def _nested_tags_index(self, offsets: Index, counts: Sequence[Index]):
-        return self.nested_tags_index(
-            offsets,
-            counts,
-            backend=self._backend,
-            tags_cls=type(self._tags),
-            index_cls=type(self._index),
-        )
-
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
         if isinstance(self, ak.contents.UnionArray):
             raise ak._errors.index_error(


### PR DESCRIPTION
`ak._do` serves a particular purpose; to provide entrypoints to L3 functions in the `Content` class. I briefly outlined how this should ultimately be organised (in my view) [here](https://github.com/scikit-hep/awkward/issues/2108).

For now, the only user of this L3 function is `ak_concatenate`, so I'm placing it in that module.

Also, this PR removes an unused L3 function.