### PR TITLE
refactor: wrap exceptions at catch time

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-select = AK1
-exclude = studies, pybind11, rapidjson, docs-*, src/awkward/_typeparser/generated_parser.py, tests/*, dev/*, src/awkward/__init__.py, src/awkward/_connect/numba/*, src/awkward/_errors.py
-
-[flake8:local-plugins]
-extension =
-    AK1 = flake8_awkward:AwkwardASTPlugin
-paths =
-    ./dev/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,11 +38,6 @@ repos:
   - id: cmake-format
     additional_dependencies: [pyyaml]
 
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
-  hooks:
-  - id: flake8
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.257
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,7 +299,7 @@ unfixable = [
     "T20",  # Removes print statements
     "F841", # Removes unused variables
 ]
-external = ["AK101"]
+external = []
 mccabe.max-complexity = 100
 
 [tool.ruff.per-file-ignores]

--- a/src/awkward/_backends.py
+++ b/src/awkward/_backends.py
@@ -30,20 +30,20 @@ class Backend(Singleton, ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def nplike(self) -> NumpyLike:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def index_nplike(self) -> NumpyLike:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def __getitem__(self, key: KernelKeyType) -> KernelType:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def apply_reducer(
         self,
@@ -103,9 +103,7 @@ class CupyBackend(Backend):
         if func is not None:
             return CupyKernel(func, index)
         else:
-            raise ak._errors.wrap_error(
-                AssertionError(f"CuPyKernel not found: {index!r}")
-            )
+            raise AssertionError(f"CuPyKernel not found: {index!r}")
 
 
 class JaxBackend(Backend):
@@ -146,9 +144,7 @@ class JaxBackend(Backend):
         from awkward._connect.jax import get_jax_ufunc
 
         if method != "__call__":
-            raise ak._errors.wrap_error(
-                ValueError(f"unsupported ufunc method {method} called")
-            )
+            raise ValueError(f"unsupported ufunc method {method} called")
 
         jax_ufunc = get_jax_ufunc(ufunc)
         return jax_ufunc(*args, **kwargs)
@@ -212,7 +208,7 @@ def _backend_for_nplike(nplike: NumpyLike) -> Backend:
     elif isinstance(nplike, TypeTracer):
         return TypeTracerBackend.instance()
     else:
-        raise ak._errors.wrap_error(ValueError("unrecognised nplike", nplike))
+        raise ValueError("unrecognised nplike", nplike)
 
 
 def common_backend(backends: Collection[Backend]) -> Backend:
@@ -226,11 +222,9 @@ def common_backend(backends: Collection[Backend]) -> Backend:
             if not backend.nplike.known_data:
                 return backend
 
-        raise ak._errors.wrap_error(
-            ValueError(
-                "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
-                "to the same backend"
-            )
+        raise ValueError(
+            "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
+            "to the same backend"
         )
 
 
@@ -255,7 +249,7 @@ def backend_of(*objects, default: D = _UNSET) -> Backend | D:
     if nplike is not None:
         return _backend_for_nplike(nplike)
     elif default is _UNSET:
-        raise ak._errors.wrap_error(ValueError("could not find backend for", objects))
+        raise ValueError("could not find backend for", objects)
     else:
         return default
 
@@ -271,4 +265,4 @@ def regularize_backend(backend: str | Backend) -> Backend:
     elif backend in _backends:
         return _backends[backend].instance()
     else:
-        raise ak._errors.wrap_error(ValueError(f"No such backend {backend!r} exists."))
+        raise ValueError(f"No such backend {backend!r} exists.")

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -111,15 +111,13 @@ def checklength(inputs, options):
     length = inputs[0].length
     for x in inputs[1:]:
         if x.length != length:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot broadcast {} of length {} with {} of length {}{}".format(
-                        type(inputs[0]).__name__,
-                        length,
-                        type(x).__name__,
-                        x.length,
-                        in_function(options),
-                    )
+            raise ValueError(
+                "cannot broadcast {} of length {} with {} of length {}{}".format(
+                    type(inputs[0]).__name__,
+                    length,
+                    type(x).__name__,
+                    x.length,
+                    in_function(options),
                 )
             )
 
@@ -322,11 +320,9 @@ def one_to_one_parameters_factory(
 
     def apply(n_outputs) -> list[dict[str, Any] | None]:
         if n_outputs != len(inputs):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot follow one-to-one parameter broadcasting rule for actions "
-                    "which change the number of outputs."
-                )
+            raise ValueError(
+                "cannot follow one-to-one parameter broadcasting rule for actions "
+                "which change the number of outputs."
             )
         return input_parameters
 
@@ -431,20 +427,16 @@ def apply_step(
     try:
         parameters_factory_impl = BROADCAST_RULE_TO_FACTORY_IMPL[rule]
     except KeyError:
-        raise ak._errors.wrap_error(
-            ValueError(
-                f"`broadcast_parameters_rule` should be one of {[str(x) for x in BroadcastParameterRule]}, "
-                f"but this routine received `{rule}`"
-            )
+        raise ValueError(
+            f"`broadcast_parameters_rule` should be one of {[str(x) for x in BroadcastParameterRule]}, "
+            f"but this routine received `{rule}`"
         ) from None
     parameters_factory = parameters_factory_impl(inputs)
 
     # This whole function is one big switch statement.
     def broadcast_any_record():
         if not options["allow_records"]:
-            raise ak._errors.wrap_error(
-                ValueError(f"cannot broadcast records {in_function(options)}")
-            )
+            raise ValueError(f"cannot broadcast records {in_function(options)}")
 
         fields, length, istuple = unset, unset, unset
         for x in contents:
@@ -452,25 +444,21 @@ def apply_step(
                 if fields is unset:
                     fields = x.fields
                 elif set(fields) != set(x.fields):
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "cannot broadcast records because fields don't "
-                            "match{}:\n    {}\n    {}".format(
-                                in_function(options),
-                                ", ".join(sorted(fields)),
-                                ", ".join(sorted(x.fields)),
-                            )
+                    raise ValueError(
+                        "cannot broadcast records because fields don't "
+                        "match{}:\n    {}\n    {}".format(
+                            in_function(options),
+                            ", ".join(sorted(fields)),
+                            ", ".join(sorted(x.fields)),
                         )
                     )
                 if length is unset:
                     length = x.length
                 elif length != x.length:
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "cannot broadcast RecordArray of length {} "
-                            "with RecordArray of length {}{}".format(
-                                length, x.length, in_function(options)
-                            )
+                    raise ValueError(
+                        "cannot broadcast RecordArray of length {} "
+                        "with RecordArray of length {}{}".format(
+                            length, x.length, in_function(options)
                         )
                     )
                 # Records win over tuples
@@ -552,12 +540,10 @@ def apply_step(
                         elif dimsize == 0:
                             nextinputs.append(x.content[:0])
                         else:
-                            raise ak._errors.wrap_error(
-                                ValueError(
-                                    "cannot broadcast RegularArray of size "
-                                    "{} with RegularArray of size {} {}".format(
-                                        x.size, dimsize, in_function(options)
-                                    )
+                            raise ValueError(
+                                "cannot broadcast RegularArray of size "
+                                "{} with RegularArray of size {} {}".format(
+                                    x.size, dimsize, in_function(options)
                                 )
                             )
                     else:
@@ -687,11 +673,9 @@ def apply_step(
                     for x, p in zip(outcontent, parameters)
                 )
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "unexpected offsets, starts: {}, {}".format(
-                            type(offsets), type(starts)
-                        )
+                raise AssertionError(
+                    "unexpected offsets, starts: {}, {}".format(
+                        type(offsets), type(starts)
                     )
                 )
 
@@ -893,14 +877,12 @@ def apply_step(
                     if length is None:
                         length = tags.shape[0]
                     elif length != tags.shape[0]:
-                        raise ak._errors.wrap_error(
-                            ValueError(
-                                "cannot broadcast UnionArray of length {} "
-                                "with UnionArray of length {}{}".format(
-                                    length,
-                                    tags.shape[0],
-                                    in_function(options),
-                                )
+                        raise ValueError(
+                            "cannot broadcast UnionArray of length {} "
+                            "with UnionArray of length {}{}".format(
+                                length,
+                                tags.shape[0],
+                                in_function(options),
                             )
                         )
             assert length is not unknown_length
@@ -1037,11 +1019,9 @@ def apply_step(
             return broadcast_any_record()
 
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot broadcast: {}{}".format(
-                        ", ".join(repr(type(x)) for x in inputs), in_function(options)
-                    )
+            raise ValueError(
+                "cannot broadcast: {}{}".format(
+                    ", ".join(repr(type(x)) for x in inputs), in_function(options)
                 )
             )
 
@@ -1061,7 +1041,7 @@ def apply_step(
     elif result is None:
         return continuation()
     else:
-        raise ak._errors.wrap_error(AssertionError(result))
+        raise AssertionError(result)
 
 
 def broadcast_and_apply(

--- a/src/awkward/_connect/avro.py
+++ b/src/awkward/_connect/avro.py
@@ -26,8 +26,8 @@ class ReadAvroFT:
             try:
                 self.temp_header += self.data.read(numbytes)
                 if not self.check_valid():
-                    raise ak._errors.wrap_error(
-                        TypeError("invalid Avro file: first 4 bytes are not b'Obj\x01'")
+                    raise TypeError(
+                        "invalid Avro file: first 4 bytes are not b'Obj\x01'"
                     )
                 pos = 4
                 pos, self.pairs = self.decode_varint(4, self.temp_header)
@@ -83,7 +83,7 @@ class ReadAvroFT:
                 pos, num_items, len_block = self.decode_block()
                 temp_data = self.data.read(len_block)
                 if len(temp_data) < len_block:
-                    raise _ReachedEndofArrayError  # noqa: AK101
+                    raise _ReachedEndofArrayError
                 self.update_pos(len_block)
             except _ReachedEndofArrayError:
                 break
@@ -144,14 +144,14 @@ class ReadAvroFT:
             key = self.temp_header[pos : pos + int(dat)]
             pos = pos + int(dat)
             if len(key) < int(dat):
-                raise _ReachedEndofArrayError  # noqa: AK101
+                raise _ReachedEndofArrayError
 
             pos, dat = self.decode_varint(pos, self.temp_header)
             dat = self.decode_zigzag(dat)
             val = self.temp_header[pos : pos + int(dat)]
             pos = pos + int(dat)
             if len(val) < int(dat):
-                raise _ReachedEndofArrayError  # noqa: AK101
+                raise _ReachedEndofArrayError
             if key == b"avro.schema":
                 self.metadata[key.decode()] = json.loads(val.decode())
             else:
@@ -164,7 +164,7 @@ class ReadAvroFT:
     def check_valid(self):
         init = self.temp_header[0:4]
         if len(init) < 4:
-            raise _ReachedEndofArrayError  # noqa: AK101
+            raise _ReachedEndofArrayError
         return init == b"Obj\x01"
 
     def decode_varint(self, pos, _data):
@@ -172,7 +172,7 @@ class ReadAvroFT:
         result = 0
         while True:
             if pos >= len(_data):
-                raise _ReachedEndofArrayError  # noqa: AK101
+                raise _ReachedEndofArrayError
             i = _data[pos]
             pos += 1
             result |= (i & 0x7F) << shift
@@ -203,7 +203,7 @@ class ReadAvroFT:
         elif dtype["type"] == "enum":
             return f"0 node{count}-index <- stack "
         else:
-            raise AssertionError  # noqa: AK101
+            raise AssertionError
 
     def rec_exp_json_code(
         self,
@@ -911,9 +911,7 @@ class ReadAvroFT:
             #         exec_code = exec_code+hh
             #         exec_code = exec_code+jj
             #         exec_code = exec_code+kk
-            raise ak._errors.wrap_error(NotImplementedError)
+            raise NotImplementedError
 
         else:
-            raise ak._errors.wrap_error(
-                AssertionError(f"unrecognized Avro type: {file['type']}")
-            )
+            raise AssertionError(f"unrecognized Avro type: {file['type']}")

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -482,7 +482,7 @@ def togenerator(form, flatlist_as_rvec):
         return UnionArrayGenerator.from_form(form, flatlist_as_rvec)
 
     else:
-        raise ak._errors.wrap_error(AssertionError(f"unrecognized Form: {type(form)}"))
+        raise AssertionError(f"unrecognized Form: {type(form)}")
 
 
 class Generator:
@@ -500,7 +500,7 @@ class Generator:
         elif arraytype == "uint64_t":
             return ak.index.IndexU64
         else:
-            raise ak._errors.wrap_error(AssertionError(arraytype))
+            raise AssertionError(arraytype)
 
     def class_type_suffix(self, key):
         return ak._util.identifier_hash(key)
@@ -793,7 +793,7 @@ class ListArrayGenerator(Generator, ak._lookup.ListLookup):
         elif index_type == "i64":
             self.index_type = "int64_t"
         else:
-            raise ak._errors.wrap_error(AssertionError(index_type))
+            raise AssertionError(index_type)
         self.content = content
 
         # FIXME: satisfy the ContentLookup super-class
@@ -942,7 +942,7 @@ class IndexedArrayGenerator(Generator, ak._lookup.IndexedLookup):
         elif index_type == "i64":
             self.indextype = "int64_t"
         else:
-            raise ak._errors.wrap_error(AssertionError(index_type))
+            raise AssertionError(index_type)
         self.contenttype = content
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
@@ -1017,7 +1017,7 @@ class IndexedOptionArrayGenerator(Generator, ak._lookup.IndexedOptionLookup):
         elif index_type == "i64":
             self.index_type = "int64_t"
         else:
-            raise ak._errors.wrap_error(AssertionError(index_type))
+            raise AssertionError(index_type)
         self.contenttype = content
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec
@@ -1509,7 +1509,7 @@ class UnionArrayGenerator(Generator, ak._lookup.UnionLookup):
         elif index_type == "i64":
             self.indextype = "int64_t"
         else:
-            raise ak._errors.wrap_error(AssertionError(index_type))
+            raise AssertionError(index_type)
         self.contenttypes = tuple(contents)
         self.parameters = parameters
         self.flatlist_as_rvec = flatlist_as_rvec

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -219,9 +219,8 @@ def synchronize_cuda(stream=None):
             cupy.array(NO_ERROR),
             [],
         )
-        raise awkward._errors.wrap_error(
+        raise invoked_kernel.error_context.rewrite_exception(
             ValueError(
                 f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
-            ),
-            invoked_kernel.error_context,
+            )
         )

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -6,8 +6,6 @@ import os
 
 import numpy
 
-import awkward
-
 try:
     import cupy
 
@@ -149,9 +147,8 @@ class Invocation:
 
 def import_cupy(name="Awkward Arrays with CUDA"):
     if cupy is None:
-        raise awkward._errors.wrap_error(
-            ModuleNotFoundError(error_message.format(name))
-        )
+        raise ModuleNotFoundError(error_message.format(name))
+
     return cupy
 
 
@@ -197,9 +194,7 @@ def initialize_cuda_kernels(cupy):
 
         return kernel
     else:
-        raise awkward._errors.wrap_error(
-            ModuleNotFoundError(error_message.format("Awkward Arrays with CUDA"))
-        )
+        raise ModuleNotFoundError(error_message.format("Awkward Arrays with CUDA"))
 
 
 def synchronize_cuda(stream=None):

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -214,7 +214,7 @@ def synchronize_cuda(stream=None):
             cupy.array(NO_ERROR),
             [],
         )
-        raise invoked_kernel.error_context.rewrite_exception(
+        raise invoked_kernel.error_context.decorate_exception(
             ValueError(
                 f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
             )

--- a/src/awkward/_connect/hist.py
+++ b/src/awkward/_connect/hist.py
@@ -27,9 +27,7 @@ def broadcast_and_flatten(args: Sequence[Any]) -> tuple[np.ndarray]:
         return NotImplementedError
 
     if any(x.fields for x in arrays):
-        raise ak._errors.wrap_error(
-            ValueError("cannot broadcast-and-flatten array with structure (fields)")
-        )
+        raise ValueError("cannot broadcast-and-flatten array with structure (fields)")
     return tuple(
         ak.to_numpy(ak.flatten(x, axis=None)) for x in ak.broadcast_arrays(*arrays)
     )

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -20,7 +20,7 @@ class ArgMin(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error(RuntimeError("Cannot differentiate through argmin"))
+        raise RuntimeError("Cannot differentiate through argmin")
 
 
 class ArgMax(Reducer):
@@ -34,7 +34,7 @@ class ArgMax(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error(RuntimeError("Cannot differentiate through argmax"))
+        raise RuntimeError("Cannot differentiate through argmax")
 
 
 class Count(Reducer):
@@ -47,9 +47,7 @@ class Count(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error(
-            RuntimeError("Cannot differentiate through count_zero")
-        )
+        raise RuntimeError("Cannot differentiate through count_zero")
 
 
 class CountNonzero(Reducer):
@@ -62,9 +60,7 @@ class CountNonzero(Reducer):
 
     @classmethod
     def apply(cls, array, parents, outlength):
-        raise ak._errors.wrap_error(
-            RuntimeError("Cannot differentiate through count_nonzero")
-        )
+        raise RuntimeError("Cannot differentiate through count_nonzero")
 
 
 class Sum(Reducer):
@@ -75,9 +71,7 @@ class Sum(Reducer):
     def apply(cls, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
-            raise ak._errors.wrap_error(
-                TypeError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
-            )
+            raise TypeError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
 
         result = jax.ops.segment_sum(array.data, parents.data)
 

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -6,7 +6,6 @@ import jax
 import awkward as ak
 from awkward import contents, highlevel, record
 from awkward._behavior import behavior_of
-from awkward._errors import wrap_error
 from awkward._layout import wrap_layout
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -79,7 +78,7 @@ class AuxData(Generic[T]):
         elif isinstance(obj, (contents.Content, record.Record)):
             layout = obj
         else:
-            raise wrap_error(TypeError)
+            raise TypeError
 
         # First, make sure we're all JAX
         jax_backend = ak._backends.JaxBackend.instance()
@@ -131,13 +130,11 @@ class AuxData(Generic[T]):
             # Check that JAX isn't trying to give us float0 types
             dtype = getattr(buffer, "dtype", None)
             if dtype == np.dtype([("float0", "V")]):
-                raise wrap_error(
-                    TypeError(
-                        f"a buffer with the dtype {buffer.dtype} was encountered during unflattening. "
-                        "JAX uses this dtype for the tangents of integer/boolean outputs; these cannot "
-                        "reasonably be differentiated. Make sure that you are not computing the derivative "
-                        "of a boolean/integer (array) valued function."
-                    )
+                raise TypeError(
+                    f"a buffer with the dtype {buffer.dtype} was encountered during unflattening. "
+                    "JAX uses this dtype for the tangents of integer/boolean outputs; these cannot "
+                    "reasonably be differentiated. Make sure that you are not computing the derivative "
+                    "of a boolean/integer (array) valued function."
                 )
 
         # Replace the mixed NumPy-JAX layout leaves with the given buffers (and use the JAX nplike)

--- a/src/awkward/_connect/numba/arrayview_cuda.py
+++ b/src/awkward/_connect/numba/arrayview_cuda.py
@@ -23,12 +23,10 @@ class ArrayViewArgHandler:
 
                 return tys, (pos, start, stop, arrayptrs, pylookup)
             else:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        '`ak.to_backend` should be called with `backend="cuda"` to put '
-                        "the array on the GPU before using it: "
-                        'ak.to_backend(array, backend="cuda")'
-                    )
+                raise TypeError(
+                    '`ak.to_backend` should be called with `backend="cuda"` to put '
+                    "the array on the GPU before using it: "
+                    'ak.to_backend(array, backend="cuda")'
                 )
 
         else:

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -98,9 +98,7 @@ class ContentType(numba.types.Type):
         elif arraytype.dtype.bitwidth == 64:
             return ak.index.Index64
         else:
-            raise ak._errors.wrap_error(
-                AssertionError(f"no Index* type for array: {arraytype}")
-            )
+            raise AssertionError(f"no Index* type for array: {arraytype}")
 
     def getitem_at_check(self, viewtype):
         typer = find_numba_array_typer(viewtype.type, viewtype.behavior)

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -14,16 +14,14 @@ def _import_numexpr():
     try:
         import numexpr
     except ModuleNotFoundError as err:
-        raise ak._errors.wrap_error(
-            ModuleNotFoundError(
-                """install the 'numexpr' package with:
+        raise ModuleNotFoundError(
+            """install the 'numexpr' package with:
 
     pip install numexpr --upgrade
 
 or
 
     conda install numexpr"""
-            )
         ) from err
     else:
         if not _has_checked_version:
@@ -125,9 +123,7 @@ def re_evaluate(local_dict=None):
     try:
         compiled_ex = numexpr.necompiler._numexpr_last["ex"]  # noqa: F841
     except KeyError as err:
-        raise ak._errors.wrap_error(
-            RuntimeError("not a previous evaluate() execution found")
-        ) from err
+        raise RuntimeError("not a previous evaluate() execution found") from err
     names = numexpr.necompiler._numexpr_last["argnames"]
     arguments = getArguments(names, local_dict)
 

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -54,11 +54,9 @@ def _to_rectilinear(arg):
     elif isinstance(arg, list):
         return [_to_rectilinear(x) for x in arg]
     elif is_non_string_like_iterable(arg):
-        raise ak._errors.wrap_error(
-            TypeError(
-                f"encountered an unsupported iterable value {arg!r} whilst converting arguments to NumPy-friendly "
-                f"types. If this argument should be supported, please file a bug report."
-            )
+        raise TypeError(
+            f"encountered an unsupported iterable value {arg!r} whilst converting arguments to NumPy-friendly "
+            f"types. If this argument should be supported, please file a bug report."
         )
     else:
         return arg
@@ -97,10 +95,8 @@ def implements(numpy_function):
             provided_invalid_names = parameters.arguments.keys() & unsupported_names
             if provided_invalid_names:
                 names = ", ".join(provided_invalid_names)
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        f"Awkward NEP-18 overload was provided with unsupported argument(s): {names}"
-                    )
+                raise TypeError(
+                    f"Awkward NEP-18 overload was provided with unsupported argument(s): {names}"
                 )
             return function(*args, **kwargs)
 
@@ -199,10 +195,8 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             return _array_ufunc_adjust(custom, inputs, kwargs, behavior)
 
         if ufunc is numpy.matmul:
-            raise ak._errors.wrap_error(
-                NotImplementedError(
-                    "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"
-                )
+            raise NotImplementedError(
+                "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"
             )
 
         if all(
@@ -256,11 +250,9 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         error_message.append(type(x).__name__)
                 else:
                     error_message.append(type(x).__name__)
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "no {}.{} overloads for custom types: {}".format(
-                        type(ufunc).__module__, ufunc.__name__, ", ".join(error_message)
-                    )
+            raise TypeError(
+                "no {}.{} overloads for custom types: {}".format(
+                    type(ufunc).__module__, ufunc.__name__, ", ".join(error_message)
                 )
             )
 
@@ -304,4 +296,4 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 
 
 def action_for_matmul(inputs):
-    raise ak._errors.wrap_error(NotImplementedError)
+    raise NotImplementedError

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -371,10 +371,8 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     ### Beginning of the big if-elif-elif chain!
 
     if isinstance(storage_type, pyarrow.lib.PyExtensionType):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
-            )
+        raise ValueError(
+            "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
         )
 
     elif isinstance(storage_type, pyarrow.lib.ExtensionType):
@@ -473,17 +471,15 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     elif isinstance(storage_type, pyarrow.lib.MapType):
         # FIXME: make a ListOffsetArray of 2-tuples with __array__ == "sorted_map".
         # (Make sure the keys are sorted).
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     elif isinstance(
         storage_type, (pyarrow.lib.Decimal128Type, pyarrow.lib.Decimal256Type)
     ):
         # Note: Decimal128Type and Decimal256Type are subtypes of FixedSizeBinaryType.
         # NumPy doesn't support decimal: https://github.com/numpy/numpy/issues/9789
-        raise ak._errors.wrap_error(
-            ValueError(
-                "Arrow arrays containing pyarrow.decimal128 or pyarrow.decimal256 types can't be converted into Awkward Arrays"
-            )
+        raise ValueError(
+            "Arrow arrays containing pyarrow.decimal128 or pyarrow.decimal256 types can't be converted into Awkward Arrays"
         )
 
     elif isinstance(storage_type, pyarrow.lib.FixedSizeBinaryType):
@@ -665,19 +661,15 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         )
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized Arrow array type: {storage_type!r}")
-        )
+        raise TypeError(f"unrecognized Arrow array type: {storage_type!r}")
 
 
 def form_popbuffers(awkwardarrow_type, storage_type):
     ### Beginning of the big if-elif-elif chain!
 
     if isinstance(storage_type, pyarrow.lib.PyExtensionType):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
-            )
+        raise ValueError(
+            "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
         )
 
     elif isinstance(storage_type, pyarrow.lib.ExtensionType):
@@ -695,8 +687,8 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         elif index_type is np.int32:
             index = "i32"
         else:
-            raise ak._errors.wrap_error(
-                TypeError(f"unrecognized Arrow DictionaryType index type: {index_type}")
+            raise TypeError(
+                f"unrecognized Arrow DictionaryType index type: {index_type}"
             )
 
         a, b = to_awkwardarrow_storage_types(storage_type.value_type)
@@ -755,17 +747,15 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         return form_popbuffers_finalize(out, awkwardarrow_type)
 
     elif isinstance(storage_type, pyarrow.lib.MapType):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     elif isinstance(
         storage_type, (pyarrow.lib.Decimal128Type, pyarrow.lib.Decimal256Type)
     ):
         # Note: Decimal128Type and Decimal256Type are subtypes of FixedSizeBinaryType.
         # NumPy doesn't support decimal: https://github.com/numpy/numpy/issues/9789
-        raise ak._errors.wrap_error(
-            ValueError(
-                "Arrow arrays containing pyarrow.decimal128 or pyarrow.decimal256 types can't be converted into Awkward Arrays"
-            )
+        raise ValueError(
+            "Arrow arrays containing pyarrow.decimal128 or pyarrow.decimal256 types can't be converted into Awkward Arrays"
         )
 
     elif isinstance(storage_type, pyarrow.lib.FixedSizeBinaryType):
@@ -868,9 +858,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
         return form_popbuffers_finalize(out, awkwardarrow_type)
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized Arrow array type: {storage_type!r}")
-        )
+        raise TypeError(f"unrecognized Arrow array type: {storage_type!r}")
 
 
 def to_awkwardarrow_type(
@@ -1054,7 +1042,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
         return ak.contents.RecordArray([], [], length=0)
 
     else:
-        raise ak._errors.wrap_error(TypeError(f"unrecognized Arrow type: {type(obj)}"))
+        raise TypeError(f"unrecognized Arrow type: {type(obj)}")
 
 
 def form_handle_arrow(schema, pass_empty_field=False):

--- a/src/awkward/_connect/rdataframe/from_rdataframe.py
+++ b/src/awkward/_connect/rdataframe/from_rdataframe.py
@@ -159,10 +159,8 @@ def from_rdataframe(
             form_str = ROOT.awkward.type_to_form[column_types[col], offsets_type](0)
 
             if form_str == "unsupported type":
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        f"{col!r} column's type {column_types[col]!r} is not supported."
-                    )
+                raise TypeError(
+                    f"{col!r} column's type {column_types[col]!r} is not supported."
                 )
 
             form = ak.forms.from_json(form_str)
@@ -211,9 +209,7 @@ def from_rdataframe(
                     builder, result_ptrs[col]
                 )
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError(f"unrecognized Form: {type(form)}")
-                )
+                raise AssertionError(f"unrecognized Form: {type(form)}")
 
             names_nbytes = cpp_buffers_self.names_nbytes[builder_type](builder)
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -83,9 +83,7 @@ def to_buffers(
     if backend is None:
         backend = content._backend
     if not backend.nplike.known_data:
-        raise ak._errors.wrap_error(
-            TypeError("cannot call 'to_buffers' on an array without concrete data")
-        )
+        raise TypeError("cannot call 'to_buffers' on an array without concrete data")
 
     if isinstance(buffer_key, str):
 
@@ -103,19 +101,13 @@ def to_buffers(
             )
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(
-                "buffer_key must be a string or a callable, not {}".format(
-                    type(buffer_key)
-                )
-            )
+        raise TypeError(
+            f"buffer_key must be a string or a callable, not {type(buffer_key)}"
         )
 
     if form_key is None:
-        raise ak._errors.wrap_error(
-            TypeError(
-                "a 'form_key' must be supplied, to match Form elements to buffers in the 'container'"
-            )
+        raise TypeError(
+            "a 'form_key' must be supplied, to match Form elements to buffers in the 'container'"
         )
 
     form = content.form_with_key(form_key=form_key, id_start=id_start)
@@ -138,17 +130,13 @@ def combinations(
     parameters: dict | None = None,
 ):
     if n < 1:
-        raise ak._errors.wrap_error(
-            ValueError("in combinations, 'n' must be at least 1")
-        )
+        raise ValueError("in combinations, 'n' must be at least 1")
 
     recordlookup = None
     if fields is not None:
         recordlookup = fields
         if len(recordlookup) != n:
-            raise ak._errors.wrap_error(
-                ValueError("if provided, the length of 'fields' must be 'n'")
-            )
+            raise ValueError("if provided, the length of 'fields' must be 'n'")
     return layout._combinations(n, replacement, recordlookup, parameters, axis, 1)
 
 
@@ -166,31 +154,25 @@ def unique(layout: Content, axis=None):
             branch, depth = layout.branch_depth
             if branch:
                 if negaxis <= 0:
-                    raise ak._errors.wrap_error(
-                        np.AxisError(
-                            "cannot use non-negative axis on a nested list structure "
-                            "of variable depth (negative axis counts from the leaves "
-                            "of the tree; non-negative from the root)"
-                        )
+                    raise np.AxisError(
+                        "cannot use non-negative axis on a nested list structure "
+                        "of variable depth (negative axis counts from the leaves "
+                        "of the tree; non-negative from the root)"
                     )
                 if negaxis > depth:
-                    raise ak._errors.wrap_error(
-                        np.AxisError(
-                            "cannot use axis={} on a nested list structure that splits into "
-                            "different depths, the minimum of which is depth={} from the leaves".format(
-                                axis, depth
-                            )
+                    raise np.AxisError(
+                        "cannot use axis={} on a nested list structure that splits into "
+                        "different depths, the minimum of which is depth={} from the leaves".format(
+                            axis, depth
                         )
                     )
             else:
                 if negaxis <= 0:
                     negaxis = negaxis + depth
                 if not (0 < negaxis and negaxis <= depth):
-                    raise ak._errors.wrap_error(
-                        np.AxisError(
-                            "axis={} exceeds the depth of this array ({})".format(
-                                axis, depth
-                            )
+                    raise np.AxisError(
+                        "axis={} exceeds the depth of this array ({})".format(
+                            axis, depth
                         )
                     )
 
@@ -201,11 +183,9 @@ def unique(layout: Content, axis=None):
 
         return layout._unique(negaxis, starts, parents, 1)
 
-    raise ak._errors.wrap_error(
-        np.AxisError(
-            "unique expects axis 'None' or '-1', got axis={} that is not supported yet".format(
-                axis
-            )
+    raise np.AxisError(
+        "unique expects axis 'None' or '-1', got axis={} that is not supported yet".format(
+            axis
         )
     )
 
@@ -291,10 +271,8 @@ def reduce(
         if len(parts) > 1:
             # We know that `flatten_records` must fail, so the only other type
             # that can return multiple parts here is the union array
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot use axis=None on an array containing irreducible unions"
-                )
+            raise ValueError(
+                "cannot use axis=None on an array containing irreducible unions"
             )
         elif len(parts) == 0:
             parts = [ak.contents.EmptyArray()]
@@ -322,30 +300,24 @@ def reduce(
 
         if branch:
             if negaxis <= 0:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use non-negative axis on a nested list structure "
-                        "of variable depth (negative axis counts from the leaves of "
-                        "the tree; non-negative from the root)"
-                    )
+                raise ValueError(
+                    "cannot use non-negative axis on a nested list structure "
+                    "of variable depth (negative axis counts from the leaves of "
+                    "the tree; non-negative from the root)"
                 )
             if negaxis > depth:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot use axis={} on a nested list structure that splits into "
-                        "different depths, the minimum of which is depth={} "
-                        "from the leaves".format(axis, depth)
-                    )
+                raise ValueError(
+                    "cannot use axis={} on a nested list structure that splits into "
+                    "different depths, the minimum of which is depth={} "
+                    "from the leaves".format(axis, depth)
                 )
         else:
             if negaxis <= 0:
                 negaxis += depth
             if not 0 < negaxis <= depth:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "axis={} exceeds the depth of the nested list structure "
-                        "(which is {})".format(axis, depth)
-                    )
+                raise ValueError(
+                    "axis={} exceeds the depth of the nested list structure "
+                    "(which is {})".format(axis, depth)
                 )
 
         starts = ak.index.Index64.zeros(1, layout.backend.index_nplike)
@@ -383,31 +355,25 @@ def argsort(
     branch, depth = layout.branch_depth
     if branch:
         if negaxis <= 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot use non-negative axis on a nested list structure "
-                    "of variable depth (negative axis counts from the leaves "
-                    "of the tree; non-negative from the root)"
-                )
+            raise ValueError(
+                "cannot use non-negative axis on a nested list structure "
+                "of variable depth (negative axis counts from the leaves "
+                "of the tree; non-negative from the root)"
             )
         if negaxis > depth:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot use axis={} on a nested list structure that splits into "
-                    "different depths, the minimum of which is depth={} from the leaves".format(
-                        axis, depth
-                    )
+            raise ValueError(
+                "cannot use axis={} on a nested list structure that splits into "
+                "different depths, the minimum of which is depth={} from the leaves".format(
+                    axis, depth
                 )
             )
     else:
         if negaxis <= 0:
             negaxis = negaxis + depth
         if not 0 < negaxis <= depth:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "axis={} exceeds the depth of the nested list structure "
-                    "(which is {})".format(axis, depth)
-                )
+            raise ValueError(
+                "axis={} exceeds the depth of the nested list structure "
+                "(which is {})".format(axis, depth)
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
@@ -430,31 +396,25 @@ def sort(
     branch, depth = layout.branch_depth
     if branch:
         if negaxis <= 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot use non-negative axis on a nested list structure "
-                    "of variable depth (negative axis counts from the leaves "
-                    "of the tree; non-negative from the root)"
-                )
+            raise ValueError(
+                "cannot use non-negative axis on a nested list structure "
+                "of variable depth (negative axis counts from the leaves "
+                "of the tree; non-negative from the root)"
             )
         if negaxis > depth:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot use axis={} on a nested list structure that splits into "
-                    "different depths, the minimum of which is depth={} from the leaves".format(
-                        axis, depth
-                    )
+            raise ValueError(
+                "cannot use axis={} on a nested list structure that splits into "
+                "different depths, the minimum of which is depth={} from the leaves".format(
+                    axis, depth
                 )
             )
     else:
         if negaxis <= 0:
             negaxis = negaxis + depth
         if not 0 < negaxis <= depth:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "axis={} exceeds the depth of the nested list structure "
-                    "(which is {})".format(axis, depth)
-                )
+            raise ValueError(
+                "axis={} exceeds the depth of the nested list structure "
+                "(which is {})".format(axis, depth)
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -199,11 +199,11 @@ class OperationErrorContext(ErrorContext):
                 arguments.append(f"\n        {valuestr}")
 
         extra_line = "" if len(arguments) == 0 else "\n    "
-        return f"""while calling
+        return f"""{exception}.
 
-    {self.name}({"".join(arguments)}{extra_line})
+This error occurred while calling
 
-Error details: {str(exception)}"""
+    {self.name}({"".join(arguments)}{extra_line})"""
 
 
 class SlicingErrorContext(ErrorContext):
@@ -245,20 +245,15 @@ class SlicingErrorContext(ErrorContext):
         return out
 
     def format_exception(self, exception):
-        if isinstance(exception, str):
-            message = exception
-        else:
-            message = f"Error details: {str(exception)}"
+        return f"""{exception}.
 
-        return f"""while attempting to slice
+This error occurred while attempting to slice
 
     {self.array}
 
 with
 
-    {self.where}
-
-{message}"""
+    {self.where}"""
 
     @staticmethod
     def format_slice(x):
@@ -300,26 +295,14 @@ with
 
 
 def index_error(subarray, slicer, details: str = None) -> IndexError:
-    detailsstr = ""
+    message = ""
     if details is not None:
-        detailsstr = f"""
+        message = f": {details}"
 
-Error details: {details}."""
-
-    error_context = ErrorContext.primary()
-    if not isinstance(error_context, SlicingErrorContext):
-        # Note: returns an error for the caller to raise!
-        return IndexError(
-            f"cannot slice {type(subarray).__name__} with {SlicingErrorContext.format_slice(slicer)}{detailsstr}"
-        )
-
-    else:
-        # Note: returns an error for the caller to raise!
-        return IndexError(
-            error_context.format_exception(
-                f"at inner {type(subarray).__name__} of length {subarray.length}, using sub-slice {error_context.format_slice(slicer)}.{detailsstr}"
-            )
-        )
+    # Note: returns an error for the caller to raise!
+    return IndexError(
+        f"cannot slice {type(subarray).__name__} (of length {subarray.length}) with {SlicingErrorContext.format_slice(slicer)}{message}"
+    )
 
 
 ###############################################################################

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -299,40 +299,6 @@ with
             return repr(x)
 
 
-def wrap_error(
-    exception: Exception | type[Exception], error_context: ErrorContext = None
-) -> Exception:
-    """
-    Args:
-        exception: exception object, or exception type to instantiate
-        error_context: context in which error was raised
-
-    Wrap the given exception, instantiating it if needed, to ensure meaningful error messages.
-    """
-    return exception
-    if isinstance(exception, type) and issubclass(exception, Exception):
-        try:
-            exception = exception()
-        except Exception:
-            return exception
-
-    if isinstance(exception, (NotImplementedError, AssertionError)):
-        return type(exception)(
-            str(exception)
-            + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward-1.0/issues"
-        )
-
-    if error_context is None:
-        error_context = ErrorContext.primary()
-
-    if isinstance(error_context, ErrorContext):
-        # Note: returns an error for the caller to raise!
-        return type(exception)(error_context.format_exception(exception))
-    else:
-        # Note: returns an error for the caller to raise!
-        return exception
-
-
 def index_error(subarray, slicer, details: str = None) -> IndexError:
     detailsstr = ""
     if details is not None:

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -61,7 +61,7 @@ class ErrorContext:
             # Raise modified exception
             exc = cls(
                 str(exception)
-                + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward-1.0/issues"
+                + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward/issues"
             )
             exc.__cause__ = exception
         else:

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -211,7 +211,7 @@ class OperationErrorContext(ErrorContext):
         return out
 
     def format_exception(self, exception):
-        return f"{exception}.\n{self.note}"
+        return f"{exception}\n{self.note}"
 
     @property
     def note(self) -> str:
@@ -268,7 +268,7 @@ class SlicingErrorContext(ErrorContext):
         return out
 
     def format_exception(self, exception):
-        return f"{exception}.\n{self.note}"
+        return f"{exception}\n{self.note}"
 
     @property
     def note(self) -> str:

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -33,7 +33,7 @@ class Kernel(Protocol):
 
     @abstractmethod
     def __call__(self, *args) -> KernelError | None:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
 
 class BaseKernel(Kernel):
@@ -77,8 +77,8 @@ class NumpyKernel(BaseKernel):
             elif hasattr(x, "_b_base_"):
                 return ctypes.cast(x, t)
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError("CuPy buffers shouldn't be passed to Numpy Kernels.")
+                raise AssertionError(
+                    "CuPy buffers shouldn't be passed to Numpy Kernels."
                 )
         else:
             return x

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 
 from awkward._backends import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import wrap_error
 from awkward._nplikes import nplike_of
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -52,9 +51,7 @@ def from_arraylib(array, regulararray, recordarray):
 
     def recurse(array, mask=None):
         if Jax.is_tracer(array):
-            raise wrap_error(
-                TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
-            )
+            raise TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
 
         if regulararray and len(array.shape) > 1:
             new_shape = (-1,) + array.shape[2:]
@@ -130,9 +127,7 @@ def from_arraylib(array, regulararray, recordarray):
             return ByteMaskedArray(Index8(mask), data, valid_when=False)
 
     if array.dtype == np.dtype("O"):
-        raise wrap_error(
-            TypeError("Awkward Array does not support arrays with object dtypes.")
-        )
+        raise TypeError("Awkward Array does not support arrays with object dtypes.")
 
     if isinstance(array, numpy.ma.MaskedArray):
         mask = numpy.ma.getmask(array)
@@ -160,9 +155,7 @@ def maybe_posaxis(layout, axis, depth):
 
     if isinstance(layout, Record):
         if axis == 0:
-            raise wrap_error(
-                np.AxisError("Record type at axis=0 is a scalar, not an array")
-            )
+            raise np.AxisError("Record type at axis=0 is a scalar, not an array")
         return maybe_posaxis(layout._array, axis, depth)
 
     if axis >= 0:

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -68,9 +68,7 @@ def tolookup(layout, positions):
         return UnionLookup.tolookup(layout, positions)
 
     else:
-        raise ak._errors.wrap_error(
-            AssertionError(f"unrecognized Content: {type(layout)}")
-        )
+        raise AssertionError(f"unrecognized Content: {type(layout)}")
 
 
 class ContentLookup:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Collection
 
-import awkward as ak
 from awkward._typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
@@ -31,11 +30,9 @@ def common_nplike(nplikes: Collection[NumpyLike]) -> NumpyLike:
             if not nplike.known_data:
                 return nplike
 
-        raise ak._errors.wrap_error(
-            ValueError(
-                "cannot operate on arrays with incompatible array libraries. Use #ak.to_backend to coerce the arrays "
-                "to the same backend"
-            )
+        raise ValueError(
+            "cannot operate on arrays with incompatible array libraries. Use #ak.to_backend to coerce the arrays "
+            "to the same backend"
         )
 
 
@@ -94,20 +91,16 @@ def to_nplike(
     if from_nplike is None:
         from_nplike = nplike_of(array, default=None)
         if from_nplike is None:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    f"internal error: expected an array supported by an existing nplike, got {type(array).__name__!r}"
-                )
+            raise TypeError(
+                f"internal error: expected an array supported by an existing nplike, got {type(array).__name__!r}"
             )
 
     if from_nplike is to_nplike:
         return array
 
     if isinstance(from_nplike, TypeTracer) and nplike is not from_nplike:
-        raise ak._errors.wrap_error(
-            TypeError(
-                "Converting a TypeTracer nplike to an nplike with `known_data=True` is not possible"
-            )
+        raise TypeError(
+            "Converting a TypeTracer nplike to an nplike with `known_data=True` is not possible"
         )
 
     # Copy to host memory
@@ -117,6 +110,4 @@ def to_nplike(
     if isinstance(nplike, (Numpy, Cupy, Jax, TypeTracer)):
         return nplike.asarray(array)
     else:
-        raise ak._errors.wrap_error(
-            TypeError(f"internal error: invalid nplike {type(nplike).__name__!r}")
-        )
+        raise TypeError(f"internal error: invalid nplike {type(nplike).__name__!r}")

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -5,7 +5,6 @@ import math
 
 import numpy
 
-from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._typing import Final, Literal
@@ -31,10 +30,8 @@ class ArrayModuleNumpyLike(NumpyLike):
             return self._module.asarray(obj, dtype=dtype)
         else:
             if getattr(obj, "dtype", dtype) != dtype:
-                raise wrap_error(
-                    ValueError(
-                        "asarray was called with copy=False for an array of a different dtype"
-                    )
+                raise ValueError(
+                    "asarray was called with copy=False for an array of a different dtype"
                 )
             else:
                 return self._module.asarray(obj, dtype=dtype)
@@ -131,20 +128,16 @@ class ArrayModuleNumpyLike(NumpyLike):
             try:
                 result.shape = shape
             except AttributeError:
-                raise wrap_error(
-                    ValueError("cannot reshape array without copying")
-                ) from None
+                raise ValueError("cannot reshape array without copying") from None
             return result
 
     def shape_item_as_index(self, x1: ShapeItem) -> int:
         if x1 is unknown_length:
-            raise wrap_error(
-                TypeError("array module nplikes do not support unknown lengths")
-            )
+            raise TypeError("array module nplikes do not support unknown lengths")
         elif isinstance(x1, int):
             return x1
         else:
-            raise wrap_error(TypeError(f"expected None or int type, received {x1}"))
+            raise TypeError(f"expected None or int type, received {x1}")
 
     def index_as_shape_item(self, x1: IndexType) -> int:
         return int(x1)
@@ -181,9 +174,7 @@ class ArrayModuleNumpyLike(NumpyLike):
         if 0 <= index < length:
             return index
         else:
-            raise wrap_error(
-                IndexError(f"index value out of bounds (0, {length}): {index}")
-            )
+            raise IndexError(f"index value out of bounds (0, {length}): {index}")
 
     def nonzero(self, x: ArrayLike) -> tuple[ArrayLike, ...]:
         return self._module.nonzero(x)

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -19,20 +19,16 @@ class Cupy(ArrayModuleNumpyLike):
 
     @property
     def ma(self):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "CUDA arrays cannot have missing values until CuPy implements "
-                "numpy.ma.MaskedArray"
-            )
+        raise ValueError(
+            "CUDA arrays cannot have missing values until CuPy implements "
+            "numpy.ma.MaskedArray"
         )
 
     @property
     def char(self):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "CUDA arrays cannot do string manipulations until CuPy implements "
-                "numpy.char"
-            )
+        raise ValueError(
+            "CUDA arrays cannot do string manipulations until CuPy implements "
+            "numpy.char"
         )
 
     @property
@@ -55,9 +51,7 @@ class Cupy(ArrayModuleNumpyLike):
         self, x: ArrayLike, repeats: ArrayLike | int, *, axis: int | None = None
     ):
         if axis is not None:
-            raise ak._errors.wrap_error(
-                NotImplementedError(f"repeat for CuPy with axis={axis!r}")
-            )
+            raise NotImplementedError(f"repeat for CuPy with axis={axis!r}")
         # https://github.com/cupy/cupy/issues/3849
         if isinstance(repeats, self._module.ndarray):
             all_stops = self._module.cumsum(repeats)

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -18,20 +18,16 @@ class Jax(ArrayModuleNumpyLike):
 
     @property
     def ma(self):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "JAX arrays cannot have missing values until JAX implements "
-                "numpy.ma.MaskedArray"
-            )
+        raise ValueError(
+            "JAX arrays cannot have missing values until JAX implements "
+            "numpy.ma.MaskedArray"
         )
 
     @property
     def char(self):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "JAX arrays cannot do string manipulations until JAX implements "
-                "numpy.char"
-            )
+        raise ValueError(
+            "JAX arrays cannot do string manipulations until JAX implements "
+            "numpy.char"
         )
 
     @property

--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -16,12 +16,8 @@ class _UnknownLength:
         return self
 
     def __new__(cls, *args, **kwargs):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError(
-                "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
-            )
+        raise TypeError(
+            "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
         )
 
     def __add__(self, other) -> Self | NotImplemented:
@@ -67,33 +63,19 @@ class _UnknownLength:
         return f"{__name__}.{self._name}"
 
     def __eq__(self, other) -> bool:
-        from awkward._errors import wrap_error
-
         if other is self:
             return True
         else:
-            raise wrap_error(
-                TypeError("cannot compare unknown lengths against known values")
-            )
+            raise TypeError("cannot compare unknown lengths against known values")
 
     def __gt__(self, other):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(TypeError("cannot order unknown lengths"))
+        raise TypeError("cannot order unknown lengths")
 
     def __index__(self):  # pylint: disable=invalid-index-returned
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError("cannot interpret unknown lengths as concrete index values")
-        )
+        raise TypeError("cannot interpret unknown lengths as concrete index values")
 
     def __int__(self):
-        from awkward._errors import wrap_error
-
-        raise wrap_error(
-            TypeError("cannot interpret unknown lengths as concrete values")
-        )
+        raise TypeError("cannot interpret unknown lengths as concrete values")
 
     __bool__ = __int__
     __float__ = __int__

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -7,7 +7,6 @@ import numpy
 from numpy.lib.mixins import NDArrayOperatorsMixin
 
 import awkward as ak
-from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._regularize import is_integer, is_non_string_like_sequence
@@ -190,9 +189,7 @@ def _attach_report(layout, form, report: TypeTracerReport):
             _attach_report(x, y, report)
 
     else:
-        raise ak._errors.wrap_error(
-            AssertionError(f"unrecognized layout type {type(layout)}")
-        )
+        raise AssertionError(f"unrecognized layout type {type(layout)}")
 
 
 def typetracer_with_report(form, forget_length=True):
@@ -209,10 +206,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     _shape: tuple[ShapeItem, ...]
 
     def __new__(cls, *args, **kwargs):
-        raise wrap_error(
-            TypeError(
-                "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
-            )
+        raise TypeError(
+            "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
         )
 
     def __reduce__(self):
@@ -232,11 +227,9 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         self.report = report
 
         if not isinstance(shape, tuple):
-            raise wrap_error(TypeError("typetracer shape must be a tuple"))
+            raise TypeError("typetracer shape must be a tuple")
         if any(is_unknown_scalar(x) for x in shape):
-            raise wrap_error(
-                TypeError("typetracer shape must be integers or unknown-length")
-            )
+            raise TypeError("typetracer shape must be integers or unknown-length")
         self._shape = shape
         self._dtype = np.dtype(dtype)
 
@@ -286,7 +279,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     @form_key.setter
     def form_key(self, value):
         if value is not None and not isinstance(value, str):
-            raise ak._errors.wrap_error(TypeError("form_key must be None or a string"))
+            raise TypeError("form_key must be None or a string")
         self._form_key = value
 
     @property
@@ -296,9 +289,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     @report.setter
     def report(self, value):
         if value is not None and not isinstance(value, TypeTracerReport):
-            raise ak._errors.wrap_error(
-                TypeError("report must be None or a TypeTracerReport")
-            )
+            raise TypeError("report must be None or a TypeTracerReport")
         self._report = value
 
     def touch_shape(self):
@@ -352,17 +343,13 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     def __iter__(self):
-        raise ak._errors.wrap_error(
-            AssertionError(
-                "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
-            )
+        raise AssertionError(
+            "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
         )
 
     def __array__(self, dtype=None):
-        raise ak._errors.wrap_error(
-            AssertionError(
-                "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
-            )
+        raise AssertionError(
+            "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
         )
 
     @property
@@ -377,10 +364,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return self._CTypes
 
     def __len__(self):
-        raise ak._errors.wrap_error(
-            AssertionError(
-                "bug in Awkward Array: attempt to get length of a TypeTracerArray"
-            )
+        raise AssertionError(
+            "bug in Awkward Array: attempt to get length of a TypeTracerArray"
         )
 
     def __getitem__(
@@ -413,27 +398,21 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
                 if not has_seen_ellipsis:
                     has_seen_ellipsis = True
                 else:
-                    raise wrap_error(
-                        NotImplementedError(
-                            "only one ellipsis value permitted for advanced index"
-                        )
+                    raise NotImplementedError(
+                        "only one ellipsis value permitted for advanced index"
                     )
             # Basic newaxis
             elif item is np.newaxis:
                 pass
             else:
-                raise wrap_error(
-                    NotImplementedError(
-                        "only integer, unknown scalar, slice, ellipsis, or array indices are permitted"
-                    )
+                raise NotImplementedError(
+                    "only integer, unknown scalar, slice, ellipsis, or array indices are permitted"
                 )
 
         n_dim_index = n_basic_non_ellipsis + n_advanced
         if n_dim_index > self.ndim:
-            raise wrap_error(
-                IndexError(
-                    f"too many indices for array: array is {self.ndim}-dimensional, but {n_dim_index} were indexed"
-                )
+            raise IndexError(
+                f"too many indices for array: array is {self.ndim}-dimensional, but {n_dim_index} were indexed"
             )
 
         # 2. Normalise Ellipsis and boolean arrays
@@ -501,9 +480,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
                         continue
 
                     if not 0 <= item < dimension_length:
-                        raise wrap_error(
-                            NotImplementedError("integer index out of bounds")
-                        )
+                        raise NotImplementedError("integer index out of bounds")
 
         advanced_shape = self.nplike.broadcast_shapes(*advanced_shapes)
         if advanced_is_at_front:
@@ -532,7 +509,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
     ):
         existing_value = self.__getitem__(key)
         if isinstance(value, TypeTracerArray) and value.ndim > existing_value.ndim:
-            raise wrap_error(ValueError("cannot assign shape larger than destination"))
+            raise ValueError("cannot assign shape larger than destination")
 
     def copy(self):
         self.touch_data()
@@ -547,22 +524,20 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         kwargs.pop("out", None)
 
         if method != "__call__" or len(inputs) == 0:
-            raise ak._errors.wrap_error(NotImplementedError)
+            raise NotImplementedError
 
         if len(kwargs) > 0:
-            raise ak._errors.wrap_error(
-                ValueError("TypeTracerArray does not support kwargs for ufuncs")
-            )
+            raise ValueError("TypeTracerArray does not support kwargs for ufuncs")
         return self.nplike._apply_ufunc(ufunc, *inputs)
 
     def __bool__(self) -> bool:
-        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+        raise RuntimeError("cannot realise an unknown value")
 
     def __int__(self) -> int:
-        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+        raise RuntimeError("cannot realise an unknown value")
 
     def __index__(self) -> int:
-        raise ak._errors.wrap_error(RuntimeError("cannot realise an unknown value"))
+        raise RuntimeError("cannot realise an unknown value")
 
 
 def _scalar_type_of(obj) -> numpy.dtype:
@@ -602,7 +577,7 @@ class TypeTracer(NumpyLike):
                 for x, b in zip(result, broadcasted)
             )
         else:
-            raise wrap_error(TypeError)
+            raise TypeError
 
     def _axis_is_valid(self, axis: int, ndim: int) -> bool:
         if axis < 0:
@@ -611,11 +586,11 @@ class TypeTracer(NumpyLike):
 
     @property
     def ma(self):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def char(self):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def ndarray(self):
@@ -642,10 +617,8 @@ class TypeTracer(NumpyLike):
             if dtype is None:
                 return obj
             elif copy is False and dtype != obj.dtype:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "asarray was called with copy=False for an array of a different dtype"
-                    )
+                raise ValueError(
+                    "asarray was called with copy=False for an array of a different dtype"
                 )
             else:
                 return TypeTracerArray._new(
@@ -659,14 +632,10 @@ class TypeTracer(NumpyLike):
             # Support array-like objects
             if hasattr(obj, "shape") and hasattr(obj, "dtype"):
                 if obj.dtype.kind == "S":
-                    raise ak._errors.wrap_error(
-                        TypeError("TypeTracerArray cannot be created from strings")
-                    )
+                    raise TypeError("TypeTracerArray cannot be created from strings")
                 elif copy is False and dtype != obj.dtype:
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "asarray was called with copy=False for an array of a different dtype"
-                        )
+                    raise ValueError(
+                        "asarray was called with copy=False for an array of a different dtype"
                     )
                 else:
                     return TypeTracerArray._new(obj.dtype, obj.shape)
@@ -689,19 +658,15 @@ class TypeTracer(NumpyLike):
                     # ensure this item matches!
                     if has_seen_leaf:
                         if len(node) != shape[dim - 1]:
-                            raise wrap_error(
-                                ValueError(
-                                    f"sequence at dimension {dim} does not match shape {shape[dim-1]}"
-                                )
+                            raise ValueError(
+                                f"sequence at dimension {dim} does not match shape {shape[dim-1]}"
                             )
                     else:
                         shape.append(len(node))
 
                     if isinstance(node, TypeTracerArray):
-                        raise wrap_error(
-                            AssertionError(
-                                "typetracer arrays inside sequences not currently supported"
-                            )
+                        raise AssertionError(
+                            "typetracer arrays inside sequences not currently supported"
                         )
                     # Found leaf!
                     elif len(node) == 0 or not is_non_string_like_sequence(node[0]):
@@ -723,7 +688,7 @@ class TypeTracer(NumpyLike):
                     dtype = numpy.result_type(*flat_items)
                 return TypeTracerArray._new(dtype, shape=tuple(shape))
             else:
-                raise wrap_error(TypeError)
+                raise TypeError
 
     def ascontiguousarray(
         self, x: ArrayLike, *, dtype: numpy.dtype | None = None
@@ -736,7 +701,7 @@ class TypeTracer(NumpyLike):
     ) -> TypeTracerArray:
         for x in (buffer, count):
             try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def zeros(
         self, shape: ShapeItem | tuple[ShapeItem, ...], *, dtype: np.dtype | None = None
@@ -857,7 +822,7 @@ class TypeTracer(NumpyLike):
             )
             and x.size != sorter.size
         ):
-            raise wrap_error(ValueError("x.size should equal sorter.size"))
+            raise ValueError("x.size should equal sorter.size")
 
         return TypeTracerArray._new(x.dtype, (values.size,))
 
@@ -871,7 +836,7 @@ class TypeTracer(NumpyLike):
             as_array = numpy.asarray(obj)
             return TypeTracerArray._new(as_array.dtype, ())
         else:
-            raise wrap_error(TypeError(f"expected scalar type, received {obj}"))
+            raise TypeError(f"expected scalar type, received {obj}")
 
     def shape_item_as_index(self, x1: ShapeItem) -> IndexType:
         if x1 is unknown_length:
@@ -879,7 +844,7 @@ class TypeTracer(NumpyLike):
         elif isinstance(x1, int):
             return x1
         else:
-            raise wrap_error(TypeError(f"expected None or int type, received {x1}"))
+            raise TypeError(f"expected None or int type, received {x1}")
 
     def index_as_shape_item(self, x1: IndexType) -> ShapeItem:
         if is_unknown_scalar(x1) and np.issubdtype(x1.dtype, np.integer):
@@ -913,9 +878,7 @@ class TypeTracer(NumpyLike):
         if 0 <= index < length:
             return index
         else:
-            raise wrap_error(
-                IndexError(f"index value out of bounds (0, {length}): {index}")
-            )
+            raise IndexError(f"index value out of bounds (0, {length}): {index}")
 
     def derive_slice_for_length(
         self, slice_: slice, length: ShapeItem
@@ -1018,10 +981,8 @@ class TypeTracer(NumpyLike):
                 elif result[i] == 1:
                     result[i] = item
                 else:
-                    raise wrap_error(
-                        ValueError(
-                            "known component of shape does not match broadcast result"
-                        )
+                    raise ValueError(
+                        "known component of shape does not match broadcast result"
                     )
         return tuple(result)
 
@@ -1046,7 +1007,7 @@ class TypeTracer(NumpyLike):
     def broadcast_to(
         self, x: ArrayLike, shape: tuple[ShapeItem, ...]
     ) -> TypeTracerArray:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def reshape(
         self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
@@ -1063,19 +1024,17 @@ class TypeTracer(NumpyLike):
                 # Size is no longer defined
                 new_size = unknown_length
             elif not is_integer(item):
-                raise wrap_error(
-                    ValueError(
-                        "shape must be comprised of positive integers, -1 (for placeholders), or unknown lengths"
-                    )
+                raise ValueError(
+                    "shape must be comprised of positive integers, -1 (for placeholders), or unknown lengths"
                 )
             elif item == -1:
                 if n_placeholders == 1:
-                    raise wrap_error(
-                        ValueError("only one placeholder dimension permitted per shape")
+                    raise ValueError(
+                        "only one placeholder dimension permitted per shape"
                     )
                 n_placeholders += 1
             elif item == 0:
-                raise wrap_error(ValueError("shape items cannot be zero"))
+                raise ValueError("shape items cannot be zero")
             else:
                 new_size *= item
 
@@ -1122,7 +1081,7 @@ class TypeTracer(NumpyLike):
         if axis is None:
             assert all(x.ndim == 1 for x in arrays)
         elif axis != 0:
-            raise ak._errors.wrap_error(NotImplementedError("concat with axis != 0"))
+            raise NotImplementedError("concat with axis != 0")
         for x in arrays:
             try_touch_data(x)
 
@@ -1132,19 +1091,15 @@ class TypeTracer(NumpyLike):
             if inner_shape is None:
                 inner_shape = x.shape[1:]
             elif inner_shape != x.shape[1:]:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "inner dimensions don't match in concatenate: {} vs {}".format(
-                            inner_shape, x.shape[1:]
-                        )
+                raise ValueError(
+                    "inner dimensions don't match in concatenate: {} vs {}".format(
+                        inner_shape, x.shape[1:]
                     )
                 )
             emptyarrays.append(_emptyarray(x))
 
         if inner_shape is None:
-            raise ak._errors.wrap_error(
-                ValueError("need at least one array to concatenate")
-            )
+            raise ValueError("need at least one array to concatenate")
 
         return TypeTracerArray._new(
             numpy.concatenate(emptyarrays).dtype, (unknown_length, *inner_shape)
@@ -1159,11 +1114,11 @@ class TypeTracer(NumpyLike):
     ) -> TypeTracerArray:
         try_touch_data(x)
         try_touch_data(repeats)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def tile(self, x: ArrayLike, reps: int) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def stack(
         self,
@@ -1173,7 +1128,7 @@ class TypeTracer(NumpyLike):
     ) -> TypeTracerArray:
         for x in arrays:
             try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def packbits(
         self,
@@ -1183,7 +1138,7 @@ class TypeTracer(NumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def unpackbits(
         self,
@@ -1194,7 +1149,7 @@ class TypeTracer(NumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     ############################ ufuncs
 
@@ -1287,7 +1242,7 @@ class TypeTracer(NumpyLike):
         if axis is None:
             return TypeTracerArray._new(np.bool_, shape=())
         else:
-            raise ak._errors.wrap_error(NotImplementedError)
+            raise NotImplementedError
 
     def any(
         self,
@@ -1301,13 +1256,13 @@ class TypeTracer(NumpyLike):
         if axis is None:
             return TypeTracerArray._new(np.bool_, shape=())
         else:
-            raise ak._errors.wrap_error(NotImplementedError)
+            raise NotImplementedError
 
     def count_nonzero(
         self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
     ) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def min(
         self,
@@ -1318,7 +1273,7 @@ class TypeTracer(NumpyLike):
         maybe_out: ArrayLike | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def max(
         self,
@@ -1329,7 +1284,7 @@ class TypeTracer(NumpyLike):
         maybe_out: ArrayLike | None = None,
     ) -> TypeTracerArray:
         try_touch_data(x)
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def array_str(
         self,

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -316,4 +316,4 @@ def valuestr(data, limit_rows, limit_cols):
         return "\n".join(out)
 
     else:
-        raise ak._errors.wrap_error(AssertionError(type(data)))
+        raise AssertionError(type(data))

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -59,11 +59,11 @@ class Reducer(ABC):
 
     @abstractmethod
     def identity_for(self, dtype: DTypeLike | None):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def apply(self, array, parents, outlength: int):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
 
 class ArgMin(Reducer):
@@ -256,9 +256,7 @@ class Sum(Reducer):
     def apply(self, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
-            raise ak._errors.wrap_error(
-                ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
-            )
+            raise ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
         else:
             dtype = self.maybe_other_type(array.dtype)
         result = array.backend.nplike.empty(
@@ -300,7 +298,7 @@ class Sum(Reducer):
                     )
                 )
             else:
-                raise ak._errors.wrap_error(NotImplementedError)
+                raise NotImplementedError
         elif array.dtype.type in (np.complex128, np.complex64):
             assert parents.nplike is array.backend.index_nplike
             array._handle_error(
@@ -361,9 +359,7 @@ class Prod(Reducer):
     def apply(self, array, parents, outlength):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind.upper() == "M":
-            raise ak._errors.wrap_error(
-                ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
-            )
+            raise ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
         if array.dtype == np.bool_:
             result = array.backend.nplike.empty(
                 self.maybe_double_length(array.dtype.type, outlength),

--- a/src/awkward/_v2.py
+++ b/src/awkward/_v2.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-raise ModuleNotFoundError(  # noqa: AK101
+raise ModuleNotFoundError(
     """The awkward._v2 submodule was provided for early access to awkward>=2, as it developed.
 
 Now that version 2 has been released, awkward._v2 is no longer needed.

--- a/src/awkward/behaviors/mixins.py
+++ b/src/awkward/behaviors/mixins.py
@@ -88,9 +88,7 @@ def mixin_class_method(ufunc, rhs=None, *, transpose=True):
 
     def register(method):
         if not isinstance(rhs, (set, type(None))):
-            raise ak._errors.wrap_error(
-                ValueError("expected a set of right-hand-side argument types")
-            )
+            raise ValueError("expected a set of right-hand-side argument types")
         if transpose and rhs is not None:
             # make a copy of rhs, we will edit it later
             # use partial & a module-scoped function so that this is pickleable

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -41,17 +41,13 @@ class ByteBehavior(Array):
         if isinstance(other, (bytes, ByteBehavior)):
             return bytes(self) + bytes(other)
         else:
-            raise ak._errors.wrap_error(
-                TypeError("can only concatenate bytes to bytes")
-            )
+            raise TypeError("can only concatenate bytes to bytes")
 
     def __radd__(self, other):
         if isinstance(other, (bytes, ByteBehavior)):
             return bytes(other) + bytes(self)
         else:
-            raise ak._errors.wrap_error(
-                TypeError("can only concatenate bytes to bytes")
-            )
+            raise TypeError("can only concatenate bytes to bytes")
 
 
 class CharBehavior(Array):
@@ -86,13 +82,13 @@ class CharBehavior(Array):
         if isinstance(other, (str, CharBehavior)):
             return str(self) + str(other)
         else:
-            raise ak._errors.wrap_error(TypeError("can only concatenate str to str"))
+            raise TypeError("can only concatenate str to str")
 
     def __radd__(self, other):
         if isinstance(other, (str, CharBehavior)):
             return str(other) + str(self)
         else:
-            raise ak._errors.wrap_error(TypeError("can only concatenate str to str"))
+            raise TypeError("can only concatenate str to str")
 
 
 class ByteStringBehavior(Array):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -120,74 +120,58 @@ class BitMaskedArray(Content):
         self, mask, content, valid_when, length, lsb_order, *, parameters=None
     ):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.uint8)):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'mask' must be an Index with dtype=uint8, not {}".format(
-                        type(self).__name__, repr(mask)
-                    )
+            raise TypeError(
+                "{} 'mask' must be an Index with dtype=uint8, not {}".format(
+                    type(self).__name__, repr(mask)
                 )
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if content.is_union or content.is_indexed or content.is_option:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
-                        type(self).__name__, type(content).__name__
-                    )
+            raise TypeError(
+                "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
+                    type(self).__name__, type(content).__name__
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'valid_when' must be boolean, not {}".format(
-                        type(self).__name__, repr(valid_when)
-                    )
+            raise TypeError(
+                "{} 'valid_when' must be boolean, not {}".format(
+                    type(self).__name__, repr(valid_when)
                 )
             )
         if length is not unknown_length:
             if not (is_integer(length) and length >= 0):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'length' must be a non-negative integer, not {}".format(
-                            type(self).__name__, length
-                        )
+                raise TypeError(
+                    "{} 'length' must be a non-negative integer, not {}".format(
+                        type(self).__name__, length
                     )
                 )
         if not isinstance(lsb_order, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'lsb_order' must be boolean, not {}".format(
-                        type(self).__name__, repr(lsb_order)
-                    )
+            raise TypeError(
+                "{} 'lsb_order' must be boolean, not {}".format(
+                    type(self).__name__, repr(lsb_order)
                 )
             )
         if (
             not (length is unknown_length or mask.length is unknown_length)
             and length > mask.length * 8
         ):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} 'length' ({}) must be <= len(mask) * 8 ({})".format(
-                        type(self).__name__, length, mask.length * 8
-                    )
+            raise ValueError(
+                "{} 'length' ({}) must be <= len(mask) * 8 ({})".format(
+                    type(self).__name__, length, mask.length * 8
                 )
             )
         if (
             not (length is unknown_length or content.length is unknown_length)
             and length > content.length * 8
         ):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} 'length' ({}) must be <= len(content) ({})".format(
-                        type(self).__name__, length, content.length
-                    )
+            raise ValueError(
+                "{} 'length' ({}) must be <= len(content) ({})".format(
+                    type(self).__name__, length, content.length
                 )
             )
 
@@ -556,7 +540,7 @@ class BitMaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def project(self, mask=None):
         return self.to_ByteMaskedArray().project(mask)
@@ -754,7 +738,7 @@ class BitMaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         if self._content.is_record:
@@ -790,9 +774,7 @@ class BitMaskedArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -91,46 +91,36 @@ class ByteMaskedArray(Content):
 
     def __init__(self, mask, content, valid_when, *, parameters=None):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.int8)):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'mask' must be an Index with dtype=int8, not {}".format(
-                        type(self).__name__, repr(mask)
-                    )
+            raise TypeError(
+                "{} 'mask' must be an Index with dtype=int8, not {}".format(
+                    type(self).__name__, repr(mask)
                 )
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if content.is_union or content.is_indexed or content.is_option:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
-                        type(self).__name__, type(content).__name__
-                    )
+            raise TypeError(
+                "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
+                    type(self).__name__, type(content).__name__
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'valid_when' must be boolean, not {}".format(
-                        type(self).__name__, repr(valid_when)
-                    )
+            raise TypeError(
+                "{} 'valid_when' must be boolean, not {}".format(
+                    type(self).__name__, repr(valid_when)
                 )
             )
         if (
             not (mask.length is unknown_length or content.length is unknown_length)
             and mask.length > content.length
         ):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} len(mask) ({}) must be <= len(content) ({})".format(
-                        type(self).__name__, mask.length, content.length
-                    )
+            raise ValueError(
+                "{} len(mask) ({}) must be <= len(content) ({})".format(
+                    type(self).__name__, mask.length, content.length
                 )
             )
 
@@ -572,7 +562,7 @@ class ByteMaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def project(self, mask=None):
         mask_length = self._mask.length
@@ -580,11 +570,9 @@ class ByteMaskedArray(Content):
 
         if mask is not None:
             if self._backend.nplike.known_data and mask_length != mask.length:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "mask length ({}) is not equal to {} length ({})".format(
-                            mask.length, type(self).__name__, mask_length
-                        )
+                raise ValueError(
+                    "mask length ({}) is not equal to {} length ({})".format(
+                        mask.length, type(self).__name__, mask_length
                     )
                 )
 
@@ -658,7 +646,7 @@ class ByteMaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex()
 
@@ -801,9 +789,7 @@ class ByteMaskedArray(Content):
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         if n < 1:
-            raise ak._errors.wrap_error(
-                ValueError("in combinations, 'n' must be at least 1")
-            )
+            raise ValueError("in combinations, 'n' must be at least 1")
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -954,12 +940,10 @@ class ByteMaskedArray(Content):
             elif out.is_regular:
                 out_content = out.content
             else:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "reduce_next with unbranching depth > negaxis is only "
-                        "expected to return RegularArray or ListOffsetArray64; "
-                        "instead, it returned " + out
-                    )
+                raise ValueError(
+                    "reduce_next with unbranching depth > negaxis is only "
+                    "expected to return RegularArray or ListOffsetArray64; "
+                    "instead, it returned " + out
                 )
 
             outoffsets = ak.index.Index64.empty(
@@ -1110,7 +1094,7 @@ class ByteMaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         if self._content.is_record:
@@ -1134,9 +1118,7 @@ class ByteMaskedArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -83,11 +83,9 @@ class Content:
         if parameters is None:
             pass
         elif not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be a dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be a dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         else:
@@ -95,46 +93,36 @@ class Content:
                 "string",
                 "bytestring",
             ):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                            type(self).__name__, parameters["__array__"]
-                        )
+                raise TypeError(
+                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                        type(self).__name__, parameters["__array__"]
                     )
                 )
             if not isinstance(self, ak.contents.NumpyArray) and parameters.get(
                 "__array__"
             ) in ("char", "byte"):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                            type(self).__name__, parameters["__array__"]
-                        )
+                raise TypeError(
+                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                        type(self).__name__, parameters["__array__"]
                     )
                 )
             if not self.is_indexed and parameters.get("__array__") == "categorical":
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                            type(self).__name__, parameters["__array__"]
-                        )
+                raise TypeError(
+                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                        type(self).__name__, parameters["__array__"]
                     )
                 )
             if not self.is_record and parameters.get("__array__") == "sorted_map":
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                            type(self).__name__, parameters["__array__"]
-                        )
+                raise TypeError(
+                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                        type(self).__name__, parameters["__array__"]
                     )
                 )
 
         if not isinstance(backend, Backend):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'backend' must be a Backend, not {}".format(
-                        type(self).__name__, repr(backend)
-                    )
+            raise TypeError(
+                "{} 'backend' must be a Backend, not {}".format(
+                    type(self).__name__, repr(backend)
                 )
             )
 
@@ -199,11 +187,9 @@ class Content:
                 return out
 
         else:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "form_key must be None, a string, or a callable, not {}".format(
-                        type(form_key)
-                    )
+            raise TypeError(
+                "form_key must be None, a string, or a callable, not {}".format(
+                    type(form_key)
                 )
             )
 
@@ -213,27 +199,27 @@ class Content:
         self,
         getkey: Callable[[Content], Form],
     ) -> Form:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def form_cls(self) -> type[Form]:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_typetracer(self, forget_length: bool = False) -> Self:
         return self._to_typetracer(forget_length)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _touch_data(self, recursive):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _touch_shape(self, recursive):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def length(self) -> ShapeItem:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _to_buffers(
         self,
@@ -243,7 +229,7 @@ class Content:
         backend: Backend,
         byteorder: Literal["<", ">"],
     ) -> tuple[Form, int, Mapping[str, Any]]:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def __len__(self) -> int:
         return int(self.length)
@@ -274,7 +260,7 @@ class Content:
             message = error.str.decode(errors="surrogateescape")
 
             if error.pass_through:
-                raise ak._errors.wrap_error(ValueError(message + filename))
+                raise ValueError(message + filename)
 
             else:
                 if error.attempt != ak._util.kSliceNone:
@@ -283,7 +269,7 @@ class Content:
                 message += filename
 
                 if slicer is None:
-                    raise ak._errors.wrap_error(ValueError(message))
+                    raise ValueError(message)
                 else:
                     raise ak._errors.index_error(self, slicer, message)
 
@@ -300,7 +286,7 @@ class Content:
             message = error.str.decode(errors="surrogateescape")
 
             if error.pass_through:
-                raise ak._errors.wrap_error(ValueError(message + filename))
+                raise ValueError(message + filename)
 
             else:
                 if error.attempt != ak._util.kSliceNone:
@@ -308,34 +294,26 @@ class Content:
 
                 message += filename
 
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
-            )
+        raise TypeError(
+            "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
         )
 
     def __array_function__(self, func, types, args, kwargs):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
-            )
+        raise TypeError(
+            "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
         )
 
     def __array__(self, **kwargs):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "do not try to convert low-level layouts (Content subclasses) into NumPy arrays; put them in ak.highlevel.Array"
-            )
+        raise TypeError(
+            "do not try to convert low-level layouts (Content subclasses) into NumPy arrays; put them in ak.highlevel.Array"
         )
 
     def __iter__(self):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot iterate on an array without concrete data")
-            )
+            raise TypeError("cannot iterate on an array without concrete data")
 
         for i in range(len(self)):
             yield self._getitem_at(i)
@@ -503,9 +481,7 @@ class Content:
 
         if isinstance(head.content, ak.contents.ListOffsetArray):
             if self._backend.nplike.known_data and self.length != 1:
-                raise ak._errors.wrap_error(
-                    NotImplementedError("reached a not-well-considered code path")
-                )
+                raise NotImplementedError("reached a not-well-considered code path")
             return self._getitem_next_missing_jagged(head, tail, advanced, self)
 
         if isinstance(head.content, ak.contents.NumpyArray):
@@ -533,11 +509,9 @@ class Content:
                         )
                     )
                 else:
-                    raise ak._errors.wrap_error(
-                        NotImplementedError(
-                            "FIXME: unhandled case of SliceMissing with RecordArray containing {}".format(
-                                content
-                            )
+                    raise NotImplementedError(
+                        "FIXME: unhandled case of SliceMissing with RecordArray containing {}".format(
+                            content
                         )
                     )
 
@@ -549,10 +523,8 @@ class Content:
             )
 
         else:
-            raise ak._errors.wrap_error(
-                NotImplementedError(
-                    f"FIXME: unhandled case of SliceMissing with {nextcontent}"
-                )
+            raise NotImplementedError(
+                f"FIXME: unhandled case of SliceMissing with {nextcontent}"
             )
 
     def __getitem__(self, where):
@@ -651,11 +623,9 @@ class Content:
                     wheres = self._backend.index_nplike.nonzero(data_as_index)
                     return self._getitem(wheres)
             else:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "array slice must be an array of integers or booleans, not\n\n    {}".format(
-                            repr(where.data).replace("\n", "\n    ")
-                        )
+                raise TypeError(
+                    "array slice must be an array of integers or booleans, not\n\n    {}".format(
+                        repr(where.data).replace("\n", "\n    ")
                     )
                 )
 
@@ -695,10 +665,8 @@ class Content:
             if nplike is not None and nplike.is_own_array(where):
                 # Is it a scalar, not array?
                 if len(where.shape) == 0:
-                    raise ak._errors.wrap_error(
-                        AssertionError(
-                            "scalar arrays should be handled by integer-like indexing"
-                        )
+                    raise AssertionError(
+                        "scalar arrays should be handled by integer-like indexing"
                     )
                 else:
                     layout = ak.operations.ak_to_layout._impl(
@@ -725,31 +693,29 @@ class Content:
                 return self._getitem(layout)
 
         else:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "only integers, slices (`:`), ellipsis (`...`), np.newaxis (`None`), "
-                    "integer/boolean arrays (possibly with variable-length nested "
-                    "lists or missing values), field name (str) or names (non-tuple "
-                    "iterable of str) are valid indices for slicing, not\n\n    "
-                    + repr(where).replace("\n", "\n    ")
-                )
+            raise TypeError(
+                "only integers, slices (`:`), ellipsis (`...`), np.newaxis (`None`), "
+                "integer/boolean arrays (possibly with variable-length nested "
+                "lists or missing values), field name (str) or names (non-tuple "
+                "iterable of str) are valid indices for slicing, not\n\n    "
+                + repr(where).replace("\n", "\n    ")
             )
 
     def _getitem_at(self, where: IndexType):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _getitem_range(self, start: SupportsIndex, stop: IndexType) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _getitem_field(
         self, where: str | SupportsIndex, only_fields: tuple[str, ...] = ()
     ) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _getitem_fields(
         self, where: list[str], only_fields: tuple[str, ...] = ()
     ) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _getitem_next(
         self,
@@ -757,10 +723,10 @@ class Content:
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _carry(self, carry: Index, allow_lazy: bool) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _local_index_axis0(self) -> ak.contents.NumpyArray:
         localindex = Index64.empty(self.length, self._backend.index_nplike)
@@ -775,22 +741,20 @@ class Content:
         )
 
     def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _mergemany(
         self,
         others: list[Content],
     ) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _merging_strategy(
         self, others: list[Content]
     ) -> tuple[list[Content], list[Content]]:
         if len(others) == 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "to merge this array with 'others', at least one other must be provided"
-                )
+            raise ValueError(
+                "to merge this array with 'others', at least one other must be provided"
             )
 
         head = [self]
@@ -832,7 +796,7 @@ class Content:
         return (head, tail)
 
     def _local_index(self, axis: int, depth: int):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _reduce_next(
         self,
@@ -846,7 +810,7 @@ class Content:
         keepdims: bool,
         behavior: dict | None,
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _argsort_next(
         self,
@@ -858,7 +822,7 @@ class Content:
         ascending: bool,
         stable: bool,
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _sort_next(
         self,
@@ -869,7 +833,7 @@ class Content:
         ascending: bool,
         stable: bool,
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _combinations_axis0(
         self,
@@ -953,7 +917,7 @@ class Content:
         axis: int,
         depth: int,
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _validity_error_parameters(self, path: str) -> str:
         if self.parameter("__array__") == "categorical":
@@ -964,7 +928,7 @@ class Content:
         return ""
 
     def _validity_error(self, path: str) -> str:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def nbytes(self) -> int:
@@ -987,7 +951,7 @@ class Content:
         parents: Index,
         outlength: int,
     ) -> bool:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _unique(
         self,
@@ -996,7 +960,7 @@ class Content:
         parents: Index,
         outlength: int,
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def is_identity_like(self) -> bool:
@@ -1066,7 +1030,7 @@ class Content:
         )
 
     def _pad_none(self, target: int, axis: int, depth: int, clip: bool) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_arrow(
         self,
@@ -1107,7 +1071,7 @@ class Content:
         length: int,
         options: dict[str, Any],
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_numpy(self, allow_missing: bool = True):
         ak._errors.deprecate(
@@ -1129,16 +1093,16 @@ class Content:
         return self._to_backend_array(allow_missing, backend)
 
     def _to_backend_array(self, allow_missing: bool, backend: ak._backends.Backend):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def drop_none(self):
         return self._drop_none()
 
     def _drop_none(self) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _remove_structure(self, backend, options):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _recursively_apply(
         self,
@@ -1149,7 +1113,7 @@ class Content:
         lateral_context: dict | None,
         options: RecursivelyApplyOptionsType,
     ) -> Content | None:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_json(
         self,
@@ -1187,7 +1151,7 @@ class Content:
         )
 
     def to_packed(self) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_list(self, behavior: dict | None = None) -> list:
         return self.to_packed()._to_list(behavior, None)
@@ -1195,7 +1159,7 @@ class Content:
     def _to_list(
         self, behavior: dict | None, json_conversions: dict[str, Any] | None
     ) -> list:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _to_list_custom(
         self, behavior: dict | None, json_conversions: dict[str, Any] | None
@@ -1298,7 +1262,7 @@ class Content:
             return out
 
     def _offsets_and_flattened(self, axis: int, depth: int) -> tuple[Index, Content]:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def to_backend(self, backend: Backend | str | None = None) -> Self:
         if backend is None:
@@ -1311,7 +1275,7 @@ class Content:
             return self._to_backend(backend)
 
     def _to_backend(self, backend: Backend) -> Self:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def with_parameter(self, key: str, value: Any) -> Self:
         out = copy.copy(self)
@@ -1326,10 +1290,10 @@ class Content:
         return out
 
     def __copy__(self):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def __deepcopy__(self, memo):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def is_equal_to(
         self, other: Content, index_dtype: bool = True, numpyarray: bool = True
@@ -1342,16 +1306,16 @@ class Content:
         )
 
     def _is_equal_to(self, other: Self, index_dtype: bool, numpyarray: bool) -> bool:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _repr(self, indent: str, pre: str, post: str) -> str:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _numbers_to_type(self, name: str, including_unknown: bool) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _fill_none(self, value: Content) -> Content:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def copy(self, *, parameters: JSONMapping | None = unset) -> Self:
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -228,14 +228,12 @@ class EmptyArray(Content):
             raise ak._errors.index_error(self, head, "array is empty")
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(
-                np.AxisError(self, "axis=0 not allowed for flatten")
-            )
+            raise np.AxisError(self, "axis=0 not allowed for flatten")
         else:
             offsets = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
             return (
@@ -266,9 +264,7 @@ class EmptyArray(Content):
                 backend=self._backend,
             )
         else:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     def _numbers_to_type(self, name, including_unknown):
         if including_unknown:
@@ -332,9 +328,7 @@ class EmptyArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self._pad_none_axis0(target, True)
 
@@ -402,16 +396,14 @@ class EmptyArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         return self
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
         return []
 
     def _to_backend(self, backend: ak._backends.Backend) -> Self:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -92,27 +92,21 @@ class IndexedArray(Content):
                 np.dtype(np.int64),
             )
         ):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
-                    "not {}".format(type(self).__name__, repr(index))
-                )
+            raise TypeError(
+                "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
+                "not {}".format(type(self).__name__, repr(index))
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         is_cat = parameters is not None and parameters.get("__array__") == "categorical"
         if (content.is_union and not is_cat) or content.is_indexed or content.is_option:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{0} cannot contain a union-type (unless categorical), option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
-                        type(self).__name__, type(content).__name__
-                    )
+            raise TypeError(
+                "{0} cannot contain a union-type (unless categorical), option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
+                    type(self).__name__, type(content).__name__
                 )
             )
 
@@ -407,16 +401,14 @@ class IndexedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def project(self, mask=None):
         if mask is not None:
             if self._backend.nplike.known_data and self._index.length != mask.length:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "mask length ({}) is not equal to {} length ({})".format(
-                            mask.length(), type(self).__name__, self._index.length
-                        )
+                raise ValueError(
+                    "mask length ({}) is not equal to {} length ({})".format(
+                        mask.length(), type(self).__name__, self._index.length
                     )
                 )
             nextindex = ak.index.Index64.empty(
@@ -475,7 +467,7 @@ class IndexedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
 
         else:
             return self.project()._offsets_and_flattened(axis, depth)
@@ -494,10 +486,8 @@ class IndexedArray(Content):
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "to merge this array with 'others', at least one other must be provided"
-                )
+            raise ValueError(
+                "to merge this array with 'others', at least one other must be provided"
             )
 
         head = [self]
@@ -673,8 +663,8 @@ class IndexedArray(Content):
 
     def _fill_none(self, value: Content) -> Content:
         if value.backend.nplike.known_data and value.length != 1:
-            raise ak._errors.wrap_error(
-                ValueError(f"fill_none value length ({value.length}) is not equal to 1")
+            raise ValueError(
+                f"fill_none value length ({value.length}) is not equal to 1"
             )
         return IndexedArray(
             self._index, self._content._fill_none(value), parameters=self._parameters
@@ -855,12 +845,10 @@ class IndexedArray(Content):
 
             if isinstance(unique, ak.contents.ListOffsetArray):
                 if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                    raise ak._errors.wrap_error(
-                        AssertionError(
-                            "reduce_next with unbranching depth > negaxis expects a "
-                            "ListOffsetArray64 whose offsets start at zero ({})".format(
-                                starts[0]
-                            )
+                    raise AssertionError(
+                        "reduce_next with unbranching depth > negaxis expects a "
+                        "ListOffsetArray64 whose offsets start at zero ({})".format(
+                            starts[0]
                         )
                     )
 
@@ -899,7 +887,7 @@ class IndexedArray(Content):
                     nextoutindex, unique, parameters=self._parameters
                 )
 
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _argsort_next(
         self, negaxis, starts, shifts, parents, outlength, ascending, stable
@@ -1104,7 +1092,7 @@ class IndexedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         if self.parameter("__array__") == "categorical":
@@ -1116,9 +1104,7 @@ class IndexedArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -90,27 +90,21 @@ class IndexedOptionArray(Content):
                 np.dtype(np.int64),
             )
         ):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
-                    "not {}".format(type(self).__name__, repr(index))
-                )
+            raise TypeError(
+                "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
+                "not {}".format(type(self).__name__, repr(index))
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         is_cat = parameters is not None and parameters.get("__array__") == "categorical"
         if (content.is_union and not is_cat) or content.is_indexed or content.is_option:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{0} cannot contain a union-type (unless categorical), option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
-                        type(self).__name__, type(content).__name__
-                    )
+            raise TypeError(
+                "{0} cannot contain a union-type (unless categorical), option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
+                    type(self).__name__, type(content).__name__
                 )
             )
 
@@ -489,16 +483,14 @@ class IndexedOptionArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def project(self, mask=None):
         if mask is not None:
             if self._backend.nplike.known_data and self._index.length != mask.length:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "mask length ({}) is not equal to {} length ({})".format(
-                            mask.length(), type(self).__name__, self._index.length
-                        )
+                raise ValueError(
+                    "mask length ({}) is not equal to {} length ({})".format(
+                        mask.length(), type(self).__name__, self._index.length
                     )
                 )
             nextindex = ak.index.Index64.empty(
@@ -571,7 +563,7 @@ class IndexedOptionArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex()
             next = self._content._carry(nextcarry, False)
@@ -628,10 +620,8 @@ class IndexedOptionArray(Content):
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "to merge this array with 'others', at least one other must be provided"
-                )
+            raise ValueError(
+                "to merge this array with 'others', at least one other must be provided"
             )
 
         head = [self]
@@ -810,8 +800,8 @@ class IndexedOptionArray(Content):
 
     def _fill_none(self, value: Content) -> Content:
         if value.backend.nplike.known_data and value.length != 1:
-            raise ak._errors.wrap_error(
-                ValueError(f"fill_none value length ({value.length}) is not equal to 1")
+            raise ValueError(
+                f"fill_none value length ({value.length}) is not equal to 1"
             )
 
         contents = [self._content, value]
@@ -1389,23 +1379,17 @@ class IndexedOptionArray(Content):
             elif out.is_regular:
                 out_content = out.content
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "reduce_next with unbranching depth > negaxis is only "
-                        "expected to return RegularArray or ListOffsetArray or "
-                        "IndexedOptionArray; "
-                        "instead, it returned {}".format(type(out).__name__)
-                    )
+                raise AssertionError(
+                    "reduce_next with unbranching depth > negaxis is only "
+                    "expected to return RegularArray or ListOffsetArray or "
+                    "IndexedOptionArray; "
+                    "instead, it returned {}".format(type(out).__name__)
                 )
 
             if starts.nplike.known_data and starts.length > 0 and starts[0] != 0:
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "reduce_next with unbranching depth > negaxis expects a "
-                        "ListOffsetArray whose offsets start at zero ({})".format(
-                            starts[0]
-                        )
-                    )
+                raise AssertionError(
+                    "reduce_next with unbranching depth > negaxis expects a "
+                    "ListOffsetArray whose offsets start at zero ({})".format(starts[0])
                 )
             # In this branch, we're above the axis at which the reduction takes place.
             # `next._reduce_next` is therefore expected to return a list/regular layout
@@ -1578,18 +1562,14 @@ class IndexedOptionArray(Content):
                 elif np.issubdtype(content.dtype, np.bytes_):
                     data[mask0] = b""
                 else:
-                    raise ak._errors.wrap_error(
-                        AssertionError(f"unrecognized dtype: {content.dtype}")
-                    )
+                    raise AssertionError(f"unrecognized dtype: {content.dtype}")
 
                 return nplike.ma.MaskedArray(data, mask)
             else:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "Content.to_nplike cannot convert 'None' values to "
-                        "np.ma.MaskedArray unless the "
-                        "'allow_missing' parameter is set to True"
-                    )
+                raise ValueError(
+                    "Content.to_nplike cannot convert 'None' values to "
+                    "np.ma.MaskedArray unless the "
+                    "'allow_missing' parameter is set to True"
                 )
         else:
             if allow_missing:
@@ -1678,7 +1658,7 @@ class IndexedOptionArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         original_index = self._index.raw(self._backend.nplike)
@@ -1708,9 +1688,7 @@ class IndexedOptionArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -108,27 +108,19 @@ class ListArray(Content):
             np.dtype(np.uint32),
             np.dtype(np.int64),
         ):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'starts' must be an Index with dtype in (int32, uint32, int64), "
-                    "not {}".format(type(self).__name__, repr(starts))
-                )
+            raise TypeError(
+                "{} 'starts' must be an Index with dtype in (int32, uint32, int64), "
+                "not {}".format(type(self).__name__, repr(starts))
             )
         if not (isinstance(stops, Index) and starts.dtype == stops.dtype):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'stops' must be an Index with the same dtype as 'starts' ({}), "
-                    "not {}".format(
-                        type(self).__name__, repr(starts.dtype), repr(stops)
-                    )
-                )
+            raise TypeError(
+                "{} 'stops' must be an Index with the same dtype as 'starts' ({}), "
+                "not {}".format(type(self).__name__, repr(starts.dtype), repr(stops))
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if (
@@ -136,30 +128,24 @@ class ListArray(Content):
             and stops.nplike.known_data
             and starts.length > stops.length
         ):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} len(starts) ({}) must be <= len(stops) ({})".format(
-                        type(self).__name__, starts.length, stops.length
-                    )
+            raise ValueError(
+                "{} len(starts) ({}) must be <= len(stops) ({})".format(
+                    type(self).__name__, starts.length, stops.length
                 )
             )
 
         if parameters is not None and parameters.get("__array__") == "string":
             if not content.is_numpy or not content.parameter("__array__") == "char":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if parameters is not None and parameters.get("__array__") == "bytestring":
             if not content.is_numpy or not content.parameter("__array__") == "byte":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
 
@@ -644,11 +630,9 @@ class ListArray(Content):
                     parameters=self._parameters,
                 )
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "expected ListOffsetArray from ListArray._getitem_next_jagged, got {}".format(
-                            type(out).__name__
-                        )
+                raise AssertionError(
+                    "expected ListOffsetArray from ListArray._getitem_next_jagged, got {}".format(
+                        type(out).__name__
                     )
                 )
 
@@ -656,11 +640,9 @@ class ListArray(Content):
             return self
 
         else:
-            raise ak._errors.wrap_error(
-                AssertionError(
-                    "expected Index/IndexedOptionArray/ListOffsetArray in ListArray._getitem_next_jagged, got {}".format(
-                        type(slicecontent).__name__
-                    )
+            raise AssertionError(
+                "expected Index/IndexedOptionArray/ListOffsetArray in ListArray._getitem_next_jagged, got {}".format(
+                    type(slicecontent).__name__
                 )
             )
 
@@ -1023,7 +1005,7 @@ class ListArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
@@ -1081,14 +1063,12 @@ class ListArray(Content):
             ):
                 contents.append(array.content)
             else:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "cannot merge "
-                        + type(self).__name__
-                        + " with "
-                        + type(array).__name__
-                        + "."
-                    )
+                raise ValueError(
+                    "cannot merge "
+                    + type(self).__name__
+                    + " with "
+                    + type(array).__name__
+                    + "."
                 )
 
         tail_contents = contents[1:]
@@ -1529,16 +1509,14 @@ class ListArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         return self.to_ListOffsetArray64(True).to_packed()
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         return ListOffsetArray._to_list(self, behavior, json_conversions)
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -100,45 +100,35 @@ class ListOffsetArray(Content):
             np.dtype(np.uint32),
             np.dtype(np.int64),
         ):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'offsets' must be an Index with dtype in (int32, uint32, int64), "
-                    "not {}".format(type(self).__name__, repr(offsets))
-                )
+            raise TypeError(
+                "{} 'offsets' must be an Index with dtype in (int32, uint32, int64), "
+                "not {}".format(type(self).__name__, repr(offsets))
             )
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if offsets.length is not unknown_length and offsets.length == 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} len(offsets) ({}) must be >= 1".format(
-                        type(self).__name__, offsets.length
-                    )
+            raise ValueError(
+                "{} len(offsets) ({}) must be >= 1".format(
+                    type(self).__name__, offsets.length
                 )
             )
 
         if parameters is not None and parameters.get("__array__") == "string":
             if not content.is_numpy or not content.parameter("__array__") == "char":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if parameters is not None and parameters.get("__array__") == "bytestring":
             if not content.is_numpy or not content.parameter("__array__") == "byte":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
 
@@ -378,20 +368,16 @@ class ListOffsetArray(Content):
 
     def _broadcast_tooffsets64(self, offsets):
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
-            raise ak._errors.wrap_error(
-                AssertionError(
-                    "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
-                        "(empty)" if offsets.length == 0 else str(offsets[0])
-                    )
+            raise AssertionError(
+                "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
+                    "(empty)" if offsets.length == 0 else str(offsets[0])
                 )
             )
 
         if offsets.nplike.known_data and offsets.length - 1 != self.length:
-            raise ak._errors.wrap_error(
-                AssertionError(
-                    "cannot broadcast {} of length {} to length {}".format(
-                        type(self).__name__, self.length, offsets.length - 1
-                    )
+            raise AssertionError(
+                "cannot broadcast {} of length {} to length {}".format(
+                    type(self).__name__, self.length, offsets.length - 1
                 )
             )
 
@@ -716,12 +702,12 @@ class ListOffsetArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
 
         elif posaxis is not None and posaxis + 1 == depth + 1:
             listoffsetarray = self.to_ListOffsetArray64(True)
@@ -884,10 +870,8 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis is not None and negaxis != depth):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "array with strings can only be checked on uniqueness with axis=-1"
-                    )
+                raise ValueError(
+                    "array with strings can only be checked on uniqueness with axis=-1"
                 )
 
             # FIXME: check validity error
@@ -939,9 +923,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -956,9 +938,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1059,9 +1039,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1107,9 +1085,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1248,9 +1224,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1294,9 +1268,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._errors.wrap_error(
-                    np.AxisError("array with strings can only be sorted with axis=-1")
-                )
+                raise np.AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1387,10 +1359,8 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
-                    )
+                raise ValueError(
+                    "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                 )
 
             starts = self.starts
@@ -2151,7 +2121,7 @@ class ListOffsetArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         next = self.to_ListOffsetArray64(True)
@@ -2169,9 +2139,7 @@ class ListOffsetArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         starts, stops = self.starts, self.stops
         starts_data = starts.raw(numpy)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -101,21 +101,17 @@ class NumpyArray(Content):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
 
         if len(self._data.shape) == 0:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'data' must be an array, not a scalar: {}".format(
-                        type(self).__name__, repr(data)
-                    )
+            raise TypeError(
+                "{} 'data' must be an array, not a scalar: {}".format(
+                    type(self).__name__, repr(data)
                 )
             )
 
         if parameters is not None and parameters.get("__array__") in ("char", "byte"):
             if data.dtype != np.dtype(np.uint8) or len(data.shape) != 1:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a {}, so its 'data' must be 1-dimensional and uint8, not {}".format(
-                            type(self).__name__, parameters["__array__"], repr(data)
-                        )
+                raise ValueError(
+                    "{} is a {}, so its 'data' must be 1-dimensional and uint8, not {}".format(
+                        type(self).__name__, parameters["__array__"], repr(data)
                     )
                 )
 
@@ -404,20 +400,18 @@ class NumpyArray(Content):
             return next._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
 
         elif len(self.shape) != 1:
             return self.to_RegularArray()._offsets_and_flattened(axis, depth)
 
         else:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     def _mergeable_next(self, other, mergebool):
         # Is the other content is an identity, or a union?
@@ -488,13 +482,11 @@ class NumpyArray(Content):
             if isinstance(array, ak.contents.NumpyArray):
                 contiguous_arrays.append(array.data)
             else:
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "cannot merge "
-                        + type(self).__name__
-                        + " with "
-                        + type(array).__name__
-                    )
+                raise AssertionError(
+                    "cannot merge "
+                    + type(self).__name__
+                    + " with "
+                    + type(array).__name__
                 )
 
         contiguous_arrays = self._backend.nplike.concat(contiguous_arrays)
@@ -520,9 +512,7 @@ class NumpyArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif len(self.shape) <= 1:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self.to_RegularArray()._local_index(axis, depth)
 
@@ -885,9 +875,7 @@ class NumpyArray(Content):
         self, negaxis, starts, shifts, parents, outlength, ascending, stable
     ):
         if len(self.shape) == 0:
-            raise ak._errors.wrap_error(
-                TypeError(f"{type(self).__name__} attempting to argsort a scalar ")
-            )
+            raise TypeError(f"{type(self).__name__} attempting to argsort a scalar ")
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
             return contiguous_self.to_RegularArray()._argsort_next(
@@ -994,9 +982,7 @@ class NumpyArray(Content):
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
         if len(self.shape) == 0:
-            raise ak._errors.wrap_error(
-                TypeError(f"{type(self).__name__} attempting to sort a scalar ")
-            )
+            raise TypeError(f"{type(self).__name__} attempting to sort a scalar ")
 
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
@@ -1080,9 +1066,7 @@ class NumpyArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif len(self.shape) <= 1:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self.to_RegularArray()._combinations(
                 n, replacement, recordlookup, parameters, axis, depth
@@ -1213,16 +1197,12 @@ class NumpyArray(Content):
 
     def _pad_none(self, target, axis, depth, clip):
         if len(self.shape) == 0:
-            raise ak._errors.wrap_error(
-                ValueError("cannot apply ak.pad_none to a scalar")
-            )
+            raise ValueError("cannot apply ak.pad_none to a scalar")
         elif len(self.shape) > 1 or not self.is_contiguous:
             return self.to_RegularArray()._pad_none(target, axis, depth, clip)
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         if not clip:
             if target < self.length:
                 return self
@@ -1318,16 +1298,14 @@ class NumpyArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         return self.to_contiguous().to_RegularArray()
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         if self.parameter("__array__") == "byte":
             convert_bytes = (

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -136,11 +136,9 @@ class RecordArray(Content):
         if not (length is None or length is unknown_length):
             length = int(length)  # TODO: this should not happen!
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         if not isinstance(contents, list):
@@ -148,23 +146,19 @@ class RecordArray(Content):
 
         for content in contents:
             if not isinstance(content, Content):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Content subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Content subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
             if backend is None:
                 backend = content.backend
             elif backend is not content.backend:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'contents' must use the same array library (backend): {} vs {}".format(
-                            type(self).__name__,
-                            type(backend).__name__,
-                            type(content.backend).__name__,
-                        )
+                raise TypeError(
+                    "{} 'contents' must use the same array library (backend): {} vs {}".format(
+                        type(self).__name__,
+                        type(backend).__name__,
+                        type(content.backend).__name__,
                     )
                 )
 
@@ -174,11 +168,9 @@ class RecordArray(Content):
 
         if length is None:
             if len(contents) == 0:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} if len(contents) == 0, a 'length' must be specified".format(
-                            type(self).__name__
-                        )
+                raise TypeError(
+                    "{} if len(contents) == 0, a 'length' must be specified".format(
+                        type(self).__name__
                     )
                 )
 
@@ -209,20 +201,16 @@ class RecordArray(Content):
         elif length is not unknown_length:
             for content in contents:
                 if content.length is not unknown_length and content.length < length:
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "{} len(content) ({}) must be >= length ({}) for all 'contents'".format(
-                                type(self).__name__, content.length, length
-                            )
+                    raise ValueError(
+                        "{} len(content) ({}) must be >= length ({}) for all 'contents'".format(
+                            type(self).__name__, content.length, length
                         )
                     )
 
             if not (is_integer(length) and length >= 0):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'length' must be a non-negative integer or None, not {}".format(
-                            type(self).__name__, repr(length)
-                        )
+                raise TypeError(
+                    "{} 'length' must be a non-negative integer or None, not {}".format(
+                        type(self).__name__, repr(length)
                     )
                 )
 
@@ -230,27 +218,21 @@ class RecordArray(Content):
             if not isinstance(fields, list):
                 fields = list(fields)
             if not all(isinstance(x, str) for x in fields):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'fields' must all be strings, not {}".format(
-                            type(self).__name__, repr(fields)
-                        )
+                raise TypeError(
+                    "{} 'fields' must all be strings, not {}".format(
+                        type(self).__name__, repr(fields)
                     )
                 )
             if not len(contents) == len(fields):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} len(contents) ({}) must be equal to len(fields) ({})".format(
-                            type(self).__name__, len(contents), len(fields)
-                        )
+                raise ValueError(
+                    "{} len(contents) ({}) must be equal to len(fields) ({})".format(
+                        type(self).__name__, len(contents), len(fields)
                     )
                 )
         elif fields is not None:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'fields' must be an iterable or None, not {}".format(
-                        type(self).__name__, repr(fields)
-                    )
+            raise TypeError(
+                "{} 'fields' must be an iterable or None, not {}".format(
+                    type(self).__name__, repr(fields)
                 )
             )
 
@@ -610,13 +592,11 @@ class RecordArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
 
         elif posaxis is not None and posaxis + 1 == depth + 1:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "arrays of records cannot be flattened (but their contents can be; try a different 'axis')"
-                )
+            raise ValueError(
+                "arrays of records cannot be flattened (but their contents can be; try a different 'axis')"
             )
 
         else:
@@ -625,10 +605,8 @@ class RecordArray(Content):
                 trimmed = content._getitem_range(0, self.length)
                 offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
-                    raise ak._errors.wrap_error(
-                        AssertionError(
-                            "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
-                        )
+                    raise AssertionError(
+                        "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
                     )
                 contents.append(flattened)
             offsets = ak.index.Index64.zeros(
@@ -711,23 +689,17 @@ class RecordArray(Content):
                                 field = array[self.index_to_field(i)]
                                 for_each_field[i].append(field[0 : array.length])
                         else:
-                            raise ak._errors.wrap_error(
-                                ValueError(
-                                    "cannot merge tuples with different numbers of fields"
-                                )
+                            raise ValueError(
+                                "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ak._errors.wrap_error(
-                            ValueError("cannot merge tuple with non-tuple record")
-                        )
+                        raise ValueError("cannot merge tuple with non-tuple record")
                 else:
-                    raise ak._errors.wrap_error(
-                        AssertionError(
-                            "cannot merge "
-                            + type(self).__name__
-                            + " with "
-                            + type(array).__name__
-                        )
+                    raise AssertionError(
+                        "cannot merge "
+                        + type(self).__name__
+                        + " with "
+                        + type(array).__name__
                     )
 
         else:
@@ -749,26 +721,20 @@ class RecordArray(Content):
                                 trimmed = field[0 : array.length]
                                 for_each_field[i].append(trimmed)
                         else:
-                            raise ak._errors.wrap_error(
-                                AssertionError(
-                                    "cannot merge records with different sets of field names"
-                                )
+                            raise AssertionError(
+                                "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise ak._errors.wrap_error(
-                            AssertionError("cannot merge non-tuple record with tuple")
-                        )
+                        raise AssertionError("cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
                 else:
-                    raise ak._errors.wrap_error(
-                        AssertionError(
-                            "cannot merge "
-                            + type(self).__name__
-                            + " with "
-                            + type(array).__name__
-                        )
+                    raise AssertionError(
+                        "cannot merge "
+                        + type(self).__name__
+                        + " with "
+                        + type(array).__name__
                     )
 
         nextcontents = []
@@ -853,12 +819,12 @@ class RecordArray(Content):
         return True
 
     def _unique(self, negaxis, starts, parents, outlength):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _argsort_next(
         self, negaxis, starts, shifts, parents, outlength, ascending, stable
     ):
-        raise ak._errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
         if self._fields is None or len(self._fields) == 0:
@@ -917,18 +883,14 @@ class RecordArray(Content):
     ):
         reducer_recordclass = find_record_reducer(reducer, self, behavior)
         if reducer_recordclass is None:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "no ak.{} overloads for custom types: {}".format(
-                        reducer.name, ", ".join(self._fields)
-                    )
+            raise TypeError(
+                "no ak.{} overloads for custom types: {}".format(
+                    reducer.name, ", ".join(self._fields)
                 )
             )
         else:
-            raise ak._errors.wrap_error(
-                NotImplementedError(
-                    "overloading reducers for RecordArrays has not been implemented yet"
-                )
+            raise NotImplementedError(
+                "overloading reducers for RecordArrays has not been implemented yet"
             )
 
     def _validity_error(self, path):
@@ -1007,9 +969,7 @@ class RecordArray(Content):
             return backend.nplike.empty(self.length, dtype=[])
         contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
-            raise ak._errors.wrap_error(
-                ValueError(f"cannot convert {self} into np.ndarray")
-            )
+            raise ValueError(f"cannot convert {self} into np.ndarray")
         out = backend.nplike.empty(
             self.length,
             dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],
@@ -1040,14 +1000,12 @@ class RecordArray(Content):
             in_function = ""
             if options["function_name"] is not None:
                 in_function = " in " + options["function_name"]
-            raise ak._errors.wrap_error(
-                TypeError(
-                    (
-                        "encountered a record whilst removing array structure{}, "
-                        "but this operation does not support erasing records. "
-                        "Try first calling `ak.ravel` or `ak.flatten(..., axis=None)."
-                    ).format(in_function)
-                )
+            raise TypeError(
+                (
+                    "encountered a record whilst removing array structure{}, "
+                    "but this operation does not support erasing records. "
+                    "Try first calling `ak.ravel` or `ak.flatten(..., axis=None)."
+                ).format(in_function)
             )
 
     def _recursively_apply(
@@ -1063,10 +1021,8 @@ class RecordArray(Content):
 
             def continuation():
                 if not options["allow_records"]:
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            f"cannot broadcast records in {options['function_name']}"
-                        )
+                    raise ValueError(
+                        f"cannot broadcast records in {options['function_name']}"
                     )
                 return RecordArray(
                     [
@@ -1115,7 +1071,7 @@ class RecordArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         return RecordArray(
@@ -1133,9 +1089,7 @@ class RecordArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -104,67 +104,53 @@ class RegularArray(Content):
 
     def __init__(self, content, size, zeros_length=0, *, parameters=None):
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if size is unknown_length:
             if content.backend.index_nplike.known_data:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'size' must be a non-negative integer for backends with known shapes, not None".format(
-                            type(self).__name__
-                        )
+                raise TypeError(
+                    "{} 'size' must be a non-negative integer for backends with known shapes, not None".format(
+                        type(self).__name__
                     )
                 )
         else:
             if not (is_integer(size) and size >= 0):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'size' must be a non-negative integer, not {}".format(
-                            type(self).__name__, size
-                        )
+                raise TypeError(
+                    "{} 'size' must be a non-negative integer, not {}".format(
+                        type(self).__name__, size
                     )
                 )
 
         if zeros_length is unknown_length:
             if content.backend.index_nplike.known_data:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'zeros_length' must be a non-negative integer for backends with known shapes, not None".format(
-                            type(self).__name__
-                        )
+                raise TypeError(
+                    "{} 'zeros_length' must be a non-negative integer for backends with known shapes, not None".format(
+                        type(self).__name__
                     )
                 )
         else:
             if not (is_integer(zeros_length) and zeros_length >= 0):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'zeros_length' must be a non-negative integer, not {}".format(
-                            type(self).__name__, zeros_length
-                        )
+                raise TypeError(
+                    "{} 'zeros_length' must be a non-negative integer, not {}".format(
+                        type(self).__name__, zeros_length
                     )
                 )
 
         if parameters is not None and parameters.get("__array__") == "string":
             if not content.is_numpy or not content.parameter("__array__") == "char":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a string, so its 'content' must be uint8 NumpyArray of char, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if parameters is not None and parameters.get("__array__") == "bytestring":
             if not content.is_numpy or not content.parameter("__array__") == "byte":
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise ValueError(
+                    "{} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
 
@@ -406,20 +392,16 @@ class RegularArray(Content):
 
     def _broadcast_tooffsets64(self, offsets):
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
-            raise ak._errors.wrap_error(
-                AssertionError(
-                    "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
-                        "(empty)" if offsets.length == 0 else str(offsets[0])
-                    )
+            raise AssertionError(
+                "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
+                    "(empty)" if offsets.length == 0 else str(offsets[0])
                 )
             )
 
         if offsets.nplike.known_data and offsets.length - 1 != self._length:
-            raise ak._errors.wrap_error(
-                AssertionError(
-                    "cannot broadcast RegularArray of length {} to length {}".format(
-                        self._length, offsets.length - 1
-                    )
+            raise AssertionError(
+                "cannot broadcast RegularArray of length {} to length {}".format(
+                    self._length, offsets.length - 1
                 )
             )
 
@@ -718,7 +700,7 @@ class RegularArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
@@ -899,10 +881,8 @@ class RegularArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
-                    )
+                raise ValueError(
+                    "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                 )
 
             size = self._size
@@ -1378,7 +1358,7 @@ class RegularArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         index_nplike = self._backend.index_nplike
@@ -1396,9 +1376,7 @@ class RegularArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         if self.parameter("__array__") == "bytestring":
             convert_bytes = (

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -88,11 +88,9 @@ class UnionArray(Content):
 
     def __init__(self, tags, index, contents, *, parameters=None):
         if not (isinstance(tags, Index) and tags.dtype == np.dtype(np.int8)):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'tags' must be an Index with dtype=int8, not {}".format(
-                        type(self).__name__, repr(tags)
-                    )
+            raise TypeError(
+                "{} 'tags' must be an Index with dtype=int8, not {}".format(
+                    type(self).__name__, repr(tags)
                 )
             )
 
@@ -101,43 +99,33 @@ class UnionArray(Content):
             np.dtype(np.uint32),
             np.dtype(np.int64),
         ):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
-                    "not {}".format(type(self).__name__, repr(index))
-                )
+            raise TypeError(
+                "{} 'index' must be an Index with dtype in (int32, uint32, int64), "
+                "not {}".format(type(self).__name__, repr(index))
             )
 
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         if not isinstance(contents, list):
             contents = list(contents)
 
         if len(contents) < 2:
-            raise ak._errors.wrap_error(
-                TypeError(f"{type(self).__name__} must have at least 2 'contents'")
-            )
+            raise TypeError(f"{type(self).__name__} must have at least 2 'contents'")
         for content in contents:
             if not isinstance(content, Content):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Content subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Content subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
             if content.is_union:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{0} cannot contain union-types in its 'contents' ({1}); try {0}.simplified instead".format(
-                            type(self).__name__, type(content).__name__
-                        )
+                raise TypeError(
+                    "{0} cannot contain union-types in its 'contents' ({1}); try {0}.simplified instead".format(
+                        type(self).__name__, type(content).__name__
                     )
                 )
 
@@ -145,11 +133,9 @@ class UnionArray(Content):
             not (tags.length is unknown_length or index.length is unknown_length)
             and tags.length > index.length
         ):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} len(tags) ({}) must be <= len(index) ({})".format(
-                        type(self).__name__, tags.length, index.length
-                    )
+            raise ValueError(
+                "{} len(tags) ({}) must be <= len(index) ({})".format(
+                    type(self).__name__, tags.length, index.length
                 )
             )
 
@@ -158,13 +144,11 @@ class UnionArray(Content):
             if backend is None:
                 backend = content.backend
             elif backend is not content.backend:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'contents' must use the same array library (backend): {} vs {}".format(
-                            type(self).__name__,
-                            type(backend).__name__,
-                            type(content.backend).__name__,
-                        )
+                raise TypeError(
+                    "{} 'contents' must use the same array library (backend): {} vs {}".format(
+                        type(self).__name__,
+                        type(backend).__name__,
+                        type(content.backend).__name__,
                     )
                 )
 
@@ -236,20 +220,16 @@ class UnionArray(Content):
             if backend is None:
                 backend = content.backend
             elif backend is not content.backend:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} 'contents' must use the same array library (backend): {} vs {}".format(
-                            cls.__name__,
-                            type(backend).__name__,
-                            type(content.backend).__name__,
-                        )
+                raise TypeError(
+                    "{} 'contents' must use the same array library (backend): {} vs {}".format(
+                        cls.__name__,
+                        type(backend).__name__,
+                        type(content.backend).__name__,
                     )
                 )
 
         if backend.nplike.known_data and self_index.length < self_tags.length:
-            raise ak._errors.wrap_error(
-                ValueError("invalid UnionArray: len(index) < len(tags)")
-            )
+            raise ValueError("invalid UnionArray: len(index) < len(tags)")
 
         length = self_tags.length
         tags = ak.index.Index8.empty(length, backend.index_nplike)
@@ -399,10 +379,8 @@ class UnionArray(Content):
                     contents.append(self_cont)
 
         if len(contents) > 2**7:
-            raise ak._errors.wrap_error(
-                NotImplementedError(
-                    "FIXME: handle UnionArray with more than 127 contents"
-                )
+            raise NotImplementedError(
+                "FIXME: handle UnionArray with more than 127 contents"
             )
 
         if len(contents) == 1:
@@ -825,13 +803,13 @@ class UnionArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
 
         else:
             has_offsets = False
@@ -945,10 +923,8 @@ class UnionArray(Content):
 
     def _merging_strategy(self, others):
         if len(others) == 0:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "to merge this array with 'others', at least one other must be provided"
-                )
+            raise ValueError(
+                "to merge this array with 'others', at least one other must be provided"
             )
 
         head = [self]
@@ -1040,9 +1016,7 @@ class UnionArray(Content):
         )
 
         if len(contents) > 2**7:
-            raise ak._errors.wrap_error(
-                AssertionError("FIXME: handle UnionArray with more than 127 contents")
-            )
+            raise AssertionError("FIXME: handle UnionArray with more than 127 contents")
 
         return ak.contents.UnionArray.simplified(
             tags, index, contents, parameters=self._parameters
@@ -1141,9 +1115,7 @@ class UnionArray(Content):
                 nextcontents.append(array)
 
         if len(nextcontents) > 127:
-            raise ak._errors.wrap_error(
-                ValueError("FIXME: handle UnionArray with more than 127 contents")
-            )
+            raise ValueError("FIXME: handle UnionArray with more than 127 contents")
 
         next = ak.contents.UnionArray.simplified(
             nexttags,
@@ -1222,9 +1194,7 @@ class UnionArray(Content):
             mergebool=True,
         )
         if isinstance(simplified, ak.contents.UnionArray):
-            raise ak._errors.wrap_error(
-                ValueError("cannot check if an irreducible UnionArray is unique")
-            )
+            raise ValueError("cannot check if an irreducible UnionArray is unique")
 
         return simplified._is_unique(negaxis, starts, parents, outlength)
 
@@ -1238,9 +1208,7 @@ class UnionArray(Content):
             mergebool=True,
         )
         if isinstance(simplified, ak.contents.UnionArray):
-            raise ak._errors.wrap_error(
-                ValueError("cannot make a unique irreducible UnionArray")
-            )
+            raise ValueError("cannot make a unique irreducible UnionArray")
 
         return simplified._unique(negaxis, starts, parents, outlength)
 
@@ -1262,9 +1230,7 @@ class UnionArray(Content):
             )
 
         if isinstance(simplified, ak.contents.UnionArray):
-            raise ak._errors.wrap_error(
-                ValueError("cannot argsort an irreducible UnionArray")
-            )
+            raise ValueError("cannot argsort an irreducible UnionArray")
 
         return simplified._argsort_next(
             negaxis, starts, shifts, parents, outlength, ascending, stable
@@ -1285,9 +1251,7 @@ class UnionArray(Content):
             return simplified
 
         if isinstance(simplified, ak.contents.UnionArray):
-            raise ak._errors.wrap_error(
-                ValueError("cannot sort an irreducible UnionArray")
-            )
+            raise ValueError("cannot sort an irreducible UnionArray")
 
         return simplified._sort_next(
             negaxis, starts, parents, outlength, ascending, stable
@@ -1307,9 +1271,7 @@ class UnionArray(Content):
     ):
         # If we have a UnionArray, it must be irreducible, thanks to the
         # canonical checks in the constructor.
-        raise ak._errors.wrap_error(
-            ValueError(f"cannot call ak.{reducer.name} on an irreducible UnionArray")
-        )
+        raise ValueError(f"cannot call ak.{reducer.name} on an irreducible UnionArray")
 
     def _validity_error(self, path):
         if self._backend.nplike.known_data and self.index.length < self.tags.length:
@@ -1474,16 +1436,14 @@ class UnionArray(Content):
             try:
                 out = backend.nplike.ma.concatenate(contents)
             except Exception as err:
-                raise ak._errors.wrap_error(
-                    ValueError(f"cannot convert {self} into numpy.ma.MaskedArray")
+                raise ValueError(
+                    f"cannot convert {self} into numpy.ma.MaskedArray"
                 ) from err
         else:
             try:
                 out = backend.nplike.concat(contents)
             except Exception as err:
-                raise ak._errors.wrap_error(
-                    ValueError(f"cannot convert {self} into np.ndarray")
-                ) from err
+                raise ValueError(f"cannot convert {self} into np.ndarray") from err
 
         tags = backend.index_nplike.asarray(self.tags)
         for tag, content in enumerate(contents):
@@ -1562,7 +1522,7 @@ class UnionArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         tags = self._tags.raw(self._backend.nplike)
@@ -1593,9 +1553,7 @@ class UnionArray(Content):
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -67,19 +67,15 @@ class UnmaskedArray(Content):
 
     def __init__(self, content, *, parameters=None):
         if not isinstance(content, Content):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Content subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Content subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if content.is_union or content.is_indexed or content.is_option:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
-                        type(self).__name__, type(content).__name__
-                    )
+            raise TypeError(
+                "{0} cannot contain a union-type, option-type, or indexed 'content' ({1}); try {0}.simplified instead".format(
+                    type(self).__name__, type(content).__name__
                 )
             )
         self._content = content
@@ -289,7 +285,7 @@ class UnmaskedArray(Content):
             return self._getitem_next_missing(head, tail, advanced)
 
         else:
-            raise ak._errors.wrap_error(AssertionError(repr(head)))
+            raise AssertionError(repr(head))
 
     def project(self, mask=None):
         if mask is not None:
@@ -302,7 +298,7 @@ class UnmaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise ak._errors.wrap_error(np.AxisError("axis=0 not allowed for flatten"))
+            raise np.AxisError("axis=0 not allowed for flatten")
         else:
             offsets, flattened = self._content._offsets_and_flattened(axis, depth)
             if offsets.length == 0:
@@ -532,16 +528,14 @@ class UnmaskedArray(Content):
         elif result is None:
             return continuation()
         else:
-            raise ak._errors.wrap_error(AssertionError(result))
+            raise AssertionError(result)
 
     def to_packed(self) -> Self:
         return UnmaskedArray(self._content.to_packed(), parameters=self._parameters)
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:
-            raise ak._errors.wrap_error(
-                TypeError("cannot convert typetracer arrays to Python lists")
-            )
+            raise TypeError("cannot convert typetracer arrays to Python lists")
 
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -22,35 +22,27 @@ class BitMaskedForm(Form):
         form_key=None,
     ):
         if not isinstance(mask, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'mask' must be of type str, not {}".format(
-                        type(self).__name__, repr(mask)
-                    )
+            raise TypeError(
+                "{} 'mask' must be of type str, not {}".format(
+                    type(self).__name__, repr(mask)
                 )
             )
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'valid_when' must be bool, not {}".format(
-                        type(self).__name__, repr(valid_when)
-                    )
+            raise TypeError(
+                "{} 'valid_when' must be bool, not {}".format(
+                    type(self).__name__, repr(valid_when)
                 )
             )
         if not isinstance(lsb_order, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'lsb_order' must be bool, not {}".format(
-                        type(self).__name__, repr(lsb_order)
-                    )
+            raise TypeError(
+                "{} 'lsb_order' must be bool, not {}".format(
+                    type(self).__name__, repr(lsb_order)
                 )
             )
 

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -21,27 +21,21 @@ class ByteMaskedForm(Form):
         form_key=None,
     ):
         if not isinstance(mask, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'mask' must be of type str, not {}".format(
-                        type(self).__name__, repr(mask)
-                    )
+            raise TypeError(
+                "{} 'mask' must be of type str, not {}".format(
+                    type(self).__name__, repr(mask)
                 )
             )
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if not isinstance(valid_when, bool):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'valid_when' must be bool, not {}".format(
-                        type(self).__name__, repr(valid_when)
-                    )
+            raise TypeError(
+                "{} 'valid_when' must be bool, not {}".format(
+                    type(self).__name__, repr(valid_when)
                 )
             )
 

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -7,7 +7,6 @@ import re
 from collections.abc import Mapping
 
 import awkward as ak
-from awkward import _errors
 from awkward._behavior import find_typestrs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -82,9 +81,7 @@ def from_dict(input: dict) -> Form:
         # New serialisation
         if "fields" in input:
             if isinstance(input["contents"], Mapping):
-                raise _errors.wrap_error(
-                    TypeError("new-style RecordForm contents must not be mappings")
-                )
+                raise TypeError("new-style RecordForm contents must not be mappings")
             contents = [from_dict(content) for content in input["contents"]]
             fields = input["fields"]
         # Old style record
@@ -171,15 +168,11 @@ def from_dict(input: dict) -> Form:
         )
 
     elif input["class"] == "VirtualArray":
-        raise _errors.wrap_error(
-            ValueError("Awkward 1.x VirtualArrays are not supported")
-        )
+        raise ValueError("Awkward 1.x VirtualArrays are not supported")
 
     else:
-        raise _errors.wrap_error(
-            ValueError(
-                "input class: {} was not recognised".format(repr(input["class"]))
-            )
+        raise ValueError(
+            "input class: {} was not recognised".format(repr(input["class"]))
         )
 
 
@@ -219,19 +212,15 @@ class Form:
 
     def _init(self, *, parameters, form_key):
         if parameters is not None and not isinstance(parameters, dict):
-            raise _errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if form_key is not None and not isinstance(form_key, str):
-            raise _errors.wrap_error(
-                TypeError(
-                    "{} 'form_key' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(form_key)
-                    )
+            raise TypeError(
+                "{} 'form_key' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(form_key)
                 )
             )
 
@@ -247,7 +236,7 @@ class Form:
     @property
     def is_identity_like(self):
         """Return True if the content or its non-list descendents are an identity"""
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def parameter(self, key: str) -> JSONSerializable:
         if self._parameters is None:
@@ -256,31 +245,31 @@ class Form:
             return self._parameters.get(key)
 
     def purelist_parameter(self, key: str) -> JSONSerializable:
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def purelist_isregular(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def purelist_depth(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def minmax_depth(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def branch_depth(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def fields(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def is_tuple(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     @property
     def form_key(self):
@@ -289,7 +278,7 @@ class Form:
     @form_key.setter
     def form_key(self, value):
         if value is not None and not isinstance(value, str):
-            raise ak._errors.wrap_error(TypeError("form_key must be None or a string"))
+            raise TypeError("form_key must be None or a string")
         self._form_key = value
 
     def __str__(self):
@@ -334,8 +323,8 @@ class Form:
 
         for item in specifier:
             if not isinstance(item, str):
-                raise _errors.wrap_error(
-                    TypeError("a column-selection specifier must be a list of strings")
+                raise TypeError(
+                    "a column-selection specifier must be a list of strings"
                 )
 
         if expand_braces:
@@ -355,19 +344,19 @@ class Form:
         return self._column_types()
 
     def _columns(self, path, output, list_indicator):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _select_columns(self, index, specifier, matches, output):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _column_types(self):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _to_dict_part(self, verbose, toplevel):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def _type(self, typestrs):
-        raise _errors.wrap_error(NotImplementedError)
+        raise NotImplementedError
 
     def length_zero_array(
         self, *, backend=numpy_backend, highlevel=True, behavior=None

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -20,19 +20,15 @@ class IndexedForm(Form):
         form_key=None,
     ):
         if not isinstance(index, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be of type str, not {}".format(
-                        type(self).__name__, repr(index)
-                    )
+            raise TypeError(
+                "{} 'index' must be of type str, not {}".format(
+                    type(self).__name__, repr(index)
                 )
             )
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
 

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -21,19 +21,15 @@ class IndexedOptionForm(Form):
         form_key=None,
     ):
         if not isinstance(index, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be of type str, not {}".format(
-                        type(self).__name__, repr(index)
-                    )
+            raise TypeError(
+                "{} 'index' must be of type str, not {}".format(
+                    type(self).__name__, repr(index)
                 )
             )
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
 

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -21,27 +21,21 @@ class ListForm(Form):
         form_key=None,
     ):
         if not isinstance(starts, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'starts' must be of type str, not {}".format(
-                        type(self).__name__, repr(starts)
-                    )
+            raise TypeError(
+                "{} 'starts' must be of type str, not {}".format(
+                    type(self).__name__, repr(starts)
                 )
             )
         if not isinstance(stops, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'starts' must be of type str, not {}".format(
-                        type(self).__name__, repr(starts)
-                    )
+            raise TypeError(
+                "{} 'starts' must be of type str, not {}".format(
+                    type(self).__name__, repr(starts)
                 )
             )
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
 

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -13,11 +13,9 @@ class ListOffsetForm(Form):
 
     def __init__(self, offsets, content, *, parameters=None, form_key=None):
         if not isinstance(offsets, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'offsets' must be of type str, not {}".format(
-                        type(self).__name__, repr(offsets)
-                    )
+            raise TypeError(
+                "{} 'offsets' must be of type str, not {}".format(
+                    type(self).__name__, repr(offsets)
                 )
             )
 

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -53,11 +53,9 @@ class NumpyForm(Form):
             ak.types.numpytype.primitive_to_dtype(primitive)
         )
         if not isinstance(inner_shape, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'inner_shape' must be iterable, not {}".format(
-                        type(self).__name__, repr(inner_shape)
-                    )
+            raise TypeError(
+                "{} 'inner_shape' must be iterable, not {}".format(
+                    type(self).__name__, repr(inner_shape)
                 )
             )
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -24,28 +24,22 @@ class RecordForm(Form):
         form_key=None,
     ):
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         for content in contents:
             if not isinstance(content, Form):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Form subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Form subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if fields is not None and not isinstance(fields, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'fields' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'fields' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
 
@@ -105,11 +99,9 @@ class RecordForm(Form):
             else:
                 return self._fields[index]
         else:
-            raise ak._errors.wrap_error(
-                IndexError(
-                    "no index {} in record with {} fields".format(
-                        index, len(self._contents)
-                    )
+            raise IndexError(
+                "no index {} in record with {} fields".format(
+                    index, len(self._contents)
                 )
             )
 
@@ -129,11 +121,9 @@ class RecordForm(Form):
                 pass
             else:
                 return i
-        raise ak._errors.wrap_error(
-            ak._errors.FieldNotFoundError(
-                "no field {} in record with {} fields".format(
-                    repr(field), len(self._contents)
-                )
+        raise ak._errors.FieldNotFoundError(
+            "no field {} in record with {} fields".format(
+                repr(field), len(self._contents)
             )
         )
 
@@ -154,11 +144,9 @@ class RecordForm(Form):
         elif isinstance(index_or_field, str):
             index = self.field_to_index(index_or_field)
         else:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "index_or_field must be an integer (index) or string (field), not {}".format(
-                        repr(index_or_field)
-                    )
+            raise TypeError(
+                "index_or_field must be an integer (index) or string (field), not {}".format(
+                    repr(index_or_field)
                 )
             )
         return self._contents[index]

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -16,19 +16,15 @@ class RegularForm(Form):
 
     def __init__(self, content, size, *, parameters=None, form_key=None):
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if not (size is unknown_length or (is_integer(size) and size >= 0)):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'size' must be a non-negative int or None, not {}".format(
-                        type(self).__name__, repr(size)
-                    )
+            raise TypeError(
+                "{} 'size' must be a non-negative int or None, not {}".format(
+                    type(self).__name__, repr(size)
                 )
             )
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -24,36 +24,28 @@ class UnionForm(Form):
         form_key=None,
     ):
         if not isinstance(tags, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'tags' must be of type str, not {}".format(
-                        type(self).__name__, repr(tags)
-                    )
+            raise TypeError(
+                "{} 'tags' must be of type str, not {}".format(
+                    type(self).__name__, repr(tags)
                 )
             )
         if not isinstance(index, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'index' must be of type str, not {}".format(
-                        type(self).__name__, repr(index)
-                    )
+            raise TypeError(
+                "{} 'index' must be of type str, not {}".format(
+                    type(self).__name__, repr(index)
                 )
             )
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         for content in contents:
             if not isinstance(content, Form):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Form subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Form subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
 

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -19,11 +19,9 @@ class UnmaskedForm(Form):
         form_key=None,
     ):
         if not isinstance(content, Form):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Form subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Form subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -199,13 +199,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 if length is None:
                     length = contents[-1].length
                 elif length != contents[-1].length:
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "dict of arrays in ak.Array constructor must have arrays "
-                            "of equal length ({} vs {})".format(
-                                length, contents[-1].length
-                            )
-                        )
+                    raise ValueError(
+                        "dict of arrays in ak.Array constructor must have arrays "
+                        "of equal length ({} vs {})".format(length, contents[-1].length)
                     )
             layout = ak.contents.RecordArray(contents, fields)
 
@@ -218,9 +214,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             )
 
         if not isinstance(layout, ak.contents.Content):
-            raise ak._errors.wrap_error(
-                TypeError("could not convert data into an ak.Array")
-            )
+            raise TypeError("could not convert data into an ak.Array")
 
         if with_name is not None:
             layout = ak.operations.with_name(
@@ -296,9 +290,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             self._layout = layout
             self._numbaview = None
         else:
-            raise ak._errors.wrap_error(
-                TypeError("layout must be a subclass of ak.contents.Content")
-            )
+            raise TypeError("layout must be a subclass of ak.contents.Content")
 
     @property
     def behavior(self):
@@ -325,7 +317,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             self.__class__ = get_array_class(self._layout, behavior)
             self._behavior = behavior
         else:
-            raise ak._errors.wrap_error(TypeError("behavior must be None or a dict"))
+            raise TypeError("behavior must be None or a dict")
 
     class Mask:
         def __init__(self, array):
@@ -1028,9 +1020,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise ak._errors.wrap_error(
-                    TypeError("only fields may be assigned in-place (by field name)")
-                )
+                raise TypeError("only fields may be assigned in-place (by field name)")
 
             self._layout = ak.operations.with_field(
                 self._layout, what, where, highlevel=False
@@ -1061,9 +1051,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise ak._errors.wrap_error(
-                    TypeError("only fields may be removed in-place (by field name)")
-                )
+                raise TypeError("only fields may be removed in-place (by field name)")
 
             self._layout = ak.operations.ak_without_field._impl(
                 self._layout, where, highlevel=False, behavior=self._behavior
@@ -1113,14 +1101,12 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 try:
                     return self[where]
                 except Exception as err:
-                    raise ak._errors.wrap_error(
-                        AttributeError(
-                            "while trying to get field {}, an exception "
-                            "occurred:\n{}: {}".format(repr(where), type(err), str(err))
-                        )
+                    raise AttributeError(
+                        "while trying to get field {}, an exception "
+                        "occurred:\n{}: {}".format(repr(where), type(err), str(err))
                     ) from err
             else:
-                raise ak._errors.wrap_error(AttributeError(f"no field named {where!r}"))
+                raise AttributeError(f"no field named {where!r}")
 
     def __setattr__(self, name, value):
         """
@@ -1149,16 +1135,12 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         if name.startswith("_") or hasattr(type(self), name):
             super().__setattr__(name, value)
         elif name in self._layout.fields:
-            raise ak._errors.wrap_error(
-                AttributeError(
-                    "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
-                )
+            raise AttributeError(
+                "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
             )
         else:
-            raise ak._errors.wrap_error(
-                AttributeError(
-                    "only private attributes (started with an underscore) can be set on arrays"
-                )
+            raise AttributeError(
+                "only private attributes (started with an underscore) can be set on arrays"
             )
 
     def __dir__(self):
@@ -1454,11 +1436,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         if len(self) == 1:
             return bool(self[0])
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "the truth value of an array whose length is not 1 is ambiguous; "
-                    "use ak.any() or ak.all()"
-                )
+            raise ValueError(
+                "the truth value of an array whose length is not 1 is ambiguous; "
+                "use ak.any() or ak.all()"
             )
 
     @property
@@ -1565,17 +1545,15 @@ class Record(NDArrayOperatorsMixin):
             layout = ak.record.Record(ak.contents.RecordArray(contents, fields), at=0)
 
         elif isinstance(data, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError("could not convert non-dict into an ak.Record; try ak.Array")
+            raise TypeError(
+                "could not convert non-dict into an ak.Record; try ak.Array"
             )
 
         else:
             layout = None
 
         if not isinstance(layout, ak.record.Record):
-            raise ak._errors.wrap_error(
-                TypeError("could not convert data into an ak.Record")
-            )
+            raise TypeError("could not convert data into an ak.Record")
 
         if with_name is not None:
             layout = ak.operations.with_name(layout, with_name, highlevel=False)
@@ -1641,9 +1619,7 @@ class Record(NDArrayOperatorsMixin):
             self._layout = layout
             self._numbaview = None
         else:
-            raise ak._errors.wrap_error(
-                TypeError("layout must be a subclass of ak.record.Record")
-            )
+            raise TypeError("layout must be a subclass of ak.record.Record")
 
     @property
     def behavior(self):
@@ -1670,7 +1646,7 @@ class Record(NDArrayOperatorsMixin):
             self.__class__ = get_record_class(self._layout, behavior)
             self._behavior = behavior
         else:
-            raise ak._errors.wrap_error(TypeError("behavior must be None or a dict"))
+            raise TypeError("behavior must be None or a dict")
 
     def tolist(self):
         """
@@ -1815,9 +1791,7 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise ak._errors.wrap_error(
-                    TypeError("only fields may be assigned in-place (by field name)")
-                )
+                raise TypeError("only fields may be assigned in-place (by field name)")
 
             self._layout = ak.operations.ak_with_field._impl(
                 self._layout, what, where, highlevel=False, behavior=self._behavior
@@ -1849,9 +1823,7 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise ak._errors.wrap_error(
-                    TypeError("only fields may be removed in-place (by field name)")
-                )
+                raise TypeError("only fields may be removed in-place (by field name)")
 
             self._layout = ak.operations.ak_without_field._impl(
                 self._layout, where, highlevel=False, behavior=self._behavior
@@ -2123,11 +2095,9 @@ class Record(NDArrayOperatorsMixin):
         )
 
     def __bool__(self):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "the truth value of a record is ambiguous; "
-                "use ak.any() or ak.all() or pick a field"
-            )
+        raise ValueError(
+            "the truth value of a record is ambiguous; "
+            "use ak.any() or ak.all() or pick a field"
         )
 
 
@@ -2312,7 +2282,7 @@ class ArrayBuilder(Sized):
         if behavior is None or isinstance(behavior, dict):
             self._behavior = behavior
         else:
-            raise ak._errors.wrap_error(TypeError("behavior must be None or a dict"))
+            raise TypeError("behavior must be None or a dict")
 
     def tolist(self):
         """
@@ -2431,11 +2401,9 @@ class ArrayBuilder(Sized):
         if len(self) == 1:
             return bool(self[0])
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "the truth value of an array whose length is not 1 is ambiguous; "
-                    "use ak.any() or ak.all()"
-                )
+            raise ValueError(
+                "the truth value of an array whose length is not 1 is ambiguous; "
+                "use ak.any() or ak.all()"
             )
 
     def snapshot(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1893,14 +1893,12 @@ class Record(NDArrayOperatorsMixin):
                 try:
                     return self[where]
                 except Exception as err:
-                    raise ak._errors.wrap_error(
-                        AttributeError(
-                            "while trying to get field {}, an exception "
-                            "occurred:\n{}: {}".format(repr(where), type(err), str(err))
-                        )
+                    raise AttributeError(
+                        "while trying to get field {}, an exception "
+                        "occurred:\n{}: {}".format(repr(where), type(err), str(err))
                     ) from err
             else:
-                raise ak._errors.wrap_error(AttributeError(f"no field named {where!r}"))
+                raise AttributeError(f"no field named {where!r}")
 
     def __setattr__(self, name, value):
         """
@@ -1929,16 +1927,12 @@ class Record(NDArrayOperatorsMixin):
         if name.startswith("_") or hasattr(type(self), name):
             super().__setattr__(name, value)
         elif name in self._layout.fields:
-            raise ak._errors.wrap_error(
-                AttributeError(
-                    "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
-                )
+            raise AttributeError(
+                "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
             )
         else:
-            raise ak._errors.wrap_error(
-                AttributeError(
-                    "only private attributes (started with an underscore) can be set on records"
-                )
+            raise AttributeError(
+                "only private attributes (started with an underscore) can be set on records"
             )
 
     def __dir__(self):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import copy
 
-import awkward as ak
 from awkward._nplikes import nplike_of, to_nplike
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
@@ -37,9 +36,7 @@ def _form_to_zero_length(form):
     elif form == "i64":
         return Index64(numpy.zeros(0, dtype=np.int64))
     else:
-        raise ak._errors.wrap_error(
-            AssertionError(f"unrecognized Index form: {form!r}")
-        )
+        raise AssertionError(f"unrecognized Index form: {form!r}")
 
 
 class Index:
@@ -50,9 +47,7 @@ class Index:
             nplike = nplike_of(data)
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
-            raise ak._errors.wrap_error(
-                TypeError("Index metadata must be None or a dict")
-            )
+            raise TypeError("Index metadata must be None or a dict")
         self._metadata = metadata
         # We don't care about F, C (it's one dimensional), but we do need
         # the array to be contiguous. This should _not_ return a copy if already
@@ -61,7 +56,7 @@ class Index:
         )
 
         if len(self._data.shape) != 1:
-            raise ak._errors.wrap_error(TypeError("Index data must be one-dimensional"))
+            raise TypeError("Index data must be one-dimensional")
 
         if issubclass(self._data.dtype.type, np.longlong):
             assert (
@@ -82,19 +77,15 @@ class Index:
             elif self._data.dtype == np.dtype(np.int64):
                 self.__class__ = Index64
             else:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "Index data must be int8, uint8, int32, uint32, int64, not "
-                        + repr(self._data.dtype)
-                    )
+                raise TypeError(
+                    "Index data must be int8, uint8, int32, uint32, int64, not "
+                    + repr(self._data.dtype)
                 )
         else:
             if self._data.dtype != self._expected_dtype:
                 # self._data = self._data.astype(self._expected_dtype)   # copy/convert
-                raise ak._errors.wrap_error(
-                    NotImplementedError(
-                        "while developing, we want to catch these errors"
-                    )
+                raise NotImplementedError(
+                    "while developing, we want to catch these errors"
                 )
 
     @classmethod

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -6,7 +6,6 @@ import weakref
 
 import awkward as ak
 from awkward import highlevel
-from awkward._errors import wrap_error
 from awkward._nplikes.numpy import Numpy
 from awkward._typing import TypeVar
 
@@ -14,7 +13,7 @@ numpy = Numpy.instance()
 
 
 def assert_never(arg) -> None:
-    raise wrap_error(AssertionError(f"this should never be run: {arg}"))
+    raise AssertionError(f"this should never be run: {arg}")
 
 
 class _RegistrationState(enum.Enum):
@@ -35,9 +34,8 @@ def register_and_check():
         import jax  # noqa: TID251
 
     except ModuleNotFoundError:
-        raise wrap_error(
-            ModuleNotFoundError(
-                """install the 'jax' package with:
+        raise ModuleNotFoundError(
+            """install the 'jax' package with:
 
         python3 -m pip install jax jaxlib
 
@@ -45,7 +43,6 @@ def register_and_check():
 
         conda install -c conda-forge jax jaxlib
     """
-            )
         ) from None
 
     _register()
@@ -111,7 +108,7 @@ def _register():
                 jax_connect.register_pytree_class(cls)
         except Exception:
             _registration_state = _RegistrationState.FAILED
-            raise  # noqa: AK101
+            raise
         else:
             _registration_state = _RegistrationState.SUCCESS
 
@@ -120,16 +117,12 @@ def assert_registered():
     """Ensure that JAX integration is registered. Raise a RuntimeError if not."""
     with _registration_lock:
         if _registration_state == _RegistrationState.INIT:
-            raise wrap_error(
-                RuntimeError("JAX features require `ak.jax.register_and_check()`")
-            )
+            raise RuntimeError("JAX features require `ak.jax.register_and_check()`")
         elif _registration_state == _RegistrationState.FAILED:
-            raise wrap_error(
-                RuntimeError(
-                    "JAX features require `ak.jax.register_and_check()`, "
-                    "but the last call to `ak.jax.register_and_check()` did not succeed. "
-                    "Please look for a traceback to identify the error."
-                )
+            raise RuntimeError(
+                "JAX features require `ak.jax.register_and_check()`, "
+                "but the last call to `ak.jax.register_and_check()` did not succeed. "
+                "Please look for a traceback to identify the error."
             )
         elif _registration_state == _RegistrationState.SUCCESS:
             return

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -71,7 +71,7 @@ def all(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -6,7 +6,6 @@ __all__ = ("almost_equal",)
 
 from awkward._backends import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
-from awkward._errors import wrap_error
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
@@ -54,10 +53,8 @@ def almost_equal(
 
     backend = backend_of(left, right)
     if not backend.nplike.known_data:
-        raise wrap_error(
-            NotImplementedError(
-                "Awkward Arrays with typetracer backends cannot yet be compared with `ak.almost_equal`."
-            )
+        raise NotImplementedError(
+            "Awkward Arrays with typetracer backends cannot yet be compared with `ak.almost_equal`."
         )
 
     def is_approx_dtype(left, right) -> bool:
@@ -142,6 +139,6 @@ def almost_equal(
             return True
 
         else:
-            raise wrap_error(AssertionError)
+            raise AssertionError
 
     return visitor(left, right)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -71,7 +71,7 @@ def any(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -93,9 +93,7 @@ def _impl(
         parameters["__record__"] = with_name
 
     if axis < 0:
-        raise ak._errors.wrap_error(
-            ValueError("the 'axis' for argcombinations must be non-negative")
-        )
+        raise ValueError("the 'axis' for argcombinations must be non-negative")
     else:
         layout = ak._do.local_index(
             ak.operations.to_layout(array, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -78,7 +78,7 @@ def argmax(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -142,7 +142,7 @@ def nanargmax(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -78,7 +78,7 @@ def argmin(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -141,7 +141,7 @@ def nanargmin(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -77,9 +77,7 @@ def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
     elif kind in ("heapsort", "quicksort"):
         stable = False
     else:
-        raise ak._errors.wrap_error(
-            ValueError(
-                f"unsupported value for 'kind' passed to overloaded NumPy function 'argsort': {kind!r}"
-            )
+        raise ValueError(
+            f"unsupported value for 'kind' passed to overloaded NumPy function 'argsort': {kind!r}"
         )
     return argsort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -80,9 +80,9 @@ def _impl(arrays, highlevel, behavior):
         elif layout.is_leaf:
             return pullback, layout
         elif layout.is_union:
-            raise ak._errors.wrap_error(TypeError("unions are not supported"))
+            raise TypeError("unions are not supported")
         else:
-            raise ak._errors.wrap_error(AssertionError("unexpected content type"))
+            raise AssertionError("unexpected content type")
 
     # Like broadcast_and_apply, we want to walk into each layout, correct the structure, and then rebuilt the arrays
     # We do this using "pull back" functions that accept a child content, and return the top-level layout. Unlike
@@ -95,10 +95,8 @@ def _impl(arrays, highlevel, behavior):
         # We can only work with all non-record, or all record/identity
         if any(c.is_record for c in next_inputs):
             if not all(c.is_record or c.is_identity_like for c in next_inputs):
-                raise ak._errors.wrap_error(
-                    AssertionError(
-                        "if any inputs are records, all inputs must be records or identities"
-                    )
+                raise AssertionError(
+                    "if any inputs are records, all inputs must be records or identities"
                 )
         # With no records, we can exit here
         else:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -243,13 +243,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
     # Validate `posaxis`
     if posaxis is None or posaxis < 0:
-        raise ak._errors.wrap_error(ValueError("negative axis depth is ambiguous"))
+        raise ValueError("negative axis depth is ambiguous")
     for layout in layouts[1:]:
         if maybe_posaxis(layout, axis, 1) != posaxis:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "arrays to cartesian-product do not have the same depth for negative axis"
-                )
+            raise ValueError(
+                "arrays to cartesian-product do not have the same depth for negative axis"
             )
 
     # Validate `nested`
@@ -263,29 +261,23 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     else:
         if isinstance(array_layouts, dict):
             if any(not (isinstance(x, str) and x in array_layouts) for x in nested):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "the 'nested' parameter of cartesian must be dict keys "
-                        "for a dict of arrays"
-                    )
+                raise ValueError(
+                    "the 'nested' parameter of cartesian must be dict keys "
+                    "for a dict of arrays"
                 )
             if len(nested) >= len(array_layouts):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "the `nested` parameter of cartesian must contain "
-                        "fewer items than there are arrays"
-                    )
+                raise ValueError(
+                    "the `nested` parameter of cartesian must contain "
+                    "fewer items than there are arrays"
                 )
         else:
             if any(
                 not (isinstance(x, int) and 0 <= x < len(array_layouts) - 1)
                 for x in nested
             ):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "the 'nested' parameter of cartesian must be integers in "
-                        "[0, len(arrays) - 1) for an iterable of arrays"
-                    )
+                raise ValueError(
+                    "the 'nested' parameter of cartesian must be integers in "
+                    "[0, len(arrays) - 1) for an iterable of arrays"
                 )
 
     if posaxis == 0:
@@ -359,11 +351,9 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                     layout.parameter("__array__") == "string"
                     or layout.parameter("__array__") == "bytestring"
                 ):
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "ak.cartesian does not compute combinations of the "
-                            "characters of a string; please split it into lists"
-                        )
+                    raise ValueError(
+                        "ak.cartesian does not compute combinations of the "
+                        "characters of a string; please split it into lists"
                     )
                 nextlayout = ak._do.recursively_apply(
                     layout,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -79,9 +79,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
 
     contents = [x for x in content_or_others if isinstance(x, ak.contents.Content)]
     if len(contents) == 0:
-        raise ak._errors.wrap_error(
-            ValueError("need at least one array to concatenate")
-        )
+        raise ValueError("need at least one array to concatenate")
 
     posaxis = maybe_posaxis(contents[0], axis, 1)
     maxdepth = max(
@@ -90,20 +88,16 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
         if isinstance(x, ak.contents.Content)
     )
     if posaxis is None or not 0 <= posaxis < maxdepth:
-        raise ak._errors.wrap_error(
-            ValueError(
-                "axis={} is beyond the depth of this array or the depth of this array "
-                "is ambiguous".format(axis)
-            )
+        raise ValueError(
+            "axis={} is beyond the depth of this array or the depth of this array "
+            "is ambiguous".format(axis)
         )
     for x in content_or_others:
         if isinstance(x, ak.contents.Content):
             if maybe_posaxis(x, axis, 1) != posaxis:
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "arrays to concatenate do not have the same depth for negative "
-                        "axis={}".format(axis)
-                    )
+                raise ValueError(
+                    "arrays to concatenate do not have the same depth for negative "
+                    "axis={}".format(axis)
                 )
 
     if posaxis == 0:
@@ -157,11 +151,9 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                         if not is_integer(length):
                             length = x.length
                         elif length != x.length and is_integer(x.length):
-                            raise ak._errors.wrap_error(
-                                ValueError(
-                                    "all arrays must have the same length for "
-                                    "axis={}".format(axis)
-                                )
+                            raise ValueError(
+                                "all arrays must have the same length for "
+                                "axis={}".format(axis)
                             )
 
             if depth == posaxis and all(
@@ -275,11 +267,9 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                 for x in inputs
                 if isinstance(x, ak.contents.Content)
             ):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "at least one array is not deep enough to concatenate at "
-                        "axis={}".format(axis)
-                    )
+                raise ValueError(
+                    "at least one array is not deep enough to concatenate at "
+                    "axis={}".format(axis)
                 )
 
             else:

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -77,7 +77,7 @@ def corr(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, y, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -113,7 +113,7 @@ def count(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -72,7 +72,7 @@ def count_nonzero(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -74,7 +74,7 @@ def covar(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, y, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -69,10 +69,8 @@ def _impl(array, axis, highlevel, behavior):
     else:
         max_axis = layout.branch_depth[1] - 1
         if axis > max_axis:
-            raise ak._errors.wrap_error(
-                np.AxisError(
-                    f"axis={axis} exceeds the depth ({max_axis}) of this array"
-                )
+            raise np.AxisError(
+                f"axis={axis} exceeds the depth ({max_axis}) of this array"
             )
 
         def recompute_offsets(layout, depth, **kwargs):
@@ -91,10 +89,8 @@ def _impl(array, axis, highlevel, behavior):
             if layout.is_record:
                 posaxises = {maybe_posaxis(x, axis, depth) for x in layout.contents}
                 if len(posaxises) > 1 and any(x < depth for x in posaxises):
-                    raise ak._errors.wrap_error(
-                        np.AxisError(
-                            f"axis={axis} implies different levels in records that might require part of a record to be dropped, which is impossible"
-                        )
+                    raise np.AxisError(
+                        f"axis={axis} implies different levels in records that might require part of a record to be dropped, which is impossible"
                     )
             posaxis = maybe_posaxis(layout, axis, depth)
             if posaxis == 0:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -134,10 +134,8 @@ def _impl(array, value, axis, highlevel, behavior):
                     return layout
 
             elif layout.is_leaf:
-                raise ak._errors.wrap_error(
-                    np.AxisError(
-                        f"axis={axis} exceeds the depth of this array ({depth})"
-                    )
+                raise np.AxisError(
+                    f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
     out = ak._do.recursively_apply(arraylayout, action, behavior)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -53,9 +53,7 @@ def _impl(array, axis, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
 
     if not is_integer(axis):
-        raise ak._errors.wrap_error(
-            TypeError(f"'axis' must be an integer, not {axis!r}")
-        )
+        raise TypeError(f"'axis' must be an integer, not {axis!r}")
 
     if maybe_posaxis(layout, axis, 1) == 0:
         # specialized logic; it's tested in test_0582-propagate-context-in-broadcast_and_apply.py
@@ -92,10 +90,8 @@ def _impl(array, axis, highlevel, behavior):
                 )
 
             elif layout.is_leaf:
-                raise ak._errors.wrap_error(
-                    np.AxisError(
-                        f"axis={axis} exceeds the depth of this array ({depth})"
-                    )
+                raise np.AxisError(
+                    f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
         out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -52,10 +52,8 @@ def from_avro_file(
 
         else:
             if not hasattr(file, "read") or not hasattr(file, "seek"):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "'file' must either be a filename string or be a file-like object with 'read' and 'seek' methods"
-                    )
+                raise TypeError(
+                    "'file' must either be a filename string or be a file-like object with 'read' and 'seek' methods"
                 )
             else:
                 form, length, container = awkward._connect.avro.ReadAvroFT(

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -120,15 +120,11 @@ def _impl(
         form = ak.forms.from_dict(form)
 
     if not (is_integer(length) and length >= 0):
-        raise ak._errors.wrap_error(
-            TypeError("'length' argument must be a non-negative integer")
-        )
+        raise TypeError("'length' argument must be a non-negative integer")
 
     if not isinstance(form, ak.forms.Form):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "'form' argument must be a Form or its Python dict/JSON string representation"
-            )
+        raise TypeError(
+            "'form' argument must be a Form or its Python dict/JSON string representation"
         )
 
     if isinstance(buffer_key, str):
@@ -142,10 +138,8 @@ def _impl(
             return buffer_key(form_key=form.form_key, attribute=attribute, form=form)
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(
-                f"buffer_key must be a string or a callable, not {type(buffer_key)}"
-            )
+        raise TypeError(
+            f"buffer_key must be a string or a callable, not {type(buffer_key)}"
         )
 
     out = reconstitute(form, length, container, getkey, backend, byteorder, simplify)
@@ -167,10 +161,8 @@ def _from_buffer(nplike, buffer, dtype, count, byteorder):
 
         # Require 1D
         if array.size < count:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    f"size of array ({array.size}) is less than size of form ({count})"
-                )
+            raise TypeError(
+                f"size of array ({array.size}) is less than size of form ({count})"
             )
 
         return array[:count]
@@ -185,9 +177,7 @@ def _from_buffer(nplike, buffer, dtype, count, byteorder):
 def reconstitute(form, length, container, getkey, backend, byteorder, simplify):
     if isinstance(form, ak.forms.EmptyForm):
         if length != 0:
-            raise ak._errors.wrap_error(
-                ValueError(f"EmptyForm node, but the expected length is {length}")
-            )
+            raise ValueError(f"EmptyForm node, but the expected length is {length}")
         return ak.contents.EmptyArray()
 
     elif isinstance(form, ak.forms.NumpyForm):
@@ -439,6 +429,4 @@ def reconstitute(form, length, container, getkey, backend, byteorder, simplify):
         )
 
     else:
-        raise ak._errors.wrap_error(
-            AssertionError("unexpected form node type: " + str(type(form)))
-        )
+        raise AssertionError("unexpected form node type: " + str(type(form)))

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -75,10 +75,8 @@ def from_iter(
 
 def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
     if not isinstance(iterable, Iterable):
-        raise ak._errors.wrap_error(
-            TypeError(
-                f"cannot produce an array from a non-iterable object ({type(iterable)!r})"
-            )
+        raise TypeError(
+            f"cannot produce an array from a non-iterable object ({type(iterable)!r})"
         )
 
     if isinstance(iterable, dict):
@@ -92,10 +90,8 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
                 resize,
             )[0]
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "cannot produce an array from a single dict (that would be a record)"
-                )
+            raise ValueError(
+                "cannot produce an array from a single dict (that would be a record)"
             )
 
     # Ensure that tuples are treated as iterables, not records

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -449,18 +449,14 @@ def _record_to_complex(layout, complex_record_fields):
                                 + node.backend.nplike.asarray(imag) * 1j
                             )
                     else:
-                        raise ak._errors.wrap_error(
-                            ValueError(
-                                f"expected record with fields {complex_record_fields[0]!r} and {complex_record_fields[1]!r} to have integer or floating point types, not {str(real.form.type)!r} and {str(imag.form.type)!r}"
-                            )
+                        raise ValueError(
+                            f"expected record with fields {complex_record_fields[0]!r} and {complex_record_fields[1]!r} to have integer or floating point types, not {str(real.form.type)!r} and {str(imag.form.type)!r}"
                         )
 
         return ak._do.recursively_apply(layout, action)
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError("complex_record_fields must be None or a pair of strings")
-        )
+        raise TypeError("complex_record_fields must be None or a pair of strings")
 
 
 def _no_schema(
@@ -492,7 +488,7 @@ def _no_schema(
                 neginf_string,
             )
         except Exception as err:
-            raise ak._errors.wrap_error(ValueError(str(err))) from None
+            raise ValueError(str(err)) from None
 
     formstr, length, buffers = builder.to_buffers()
     form = ak.forms.from_json(formstr)
@@ -529,18 +525,14 @@ def _yes_schema(
         schema = json.loads(schema)
 
     if not isinstance(schema, dict):
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
-        )
+        raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
 
     container = {}
     instructions = []
 
     if schema.get("type") == "array":
         if "items" not in schema:
-            raise ak._errors.wrap_error(
-                TypeError("JSONSchema type is not concrete: array without items")
-            )
+            raise TypeError("JSONSchema type is not concrete: array without items")
 
         instructions.append(["TopLevelArray"])
         form = build_assembly(schema["items"], container, instructions)
@@ -551,10 +543,8 @@ def _yes_schema(
         is_record = True
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(
-                "only 'array' and 'object' types supported at the JSONSchema root"
-            )
+        raise TypeError(
+            "only 'array' and 'object' types supported at the JSONSchema root"
         )
 
     read_one = not line_delimited
@@ -574,7 +564,7 @@ def _yes_schema(
                 resize,
             )
         except Exception as err:
-            raise ak._errors.wrap_error(ValueError(str(err))) from None
+            raise ValueError(str(err)) from None
 
     layout = ak.operations.from_buffers(
         form, length, container, byteorder=ak._util.native_byteorder, highlevel=False
@@ -592,14 +582,10 @@ def _yes_schema(
 
 def build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
-        )
+        raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
 
     if "type" not in schema is None:
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized JSONSchema: no 'type' in {schema!r}")
-        )
+        raise TypeError(f"unrecognized JSONSchema: no 'type' in {schema!r}")
 
     tpe = schema["type"]
 
@@ -726,9 +712,7 @@ def build_assembly(schema, container, instructions):
         # https://json-schema.org/understanding-json-schema/reference/array.html
 
         if "items" not in schema:
-            raise ak._errors.wrap_error(
-                TypeError("JSONSchema type is not concrete: array without 'items'")
-            )
+            raise TypeError("JSONSchema type is not concrete: array without 'items'")
 
         if schema.get("minItems") == schema.get("maxItems") != None:  # noqa: E711
             assert is_integer(schema.get("minItems"))
@@ -774,10 +758,8 @@ def build_assembly(schema, container, instructions):
         # https://json-schema.org/understanding-json-schema/reference/object.html
 
         if "properties" not in schema:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "JSONSchema type is not concrete: object without 'properties'"
-                )
+            raise TypeError(
+                "JSONSchema type is not concrete: object without 'properties'"
             )
 
         names = []
@@ -810,9 +792,7 @@ def build_assembly(schema, container, instructions):
             return out
 
     elif isinstance(tpe, list):
-        raise ak._errors.wrap_error(
-            NotImplementedError("arbitrary unions of types are not yet supported")
-        )
+        raise NotImplementedError("arbitrary unions of types are not yet supported")
 
     else:
-        raise ak._errors.wrap_error(TypeError(f"unrecognized JSONSchema: {tpe!r}"))
+        raise TypeError(f"unrecognized JSONSchema: {tpe!r}")

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -104,11 +104,9 @@ def metadata(
 
     if row_groups is not None:
         if not all(is_integer(x) and x >= 0 for x in row_groups):
-            raise ak._errors.wrap_error(
-                ValueError("row_groups must be a set of non-negative integers")
-            )
+            raise ValueError("row_groups must be a set of non-negative integers")
         if len(set(row_groups)) < len(row_groups):
-            raise ak._errors.wrap_error(ValueError("row group indices must not repeat"))
+            raise ValueError("row group indices must not repeat")
 
     fs, _, paths = fsspec.get_fs_token_paths(
         path, mode="rb", storage_options=storage_options
@@ -159,16 +157,12 @@ def metadata(
                 metadata.append_row_groups(md)
     if row_groups is not None:
         if any(_ >= metadata.num_row_groups for _ in row_groups):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    f"Row group selection out of bounds 0..{metadata.num_row_groups - 1}"
-                )
+            raise ValueError(
+                f"Row group selection out of bounds 0..{metadata.num_row_groups - 1}"
             )
         if not can_sub:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "Requested selection of row-groups, but not scanning metadata"
-                )
+            raise TypeError(
+                "Requested selection of row-groups, but not scanning metadata"
             )
 
         path_rgs = {}
@@ -356,8 +350,6 @@ def _all_and_metadata_paths(path, fs, paths, ignore_metadata=False, scan_files=T
     all_paths = [x for x, is_meta, is_comm in all_paths if not is_meta and not is_comm]
 
     if len(all_paths) == 0:
-        raise ak._errors.wrap_error(
-            ValueError(f"no *.parquet or *.parq matches for path {path!r}")
-        )
+        raise ValueError(f"no *.parquet or *.parq matches for path {path!r}")
 
     return all_paths, path_for_metadata, can_sub

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -75,10 +75,8 @@ def _impl(
         project = False
 
     if not all(isinstance(x, str) for x in columns):
-        raise ak._errors.wrap_error(
-            TypeError(
-                f"'columns' must be a string or an iterable of strings, not {columns!r}"
-            )
+        raise TypeError(
+            f"'columns' must be a string or an iterable of strings, not {columns!r}"
         )
 
     if not isinstance(offsets_type, str) or offsets_type not in (
@@ -86,11 +84,9 @@ def _impl(
         "uint32",
         "int64",
     ):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "'offsets_type' must be a string in (int32, uint32, int64), "
-                "not {}".format(repr(offsets_type))
-            )
+        raise TypeError(
+            "'offsets_type' must be a string in (int32, uint32, int64), "
+            "not {}".format(repr(offsets_type))
         )
     else:
         offsets_type = f"{offsets_type}_t"

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -69,10 +69,8 @@ def _impl(array, axis, highlevel, behavior):
             elif posaxis == depth and layout.is_list:
                 return layout
             elif layout.is_leaf:
-                raise ak._errors.wrap_error(
-                    np.AxisError(
-                        f"axis={axis} exceeds the depth of this array ({depth})"
-                    )
+                raise np.AxisError(
+                    f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
         out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -38,9 +38,7 @@ def _impl(array, axis, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
 
     if not is_integer(axis):
-        raise ak._errors.wrap_error(
-            TypeError(f"'axis' must be an integer, not {axis!r}")
-        )
+        raise TypeError(f"'axis' must be an integer, not {axis!r}")
 
     def action(layout, depth, lateral_context, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
@@ -59,9 +57,7 @@ def _impl(array, axis, highlevel, behavior):
                 )
 
         elif layout.is_leaf:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -107,9 +107,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
         if isinstance(layoutmask, ak.contents.NumpyArray):
             m = backend.nplike.asarray(layoutmask)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
-                raise ak._errors.wrap_error(
-                    ValueError(f"mask must have boolean type, not {repr(m.dtype)}")
-                )
+                raise ValueError(f"mask must have boolean type, not {repr(m.dtype)}")
             bytemask = ak.index.Index8(m.view(np.int8))
             return (
                 ak.contents.ByteMaskedArray.simplified(

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -80,7 +80,7 @@ def max(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(
@@ -154,7 +154,7 @@ def nanmax(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -99,7 +99,7 @@ def mean(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, weight, axis, keepdims, mask_identity)
@@ -162,7 +162,7 @@ def nanmean(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         x = ak.operations.ak_nan_to_none._impl(x, False, None)

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -67,9 +67,7 @@ def _impl(array, axis, highlevel, behavior):
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
         if depth < posaxis + 1 and layout.is_leaf:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         elif depth == posaxis + 1 and layout.is_option and layout.content.is_record:
             layout = layout.to_IndexedOptionArray64()
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -154,9 +154,7 @@ def _impl(array, axis, highlevel, behavior):
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
         if depth < posaxis + 1 and layout.is_leaf:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         elif depth == posaxis + 1 and layout.is_union:
             if not all(
                 x.is_record or x.is_indexed or x.is_option for x in layout.contents

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -78,7 +78,7 @@ def min(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(
@@ -152,7 +152,7 @@ def nanmin(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -78,7 +78,7 @@ def moment(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, n, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -81,9 +81,7 @@ def _impl(array, axis, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
 
     if not is_integer(axis):
-        raise ak._errors.wrap_error(
-            TypeError(f"'axis' must be an integer, not {axis!r}")
-        )
+        raise TypeError(f"'axis' must be an integer, not {axis!r}")
 
     if maybe_posaxis(layout, axis, 1) == 0:
         if isinstance(layout, ak.record.Record):
@@ -98,9 +96,7 @@ def _impl(array, axis, highlevel, behavior):
             return ak.contents.NumpyArray(layout.stops.data - layout.starts.data)
 
         elif layout.is_leaf:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -71,7 +71,7 @@ def prod(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -131,7 +131,7 @@ def nanprod(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -74,7 +74,7 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True, flatten_records
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -157,9 +157,7 @@ def _impl(array, highlevel, behavior):
                 return ak.contents.NumpyArray(nextcontent)
 
             if not isinstance(layout, (ak.contents.NumpyArray, ak.contents.EmptyArray)):
-                raise ak._errors.wrap_error(
-                    NotImplementedError("run_lengths on " + type(layout).__name__)
-                )
+                raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
             nextcontent, _ = lengths_of(backend.nplike.asarray(layout), None)
             return ak.contents.NumpyArray(nextcontent)
@@ -169,9 +167,7 @@ def _impl(array, highlevel, behavior):
                 layout = layout.project()
 
             if not layout.is_list:
-                raise ak._errors.wrap_error(
-                    NotImplementedError("run_lengths on " + type(layout).__name__)
-                )
+                raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
             if (
                 layout.content.parameter("__array__") == "string"
@@ -204,13 +200,11 @@ def _impl(array, highlevel, behavior):
             if not isinstance(
                 content, (ak.contents.NumpyArray, ak.contents.EmptyArray)
             ):
-                raise ak._errors.wrap_error(
-                    NotImplementedError(
-                        "run_lengths on "
-                        + type(layout).__name__
-                        + " with content "
-                        + type(content).__name__
-                    )
+                raise NotImplementedError(
+                    "run_lengths on "
+                    + type(layout).__name__
+                    + " with content "
+                    + type(content).__name__
                 )
 
             nextcontent, nextoffsets = lengths_of(

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -53,9 +53,7 @@ def _impl(array, axis, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
 
     if not is_integer(axis):
-        raise ak._errors.wrap_error(
-            TypeError(f"'axis' must be an integer, not {axis!r}")
-        )
+        raise TypeError(f"'axis' must be an integer, not {axis!r}")
 
     def action(layout, depth, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
@@ -82,9 +80,7 @@ def _impl(array, axis, highlevel, behavior):
                 return ak.contents.RegularArray(layout, 1).to_ListOffsetArray64(True)
 
         elif layout.is_leaf:
-            raise ak._errors.wrap_error(
-                np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
-            )
+            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -61,7 +61,7 @@ def softmax(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -64,9 +64,7 @@ def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
     elif kind in ("heapsort", "quicksort"):
         stable = False
     else:
-        raise ak._errors.wrap_error(
-            ValueError(
-                f"unsupported value for 'kind' passed to overloaded NumPy function 'sort': {kind!r}"
-            )
+        raise ValueError(
+            f"unsupported value for 'kind' passed to overloaded NumPy function 'sort': {kind!r}"
         )
     return sort(a, axis=axis, stable=stable)

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -83,7 +83,7 @@ def std(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, weight, ddof, axis, keepdims, mask_identity)
@@ -151,7 +151,7 @@ def nanstd(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         x = ak.operations.ak_nan_to_none._impl(x, False, None)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -215,7 +215,7 @@ def sum(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -279,7 +279,7 @@ def nansum(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         array = ak.operations.ak_nan_to_none._impl(array, False, None)

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -138,16 +138,14 @@ def _impl(array, how, levelname, anonymous):
     try:
         import pandas
     except ImportError as err:
-        raise ak._errors.wrap_error(
-            ImportError(
-                """install the 'pandas' package with:
+        raise ImportError(
+            """install the 'pandas' package with:
 
     pip install pandas --upgrade
 
 or
 
     conda install pandas"""
-            )
         ) from err
 
     if how is not None:

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -185,9 +185,7 @@ def _impl(
         out = ak.contents.NumpyArray(array)
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(f"unrecognized array type: {repr(array)}")
-        )
+        raise TypeError(f"unrecognized array type: {repr(array)}")
 
     jsondata = out.to_json(
         nan_string=nan_string,
@@ -295,7 +293,7 @@ def _impl(
                     )
 
     except Exception as err:
-        raise ak._errors.wrap_error(err) from err
+        raise err from err
 
 
 class _NoContextManager:

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -58,9 +58,7 @@ def _impl(array, allow_record, allow_other, regulararray):
 
     elif isinstance(array, ak.record.Record):
         if not allow_record:
-            raise _errors.wrap_error(
-                TypeError("ak.Record objects are not allowed in this function")
-            )
+            raise TypeError("ak.Record objects are not allowed in this function")
         else:
             return array
 
@@ -69,9 +67,7 @@ def _impl(array, allow_record, allow_other, regulararray):
 
     elif isinstance(array, ak.highlevel.Record):
         if not allow_record:
-            raise _errors.wrap_error(
-                TypeError("ak.Record objects are not allowed in this function")
-            )
+            raise TypeError("ak.Record objects are not allowed in this function")
         else:
             return array.layout
 
@@ -101,10 +97,8 @@ def _impl(array, allow_record, allow_other, regulararray):
             array = backend.nplike.reshape(array, (1,))
 
         if array.dtype.kind in {"S", "U"}:
-            raise _errors.wrap_error(
-                NotImplementedError(
-                    "strings are currently not supported for typetracer arrays"
-                )
+            raise NotImplementedError(
+                "strings are currently not supported for typetracer arrays"
             )
 
         return ak.contents.NumpyArray(array, parameters=None, backend=backend)
@@ -124,10 +118,8 @@ def _impl(array, allow_record, allow_other, regulararray):
         )
 
     elif not allow_other:
-        raise _errors.wrap_error(
-            TypeError(
-                f"{array} cannot be converted into an Awkward Array, and non-array-like objects are not supported."
-            )
+        raise TypeError(
+            f"{array} cannot be converted into an Awkward Array, and non-array-like objects are not supported."
         )
 
     else:

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -57,19 +57,13 @@ def _impl(
     import awkward._connect.rdataframe.to_rdataframe  # noqa: F401
 
     if not isinstance(arrays, Mapping):
-        raise ak._errors.wrap_error(
-            TypeError("'arrays' must be a dict (to provide C++ names for the arrays)")
-        )
+        raise TypeError("'arrays' must be a dict (to provide C++ names for the arrays)")
     elif not all(isinstance(name, str) for name in arrays):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "keys of 'arrays' dict must be strings (to provide C++ names for the arrays)"
-            )
+        raise TypeError(
+            "keys of 'arrays' dict must be strings (to provide C++ names for the arrays)"
         )
     elif len(arrays) == 0:
-        raise ak._errors.wrap_error(
-            TypeError("'arrays' must contain at least one array")
-        )
+        raise TypeError("'arrays' must contain at least one array")
 
     layouts = {}
     length = None
@@ -80,9 +74,7 @@ def _impl(
         if length is None:
             length = layouts[name].length
         elif length != layouts[name].length:
-            raise ak._errors.wrap_error(
-                ValueError("lengths of 'arrays' must all be the same")
-            )
+            raise ValueError("lengths of 'arrays' must all be the same")
 
     return ak._connect.rdataframe.to_rdataframe.to_rdataframe(
         layouts,

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -81,10 +81,8 @@ def _impl(array, axis, highlevel, behavior):
                 return layout.to_RegularArray()
 
             elif layout.is_leaf:
-                raise ak._errors.wrap_error(
-                    np.AxisError(
-                        f"axis={axis} exceeds the depth of this array ({depth})"
-                    )
+                raise np.AxisError(
+                    f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
         out = ak._do.recursively_apply(layout, action, behavior)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -497,10 +497,8 @@ def _impl(
                 return out
 
             else:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        f"transformation must return a Content or None, not {type(out)}\n\n{out!r}"
-                    )
+                raise TypeError(
+                    f"transformation must return a Content or None, not {type(out)}\n\n{out!r}"
                 )
 
         # An exception to the rule of ak._do.recursively_apply, for symmetry with
@@ -531,10 +529,8 @@ def _impl(
             elif isinstance(out, tuple):
                 for x in out:
                     if not isinstance(x, ak.contents.Content):
-                        raise ak._errors.wrap_error(
-                            TypeError(
-                                f"transformation must return a Content, tuple of Contents, or None, not a tuple containing {type(x)}\n\n{x!r}"
-                            )
+                        raise TypeError(
+                            f"transformation must return a Content, tuple of Contents, or None, not a tuple containing {type(x)}\n\n{x!r}"
                         )
                 return out
 
@@ -542,10 +538,8 @@ def _impl(
                 return (out,)
 
             else:
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        f"transformation must return a Content, tuple of Contents, or None, not {type(out)}\n\n{out!r}"
-                    )
+                raise TypeError(
+                    f"transformation must return a Content, tuple of Contents, or None, not {type(out)}\n\n{out!r}"
                 )
 
         inputs = [layout, *more_layouts]

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -129,6 +129,4 @@ def _impl(array, behavior):
             return _impl(layout, behavior)
 
         else:
-            raise ak._errors.wrap_error(
-                TypeError(f"unrecognized array type: {array!r}")
-            )
+            raise TypeError(f"unrecognized array type: {array!r}")

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -116,17 +116,15 @@ def _impl(array, counts, axis, highlevel, behavior):
             counts = counts.to_backend_array()
             mask = False
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "counts must be an integer or a one-dimensional array of integers"
-                )
+            raise ValueError(
+                "counts must be an integer or a one-dimensional array of integers"
             )
 
         if counts.ndim != 1:
-            raise ak._errors.wrap_error(ValueError("counts must be one-dimensional"))
+            raise ValueError("counts must be one-dimensional")
 
         if not np.issubdtype(counts.dtype, np.integer):
-            raise ak._errors.wrap_error(ValueError("counts must be integers"))
+            raise ValueError("counts must be integers")
 
         current_offsets = backend.index_nplike.empty(counts.size + 1, dtype=np.int64)
         current_offsets[0] = 0
@@ -141,9 +139,7 @@ def _impl(array, counts, axis, highlevel, behavior):
                 and layout.length is not unknown_length
                 and not 0 <= counts < layout.length
             ):
-                raise ak._errors.wrap_error(
-                    ValueError("too large counts for array or negative counts")
-                )
+                raise ValueError("too large counts for array or negative counts")
             out = ak.contents.RegularArray(layout, counts)
 
         else:
@@ -166,11 +162,9 @@ def _impl(array, counts, axis, highlevel, behavior):
                     or current_offsets[position] != layout.length
                 )
             ):
-                raise ak._errors.wrap_error(
-                    ValueError(
-                        "structure imposed by 'counts' does not fit in the array or partition "
-                        "at axis={}".format(axis)
-                    )
+                raise ValueError(
+                    "structure imposed by 'counts' does not fit in the array or partition "
+                    "at axis={}".format(axis)
                 )
 
             offsets = current_offsets[: position + 1]
@@ -221,11 +215,9 @@ def _impl(array, counts, axis, highlevel, behavior):
                 if not backend.index_nplike.array_equal(
                     inneroffsets[positions], outeroffsets
                 ):
-                    raise ak._errors.wrap_error(
-                        ValueError(
-                            "structure imposed by 'counts' does not fit in the array or partition "
-                            "at axis={}".format(axis)
-                        )
+                    raise ValueError(
+                        "structure imposed by 'counts' does not fit in the array or partition "
+                        "at axis={}".format(axis)
                     )
                 positions[0] = 0
 
@@ -238,11 +230,9 @@ def _impl(array, counts, axis, highlevel, behavior):
         and current_offsets.size is not unknown_length
         and not (current_offsets.size == 1 and current_offsets[0] == 0)
     ):
-        raise ak._errors.wrap_error(
-            ValueError(
-                "structure imposed by 'counts' does not fit in the array or partition "
-                "at axis={}".format(axis)
-            )
+        raise ValueError(
+            "structure imposed by 'counts' does not fit in the array or partition "
+            "at axis={}".format(axis)
         )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -53,8 +53,8 @@ def _impl(array, highlevel, behavior):
         elif isinstance(layout, ak.contents.UnionArray):
             for content in layout.contents:
                 if set(ak.operations.fields(content)) != set(fields):
-                    raise ak._errors.wrap_error(
-                        ValueError("union of different sets of fields, cannot ak.unzip")
+                    raise ValueError(
+                        "union of different sets of fields, cannot ak.unzip"
                     )
 
         elif hasattr(layout, "content"):

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -31,6 +31,6 @@ def _impl(array, exception):
     out = ak._do.validity_error(layout, path="highlevel")
 
     if out not in (None, "") and exception:
-        raise ak._errors.wrap_error(ValueError(out))
+        raise ValueError(out)
     else:
         return out

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -88,7 +88,7 @@ def var(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         return _impl(x, weight, ddof, axis, keepdims, mask_identity)
@@ -156,7 +156,7 @@ def nanvar(
                 "and flatten the array."
             )
             if flatten_records:
-                raise ak._errors.wrap_error(ValueError(message))
+                raise ValueError(message)
             else:
                 ak._errors.deprecate(message, "2.2.0")
         x = ak.operations.ak_nan_to_none._impl(x, False, None)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -49,9 +49,7 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
             return _impl1(condition, mergebool, highlevel, behavior)
 
     elif len(args) == 1:
-        raise ak._errors.wrap_error(
-            ValueError("either both or neither of x and y should be given")
-        )
+        raise ValueError("either both or neither of x and y should be given")
 
     elif len(args) == 2:
         x, y = args
@@ -68,11 +66,9 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
             return _impl3(condition, x, y, mergebool, highlevel, behavior)
 
     else:
-        raise ak._errors.wrap_error(
-            TypeError(
-                "where() takes from 1 to 3 positional arguments but {} were "
-                "given".format(len(args) + 1)
-            )
+        raise TypeError(
+            "where() takes from 1 to 3 positional arguments but {} were "
+            "given".format(len(args) + 1)
         )
 
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -56,11 +56,9 @@ def _impl(base, what, where, highlevel, behavior):
             and all(isinstance(x, str) for x in where)
         )
     ):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "New fields may only be assigned by field name(s) "
-                "or as a new integer slot by passing None for 'where'"
-            )
+        raise TypeError(
+            "New fields may only be assigned by field name(s) "
+            "or as a new integer slot by passing None for 'where'"
         )
 
     if is_non_string_like_sequence(where) and len(where) > 1:
@@ -86,9 +84,7 @@ def _impl(base, what, where, highlevel, behavior):
         base = ak.operations.to_layout(base, allow_record=True, allow_other=False)
 
         if len(base.fields) == 0:
-            raise ak._errors.wrap_error(
-                ValueError("no tuples or records in array; cannot add a new field")
-            )
+            raise ValueError("no tuples or records in array; cannot add a new field")
 
         what = ak.operations.to_layout(what, allow_record=True, allow_other=True)
 

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -42,10 +42,8 @@ def _impl(base, where, highlevel, behavior):
     if isinstance(where, str):
         where = [where]
     elif not (isinstance(where, Sequence) and all(isinstance(x, str) for x in where)):
-        raise ak._errors.wrap_error(
-            TypeError(
-                "Field names must be given as a single string, or a sequence of strings"
-            )
+        raise TypeError(
+            "Field names must be given as a single string, or a sequence of strings"
         )
 
     behavior = behavior_of(base, behavior=behavior)

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -167,9 +167,7 @@ def _impl(
     behavior,
 ):
     if depth_limit is not None and depth_limit <= 0:
-        raise ak._errors.wrap_error(
-            ValueError("depth_limit must be None or at least 1")
-        )
+        raise ValueError("depth_limit must be None or at least 1")
 
     if isinstance(arrays, dict):
         behavior = behavior_of(*arrays.values(), behavior=behavior)

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -35,18 +35,12 @@ class Record:
 
     def __init__(self, array, at):
         if not isinstance(array, ak.contents.RecordArray):
-            raise ak._errors.wrap_error(
-                TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
-            )
+            raise TypeError(f"Record 'array' must be a RecordArray, not {array!r}")
         if not is_integer(at):
-            raise ak._errors.wrap_error(
-                TypeError(f"Record 'at' must be an integer, not {array!r}")
-            )
+            raise TypeError(f"Record 'at' must be an integer, not {array!r}")
         if not (array.length is unknown_length or 0 <= at < array.length):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    f"Record 'at' must be >= 0 and < len(array) == {array.length}, not {at}"
-                )
+            raise ValueError(
+                f"Record 'at' must be >= 0 and < len(array) == {array.length}, not {at}"
             )
         else:
             self._array = array
@@ -141,27 +135,19 @@ class Record:
 
     def _getitem(self, where):
         if is_integer(where):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an integer")
-            )
+            raise IndexError("scalar Record cannot be sliced by an integer")
 
         elif isinstance(where, slice):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by a range slice (`:`)")
-            )
+            raise IndexError("scalar Record cannot be sliced by a range slice (`:`)")
 
         elif isinstance(where, str):
             return self._getitem_field(where)
 
         elif where is np.newaxis:
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by np.newaxis (`None`)")
-            )
+            raise IndexError("scalar Record cannot be sliced by np.newaxis (`None`)")
 
         elif where is Ellipsis:
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an ellipsis (`...`)")
-            )
+            raise IndexError("scalar Record cannot be sliced by an ellipsis (`...`)")
 
         elif isinstance(where, tuple) and len(where) == 0:
             return self
@@ -173,35 +159,25 @@ class Record:
             return self._getitem_field(where[0])._getitem(where[1:])
 
         elif isinstance(where, ak.highlevel.Array):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an array")
-            )
+            raise IndexError("scalar Record cannot be sliced by an array")
 
         elif isinstance(where, ak.contents.Content):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an array")
-            )
+            raise IndexError("scalar Record cannot be sliced by an array")
 
         elif isinstance(where, Content):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an array")
-            )
+            raise IndexError("scalar Record cannot be sliced by an array")
 
         elif isinstance(where, Iterable) and all(isinstance(x, str) for x in where):
             return self._getitem_fields(where)
 
         elif isinstance(where, Iterable):
-            raise ak._errors.wrap_error(
-                IndexError("scalar Record cannot be sliced by an array")
-            )
+            raise IndexError("scalar Record cannot be sliced by an array")
 
         else:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "only field name (str) or names (non-tuple iterable of str) "
-                    "are valid indices for slicing a scalar record, not\n\n    "
-                    + repr(where)
-                )
+            raise TypeError(
+                "only field name (str) or names (non-tuple iterable of str) "
+                "are valid indices for slicing a scalar record, not\n\n    "
+                + repr(where)
             )
 
     def _getitem_field(self, where, only_fields: tuple[str, ...] = ()) -> Content:

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -9,19 +9,15 @@ from awkward._regularize import is_integer
 class ArrayType:
     def __init__(self, content, length):
         if not isinstance(content, ak.types.Type):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Type subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Type subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if not ((is_integer(length) and length >= 0) or length is unknown_length):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} 'length' must be a non-negative integer or unknown length, not {}".format(
-                        type(self).__name__, repr(length)
-                    )
+            raise ValueError(
+                "{} 'length' must be a non-negative integer or unknown length, not {}".format(
+                    type(self).__name__, repr(length)
                 )
             )
         self._content = content

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
@@ -10,27 +9,21 @@ from awkward.types.type import Type
 class ListType(Type):
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Type subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Type subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._content = content

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -3,7 +3,6 @@
 import json
 import re
 
-import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
@@ -29,12 +28,10 @@ def primitive_to_dtype(primitive):
     else:
         out = _primitive_to_dtype_dict.get(primitive)
         if out is None:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "unrecognized primitive: {}. Must be one of\n\n    {}\n\nor a "
-                    "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
-                        repr(primitive), ", ".join(_primitive_to_dtype_dict)
-                    )
+            raise TypeError(
+                "unrecognized primitive: {}. Must be one of\n\n    {}\n\nor a "
+                "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
+                    repr(primitive), ", ".join(_primitive_to_dtype_dict)
                 )
             )
         return out
@@ -46,12 +43,10 @@ def dtype_to_primitive(dtype):
     else:
         out = _dtype_to_primitive_dict.get(dtype)
         if out is None:
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "unsupported dtype: {}. Must be one of\n\n    {}\n\nor a "
-                    "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
-                        repr(dtype), ", ".join(_primitive_to_dtype_dict)
-                    )
+            raise TypeError(
+                "unsupported dtype: {}. Must be one of\n\n    {}\n\nor a "
+                "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
+                    repr(dtype), ", ".join(_primitive_to_dtype_dict)
                 )
             )
         return out
@@ -99,19 +94,15 @@ class NumpyType(Type):
     def __init__(self, primitive, *, parameters=None, typestr=None):
         primitive = dtype_to_primitive(primitive_to_dtype(primitive))
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._primitive = primitive

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward.types.listtype import ListType
@@ -13,27 +12,21 @@ from awkward.types.uniontype import UnionType
 class OptionType(Type):
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Type subclass, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Type subclass, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._content = content

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -14,46 +14,36 @@ from awkward.types.type import Type
 class RecordType(Type):
     def __init__(self, contents, fields, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         if not isinstance(contents, list):
             contents = list(contents)
         for content in contents:
             if not isinstance(content, Type):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Type subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Type subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if fields is not None and not isinstance(fields, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'fields' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'fields' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._contents = contents

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-import awkward as ak
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
@@ -11,35 +10,27 @@ from awkward.types.type import Type
 class RegularType(Type):
     def __init__(self, content, size, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'content' must be a Type subtype, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} 'content' must be a Type subtype, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         if not (size is unknown_length or (is_integer(size) and size >= 0)):
-            raise ak._errors.wrap_error(
-                ValueError(
-                    "{} 'size' must be a non-negative int or None, not {}".format(
-                        type(self).__name__, repr(size)
-                    )
+            raise ValueError(
+                "{} 'size' must be a non-negative int or None, not {}".format(
+                    type(self).__name__, repr(size)
                 )
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._content = content

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -8,11 +8,9 @@ import awkward as ak
 class ScalarType:
     def __init__(self, content):
         if not isinstance(content, ak.types.Type):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} all 'contents' must be Type subclasses, not {}".format(
-                        type(self).__name__, repr(content)
-                    )
+            raise TypeError(
+                "{} all 'contents' must be Type subclasses, not {}".format(
+                    type(self).__name__, repr(content)
                 )
             )
         self._content = content

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -318,10 +318,8 @@ def from_datashape(datashape, highlevel=True):
         elif isinstance(out, RecordType):
             return out
         else:
-            raise ak._errors.wrap_error(
-                ValueError(
-                    f"type {type(out).__name__!r} is not compatible with highlevel=True"
-                )
+            raise ValueError(
+                f"type {type(out).__name__!r} is not compatible with highlevel=True"
             )
 
     else:

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Iterable
 
-import awkward as ak
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward.types.type import Type
@@ -12,38 +11,30 @@ from awkward.types.type import Type
 class UnionType(Type):
     def __init__(self, contents, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'contents' must be iterable, not {}".format(
-                        type(self).__name__, repr(contents)
-                    )
+            raise TypeError(
+                "{} 'contents' must be iterable, not {}".format(
+                    type(self).__name__, repr(contents)
                 )
             )
         if not isinstance(contents, list):
             contents = list(contents)
         for content in contents:
             if not isinstance(content, Type):
-                raise ak._errors.wrap_error(
-                    TypeError(
-                        "{} all 'contents' must be Type subclasses, not {}".format(
-                            type(self).__name__, repr(content)
-                        )
+                raise TypeError(
+                    "{} all 'contents' must be Type subclasses, not {}".format(
+                        type(self).__name__, repr(content)
                     )
                 )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._contents = contents

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
 from awkward._errors import deprecate
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
@@ -15,19 +14,15 @@ class UnknownType(Type):
                 f"{type(self).__name__} cannot contain parameters", version="2.2.0"
             )
         if parameters is not None and not isinstance(parameters, dict):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'parameters' must be of type dict or None, not {}".format(
-                        type(self).__name__, repr(parameters)
-                    )
+            raise TypeError(
+                "{} 'parameters' must be of type dict or None, not {}".format(
+                    type(self).__name__, repr(parameters)
                 )
             )
         if typestr is not None and not isinstance(typestr, str):
-            raise ak._errors.wrap_error(
-                TypeError(
-                    "{} 'typestr' must be of type string or None, not {}".format(
-                        type(self).__name__, repr(typestr)
-                    )
+            raise TypeError(
+                "{} 'typestr' must be of type string or None, not {}".format(
+                    type(self).__name__, repr(typestr)
                 )
             )
         self._parameters = parameters

--- a/studies/scalar.py
+++ b/studies/scalar.py
@@ -70,7 +70,7 @@ class JaxScalar:
     __slots__ = ["_value"]
 
     def __len__(self):
-        raise ak._errors.wrap_error(TypeError("len() of unsized object"))
+        raise TypeError("len() of unsized object")
 
     def _binop(self, op, other):
         if isinstance(other, JaxScalar):
@@ -99,9 +99,7 @@ class JaxScalar:
         return self._binop(self._value.__mul__, other)
 
     def __matmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __truediv__(self, other):
         return self._binop(self._value.__truediv__, other)
@@ -155,9 +153,7 @@ class JaxScalar:
         return self._binop(self._value.__rmul__, other)
 
     def __rmatmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __rtruediv__(self, other):
         return self._binop(self._value.__rtruediv__, other)
@@ -199,9 +195,7 @@ class JaxScalar:
         return self._binop(self._value.__imul__, other)
 
     def __imatmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __itruediv__(self, other):
         return self._binop(self._value.__itruediv__, other)
@@ -344,7 +338,7 @@ class CupyScalar:
     __slots__ = ["_value"]
 
     def __len__(self):
-        raise ak._errors.wrap_error(TypeError("len() of unsized object"))
+        raise TypeError("len() of unsized object")
 
     def _binop(self, op, other):
         if isinstance(other, CupyScalar):
@@ -373,9 +367,7 @@ class CupyScalar:
         return self._binop(self._value.__mul__, other)
 
     def __matmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __truediv__(self, other):
         return self._binop(self._value.__truediv__, other)
@@ -429,9 +421,7 @@ class CupyScalar:
         return self._binop(self._value.__rmul__, other)
 
     def __rmatmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __rtruediv__(self, other):
         return self._binop(self._value.__rtruediv__, other)
@@ -473,9 +463,7 @@ class CupyScalar:
         return self._binop(self._value.__imul__, other)
 
     def __imatmul__(self, other):
-        raise ak._errors.wrap_error(
-            ValueError("Input operand 0 does not have enough dimensions ")
-        )
+        raise ValueError("Input operand 0 does not have enough dimensions ")
 
     def __itruediv__(self, other):
         return self._binop(self._value.__itruediv__, other)

--- a/tests/test_0021_emptyarray.py
+++ b/tests/test_0021_emptyarray.py
@@ -145,31 +145,20 @@ def test_from_json_getitem():
         a[2, 1, 0]
     assert "index out of range while attempting to get index 0" in str(excinfo.value)
     assert a[2, 1][()].to_list() == []
-    with pytest.raises(IndexError) as excinfo:
+    with pytest.raises(IndexError, match=r"array is empty") as excinfo:
         a[2, 1][0]
-    assert (
-        "<Array [] type='0 * unknown'>\n\nwith\n\n    0\n\nat inner EmptyArray of length 0, using sub-slice 0.\n\nError details: array is empty."
-        in str(excinfo.value)
-    )
     assert a[2, 1][100:200].to_list() == []
     assert a[2, 1, 100:200].to_list() == []
     assert a[2, 1][np.array([], dtype=np.int64)].to_list() == []
     assert a[2, 1, np.array([], dtype=np.int64)].to_list() == []
-    with pytest.raises(IndexError) as excinfo:
+    with pytest.raises(
+        IndexError, match=r"index out of range while attempting to get index 0"
+    ) as excinfo:
         a[2, 1, np.array([0], dtype=np.int64)]
-    assert "index out of range while attempting to get index 0" in str(excinfo.value)
-    with pytest.raises(IndexError) as excinfo:
+    with pytest.raises(IndexError, match="array is empty") as excinfo:
         a[2, 1][100:200, 0]
-    assert (
-        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 0)\n\nat inner EmptyArray of length 0, using sub-slice array(0).\n\nError details: array is empty."
-        in str(excinfo.value)
-    )
-    with pytest.raises(IndexError) as excinfo:
+    with pytest.raises(IndexError, match="array is empty") as excinfo:
         a[2, 1][100:200, 200:300]
-    assert (
-        "<Array [] type='0 * unknown'>\n\nwith\n\n    (100:200, 200:300)\n\nat inner EmptyArray of length 0, using sub-slice 200:300.\n\nError details: array is empty."
-        in str(excinfo.value)
-    )
 
     # FIXME: Failed: DID NOT RAISE <class 'IndexError'>
     # with pytest.raises(IndexError) as excinfo:
@@ -177,6 +166,7 @@ def test_from_json_getitem():
     # assert ", too many dimensions in slice" in str(excinfo.value)
 
     assert a[1:, 1:].to_list() == [[[]], [[], []]]
-    with pytest.raises(IndexError) as excinfo:
+    with pytest.raises(
+        IndexError, match=r"index out of range while attempting to get index 0"
+    ) as excinfo:
         a[1:, 1:, 0]
-    assert "index out of range while attempting to get index 0" in str(excinfo.value)


### PR DESCRIPTION
Fixes #2369 by deferring stringifying until the top-level exception is caught by the error context. These exceptions leave Awkward's scope, and therefore count as true exceptions. Otherwise, we're decorating exceptions that might not be shown to the user, doing more busywork as a result!

NB, there are other ways to fix #2369, but this one also removes a lot of boilerplate!

