### PR TITLE
fix: don't touch for `ascontiguousarray`

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -15,6 +15,7 @@ from awkward._typing import Protocol, TypeAlias
 KernelKeyType: TypeAlias = tuple  # Tuple[str, Unpack[Tuple[metadata.dtype, ...]]]
 
 
+numpy = Numpy.instance()
 metadata = NumpyMetadata.instance()
 
 
@@ -69,8 +70,8 @@ class NumpyKernel(BaseKernel):
     def _cast(cls, x, t):
         if issubclass(t, ctypes._Pointer):
             # Do we have a NumPy-owned array?
-            if Numpy.is_own_array(x):
-                assert Numpy.is_c_contiguous(x), "kernel expects contiguous array"
+            if numpy.is_own_array(x):
+                assert numpy.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
                     return ctypes.cast(x.ctypes.data, t)
                 else:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -36,10 +36,11 @@ class ArrayModuleNumpyLike(NumpyLike):
             else:
                 return self._module.asarray(obj, dtype=dtype)
 
-    def ascontiguousarray(
-        self, x: ArrayLike, *, dtype: np.dtype | None = None
-    ) -> ArrayLike:
-        return self._module.ascontiguousarray(x, dtype=dtype)
+    def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
+        # Allow buffers to _pretend_ to be contiguous already
+        if x.dtype.metadata is not None and x.dtype.metadata.get("pretend_contiguous"):
+            return x
+        return self._module.ascontiguousarray(x)
 
     def frombuffer(
         self, buffer, *, dtype: np.dtype | None = None, count: int = -1

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -154,4 +154,6 @@ class Cupy(ArrayModuleNumpyLike):
         return module == "cupy"
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:
-        return x.flags["C_CONTIGUOUS"]
+        return x.flags["C_CONTIGUOUS"] or (
+            x.dtype.metadata is not None and x.dtype.metadata.get("pretend_contiguous")
+        )

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -1,8 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-import numpy
-
 import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
@@ -74,10 +72,5 @@ class Jax(ArrayModuleNumpyLike):
     def is_c_contiguous(self, x: ArrayLike) -> bool:
         return True
 
-    def ascontiguousarray(
-        self, x: ArrayLike, *, dtype: numpy.dtype | None = None
-    ) -> ArrayLike:
-        if dtype is not None:
-            return x.astype(dtype)
-        else:
-            return x
+    def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
+        return x

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -43,7 +43,9 @@ class Numpy(ArrayModuleNumpyLike):
         return issubclass(type_, numpy.ndarray)
 
     def is_c_contiguous(self, x: ArrayLike) -> bool:
-        return x.flags["C_CONTIGUOUS"]
+        return x.flags["C_CONTIGUOUS"] or (
+            x.dtype.metadata is not None and x.dtype.metadata.get("pretend_contiguous")
+        )
 
     def packbits(
         self,

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -248,9 +248,7 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
-    def ascontiguousarray(
-        self, x: ArrayLike, *, dtype: numpy.dtype | None = None
-    ) -> ArrayLike:
+    def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -698,7 +698,6 @@ class TypeTracer(NumpyLike):
     def ascontiguousarray(
         self, x: ArrayLike, *, dtype: numpy.dtype | None = None
     ) -> TypeTracerArray:
-        try_touch_data(x)
         return TypeTracerArray._new(dtype or x.dtype, shape=x.shape)
 
     def frombuffer(

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -695,10 +695,10 @@ class TypeTracer(NumpyLike):
             else:
                 raise TypeError
 
-    def ascontiguousarray(
-        self, x: ArrayLike, *, dtype: numpy.dtype | None = None
-    ) -> TypeTracerArray:
-        return TypeTracerArray._new(dtype or x.dtype, shape=x.shape)
+    def ascontiguousarray(self, x: ArrayLike) -> TypeTracerArray:
+        return TypeTracerArray._new(
+            x.dtype, shape=x.shape, form_key=x.form_key, report=x.report
+        )
 
     def frombuffer(
         self, buffer, *, dtype: np.dtype | None = None, count: int = -1

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -703,19 +703,15 @@ class NumpyArray(Content):
 
         if negaxis is None:
             contiguous_self = self.to_contiguous()
-            # Python 3.8 could use math.prod
-            flattened_shape = 1
-            for s in contiguous_self.shape:
-                flattened_shape = flattened_shape * s
 
             offsets = ak.index.Index64.zeros(2, self._backend.index_nplike)
-            offsets[1] = flattened_shape
+            offsets[1] = self._data.size
             dtype = (
                 np.dtype(np.int64)
                 if self._data.dtype.kind.upper() == "M"
                 else self._data.dtype
             )
-            out = self._backend.nplike.empty(offsets[1], dtype=dtype)
+            out = self._backend.nplike.empty(self._data.size, dtype=dtype)
             assert offsets.nplike is self._backend.index_nplike
             self._handle_error(
                 self._backend[


### PR DESCRIPTION
This is because touching should really only occur if the operation result _depends_ upon the array value, which it does not in this instance.

This PR 
1. allows `dask-awkward` to set `pretend_contiguous` on the `ndarray.dtype` for our "fake" buffers, ensuring that nplikes do not force them to become contiguous.
2. does not touch arrays in `ascontiguousarray`

The plan is to remove (1) later, once `dask-awkward` passes in its own special content types.