### PR TITLE
fix: return empty list if broadcasting no arrays

### DIFF
--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -208,6 +208,10 @@ def _impl(
     highlevel,
     behavior,
 ):
+    # Need at least one array!
+    if len(arrays) == 0:
+        return []
+
     backend = backend_of(*arrays, default=cpu)
 
     inputs = []

--- a/tests/test_2407_broadcast_no_arrays.py
+++ b/tests/test_2407_broadcast_no_arrays.py
@@ -1,0 +1,10 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    result = ak.broadcast_arrays()
+    assert result == []


### PR DESCRIPTION
`ak._broadcasting.broadcast_and_apply` expects at least one argument that has a backend, which is not satisfied if no arrays are passed. It also fails if no array-like objects are passed, but that's for another PR.