### PR TITLE
feat: add `to_backend` to `ak.record.Record`

### DIFF
--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -5,6 +5,7 @@ import copy
 from collections.abc import Iterable
 
 import awkward as ak
+from awkward._backends import Backend
 from awkward._behavior import get_record_class
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -246,6 +247,16 @@ class Record:
             return tuple(contents)
         else:
             return dict(zip(self._array.fields, contents))
+
+    def to_backend(self, backend: Backend | str | None = None) -> Self:
+        if backend is None:
+            backend = self._array.backend
+        else:
+            backend = ak._backends.regularize_backend(backend)
+        if backend is self._array.backend:
+            return self
+        else:
+            return Record(self._array._to_backend(backend), self._at)
 
     def __copy__(self) -> Self:
         return self.copy()

--- a/tests/test_2355_to_backend_record.py
+++ b/tests/test_2355_to_backend_record.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest
+
+import awkward as ak
+from awkward._backends import NumpyBackend, TypeTracerBackend
+
+
+def test():
+    layout = ak.to_layout({"x": 1, "y": 1})
+    assert ak.backend(layout) == "cpu"
+    assert layout.backend is NumpyBackend.instance()
+
+    layout_tt = layout.to_backend("typetracer")
+    assert ak.backend(layout_tt) == "typetracer"
+    assert layout_tt.backend is TypeTracerBackend.instance()
+
+    with pytest.raises(TypeError):
+        layout_tt.to_backend("cpu")


### PR DESCRIPTION
This introduces feature parity with `ak.contents.Content`, and will be useful in future PRs