### PR TITLE
fix: clarify scalar promotion in `to_layout`

### DIFF
--- a/src/awkward/_regularize.py
+++ b/src/awkward/_regularize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import numbers
 import os
 from collections.abc import Iterable, Sequence, Sized
+from numbers import Number
 
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import AxisMaybeNone, SupportsInt
@@ -48,6 +49,14 @@ def is_non_string_like_iterable(obj) -> bool:
 
 def is_non_string_like_sequence(obj) -> bool:
     return not isinstance(obj, (str, bytes)) and isinstance(obj, Sequence)
+
+
+def is_scalar(obj) -> bool:
+    return (
+        isinstance(obj, (str, bytes, Number, bool, np.generic))
+        or (is_array_like(obj) and obj.ndim == 0)
+        or obj is None
+    )
 
 
 def regularize_path(path):

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -409,7 +409,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 return None
 
         out = ak._broadcasting.broadcast_and_apply(
-            new_layouts, apply_build_record, behavior, right_broadcast=False
+            new_layouts,
+            apply_build_record,
+            behavior,
+            right_broadcast=False,
+            return_scalar=False,
         )
         assert isinstance(out, tuple) and len(out) == 1
         result = out[0]

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -282,6 +282,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
             behavior=behavior,
             allow_records=True,
             right_broadcast=False,
+            return_scalar=False,
         )[0]
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -96,4 +96,4 @@ def _impl(array, axis, highlevel, behavior):
 
         out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 
-    return wrap_layout(out, behavior, highlevel)
+    return wrap_layout(out, behavior, highlevel, allow_other=True)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -75,14 +75,11 @@ def _impl(array, axis, highlevel, behavior):
                 nplike = layout._backend.index_nplike
 
                 # this is a copy of the raw array
-                index = starts = nplike.asarray(
-                    layout.starts.raw(nplike), dtype=np.int64, copy=True
+                index = starts = nplike.astype(
+                    layout.starts.data, dtype=np.int64, copy=True
                 )
 
-                # this might be a view
-                stops = layout.stops.raw(nplike)
-
-                empties = starts == stops
+                empties = starts == layout.stops.data
                 index[empties] = -1
 
                 return ak.contents.IndexedOptionArray.simplified(

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -104,11 +104,11 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, backend, **kwargs):
         layoutarray, layoutmask = inputs
-        if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = backend.nplike.asarray(layoutmask)
-            if not issubclass(m.dtype.type, (bool, np.bool_)):
+        if layoutmask.is_numpy:
+            m = layoutmask.data
+            if not np.issubdtype(m.dtype, np.bool_):
                 raise ValueError(f"mask must have boolean type, not {repr(m.dtype)}")
-            bytemask = ak.index.Index8(m.view(np.int8))
+            bytemask = ak.index.Index8(m.view(np.int8)).to_nplike(backend.index_nplike)
             return (
                 ak.contents.ByteMaskedArray.simplified(
                     bytemask, layoutarray, valid_when=valid_when

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -2,17 +2,16 @@
 __all__ = ("to_layout",)
 
 from collections.abc import Iterable
+from numbers import Number
 
 from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward import _errors
-from awkward._backends.typetracer import TypeTracerBackend
-from awkward._nplikes.cupy import Cupy
-from awkward._nplikes.jax import Jax
+from awkward._layout import from_arraylib
+from awkward._nplikes.dispatch import nplike_of
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._nplikes.typetracer import TypeTracer
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -53,65 +52,62 @@ def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True)
         return _impl(array, allow_record, allow_other, regulararray=regulararray)
 
 
-def _impl(array, allow_record, allow_other, regulararray):
+def _to_layout_detailed(array, allow_record, allow_other, regulararray):
     if isinstance(array, ak.contents.Content):
-        return array
+        return array, False
 
     elif isinstance(array, ak.record.Record):
         if not allow_record:
             raise TypeError("ak.Record objects are not allowed in this function")
         else:
-            return array
+            return array, True
 
     elif isinstance(array, ak.highlevel.Array):
-        return array.layout
+        return array.layout, False
 
     elif isinstance(array, ak.highlevel.Record):
         if not allow_record:
             raise TypeError("ak.Record objects are not allowed in this function")
         else:
-            return array.layout
+            return array.layout, True
 
     elif isinstance(array, ak.highlevel.ArrayBuilder):
-        return array.snapshot().layout
+        return array.snapshot().layout, False
 
     elif isinstance(array, _ext.ArrayBuilder):
-        return array.snapshot()
+        return array.snapshot(), False
 
-    elif numpy.is_own_array(array):
-        return ak.operations.from_numpy(
-            array, regulararray=regulararray, recordarray=True, highlevel=False
+    elif nplike_of(array, default=None) is not None:
+        # 0D scalar arrays will be promoted
+        return (
+            from_arraylib(array, regulararray=regulararray, recordarray=True),
+            array.ndim == 0,
         )
 
-    elif Cupy.is_own_array(array):
-        return ak.operations.from_cupy(
-            array, regulararray=regulararray, highlevel=False
-        )
-
-    elif Jax.is_own_array(array):
-        return ak.operations.from_jax(array, regulararray=regulararray, highlevel=False)
-
-    elif TypeTracer.is_own_array(array):
-        backend = TypeTracerBackend.instance()
-
-        if len(array.shape) == 0:
-            array = backend.nplike.reshape(array, (1,))
-
-        if array.dtype.kind in {"S", "U"}:
-            raise NotImplementedError(
-                "strings are currently not supported for typetracer arrays"
-            )
-
-        return ak.contents.NumpyArray(array, parameters=None, backend=backend)
+    elif isinstance(array, np.generic):
+        array = numpy.asarray(array)
+        return from_arraylib(array, regulararray=regulararray, recordarray=True), True
 
     elif ak._util.in_module(array, "pyarrow"):
-        return ak.operations.from_arrow(array, highlevel=False)
+        return ak.operations.from_arrow(array, highlevel=False), False
 
-    elif isinstance(array, (str, bytes)):
-        return ak.operations.from_iter([array], highlevel=False)[0]
+    elif isinstance(array, (str, bytes, Number, bool)):
+        return ak.operations.from_iter([array], highlevel=False), True
+
+    elif array is None:
+        return (
+            ak.contents.IndexedOptionArray(
+                ak.index.Index64(
+                    numpy.full(1, -1, dtype=np.int64),
+                    nplike=numpy,
+                ),
+                ak.contents.EmptyArray(),
+            ),
+            True,
+        )
 
     elif isinstance(array, Iterable):
-        return _impl(
+        return _to_layout_detailed(
             ak.operations.from_iter(array, highlevel=False),
             allow_record,
             allow_other,
@@ -124,4 +120,8 @@ def _impl(array, allow_record, allow_other, regulararray):
         )
 
     else:
-        return array
+        return array, True
+
+
+def _impl(array, allow_record, allow_other, regulararray):
+    return _to_layout_detailed(array, allow_record, allow_other, regulararray)[0]

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -103,7 +103,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
-        if condition.is_numpy:
+        if all(x.is_numpy for x in inputs):
             npcondition = backend.index_nplike.asarray(akcondition)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -103,7 +103,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
-        if all(x.is_numpy for x in inputs):
+        if akcondition.is_numpy:
             npcondition = backend.index_nplike.asarray(akcondition)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(


### PR DESCRIPTION
Unifies scalar type handling in `ak.to_layout` such that scalars are _always_ promoted to 1D arrays. Where possible, e.g. `np.generic` objects, the dtype is preserved.