### PR TITLE
fix: only convert NEP18 arguments to layouts if required

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Iterable
 
 from awkward._backends.backend import Backend
 from awkward._nplikes.numpy import Numpy
@@ -46,7 +46,7 @@ def register_backend(primary_nplike_cls: type[NumpyLike]):
     return wrapper
 
 
-def common_backend(backends: Collection[Backend]) -> Backend:
+def common_backend(backends: Iterable[Backend]) -> Backend:
     unique_backends = frozenset(backends)
     # Either we have one nplike, or one + typetracer
     if len(unique_backends) == 1:
@@ -57,10 +57,16 @@ def common_backend(backends: Collection[Backend]) -> Backend:
             if not backend.nplike.known_data:
                 return backend
 
-        raise ValueError(
-            "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
-            "to the same backend"
-        )
+        if len(unique_backends) > 1:
+            raise ValueError(
+                "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
+                "to the same backend"
+            )
+
+        else:
+            raise ValueError(
+                "no backends were given in order to determine a common backend."
+            )
 
 
 def _backend_of(obj, default: D = unset) -> Backend | D:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -1,17 +1,22 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import collections
 import functools
 import inspect
+from collections.abc import Iterable
+from itertools import chain
 
 import numpy
 
 import awkward as ak
-from awkward._backends.dispatch import backend_of
+from awkward._backends.dispatch import backend_of, common_backend
+from awkward._backends.backend import Backend
 from awkward._behavior import (
     behavior_of,
     find_custom_cast,
     find_ufunc,
     find_ufunc_generic,
 )
+from awkward._nplikes import to_nplike
 from awkward._layout import wrap_layout
 from awkward._regularize import is_non_string_like_iterable
 from awkward._util import numpy_at_least
@@ -44,13 +49,36 @@ def convert_to_array(layout, args, kwargs):
 implemented = {}
 
 
-def _to_rectilinear(arg):
+def _find_backends(args: Iterable) -> Backend:
+    """
+    Args:
+        args: iterable of objects to visit
+
+    Returns the backend of the first layout or high-level Awkward object encountered.
+    """
+    stack = collections.deque(args)
+    while stack:
+        arg = stack.popleft()
+        # If the argument declares a backend, easy!
+        backend = backend_of(arg, default=None)
+        if backend is not None:
+            yield backend
+        # Is this object something we already associate with an nplike?
+        elif isinstance(arg, (tuple, list)):
+            stack.extend(arg)
+
+
+def _to_rectilinear(arg, backend: Backend):
     # Is this object something we already associate with a backend?
-    backend = backend_of(arg, default=None)
-    if backend is not None:
+    arg_backend = backend_of(arg, default=None)
+    if arg_backend is not None:
+        arg_nplike = arg_backend.nplike
         # Is this argument already in a backend-supported form?
-        if backend.nplike.is_own_array(arg):
-            return arg
+        if arg_nplike.is_own_array(arg):
+            # Convert to the appropriate nplike
+            return to_nplike(
+                arg_nplike.asarray(arg), backend.nplike, from_nplike=arg_nplike
+            )
         # Otherwise, cast to layout and convert
         else:
             layout = ak.to_layout(arg, allow_record=False, allow_other=False)
@@ -69,8 +97,10 @@ def _to_rectilinear(arg):
 
 
 def _array_function_no_impl(func, types, args, kwargs, behavior):
-    rectilinear_args = tuple(_to_rectilinear(x) for x in args)
-    rectilinear_kwargs = {k: _to_rectilinear(v) for k, v in kwargs.items()}
+    backend = common_backend(_find_backends(chain(args, kwargs.values())))
+
+    rectilinear_args = tuple(_to_rectilinear(x, backend) for x in args)
+    rectilinear_kwargs = {k: _to_rectilinear(v, backend) for k, v in kwargs.items()}
     result = func(*rectilinear_args, **rectilinear_kwargs)
     # We want the result to be a layout (this will fail for functions returning non-array convertibles)
     out = ak.operations.ak_to_layout._impl(

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -45,10 +45,16 @@ implemented = {}
 
 
 def _to_rectilinear(arg):
+    # Is this object something we already associate with a backend?
     backend = backend_of(arg, default=None)
-    # We have some array-like object that our backend mechanism understands
     if backend is not None:
-        return ak.operations.to_numpy(arg)
+        # Is this argument already in a backend-supported form?
+        if backend.nplike.is_own_array(arg):
+            return arg
+        # Otherwise, cast to layout and convert
+        else:
+            layout = ak.to_layout(arg, allow_record=False, allow_other=False)
+            return layout.to_backend_array(allow_missing=True)
     elif isinstance(arg, tuple):
         return tuple(_to_rectilinear(x) for x in arg)
     elif isinstance(arg, list):

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -8,17 +8,18 @@ from itertools import chain
 import numpy
 
 import awkward as ak
-from awkward._backends.dispatch import backend_of, common_backend
 from awkward._backends.backend import Backend
+from awkward._backends.dispatch import backend_of, common_backend
 from awkward._behavior import (
     behavior_of,
     find_custom_cast,
     find_ufunc,
     find_ufunc_generic,
 )
-from awkward._nplikes import to_nplike
 from awkward._layout import wrap_layout
+from awkward._nplikes import to_nplike
 from awkward._regularize import is_non_string_like_iterable
+from awkward._typing import Iterator
 from awkward._util import numpy_at_least
 from awkward.contents.numpyarray import NumpyArray
 
@@ -49,7 +50,7 @@ def convert_to_array(layout, args, kwargs):
 implemented = {}
 
 
-def _find_backends(args: Iterable) -> Backend:
+def _find_backends(args: Iterable) -> Iterator[Backend]:
     """
     Args:
         args: iterable of objects to visit
@@ -84,9 +85,9 @@ def _to_rectilinear(arg, backend: Backend):
             layout = ak.to_layout(arg, allow_record=False, allow_other=False)
             return layout.to_backend_array(allow_missing=True)
     elif isinstance(arg, tuple):
-        return tuple(_to_rectilinear(x) for x in arg)
+        return tuple(_to_rectilinear(x, backend) for x in arg)
     elif isinstance(arg, list):
-        return [_to_rectilinear(x) for x in arg]
+        return [_to_rectilinear(x, backend) for x in arg]
     elif is_non_string_like_iterable(arg):
         raise TypeError(
             f"encountered an unsupported iterable value {arg!r} whilst converting arguments to NumPy-friendly "

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -84,7 +84,7 @@ def _to_rectilinear(arg, backend: Backend):
         # Otherwise, cast to layout and convert
         else:
             layout = ak.to_layout(arg, allow_record=False, allow_other=False)
-            return layout.to_backend_array(allow_missing=True)
+            return layout.to_backend(backend).to_backend_array(allow_missing=True)
     elif isinstance(arg, tuple):
         return tuple(_to_rectilinear(x, backend) for x in arg)
     elif isinstance(arg, list):

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -55,7 +55,8 @@ def _find_backends(args: Iterable) -> Iterator[Backend]:
     Args:
         args: iterable of objects to visit
 
-    Returns the backend of the first layout or high-level Awkward object encountered.
+    Yields the encountered backends of layout / array-like arguments encountered
+    in the argument list.
     """
     stack = collections.deque(args)
     while stack:
@@ -64,7 +65,7 @@ def _find_backends(args: Iterable) -> Iterator[Backend]:
         backend = backend_of(arg, default=None)
         if backend is not None:
             yield backend
-        # Is this object something we already associate with an nplike?
+        # Otherwise, traverse into supported sequence types
         elif isinstance(arg, (tuple, list)):
             stack.extend(arg)
 

--- a/tests/test_2305_nep_18_lazy_conversion.py
+++ b/tests/test_2305_nep_18_lazy_conversion.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_binary():
+    ak_array = ak.Array(np.arange(10, dtype="<u4"))
+    np_array = np.arange(10, dtype=">u4")
+    assert np.array_equal(ak_array, np_array)
+
+
+def test_different_backend():
+    pytest.importorskip("jax")
+    ak.jax.register_and_check()
+
+    left = ak.Array([0, 1, 2], backend="jax")
+    right = ak.Array([0, 1, 2], backend="cpu")
+    with pytest.raises(
+        ValueError, match="cannot operate on arrays with incompatible backends"
+    ):
+        assert np.array_equal(left, right)


### PR DESCRIPTION
Issue #2303 raises a couple of important points;
- We don't need to build a layout only to immediately convert it to a backend array
- We should not convert to NumPy eagerly; it's possible to use NEP18 on cuda `cp.ndarray,` the same should hold for `ak.Array` with `backend="cuda"`.

This PR fixes #2303 by 
- Only converting to layouts if we identify a backend, and the object is not a backend array
- Convert all arguments to a common backend

> **Note**
> This PR replaces https://github.com/scikit-hep/awkward/pull/2305, which became stale somehow.