### PR TITLE
fix: update `GrowableBuffer::move_to` algorithm

### DIFF
--- a/header-only/growable-buffer/awkward/GrowableBuffer.h
+++ b/header-only/growable-buffer/awkward/GrowableBuffer.h
@@ -449,7 +449,7 @@ namespace awkward {
     void
     append(PRIMITIVE datum) {
       if (ptr_->current_length() == ptr_->reserved()) {
-        add_panel((size_t)ceil((double)ptr_->reserved() * (double)options_.resize()));
+        add_panel((size_t)ceil(options_.initial() * options_.resize()));
       }
       fill_panel(datum);
     }

--- a/header-only/growable-buffer/awkward/GrowableBuffer.h
+++ b/header-only/growable-buffer/awkward/GrowableBuffer.h
@@ -499,18 +499,16 @@ namespace awkward {
     /// contiguously allocated `external_pointer`. The panels are deleted,
     /// and a new #ptr is allocated.
     void
-    move_to(PRIMITIVE* to_ptr, size_t offset = 0) noexcept {
-      memcpy(to_ptr + offset,
-             reinterpret_cast<void*>(panel_.get()->data().get()),
-             panel_.get()->current_length() * sizeof(PRIMITIVE));
-
-      // move to next panel
-      panel_ = std::move(panel_.get()->next());
-      if (panel_) {
-        move_to(to_ptr, offset + panel_.get()->current_length());
-      } else {
-        clear();
+    move_to(PRIMITIVE* to_ptr) noexcept {
+      size_t next_offset = 0;
+      while(panel_) {
+        memcpy(to_ptr + next_offset,
+               reinterpret_cast<void*>(panel_.get()->data().get()),
+               panel_.get()->current_length() * sizeof(PRIMITIVE));
+        next_offset += panel_.get()->current_length();
+        panel_ = std::move(panel_.get()->next());
       }
+      clear();
     }
 
     /// @brief Copies and concatenates all accumulated data from multiple panels to one


### PR DESCRIPTION
Here is a memory allocation comparison by two algorithms: `move_to` and `concatenate`: the first releases each panel after it copies the data from it, the second copies all the data, then clears all the panels at the end.
<img width="1150" alt="Screenshot 2023-04-12 at 16 34 50" src="https://user-images.githubusercontent.com/1390682/231492938-f9f58171-d781-44e7-8e0e-08a8358b5637.png">
