### PR TITLE
fix: handle reordered contents in `ak.almost_equal`

### DIFF
--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -9,6 +9,7 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._singleton import Singleton
 from awkward._typing import (
     Literal,
+    NamedTuple,
     Protocol,
     Self,
     SupportsIndex,
@@ -17,6 +18,13 @@ from awkward._typing import (
 )
 
 IndexType: TypeAlias = "int | ArrayLike"
+
+
+class UniqueAllResult(NamedTuple):
+    values: ArrayLike
+    indices: ArrayLike
+    inverse_indices: ArrayLike
+    counts: ArrayLike
 
 
 class ArrayLike(Protocol):
@@ -400,6 +408,21 @@ class NumpyLike(Singleton, Protocol):
 
     @abstractmethod
     def unique_values(self, x: ArrayLike) -> ArrayLike:
+        ...
+
+    @abstractmethod
+    def unique_all(self, x: ArrayLike) -> UniqueAllResult:
+        ...
+
+    @abstractmethod
+    def sort(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int = -1,
+        descending: bool = False,
+        stable: bool = True,
+    ) -> ArrayLike:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -8,7 +8,13 @@ from numpy.lib.mixins import NDArrayOperatorsMixin
 
 import awkward as ak
 from awkward._nplikes.dispatch import register_nplike
-from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyLike, NumpyMetadata
+from awkward._nplikes.numpylike import (
+    ArrayLike,
+    IndexType,
+    NumpyLike,
+    NumpyMetadata,
+    UniqueAllResult,
+)
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._regularize import is_integer, is_non_string_like_sequence
 from awkward._typing import (
@@ -1080,6 +1086,26 @@ class TypeTracer(NumpyLike):
     def unique_values(self, x: ArrayLike) -> TypeTracerArray:
         try_touch_data(x)
         return TypeTracerArray._new(x.dtype, shape=(unknown_length,))
+
+    def unique_all(self, x: ArrayLike) -> UniqueAllResult:
+        try_touch_data(x)
+        return UniqueAllResult(
+            TypeTracerArray._new(x.dtype, shape=(unknown_length,)),
+            TypeTracerArray._new(np.int64, shape=(unknown_length,)),
+            TypeTracerArray._new(np.int64, shape=x.shape),
+            TypeTracerArray._new(np.int64, shape=(unknown_length,)),
+        )
+
+    def sort(
+        self,
+        x: ArrayLike,
+        *,
+        axis: int = -1,
+        descending: bool = False,
+        stable: bool = True,
+    ) -> ArrayLike:
+        try_touch_data(x)
+        return TypeTracerArray._new(x.dtype, shape=x.shape)
 
     def concat(self, arrays, *, axis: int | None = 0) -> TypeTracerArray:
         if axis is None:

--- a/tests/test_2424_almost_equal_union_record.py
+++ b/tests/test_2424_almost_equal_union_record.py
@@ -1,0 +1,49 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_records_almost_equal():
+    first = ak.contents.RecordArray(
+        [
+            ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
+            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("<M8[s]"))),
+        ],
+        ["x", "y"],
+    )
+
+    second = ak.contents.RecordArray(
+        [
+            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
+        ],
+        ["y", "x"],
+    )
+
+    assert ak.almost_equal(first, second)
+
+
+def test_unions_almost_equal():
+    # Check unions agree!
+    first = ak.contents.UnionArray(
+        ak.index.Index8([0, 0, 2, 1, 1]),
+        ak.index.Index64([0, 1, 0, 0, 1]),
+        [
+            ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
+        ],
+    )
+    second = ak.contents.UnionArray(
+        ak.index.Index8([1, 1, 0, 2, 2]),
+        ak.index.Index64([0, 1, 0, 0, 1]),
+        [
+            ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
+            ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+        ],
+    )
+    assert ak.almost_equal(first, second)


### PR DESCRIPTION
`ak.almost_equal` made some poor assumptions about content orderings, which this PR fixes. Now, unions are considered equal against unions with different content orders (as long as the tags align equally). Records are compared by field for non-tuples, addressing the same problem with records.