### PR TITLE
ci: add workflow to ensure C++ is released

### DIFF
--- a/.github/workflows/needs-cpp-release.yml
+++ b/.github/workflows/needs-cpp-release.yml
@@ -2,6 +2,9 @@ name: Needs C++ Release
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   determine-source-date-epoch:

--- a/.github/workflows/needs-cpp-release.yml
+++ b/.github/workflows/needs-cpp-release.yml
@@ -1,0 +1,46 @@
+name: Needs C++ Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  determine-source-date-epoch:
+    name: "Determine SOURCE_DATE_EPOCH"
+    runs-on: ubuntu-latest
+    outputs:
+      source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - id: log
+        name: Compute SOURCE_DATE_EPOCH
+        run: |
+          # Find latest unix timestamp in awkward-cpp, and the kernel generation files
+          epoch=$( git log -1 --format=%at -- awkward-cpp kernel-specification.yml kernel-test-data.json )
+          echo "source-date-epoch=$epoch" >> $GITHUB_OUTPUT
+
+
+  check-cpp-on-pypi:
+    name: "Check awkward-cpp dependency on PyPI"
+    runs-on: ubuntu-latest
+    needs: [determine-source-date-epoch]
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Prepare build files
+        run: pipx run nox -s prepare
+
+      - name: Build awkward-cpp sdist
+        run: pipx run build --sdist awkward-cpp
+
+      - name: Check sdist matches PyPI
+        run: pipx run nox -s check_cpp_sdist_released -- awkward-cpp/dist/awkward-cpp*.tar.gz


### PR DESCRIPTION
This PR adds a CI workflow that provides an indication of whether the C++ package is already on PyPI. A status badge has since been added to README.md:
![image](https://user-images.githubusercontent.com/1248413/231800052-65ebd3a5-46c3-4f79-a1b9-8ebc9733be3b.png)
