### PR TITLE
fix: only touch data in `nplike.asarray` if copy is required

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -607,8 +607,6 @@ class TypeTracer(NumpyLike):
         dtype: numpy.dtype | None = None,
         copy: bool | None = None,
     ) -> TypeTracerArray:
-        try_touch_data(obj)
-
         if isinstance(obj, ak.index.Index):
             obj = obj.data
 
@@ -618,11 +616,16 @@ class TypeTracer(NumpyLike):
 
             if dtype is None:
                 return obj
-            elif copy is False and dtype != obj.dtype:
+            elif dtype == obj.dtype:
+                return TypeTracerArray._new(
+                    dtype, obj.shape, form_key=form_key, report=report
+                )
+            elif copy is False:
                 raise ValueError(
                     "asarray was called with copy=False for an array of a different dtype"
                 )
             else:
+                try_touch_data(obj)
                 return TypeTracerArray._new(
                     dtype, obj.shape, form_key=form_key, report=report
                 )

--- a/tests/test_2395_copy_asarray_touch.py
+++ b/tests/test_2395_copy_asarray_touch.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.typetracer import TypeTracer, typetracer_with_report
+
+typetracer = TypeTracer.instance()
+
+
+def test_no_copy():
+    form = ak.forms.NumpyForm("int64", form_key="buffer")
+    layout, report = typetracer_with_report(form)
+
+    typetracer.asarray(layout.data)
+    assert not report.data_touched
+
+
+def test_no_copy_dtype():
+    form = ak.forms.NumpyForm("int64", form_key="buffer")
+    layout, report = typetracer_with_report(form)
+
+    typetracer.asarray(layout.data, dtype=np.int64)
+    assert not report.data_touched
+
+
+def test_copy_touch():
+    form = ak.forms.NumpyForm("int64", form_key="buffer")
+    layout, report = typetracer_with_report(form)
+
+    typetracer.asarray(layout.data, dtype=np.int32)
+    assert report.data_touched == ["buffer"]


### PR DESCRIPTION
`nplike.asarray` needs to copy data (and therefore look at buffers) iff. the array dtype doesn't match.

Partially fixes #2384