### PR TITLE
fix: consistently set a `resize` default value to 8 - that is passed to GrowableBuffer

### DIFF
--- a/awkward-cpp/src/python/content.cpp
+++ b/awkward-cpp/src/python/content.cpp
@@ -197,7 +197,7 @@ make_ArrayBuilder(const py::handle& m, const std::string& name) {
   return (py::class_<ak::ArrayBuilder>(m, name.c_str())
       .def(py::init([](const int64_t initial, double resize) -> ak::ArrayBuilder {
         return ak::ArrayBuilder({initial, resize});
-      }), py::arg("initial") = 1024, py::arg("resize") = 1.5)
+      }), py::arg("initial") = 1024, py::arg("resize") = 8)
       .def_property_readonly("_ptr",
                              [](const ak::ArrayBuilder* self) -> size_t {
         return reinterpret_cast<size_t>(self);

--- a/docs/reference/ak.builder.ArrayBuilder.rst
+++ b/docs/reference/ak.builder.ArrayBuilder.rst
@@ -10,11 +10,11 @@ object is wrapped by :class:`ak.ArrayBuilder`.
 underscores after "begin" and "end," but that hasn't happened in the
 low-level interface, yet or possibly at all.)
 
-.. py:class:: ArrayBuilder(initial=1024, resize=1.5)
+.. py:class:: ArrayBuilder(initial=1024, resize=8)
 
 .. py:method:: ArrayBuilder.__getitem__(where)
 
-.. py:method:: ArrayBuilder.__init__(initial=1024, resize=1.5)
+.. py:method:: ArrayBuilder.__init__(initial=1024, resize=8)
 
 .. py:method:: ArrayBuilder.__iter__()
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2235,7 +2235,7 @@ class ArrayBuilder(Sized):
     be considered the "least effort" approach.
     """
 
-    def __init__(self, *, behavior=None, initial=1024, resize=1.5):
+    def __init__(self, *, behavior=None, initial=1024, resize=8):
         self._layout = _ext.ArrayBuilder(initial=initial, resize=resize)
         self.behavior = behavior
 

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -18,7 +18,7 @@ def from_iter(
     highlevel=True,
     behavior=None,
     initial=1024,
-    resize=1.5,
+    resize=8,
 ):
     """
     Args:

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -28,7 +28,7 @@ def from_json(
     complex_record_fields=None,
     buffersize=65536,
     initial=1024,
-    resize=1.5,
+    resize=8,
     highlevel=True,
     behavior=None,
 ):


### PR DESCRIPTION
The new GrowableBuffer algorithm resizes its panels once. The plots show that 8 is a good compromise.
<img width="774" alt="Screenshot 2023-04-21 at 16 50 13" src="https://user-images.githubusercontent.com/1390682/233674643-162b9ba9-3407-49e7-bc1a-ee6abbf6681b.png">
<img width="774" alt="Screenshot 2023-04-21 at 16 44 43" src="https://user-images.githubusercontent.com/1390682/233674698-566b5152-a2ff-4e31-8aa7-15a7dc8930ee.png">


fixes issue #2419 