### PR TITLE
feat!: don't broadcast `EmptyArray` in `broadcast_and_apply`

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -24,7 +24,6 @@ from awkward._util import unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
-from awkward.contents.emptyarray import EmptyArray
 from awkward.contents.indexedarray import IndexedArray
 from awkward.contents.indexedoptionarray import IndexedOptionArray
 from awkward.contents.listarray import ListArray
@@ -975,29 +974,9 @@ def apply_step(
             options,
         )
 
-    def broadcast_any_unknown():
-        nextinputs = [
-            x.to_NumpyArray(np.float64, backend) if isinstance(x, EmptyArray) else x
-            for x in inputs
-        ]
-        return apply_step(
-            backend,
-            nextinputs,
-            action,
-            depth,
-            copy.copy(depth_context),
-            lateral_context,
-            behavior,
-            options,
-        )
-
     def continuation():
-        # Any EmptyArrays?
-        if any(x.is_unknown for x in contents):
-            return broadcast_any_unknown()
-
         # Any NumpyArrays with ndim != 1?
-        elif any(x.is_numpy and x.purelist_depth != 1 for x in contents):
+        if any(x.is_numpy and x.purelist_depth != 1 for x in contents):
             return broadcast_any_nd_numpy()
 
         # Any IndexedArrays?

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -103,6 +103,12 @@ def evaluate(
                     )
                 ),
             )
+        # Empty arrays are mainly placeholders; they should fail most operations
+        elif any(x.is_unknown for x in inputs):
+            raise TypeError(
+                "cannot evaluate numexpr.evaluate for EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
+            )
         else:
             return None
 
@@ -140,6 +146,12 @@ def re_evaluate(local_dict=None):
         ):
             return (
                 ak.contents.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),
+            )
+        # Empty arrays are mainly placeholders; they should fail most operations
+        elif any(x.is_unknown for x in inputs):
+            raise TypeError(
+                "cannot evaluate numexpr.reevaluate for EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
             )
         else:
             return None

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -226,6 +226,12 @@ def array_ufunc(ufunc, method, inputs, kwargs):
     inputs = _array_ufunc_custom_cast(inputs, behavior, backend)
 
     def action(inputs, **ignore):
+        if any(isinstance(x, ak.contents.EmptyArray) for x in inputs):
+            raise TypeError(
+                "cannot apply ufuncs to EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
+            )
+
         signature = _array_ufunc_signature(ufunc, inputs)
         custom = find_ufunc(behavior, signature)
         # Do we have a custom ufunc (an override of the given ufunc)?

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -226,6 +226,12 @@ def _impl(
         # the _first_ layout at that depth
         if depth == depth_limit:
             return tuple(inputs)
+        # Empty arrays are mainly placeholders; they should fail most operations
+        elif any(x.is_unknown for x in inputs):
+            raise TypeError(
+                "cannot broadcast EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
+            )
         # Walk through non-leaf nodes
         elif all(
             x.purelist_depth == 1 and not (x.is_option or x.is_indexed) for x in inputs

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -226,12 +226,6 @@ def _impl(
         # the _first_ layout at that depth
         if depth == depth_limit:
             return tuple(inputs)
-        # Empty arrays are mainly placeholders; they should fail most operations
-        elif any(x.is_unknown for x in inputs):
-            raise TypeError(
-                "cannot broadcast EmptyArray(s), use `ak.values_astype` "
-                "to convert these to arrays with known dtypes"
-            )
         # Walk through non-leaf nodes
         elif all(
             x.purelist_depth == 1 and not (x.is_option or x.is_indexed) for x in inputs

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -47,7 +47,7 @@ def _impl(a, b, rtol, atol, equal_nan, highlevel, behavior):
     two = ak.operations.to_layout(b)
 
     def action(inputs, backend, **kwargs):
-        if all(isinstance(x, ak.contents.NumpyArray) for x in inputs):
+        if all(x.is_numpy for x in inputs):
             return (
                 ak.contents.NumpyArray(
                     backend.nplike.isclose(
@@ -58,6 +58,12 @@ def _impl(a, b, rtol, atol, equal_nan, highlevel, behavior):
                         equal_nan=equal_nan,
                     )
                 ),
+            )
+        # Empty arrays are mainly placeholders; they should fail most operations
+        elif any(x.is_unknown for x in inputs):
+            raise TypeError(
+                "cannot evaluate ak.isclose for EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
             )
 
     behavior = behavior_of(a, b, behavior=behavior)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -103,14 +103,9 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 
 def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, backend, **kwargs):
-        # Empty arrays are mainly placeholders; they should fail most operations
-        if any(x.is_unknown for x in inputs):
-            raise TypeError(
-                "cannot evaluate ak.mask for EmptyArray(s), use `ak.values_astype` "
-                "to convert these to arrays with known dtypes"
-            )
-
         layoutarray, layoutmask = inputs
+        if layoutmask.is_unknown:
+            layoutmask = layoutmask.to_NumpyArray(np.bool_, backend)
         if layoutmask.is_numpy:
             m = layoutmask.data
             if not issubclass(m.dtype.type, (bool, np.bool_)):

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -103,9 +103,16 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 
 def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, backend, **kwargs):
+        # Empty arrays are mainly placeholders; they should fail most operations
+        if any(x.is_unknown for x in inputs):
+            raise TypeError(
+                "cannot evaluate ak.mask for EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
+            )
+
         layoutarray, layoutmask = inputs
-        if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = backend.nplike.asarray(layoutmask)
+        if layoutmask.is_numpy:
+            m = layoutmask.data
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ValueError(f"mask must have boolean type, not {repr(m.dtype)}")
             bytemask = ak.index.Index8(m.view(np.int8))

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -96,7 +96,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
     else:
 
         def action(inputs, backend, **kwargs):
-            if all(isinstance(x, ak.contents.NumpyArray) for x in inputs):
+            if all(x.is_numpy for x in inputs):
                 tmp_layout = backend.nplike.asarray(inputs[0])
                 if id(nan) in broadcasting_ids:
                     tmp_nan = backend.nplike.asarray(inputs[broadcasting_ids[id(nan)]])
@@ -123,6 +123,12 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
                             neginf=tmp_neginf,
                         )
                     ),
+                )
+            # Empty arrays are mainly placeholders; they should fail most operations
+            elif any(x.is_unknown for x in inputs):
+                raise TypeError(
+                    "cannot evaluate ak.nan_to_num for EmptyArray(s), use `ak.values_astype` "
+                    "to convert these to arrays with known dtypes"
                 )
             else:
                 return None

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -111,7 +111,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
-        if isinstance(akcondition, ak.contents.NumpyArray):
+        if akcondition.is_numpy:
             npcondition = backend.index_nplike.asarray(akcondition)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(
@@ -131,6 +131,11 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
                     [left, right],
                     mergebool=mergebool,
                 ),
+            )
+        elif akcondition.is_unknown:
+            raise TypeError(
+                "cannot evaluate ak.where for EmptyArray(s), use `ak.values_astype` "
+                "to convert these to arrays with known dtypes"
             )
         else:
             return None

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -111,9 +111,12 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
+        if akcondition.is_unknown:
+            akcondition = akcondition.to_NumpyArray(np.bool_, backend)
         if akcondition.is_numpy:
-            npcondition = backend.index_nplike.asarray(akcondition)
-            tags = ak.index.Index8((npcondition == 0).view(np.int8))
+            tags = ak.index.Index8((akcondition.data == 0).view(np.int8)).to_nplike(
+                backend.index_nplike
+            )
             index = ak.index.Index64(
                 backend.index_nplike.arange(tags.length, dtype=np.int64),
                 nplike=backend.index_nplike,
@@ -131,11 +134,6 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
                     [left, right],
                     mergebool=mergebool,
                 ),
-            )
-        elif akcondition.is_unknown:
-            raise TypeError(
-                "cannot evaluate ak.where for EmptyArray(s), use `ak.values_astype` "
-                "to convert these to arrays with known dtypes"
             )
         else:
             return None

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -113,7 +113,7 @@ def _impl(base, what, where, highlevel, behavior):
             base, what = inputs
             backend = base.backend
 
-            if isinstance(base, ak.contents.RecordArray):
+            if base.is_record:
                 if what is None:
                     what = ak.contents.IndexedOptionArray(
                         ak.index.Index64(

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -215,14 +215,7 @@ def _impl(
         parameters["__record__"] = with_name
 
     def action(inputs, depth, **ignore):
-        if depth_limit == depth or all(
-            x.purelist_depth == 1
-            or (
-                x.purelist_depth == 2
-                and x.purelist_parameter("__array__") in ("string", "bytestring")
-            )
-            for x in inputs
-        ):
+        if depth_limit == depth or all(x.purelist_depth == 1 for x in inputs):
             # If we want to zip after option types at this depth
             if optiontype_outside_record and any(x.is_option for x in inputs):
                 return None

--- a/tests/test_0086_nep13_ufunc.py
+++ b/tests/test_0086_nep13_ufunc.py
@@ -26,9 +26,9 @@ def test_emptyarray():
     one = ak.highlevel.Array(ak.contents.NumpyArray(np.array([])))
     two = ak.highlevel.Array(ak.contents.EmptyArray())
     assert to_list(one + one) == []
-    with pytest.raises(TypeError, match=r"ufuncs to EmptyArray"):
+    with pytest.warns(DeprecationWarning, match=r"EmptyArray\(s\) was converted"):
         assert to_list(two + two) == []
-    with pytest.raises(TypeError, match=r"ufuncs to EmptyArray"):
+    with pytest.warns(DeprecationWarning, match=r"EmptyArray\(s\) was converted"):
         assert to_list(one + two) == []
 
 

--- a/tests/test_0086_nep13_ufunc.py
+++ b/tests/test_0086_nep13_ufunc.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
+import pytest
 
 import awkward as ak
 
@@ -26,11 +26,10 @@ def test_emptyarray():
     one = ak.highlevel.Array(ak.contents.NumpyArray(np.array([])))
     two = ak.highlevel.Array(ak.contents.EmptyArray())
     assert to_list(one + one) == []
-    assert to_list(two + two) == []
-    assert to_list(one + two) == []
-    assert (one + one).layout.form == (tt(one) + tt(one)).layout.form
-    assert (two + two).layout.form == (tt(two) + tt(two)).layout.form
-    assert (one + two).layout.form == (tt(one) + tt(two)).layout.form
+    with pytest.raises(TypeError, match=r"ufuncs to EmptyArray"):
+        assert to_list(two + two) == []
+    with pytest.raises(TypeError, match=r"ufuncs to EmptyArray"):
+        assert to_list(one + two) == []
 
 
 def test_indexedarray():

--- a/tests/test_2413_broadcast_empty_array.py
+++ b/tests/test_2413_broadcast_empty_array.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+def test_broadcast_arrays():
+    x = ak.Array([])
+    assert x.layout.is_unknown
+    y = ak.Array([1])
+    with pytest.raises(
+        TypeError, match=r"EmptyArray.*convert these to arrays with known dtypes"
+    ):
+        ak.broadcast_arrays(x, y)

--- a/tests/test_2413_broadcast_empty_array.py
+++ b/tests/test_2413_broadcast_empty_array.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import pytest
 
 import awkward as ak
 
@@ -9,7 +8,41 @@ def test_broadcast_arrays():
     x = ak.Array([])
     assert x.layout.is_unknown
     y = ak.Array([1])
-    with pytest.raises(
-        TypeError, match=r"EmptyArray.*convert these to arrays with known dtypes"
-    ):
-        ak.broadcast_arrays(x, y)
+    u, v = ak.broadcast_arrays(x, y)
+
+    assert len(u) == len(v) == 0
+    assert ak.type(u) == ak.types.ArrayType(ak.types.UnknownType(), 0)
+    assert ak.type(v) == ak.types.ArrayType(ak.types.NumpyType("int64"), 0)
+
+
+def test_where_unknown_condition():
+    unknown = ak.Array([])
+    x = ak.Array(["x", "y", "z"])
+    y = ak.Array([[1, 2, 3], [4], [5, 6, 7, 8]])
+    result = ak.where(unknown, x, y)
+    assert len(result) == 0
+    assert result.type == ak.types.ArrayType(
+        ak.types.UnionType(
+            [
+                ak.types.ListType(
+                    ak.types.NumpyType(
+                        "uint8", parameters={"__array__": "char"}, typestr="char"
+                    ),
+                    parameters={"__array__": "string"},
+                    typestr="string",
+                ),
+                ak.types.ListType(ak.types.NumpyType("int64")),
+            ]
+        ),
+        0,
+    )
+
+
+def test_where_unknown_array():
+    unknown = ak.Array([])
+    cond = ak.Array([True, False, False])
+    y = ak.Array([[1, 2, 3], [4], [5, 6, 7, 8]])
+    result = ak.where(cond, unknown, y)
+    assert result.type == ak.types.ArrayType(
+        ak.types.ListType(ak.types.NumpyType("int64")), 0
+    )


### PR DESCRIPTION
Currently, we're too eager to convert `EmptyArray`s into known `NumpyArray`s. This PR starts the process of unwinding this, making `ak.broadcast_arrays` preserve the unknown array.

The planned existence of `ak.enforce_type` should ensure that we can deprecate this logic (in this PR), so that e.g. ufunc operations on unknown arrays throw warnings.

At a high level, we should permit `EmptyArray`s instead of `NumpyArray`s where it is not required that the programmer choose an arbitrary dtype. i.e., if the code requires a boolean dtype, it can accept an `EmptyArray`, whereas if the code supports many dtypes (reducers) it fails.