### PR TITLE
docs: fix extra for pyodide

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ myst-nb
 sphinx-external-toc
 jupyterlite-sphinx==0.7.3
 ipyleaflet
-jupyterlite==0.1.0b16
+jupyterlite[piplite]==0.1.0b16
 
 numpy>=1.13.1
 numba>=0.50.0


### PR DESCRIPTION
`jupyterlite-sphinx` requires `jupyterlite[piplite]` which does not seem to consider the `jupyterlite` constraint, leading to failing docs CI jobs. This PR updates our constraint to include the extra.