### PR TITLE
fix: don't permit scalars in `to_layout` / `from_iter`

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -65,7 +65,9 @@ def from_arraylib(array, regulararray, recordarray):
             )
 
         if len(array.shape) == 0:
-            array = nplike.reshape(array, (1,))
+            raise wrap_error(
+                TypeError("0D (scalar) arrays cannot be converted into Awkward Arrays")
+            )
 
         if array.dtype.kind == "S":
             assert nplike is numpy

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -1,9 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_iter",)
 
+from collections.abc import Iterable
+
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._errors import OperationErrorContext, wrap_error
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -57,7 +60,7 @@ def from_iter(
 
     See also #ak.to_list.
     """
-    with ak._errors.OperationErrorContext(
+    with OperationErrorContext(
         "ak.from_iter",
         {
             "iterable": iterable,
@@ -72,6 +75,9 @@ def from_iter(
 
 
 def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
+    if not isinstance(iterable, Iterable):
+        raise wrap_error(TypeError(f"{iterable} must be an iterable object."))
+
     if isinstance(iterable, dict):
         if allow_record:
             return _impl(
@@ -83,7 +89,7 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
                 resize,
             )[0]
         else:
-            raise ak._errors.wrap_error(
+            raise wrap_error(
                 ValueError(
                     "cannot produce an array from a single dict (that would be a record)"
                 )

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -98,7 +98,9 @@ def _impl(array, allow_record, allow_other, regulararray):
         backend = ak._backends.TypeTracerBackend.instance()
 
         if len(array.shape) == 0:
-            array = backend.nplike.reshape(array, (1,))
+            raise _errors.wrap_error(
+                TypeError("0D (scalar) arrays cannot be converted into Awkward Arrays")
+            )
 
         if array.dtype.kind in {"S", "U"}:
             raise _errors.wrap_error(


### PR DESCRIPTION
`ak.from_iter` should not (at least nominally) accept non-iterable types. Additionally, we ban Python scalars, but support 0D arrays. This PR ensures that `to_layout` only supports non-scalar numbers, and `from_iter` only accepts iterables.

We still accept strings in `from_iter`, and return a character array.
