### PR TITLE
feat: add type equality `is_equal_to` member

### DIFF
--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -50,7 +50,7 @@ class ArrayType:
         args = [repr(self._content), repr(self._length)]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
+    def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
         return (
             isinstance(other, ArrayType)
             and (
@@ -58,7 +58,7 @@ class ArrayType:
                 or self._length is unknown_length
                 or self._length == other._length
             )
-            and self._content.is_equal_to(other._content, parameters=parameters)
+            and self._content.is_equal_to(other._content, all_parameters=all_parameters)
         )
 
     __eq__ = is_equal_to

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -52,7 +52,7 @@ class ArrayType:
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
         return (
-            isinstance(other, ArrayType)
+            isinstance(other, type(self))
             and (
                 other._length is unknown_length
                 or self._length is unknown_length

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -1,4 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
 import sys
 
 import awkward as ak
@@ -48,12 +50,15 @@ class ArrayType:
         args = [repr(self._content), repr(self._length)]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, ArrayType):
-            return (
+    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
+        return (
+            isinstance(other, ArrayType)
+            and (
                 other._length is unknown_length
                 or self._length is unknown_length
                 or self._length == other._length
-            ) and self._content == other._content
-        else:
-            return False
+            )
+            and self._content.is_equal_to(other._content, parameters=parameters)
+        )
+
+    __eq__ = is_equal_to

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -71,7 +71,7 @@ class ListType(Type):
             parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
-            isinstance(other, ListType)
+            isinstance(other, type(self))
             and compare_parameters(self._parameters, other._parameters)
             and self._content == other._content
         )

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -66,11 +66,12 @@ class ListType(Type):
         args = [repr(self._content), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, ListType):
-            return (
-                type_parameters_equal(self._parameters, other._parameters)
-                and self._content == other._content
-            )
-        else:
-            return False
+    def _is_equal_to(self, other, parameters: bool):
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        return (
+            isinstance(other, ListType)
+            and compare_parameters(self._parameters, other._parameters)
+            and self._content == other._content
+        )

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -66,9 +66,9 @@ class ListType(Type):
         args = [repr(self._content), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool):
+    def _is_equal_to(self, other, all_parameters: bool):
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
             isinstance(other, ListType)

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -161,9 +161,9 @@ class NumpyType(Type):
         args = [repr(self._primitive), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool) -> bool:
+    def _is_equal_to(self, other, all_parameters: bool) -> bool:
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
             isinstance(other, type(self))

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -5,7 +5,7 @@ import re
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -161,10 +161,12 @@ class NumpyType(Type):
         args = [repr(self._primitive), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, NumpyType):
-            return self._primitive == other._primitive and type_parameters_equal(
-                self._parameters, other._parameters
-            )
-        else:
-            return False
+    def _is_equal_to(self, other, parameters: bool) -> bool:
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        return (
+            isinstance(other, type(self))
+            and (self._primitive == other._primitive)
+            and compare_parameters(self._parameters, other._parameters)
+        )

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -119,12 +119,14 @@ class OptionType(Type):
         else:
             return self
 
-    def _is_equal_to(self, other, parameters: bool) -> bool:
+    def _is_equal_to(self, other, all_parameters: bool) -> bool:
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
             isinstance(other, type(self))
             and compare_parameters(self._parameters, other._parameters)
-            and self._content._is_equal_to(other._content, parameters=parameters)
+            and self._content._is_equal_to(
+                other._content, all_parameters=all_parameters
+            )
         )

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import awkward as ak
-from awkward._parameters import parameters_union, type_parameters_equal
+from awkward._parameters import (
+    parameters_are_equal,
+    parameters_union,
+    type_parameters_equal,
+)
 from awkward._typing import final
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
@@ -81,15 +85,6 @@ class OptionType(Type):
         args = [repr(self._content), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, OptionType):
-            return (
-                type_parameters_equal(self._parameters, other._parameters)
-                and self._content == other._content
-            )
-        else:
-            return False
-
     def simplify_option_union(self):
         if isinstance(self._content, UnionType):
             contents = []
@@ -123,3 +118,13 @@ class OptionType(Type):
 
         else:
             return self
+
+    def _is_equal_to(self, other, parameters: bool) -> bool:
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        return (
+            isinstance(other, type(self))
+            and compare_parameters(self._parameters, other._parameters)
+            and self._content._is_equal_to(other._content, parameters=parameters)
+        )

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 import awkward._prettyprint
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -183,28 +183,30 @@ class RecordType(Type):
         args = [repr(self._contents), repr(self._fields), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, RecordType):
-            if not type_parameters_equal(self._parameters, other._parameters):
-                return False
-
-            if self._fields is None and other._fields is None:
-                return self._contents == other._contents
-
-            elif self._fields is not None and other._fields is not None:
-                if set(self._fields) != set(other._fields):
-                    return False
-                for field in self._fields:
-                    if self.content(field) != other.content(field):
-                        return False
-
-                return True
-
-            else:
-                return False
-
-        else:
+    def _is_equal_to(self, other, parameters: bool) -> bool:
+        if not isinstance(other, type(self)):
             return False
+
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        if not compare_parameters(self._parameters, other._parameters):
+            return False
+
+        if self._fields is None and other._fields is None:
+            for this, that in zip(self._contents, other._contents):
+                if not this._is_equal_to(that, parameters):
+                    return False
+        elif self._fields is not None and other._fields is not None:
+            if set(self._fields) != set(other._fields):
+                return False
+            for field in self._fields:
+                if not self.content(field)._is_equal_to(
+                    other.content(field), parameters
+                ):
+                    return False
+        else:
+            return True
 
     def index_to_field(self, index):
         return ak.forms.RecordForm.index_to_field(self, index)

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -205,8 +205,8 @@ class RecordType(Type):
                     other.content(field), all_parameters
                 ):
                     return False
-        else:
-            return True
+
+        return True
 
     def index_to_field(self, index):
         return ak.forms.RecordForm.index_to_field(self, index)

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -183,26 +183,26 @@ class RecordType(Type):
         args = [repr(self._contents), repr(self._fields), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool) -> bool:
+    def _is_equal_to(self, other, all_parameters: bool) -> bool:
         if not isinstance(other, type(self)):
             return False
 
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         if not compare_parameters(self._parameters, other._parameters):
             return False
 
         if self._fields is None and other._fields is None:
             for this, that in zip(self._contents, other._contents):
-                if not this._is_equal_to(that, parameters):
+                if not this._is_equal_to(that, all_parameters):
                     return False
         elif self._fields is not None and other._fields is not None:
             if set(self._fields) != set(other._fields):
                 return False
             for field in self._fields:
                 if not self.content(field)._is_equal_to(
-                    other.content(field), parameters
+                    other.content(field), all_parameters
                 ):
                     return False
         else:

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._nplikes.shape import unknown_length
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
 from awkward.types.type import Type
@@ -84,12 +84,13 @@ class RegularType(Type):
         args = [repr(self._content), repr(self._size), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, RegularType):
-            return (
-                self._size == other._size
-                and type_parameters_equal(self._parameters, other._parameters)
-                and self._content == other._content
-            )
-        else:
-            return False
+    def _is_equal_to(self, other, parameters: bool) -> bool:
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        return (
+            isinstance(other, type(self))
+            and compare_parameters(self._parameters, other._parameters)
+            and (self._size == other._size)
+            and self._content._is_equal_to(other._content, parameters)
+        )

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -84,13 +84,13 @@ class RegularType(Type):
         args = [repr(self._content), repr(self._size), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool) -> bool:
+    def _is_equal_to(self, other, all_parameters: bool) -> bool:
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
             isinstance(other, type(self))
             and compare_parameters(self._parameters, other._parameters)
             and (self._size == other._size)
-            and self._content._is_equal_to(other._content, parameters)
+            and self._content._is_equal_to(other._content, all_parameters)
         )

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -33,8 +33,9 @@ class ScalarType:
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"
 
-    def __eq__(self, other):
-        if isinstance(other, ScalarType):
-            return self._content == other._content
-        else:
-            return False
+    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
+        return isinstance(other, ScalarType) and self._content.is_equal_to(
+            other._content, parameters=parameters
+        )
+
+    __eq__ = is_equal_to

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -33,9 +33,9 @@ class ScalarType:
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"
 
-    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
+    def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
         return isinstance(other, ScalarType) and self._content.is_equal_to(
-            other._content, parameters=parameters
+            other._content, all_parameters=all_parameters
         )
 
     __eq__ = is_equal_to

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -34,7 +34,7 @@ class ScalarType:
         return f"{type(self).__name__}({self._content!r})"
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
-        return isinstance(other, ScalarType) and self._content.is_equal_to(
+        return isinstance(other, type(self)) and self._content.is_equal_to(
             other._content, all_parameters=all_parameters
         )
 

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import json
 import sys
@@ -69,6 +70,14 @@ class Type:
             out.append("typestr=" + repr(self._typestr))
 
         return out
+
+    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
+        return self._is_equal_to(other, parameters)
+
+    __eq__ = is_equal_to
+
+    def _is_equal_to(self, other, parameters: bool) -> bool:
+        raise ak._errors.wrap_error(NotImplementedError)
 
 
 class _DataShapeTransformer(Transformer):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -71,12 +71,12 @@ class Type:
 
         return out
 
-    def is_equal_to(self, other, *, parameters: bool = False) -> bool:
-        return self._is_equal_to(other, parameters)
+    def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
+        return self._is_equal_to(other, all_parameters)
 
     __eq__ = is_equal_to
 
-    def _is_equal_to(self, other, parameters: bool) -> bool:
+    def _is_equal_to(self, other, all_parameters: bool) -> bool:
         raise ak._errors.wrap_error(NotImplementedError)
 
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 from itertools import permutations
+
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -92,16 +92,16 @@ class UnionType(Type):
         args = [repr(self._contents), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool):
+    def _is_equal_to(self, other, all_parameters: bool):
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
             isinstance(other, UnionType)
             and compare_parameters(self._parameters, other._parameters)
             and len(self._contents) == len(other._contents)
             and all(
-                this._is_equal_to(that, parameters)
+                this._is_equal_to(that, all_parameters)
                 for this, that in zip(self._contents, other._contents)
             )
         )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 from collections.abc import Iterable
+from itertools import permutations
 
 import awkward as ak
 from awkward._parameters import parameters_are_equal, type_parameters_equal
@@ -100,8 +101,11 @@ class UnionType(Type):
             isinstance(other, UnionType)
             and compare_parameters(self._parameters, other._parameters)
             and len(self._contents) == len(other._contents)
-            and all(
-                this._is_equal_to(that, all_parameters)
-                for this, that in zip(self._contents, other._contents)
+            and any(
+                all(
+                    this._is_equal_to(that, all_parameters)
+                    for this, that in zip(self._contents, contents)
+                )
+                for contents in permutations(other._contents)
             )
         )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -98,7 +98,7 @@ class UnionType(Type):
             parameters_are_equal if all_parameters else type_parameters_equal
         )
         return (
-            isinstance(other, UnionType)
+            isinstance(other, type(self))
             and compare_parameters(self._parameters, other._parameters)
             and len(self._contents) == len(other._contents)
             and any(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -54,6 +54,6 @@ class UnknownType(Type):
         compare_parameters = (
             parameters_are_equal if all_parameters else type_parameters_equal
         )
-        return isinstance(other, UnknownType) and compare_parameters(
+        return isinstance(other, type(self)) and compare_parameters(
             self._parameters, other._parameters
         )

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._errors import deprecate
-from awkward._parameters import type_parameters_equal
+from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
 
@@ -50,8 +50,10 @@ class UnknownType(Type):
         args = self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def __eq__(self, other):
-        if isinstance(other, UnknownType):
-            return type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return False
+    def _is_equal_to(self, other, parameters: bool):
+        compare_parameters = (
+            parameters_are_equal if parameters else type_parameters_equal
+        )
+        return isinstance(other, UnknownType) and compare_parameters(
+            self._parameters, other._parameters
+        )

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -50,9 +50,9 @@ class UnknownType(Type):
         args = self._repr_args()
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
-    def _is_equal_to(self, other, parameters: bool):
+    def _is_equal_to(self, other, all_parameters: bool):
         compare_parameters = (
-            parameters_are_equal if parameters else type_parameters_equal
+            parameters_are_equal if all_parameters else type_parameters_equal
         )
         return isinstance(other, UnknownType) and compare_parameters(
             self._parameters, other._parameters

--- a/tests/test_2368_type_is_equal.py
+++ b/tests/test_2368_type_is_equal.py
@@ -1,0 +1,74 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+@pytest.mark.parametrize(
+    "typestr",
+    [
+        "1 * int64",
+        "1 * float32",
+        "1 * var * int64",
+        "1 * 3 * int64",
+        "1 * ?int64",
+        "1 * {x: int64, y: int64}",
+        "1 * union[float32, string]",
+        "1 * unknown",
+    ],
+)
+def test_simple_types(typestr):
+    type_ = ak.types.from_datashape(typestr)
+    assert type_ == type_
+    assert type_.is_equal_to(type_)
+    assert type_.is_equal_to(type_, all_parameters=True)
+
+
+def test_complex_types():
+    type_ = ak.types.ArrayType(
+        ak.types.ListType(
+            ak.types.RegularType(
+                ak.types.UnionType(
+                    [
+                        ak.types.ListType(
+                            ak.types.NumpyType(
+                                "uint8", parameters={"__array__": "char"}
+                            ),
+                            parameters={"__array__": "string"},
+                        ),
+                        ak.types.RecordType(
+                            [
+                                ak.types.NumpyType(
+                                    "int64", parameters={"rectilinear": True}
+                                ),
+                                ak.types.OptionType(
+                                    ak.types.RecordType(
+                                        [
+                                            ak.types.OptionType(
+                                                ak.types.NumpyType("float64")
+                                            )
+                                        ],
+                                        ["z"],
+                                    )
+                                ),
+                            ],
+                            ["x", "y"],
+                        ),
+                    ],
+                    parameters={"planets": ["mercury", "venus", "earth", "mars"]},
+                ),
+                3,
+            ),
+            parameters={"earth": "not flat"},
+        ),
+        10,
+    )
+    assert type_.is_equal_to(type_)
+    assert type_.is_equal_to(type_, all_parameters=True)
+
+    type_no_parameters = ak.types.from_datashape(
+        "10 * var * 3 * union[string, {x: int64, y: ?{z: ?float64}}]"
+    )
+    assert type_no_parameters.is_equal_to(type_, all_parameters=False)
+    assert not type_no_parameters.is_equal_to(type_, all_parameters=True)

--- a/tests/test_2368_type_is_equal.py
+++ b/tests/test_2368_type_is_equal.py
@@ -72,3 +72,15 @@ def test_complex_types():
     )
     assert type_no_parameters.is_equal_to(type_, all_parameters=False)
     assert not type_no_parameters.is_equal_to(type_, all_parameters=True)
+
+
+def test_record_tuple():
+    record_type = ak.types.from_datashape("10 * var * (int64, int32)")
+    tuple_type = ak.types.from_datashape("10 * var * {x: int64, y: int32}")
+    assert record_type != tuple_type
+
+
+def test_record_mixed():
+    record = ak.types.from_datashape("10 * var * {x: int64, y: int32}")
+    permutation = ak.types.from_datashape("10 * var * {y: int64, x: int32}")
+    assert record == permutation


### PR DESCRIPTION
In general, we have more ways of comparing types than the argument-less `__eq__` protocol permits. This PR adds support for comparison of just the nominal parameters, or all parameters.

If we're happy with this idea, I'd want to gradually rework the `Content.is_equal_to` and add a form equivalent too, probably.

In future, we can extend this signature to e.g. allow same-kind numeric comparisons.