### PR TITLE
fix: make `from_iter` require iterables!

### DIFF
--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_iter",)
 
+from collections.abc import Iterable
+
 from awkward_cpp.lib import _ext
 
 import awkward as ak
@@ -72,6 +74,13 @@ def from_iter(
 
 
 def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
+    if not isinstance(iterable, Iterable):
+        raise ak._errors.wrap_error(
+            TypeError(
+                f"cannot produce an array from a non-iterable object ({type(iterable)!r})"
+            )
+        )
+
     if isinstance(iterable, dict):
         if allow_record:
             return _impl(
@@ -89,6 +98,7 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
                 )
             )
 
+    # Ensure that tuples are treated as iterables, not records
     if isinstance(iterable, tuple):
         iterable = list(iterable)
 

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -5,6 +5,7 @@ import copy
 from collections.abc import Iterable
 
 import awkward as ak
+from awkward._backends import Backend
 from awkward._behavior import get_record_class
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -246,6 +247,16 @@ class Record:
             return tuple(contents)
         else:
             return dict(zip(self._array.fields, contents))
+
+    def to_backend(self, backend: Backend | str | None = None) -> Self:
+        if backend is None:
+            backend = self._array.backend
+        else:
+            backend = ak._backends.regularize_backend(backend)
+        if backend is self._array.backend:
+            return self
+        else:
+            return Record(self._array._to_backend(backend), self._at)
 
     def __copy__(self) -> Self:
         return self.copy()


### PR DESCRIPTION
Although `from_iter` can understand non-iterables, I think we really want to restrict it to *only* returning layouts/arrays.