### PR TITLE
fix: unify C++ and Python `GrowableBuffer::extend` algorithm

### DIFF
--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -368,11 +368,19 @@ def GrowableBuffer_extend(growablebuffer, data):
         pos = growablebuffer._pos_get()
 
         available = len(growablebuffer._panels[-1]) - pos
-        while len(data) > available:
-            growablebuffer._add_panel()
+        remaining = len(data)
+
+        if remaining > available:
+            panel_length = int(
+                math.ceil(len(growablebuffer._panels[0]) * growablebuffer._resize)
+            )
+
+            growablebuffer._panels.append(
+                numpy.empty((max(remaining, panel_length),), dtype=growablebuffer.dtype)
+            )
+            growablebuffer._pos_set(0)
             available += len(growablebuffer._panels[-1])
 
-        remaining = len(data)
         while remaining > 0:
             panel = growablebuffer._panels[panel_index]
             available_in_panel = len(panel) - pos

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -1,5 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
+import math
+
 import numba
 import numba.core.typing.npydecl
 import numpy
@@ -67,11 +69,12 @@ class GrowableBuffer:
         available = len(self._panels[-1]) - pos
         remaining = len(data)
 
-        if len(data) > available:
-            panel_length = int(numpy.ceil(len(self._panels[0]) * self._resize))
-            if remaining > panel_length:
-                panel_length = remaining
-            self._panels.append(numpy.empty((panel_length,), dtype=self.dtype))
+        if remaining > available:
+            panel_length = int(math.ceil(len(self._panels[0]) * self._resize))
+
+            self._panels.append(
+                numpy.empty((max(remaining, panel_length),), dtype=self.dtype)
+            )
             self._pos = 0
             available += len(self._panels[-1])
 
@@ -92,7 +95,7 @@ class GrowableBuffer:
         self._length_inc(len(data))
 
     def _add_panel(self):
-        panel_length = int(numpy.ceil(len(self._panels[0]) * self._resize))
+        panel_length = int(math.ceil(len(self._panels[0]) * self._resize))
 
         self._panels.append(numpy.empty((panel_length,), dtype=self.dtype))
         self._pos = 0
@@ -337,7 +340,7 @@ def GrowableBuffer_add_panel(growablebuffer):
         panel_length = len(last_panel)
         if len(growablebuffer._panels) == 1:
             # only resize the first time
-            panel_length = int(numpy.ceil(panel_length * growablebuffer._resize))
+            panel_length = int(math.ceil(panel_length * growablebuffer._resize))
 
         growablebuffer._panels.append(numpy.empty((panel_length,), last_panel.dtype))
         growablebuffer._pos_set(0)

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -68,7 +68,10 @@ class GrowableBuffer:
         remaining = len(data)
 
         if len(data) > available:
-            self._panels.append(numpy.empty((remaining,), dtype=self.dtype))
+            panel_length = int(numpy.ceil(len(self._panels[0]) * self._resize))
+            if remaining > panel_length:
+                panel_length = remaining
+            self._panels.append(numpy.empty((panel_length,), dtype=self.dtype))
             self._pos = 0
             available += len(self._panels[-1])
 

--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -335,14 +335,10 @@ def GrowableBufferType_len(growablebuffer):
 @numba.extending.overload_method(GrowableBufferType, "_add_panel")
 def GrowableBuffer_add_panel(growablebuffer):
     def add_panel(growablebuffer):
-        last_panel = growablebuffer._panels[-1]
+        first_panel = growablebuffer._panels[0]
+        panel_length = int(math.ceil(len(first_panel) * growablebuffer._resize))
 
-        panel_length = len(last_panel)
-        if len(growablebuffer._panels) == 1:
-            # only resize the first time
-            panel_length = int(math.ceil(panel_length * growablebuffer._resize))
-
-        growablebuffer._panels.append(numpy.empty((panel_length,), last_panel.dtype))
+        growablebuffer._panels.append(numpy.empty((panel_length,), first_panel.dtype))
         growablebuffer._pos_set(0)
 
     return add_panel

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -480,29 +480,29 @@ def test_numba_extend():
     # fill more than one panel, starting at a threshold
     extend_range(growablebuffer, 50, 80)
     assert snapshot(growablebuffer).tolist() == list(range(80))
-    assert len(growablebuffer._panels) == 5
+    assert len(growablebuffer._panels) == 4
 
     # fill more than one panel, not starting at a threshold, but ending on one
     extend_range(growablebuffer, 80, 110)
     assert snapshot(growablebuffer).tolist() == list(range(110))
-    assert len(growablebuffer._panels) == 6
+    assert len(growablebuffer._panels) == 5
 
     # fill lots of panels, starting at a threshold
     extend_range(growablebuffer, 110, 160)
     assert snapshot(growablebuffer).tolist() == list(range(160))
-    assert len(growablebuffer._panels) == 9
+    assert len(growablebuffer._panels) == 6
 
     # fill lots of panels, not starting at a threshold or ending on one
     extend_range(growablebuffer, 160, 200)
     assert snapshot(growablebuffer).tolist() == list(range(200))
-    assert len(growablebuffer._panels) == 11
+    assert len(growablebuffer._panels) == 7
 
     # fill lots of panels, not starting at a threshold, but ending on one
     extend_range(growablebuffer, 200, 250)
     assert snapshot(growablebuffer).tolist() == list(range(250))
-    assert len(growablebuffer._panels) == 13
+    assert len(growablebuffer._panels) == 8
 
     # fill a whole lot of panels, just for fun
     extend_range(growablebuffer, 250, 1000)
     assert snapshot(growablebuffer).tolist() == list(range(1000))
-    assert len(growablebuffer._panels) == 51
+    assert len(growablebuffer._panels) == 9

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -80,12 +80,12 @@ def test_python_extend():
     # touching the end of the second panel
     growablebuffer.extend(np.array(range(20, 30)))
     assert growablebuffer.snapshot().tolist() == list(range(30))
-    assert len(growablebuffer._panels) == 2
+    assert len(growablebuffer._panels) == 3
 
     # fill one whole panel exactly (start to end)
     growablebuffer.extend(np.array(range(30, 50)))
     assert growablebuffer.snapshot().tolist() == list(range(50))
-    assert len(growablebuffer._panels) == 3
+    assert len(growablebuffer._panels) == 4
 
     # fill more than one panel, starting at a threshold
     growablebuffer.extend(np.array(range(50, 80)))
@@ -100,22 +100,22 @@ def test_python_extend():
     # fill lots of panels, starting at a threshold
     growablebuffer.extend(np.array(range(110, 160)))
     assert growablebuffer.snapshot().tolist() == list(range(160))
-    assert len(growablebuffer._panels) == 9
+    assert len(growablebuffer._panels) == 7
 
     # fill lots of panels, not starting at a threshold or ending on one
     growablebuffer.extend(np.array(range(160, 200)))
     assert growablebuffer.snapshot().tolist() == list(range(200))
-    assert len(growablebuffer._panels) == 11
+    assert len(growablebuffer._panels) == 8
 
     # fill lots of panels, not starting at a threshold, but ending on one
     growablebuffer.extend(np.array(range(200, 250)))
     assert growablebuffer.snapshot().tolist() == list(range(250))
-    assert len(growablebuffer._panels) == 13
+    assert len(growablebuffer._panels) == 9
 
     # fill a whole lot of panels, just for fun
     growablebuffer.extend(np.array(range(250, 1000)))
     assert growablebuffer.snapshot().tolist() == list(range(1000))
-    assert len(growablebuffer._panels) == 51
+    assert len(growablebuffer._panels) == 10
 
 
 def test_unbox():

--- a/tests/test_2349_growablebuffer_in_numba.py
+++ b/tests/test_2349_growablebuffer_in_numba.py
@@ -80,42 +80,42 @@ def test_python_extend():
     # touching the end of the second panel
     growablebuffer.extend(np.array(range(20, 30)))
     assert growablebuffer.snapshot().tolist() == list(range(30))
-    assert len(growablebuffer._panels) == 3
+    assert len(growablebuffer._panels) == 2
 
     # fill one whole panel exactly (start to end)
     growablebuffer.extend(np.array(range(30, 50)))
     assert growablebuffer.snapshot().tolist() == list(range(50))
-    assert len(growablebuffer._panels) == 4
+    assert len(growablebuffer._panels) == 3
 
     # fill more than one panel, starting at a threshold
     growablebuffer.extend(np.array(range(50, 80)))
     assert growablebuffer.snapshot().tolist() == list(range(80))
-    assert len(growablebuffer._panels) == 5
+    assert len(growablebuffer._panels) == 4
 
     # fill more than one panel, not starting at a threshold, but ending on one
     growablebuffer.extend(np.array(range(80, 110)))
     assert growablebuffer.snapshot().tolist() == list(range(110))
-    assert len(growablebuffer._panels) == 6
+    assert len(growablebuffer._panels) == 5
 
     # fill lots of panels, starting at a threshold
     growablebuffer.extend(np.array(range(110, 160)))
     assert growablebuffer.snapshot().tolist() == list(range(160))
-    assert len(growablebuffer._panels) == 7
+    assert len(growablebuffer._panels) == 6
 
     # fill lots of panels, not starting at a threshold or ending on one
     growablebuffer.extend(np.array(range(160, 200)))
     assert growablebuffer.snapshot().tolist() == list(range(200))
-    assert len(growablebuffer._panels) == 8
+    assert len(growablebuffer._panels) == 7
 
     # fill lots of panels, not starting at a threshold, but ending on one
     growablebuffer.extend(np.array(range(200, 250)))
     assert growablebuffer.snapshot().tolist() == list(range(250))
-    assert len(growablebuffer._panels) == 9
+    assert len(growablebuffer._panels) == 8
 
     # fill a whole lot of panels, just for fun
     growablebuffer.extend(np.array(range(250, 1000)))
     assert growablebuffer.snapshot().tolist() == list(range(1000))
-    assert len(growablebuffer._panels) == 10
+    assert len(growablebuffer._panels) == 9
 
 
 def test_unbox():


### PR DESCRIPTION
As discussed: a `GrowableBuffer::extend` algorithm should add a single panel of a data size. The next panel added after that one should be a size of `initial*resize`.

Note, the first panel is always a size of `initial`. All next panels added after the first one should be a size of `initial*resize`. 