### PR TITLE
ci: attach header-only artifact to release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,10 @@ jobs:
       with:
         name: header-only
         path: header-only
+    - name: Create archive
+      run: |
+        # Don't include `header-only` parent directory
+        env -C header-only/ zip -r header-only.zip .
     - uses: softprops/action-gh-release@v1
       with:
-        files: header-only/*
+        files: header-only/header-only.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,9 +93,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: true
-
     - uses: actions/upload-artifact@v3
       with:
         name: header-only
@@ -114,3 +111,17 @@ jobs:
     - uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
         password: ${{ secrets.PYPI_PASSWORD }}
+
+  publish-headers:
+    name: "Publish header-only libraries alongside release"
+    runs-on: ubuntu-latest
+    needs: [bundle-headers]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: header-only
+        path: header-only
+    - uses: softprops/action-gh-release@v1
+      with:
+        files: header-only/*


### PR DESCRIPTION
I've tested this in a [playground repo](https://github.com/agoose77/github-action-playground/actions/runs/4722005250), and it works. It's unfortunate that we have to rebuild the zip, but in this instance, we don't need the zip to have the same SHA or anything like that.