### PR TITLE
fix: support empty records in `ak.with_field`

### DIFF
--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -94,9 +94,7 @@ def _impl(base, what, where, highlevel, behavior):
             def action_is_record(input, **kwargs):
                 nonlocal result
 
-                if input.is_list:
-                    return input
-                elif input.is_record:
+                if input.is_record:
                     result = True
                     return input
                 elif input.is_union:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -82,15 +82,34 @@ def _impl(base, what, where, highlevel, behavior):
 
         behavior = behavior_of(base, what, behavior=behavior)
         base = ak.operations.to_layout(base, allow_record=True, allow_other=False)
-
-        if len(base.fields) == 0:
-            raise ValueError("no tuples or records in array; cannot add a new field")
-
         what = ak.operations.to_layout(what, allow_record=True, allow_other=True)
 
         keys = copy.copy(base.fields)
         if where in base.fields:
             keys.remove(where)
+
+        def purelist_is_record(layout):
+            result = False
+
+            def action_is_record(input, **kwargs):
+                nonlocal result
+
+                if input.is_list:
+                    return input
+                elif input.is_record:
+                    result = True
+                    return input
+                elif input.is_union:
+                    result = all(purelist_is_record(x) for x in input.contents)
+                    return input
+                else:
+                    return None
+
+            ak._do.recursively_apply(layout, action_is_record, return_array=False)
+            return result
+
+        if not purelist_is_record(base):
+            raise ValueError("no tuples or records in array; cannot add a new field")
 
         def action(inputs, **kwargs):
             base, what = inputs

--- a/tests/test_2385_with_field_empty_record.py
+++ b/tests/test_2385_with_field_empty_record.py
@@ -1,0 +1,35 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+def test_no_fields():
+    no_fields = ak.Array([{}, {}, {}, {}, {}])
+    no_fields["new_field"] = ak.Array([1, 2, 3, 4, 5])
+    assert no_fields.to_list() == [
+        {"new_field": 1},
+        {"new_field": 2},
+        {"new_field": 3},
+        {"new_field": 4},
+        {"new_field": 5},
+    ]
+
+
+def test_union_partial_record():
+    no_fields = ak.Array([{}, []])
+    with pytest.raises(ValueError, match="cannot add a new field"):
+        no_fields["new_field"] = ak.Array([1, 2, 3, 4, 5])
+
+
+def test_union_record():
+    no_fields = ak.Array([{"x": 1}, {"y": 2}, {}, {}, {}])
+    no_fields["new_field"] = ak.Array([1, 2, 3, 4, 5])
+    assert no_fields.to_list() == [
+        {"new_field": 1, "x": 1, "y": None},
+        {"new_field": 2, "x": None, "y": 2},
+        {"new_field": 3, "x": None, "y": None},
+        {"new_field": 4, "x": None, "y": None},
+        {"new_field": 5, "x": None, "y": None},
+    ]


### PR DESCRIPTION
Fixes #2385 

I didn't yet add `purelist_is_record`; this feels like a very niche function, so we can start with it only as a local function to see whether its need crops up again.