### PR TITLE
fix: `ak.unzip` visits all contents

### DIFF
--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -48,17 +48,14 @@ def _impl(array, highlevel, behavior):
 
     def check_for_union(layout, **kwargs):
         if isinstance(layout, (ak.contents.RecordArray, ak.Record)):
-            pass  # don't descend into nested records
+            return layout  # don't descend into nested records
 
-        elif isinstance(layout, ak.contents.UnionArray):
+        elif layout.is_union:
             for content in layout.contents:
                 if set(ak.operations.fields(content)) != set(fields):
                     raise ak._errors.wrap_error(
                         ValueError("union of different sets of fields, cannot ak.unzip")
                     )
-
-        elif hasattr(layout, "content"):
-            check_for_union(layout.content)
 
     ak._do.recursively_apply(layout, check_for_union, behavior, return_array=False)
 

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -48,7 +48,7 @@ def _impl(array, highlevel, behavior):
 
     def check_for_union(layout, **kwargs):
         if isinstance(layout, (ak.contents.RecordArray, ak.Record)):
-            return layout  # don't descend into nested records
+            return  # don't descend into nested records
 
         elif layout.is_union:
             for content in layout.contents:

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -48,7 +48,7 @@ def _impl(array, highlevel, behavior):
 
     def check_for_union(layout, **kwargs):
         if isinstance(layout, (ak.contents.RecordArray, ak.Record)):
-            return  # don't descend into nested records
+            return layout  # don't descend into nested records
 
         elif layout.is_union:
             for content in layout.contents:

--- a/tests/test_2373_unzip_touching.py
+++ b/tests/test_2373_unzip_touching.py
@@ -1,0 +1,124 @@
+import awkward as ak
+
+
+def test():
+    form = ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": ["muon", "jet"],
+            "contents": [
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "RecordArray",
+                        "fields": ["pt", "eta", "phi", "crossref"],
+                        "contents": [
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "muon_pt!",
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "muon_eta!",
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "muon_phi!",
+                            },
+                            {
+                                "class": "ListOffsetArray",
+                                "offsets": "i64",
+                                "content": {
+                                    "class": "NumpyArray",
+                                    "primitive": "int64",
+                                    "inner_shape": [],
+                                    "parameters": {},
+                                    "form_key": "muon_crossref_content!",
+                                },
+                                "parameters": {},
+                                "form_key": "muon_crossref_index!",
+                            },
+                        ],
+                        "parameters": {},
+                        "form_key": "muon_record!",
+                    },
+                    "parameters": {},
+                    "form_key": "muon_list!",
+                },
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "RecordArray",
+                        "fields": ["pt", "eta", "phi", "crossref", "thing1"],
+                        "contents": [
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "jet_pt!",
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "jet_eta!",
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "jet_phi!",
+                            },
+                            {
+                                "class": "ListOffsetArray",
+                                "offsets": "i64",
+                                "content": {
+                                    "class": "NumpyArray",
+                                    "primitive": "int64",
+                                    "inner_shape": [],
+                                    "parameters": {},
+                                    "form_key": "jet_crossref_content!",
+                                },
+                                "parameters": {},
+                                "form_key": "jet_crossref_index!",
+                            },
+                            {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "jet_thing1!",
+                            },
+                        ],
+                        "parameters": {},
+                        "form_key": "jet_record!",
+                    },
+                    "parameters": {},
+                    "form_key": "jet_list!",
+                },
+            ],
+            "parameters": {},
+            "form_key": "outer!",
+        }
+    )
+
+    ttlayout, report = ak._nplikes.typetracer.typetracer_with_report(form)
+
+    ttarray = ak.Array(ttlayout)
+    pairs = ak.cartesian([ttarray.muon, ttarray.jet], axis=1, nested=True)
+    a, b = ak.unzip(pairs)
+    assert report.data_touched == ["muon_list!", "jet_list!"]


### PR DESCRIPTION
This fixes #2372 by arresting recursion at the first record or union. I think this was the original intention, but the codebase was in a lot of flux at this point, and so it was likely missed.

Note that, in #2372 there are additional cases below the `unzip` that might also need addressing. We should raise these as new bugs.