### PR TITLE
refactor: add custom axis error

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -7,6 +7,7 @@ from numbers import Integral
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import Any, AxisMaybeNone, Literal
 from awkward.contents.content import ActionType, Content
@@ -154,13 +155,13 @@ def unique(layout: Content, axis=None):
             branch, depth = layout.branch_depth
             if branch:
                 if negaxis <= 0:
-                    raise np.AxisError(
+                    raise AxisError(
                         "cannot use non-negative axis on a nested list structure "
                         "of variable depth (negative axis counts from the leaves "
                         "of the tree; non-negative from the root)"
                     )
                 if negaxis > depth:
-                    raise np.AxisError(
+                    raise AxisError(
                         "cannot use axis={} on a nested list structure that splits into "
                         "different depths, the minimum of which is depth={} from the leaves".format(
                             axis, depth
@@ -170,7 +171,7 @@ def unique(layout: Content, axis=None):
                 if negaxis <= 0:
                     negaxis = negaxis + depth
                 if not (0 < negaxis and negaxis <= depth):
-                    raise np.AxisError(
+                    raise AxisError(
                         "axis={} exceeds the depth of this array ({})".format(
                             axis, depth
                         )
@@ -183,7 +184,7 @@ def unique(layout: Content, axis=None):
 
         return layout._unique(negaxis, starts, parents, 1)
 
-    raise np.AxisError(
+    raise AxisError(
         "unique expects axis 'None' or '-1', got axis={} that is not supported yet".format(
             axis
         )

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -125,8 +125,6 @@ class ErrorContext:
                 valuestr = f"repr-raised-{type(err).__name__}"
 
         elif isinstance(value, np.ndarray):
-            import numpy  # noqa: TID251
-
             if not numpy.__version__.startswith("1.13."):  # 'threshold' argument
                 prefix = f"{type(value).__module__}.{type(value).__name__}("
                 suffix = ")"

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -6,6 +6,8 @@ import threading
 import warnings
 from collections.abc import Mapping, Sequence
 
+import numpy  # noqa: TID251
+
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import TypeVar
 
@@ -363,4 +365,8 @@ Issue: {}.""".format(
 
 
 class FieldNotFoundError(IndexError):
+    ...
+
+
+class AxisError(numpy.AxisError):
     ...

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -366,5 +366,4 @@ class FieldNotFoundError(IndexError):
     ...
 
 
-class AxisError(numpy.AxisError):
-    ...
+AxisError = numpy.AxisError

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._nplikes.dispatch import nplike_of
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -156,7 +157,7 @@ def maybe_posaxis(layout, axis, depth):
 
     if isinstance(layout, Record):
         if axis == 0:
-            raise np.AxisError("Record type at axis=0 is a scalar, not an array")
+            raise AxisError("Record type at axis=0 is a scalar, not an array")
         return maybe_posaxis(layout._array, axis, depth)
 
     if axis >= 0:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -7,6 +7,7 @@ import math
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -647,7 +648,7 @@ class ByteMaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex()
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -7,7 +7,7 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import deprecate
+from awkward._errors import AxisError, deprecate
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -236,7 +236,7 @@ class EmptyArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError(self, "axis=0 not allowed for flatten")
+            raise AxisError(self, "axis=0 not allowed for flatten")
         else:
             offsets = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
             return (
@@ -267,7 +267,7 @@ class EmptyArray(Content):
                 backend=self._backend,
             )
         else:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     def _numbers_to_type(self, name, including_unknown):
         if including_unknown:
@@ -331,7 +331,7 @@ class EmptyArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self._pad_none_axis0(target, True)
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -5,6 +5,7 @@ import copy
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -468,7 +469,7 @@ class IndexedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
 
         else:
             return self.project()._offsets_and_flattened(axis, depth)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -5,6 +5,7 @@ import copy
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -564,7 +565,7 @@ class IndexedOptionArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
         else:
             numnull, nextcarry, outindex = self._nextcarry_outindex()
             next = self._content._carry(nextcarry, False)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -5,6 +5,7 @@ import copy
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -708,7 +709,7 @@ class ListOffsetArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
 
         elif posaxis is not None and posaxis + 1 == depth + 1:
             listoffsetarray = self.to_ListOffsetArray64(True)
@@ -924,7 +925,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -939,7 +940,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1041,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1086,7 +1087,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1226,7 @@ class ListOffsetArray(Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1269,7 +1270,7 @@ class ListOffsetArray(Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise np.AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -8,6 +8,7 @@ from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import to_nplike
 from awkward._nplikes.jax import Jax
@@ -407,13 +408,13 @@ class NumpyArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
 
         elif len(self.shape) != 1:
             return self.to_RegularArray()._offsets_and_flattened(axis, depth)
 
         else:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     def _mergeable_next(self, other, mergebool):
         # Is the other content is an identity, or a union?
@@ -514,7 +515,7 @@ class NumpyArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._local_index_axis0()
         elif len(self.shape) <= 1:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self.to_RegularArray()._local_index(axis, depth)
 
@@ -1064,7 +1065,7 @@ class NumpyArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif len(self.shape) <= 1:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self.to_RegularArray()._combinations(
                 n, replacement, recordlookup, parameters, axis, depth
@@ -1200,7 +1201,7 @@ class NumpyArray(Content):
             return self.to_RegularArray()._pad_none(target, axis, depth, clip)
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 != depth:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         if not clip:
             if target < self.length:
                 return self

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,6 +10,7 @@ from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import find_record_reducer
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -595,7 +596,7 @@ class RecordArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
 
         elif posaxis is not None and posaxis + 1 == depth + 1:
             raise ValueError(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -810,7 +811,7 @@ class UnionArray(Content):
         posaxis = maybe_posaxis(self, axis, depth)
 
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
 
         else:
             has_offsets = False

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -6,6 +6,7 @@ import math
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
@@ -299,7 +300,7 @@ class UnmaskedArray(Content):
     def _offsets_and_flattened(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
-            raise np.AxisError("axis=0 not allowed for flatten")
+            raise AxisError("axis=0 not allowed for flatten")
         else:
             offsets, flattened = self._content._offsets_and_flattened(axis, depth)
             if offsets.length == 0:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -243,16 +244,16 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     posaxis = maybe_posaxis(layouts[0], axis, 1)
     # Validate `posaxis`
     if posaxis is None or posaxis < 0:
-        raise np.AxisError("negative axis depth is ambiguous")
+        raise AxisError("negative axis depth is ambiguous")
     # Ensure other layouts have same positive value for axis
     for layout in layouts[1:]:
         if maybe_posaxis(layout, axis, 1) != posaxis:
-            raise np.AxisError(
+            raise AxisError(
                 "arrays to cartesian-product do not have the same depth for negative axis"
             )
     depths = [obj.purelist_depth for obj in layouts]
     if posaxis >= max(depths):
-        raise np.AxisError(
+        raise AxisError(
             f"axis={axis} exceeds the max depth of the given arrays (which is {max(depths)})"
         )
 

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("drop_none",)
 import awkward as ak
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -69,9 +70,7 @@ def _impl(array, axis, highlevel, behavior):
     else:
         max_axis = layout.branch_depth[1] - 1
         if axis > max_axis:
-            raise np.AxisError(
-                f"axis={axis} exceeds the depth ({max_axis}) of this array"
-            )
+            raise AxisError(f"axis={axis} exceeds the depth ({max_axis}) of this array")
 
         def recompute_offsets(layout, depth, **kwargs):
             posaxis = maybe_posaxis(layout, axis, depth)
@@ -89,7 +88,7 @@ def _impl(array, axis, highlevel, behavior):
             if layout.is_record:
                 posaxises = {maybe_posaxis(x, axis, depth) for x in layout.contents}
                 if len(posaxises) > 1 and any(x < depth for x in posaxises):
-                    raise np.AxisError(
+                    raise AxisError(
                         f"axis={axis} implies different levels in records that might require part of a record to be dropped, which is impossible"
                     )
             posaxis = maybe_posaxis(layout, axis, depth)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -6,6 +6,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_sized_iterable, regularize_axis
@@ -136,7 +137,7 @@ def _impl(array, value, axis, highlevel, behavior):
                     return layout
 
             elif layout.is_leaf:
-                raise np.AxisError(
+                raise AxisError(
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,6 +2,7 @@
 __all__ = ("firsts",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -90,7 +91,7 @@ def _impl(array, axis, highlevel, behavior):
                 )
 
             elif layout.is_leaf:
-                raise np.AxisError(
+                raise AxisError(
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,6 +2,7 @@
 __all__ = ("from_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -69,7 +70,7 @@ def _impl(array, axis, highlevel, behavior):
             elif posaxis == depth and layout.is_list:
                 return layout
             elif layout.is_leaf:
-                raise np.AxisError(
+                raise AxisError(
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,6 +2,7 @@
 __all__ = ("is_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -57,7 +58,7 @@ def _impl(array, axis, highlevel, behavior):
                 )
 
         elif layout.is_leaf:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -3,6 +3,7 @@ __all__ = ("merge_option_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -68,7 +69,7 @@ def _impl(array, axis, highlevel, behavior):
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
         if depth < posaxis + 1 and layout.is_leaf:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         elif depth == posaxis + 1 and layout.is_option and layout.content.is_record:
             layout = layout.to_IndexedOptionArray64()
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -3,6 +3,7 @@ __all__ = ("merge_union_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -155,7 +156,7 @@ def _impl(array, axis, highlevel, behavior):
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
         if depth < posaxis + 1 and layout.is_leaf:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         elif depth == posaxis + 1 and layout.is_union:
             if not all(
                 x.is_record or x.is_indexed or x.is_option for x in layout.contents

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,6 +2,7 @@
 __all__ = ("num",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -96,7 +97,7 @@ def _impl(array, axis, highlevel, behavior):
             return ak.contents.NumpyArray(layout.stops.data - layout.starts.data)
 
         elif layout.is_leaf:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,6 +2,7 @@
 __all__ = ("singletons",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -80,7 +81,7 @@ def _impl(array, axis, highlevel, behavior):
                 return ak.contents.RegularArray(layout, 1).to_ListOffsetArray64(True)
 
         elif layout.is_leaf:
-            raise np.AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
+            raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
     out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
 

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,6 +2,7 @@
 __all__ = ("to_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -81,7 +82,7 @@ def _impl(array, axis, highlevel, behavior):
                 return layout.to_RegularArray()
 
             elif layout.is_leaf:
-                raise np.AxisError(
+                raise AxisError(
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 


### PR DESCRIPTION
> **Warning**
> This PR needs to be finalised to account for #2411 

Ergonomically, I'd prefer to import an exception from our errors module, instead of raising `np.AxisError`. This doesn't have to be a new class; we could just import the name from `numpy`. However, we should probably prefer to define our own exception types instead of directly re-using NumPy's. For most people, this won't change anything, but it means that we can detect axis errors in Awkward's code vs those from NumPy. This might not be a useful feature, though.

I haven't yet figured out how we should export these exceptions for public use.