### PR TITLE
feat: add `ak.forms.from_type`

### DIFF
--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -300,6 +300,7 @@
     generated/ak.forms.UnmaskedForm
     generated/ak.forms.from_dict
     generated/ak.forms.from_json
+    generated/ak.forms.from_type
 
 .. toctree::
     :caption: Builtin behaviors

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2127,17 +2127,8 @@ class ListOffsetArray(Content):
 
     def to_packed(self) -> Self:
         next = self.to_ListOffsetArray64(True)
-        content = next._content.to_packed()
-        packed_length = self._backend.index_nplike.index_as_shape_item(
-            next._offsets[-1]
-        )
-        if (
-            content.length is not unknown_length
-            and packed_length is not unknown_length
-            and content.length != packed_length
-        ):
-            content = content[: next._offsets[-1]]
-        return ListOffsetArray(next._offsets, content, parameters=next._parameters)
+        next_content = next._content[: next._offsets[-1]].to_packed()
+        return ListOffsetArray(next._offsets, next_content, parameters=next._parameters)
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:

--- a/src/awkward/forms/__init__.py
+++ b/src/awkward/forms/__init__.py
@@ -3,7 +3,7 @@
 from awkward.forms.bitmaskedform import BitMaskedForm  # noqa: F401
 from awkward.forms.bytemaskedform import ByteMaskedForm  # noqa: F401
 from awkward.forms.emptyform import EmptyForm  # noqa: F401
-from awkward.forms.form import Form, from_dict, from_json  # noqa: F401
+from awkward.forms.form import Form, from_dict, from_json, from_type  # noqa: F401
 from awkward.forms.indexedform import IndexedForm  # noqa: F401
 from awkward.forms.indexedoptionform import IndexedOptionForm  # noqa: F401
 from awkward.forms.listform import ListForm  # noqa: F401

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -215,8 +215,13 @@ def from_type(type: ak.types.Type) -> Form:
         )
     elif isinstance(type, ak.types.UnknownType):
         return ak.forms.EmptyForm(parameters=type.parameters)
+    elif isinstance(type, (ak.types.ArrayType, ak.types.ScalarType)):
+        raise TypeError(
+            "High-level types (ak.types.ArrayType, ak.types.ScalarType) do not have representations as Awkward forms. "
+            "Instead the low level type should be used."
+        )
     else:
-        raise ak._errors.wrap_error(TypeError(f"unsupported type {type!r}"))
+        raise TypeError(f"unsupported type {type!r}")
 
 
 def _expand_braces(text, seen=None):

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,12 +1,20 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 from awkward._parameters import parameters_are_equal, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 
 @final
 class ListType(Type):
+    def copy(self, *, content: Type = unset, parameters=unset, typestr=unset) -> Self:
+        return ListType(
+            self._content if content is unset else content,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
             raise TypeError(

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -5,7 +5,8 @@ import re
 
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 np = NumpyMetadata.instance()
@@ -91,6 +92,13 @@ for primitive, dtype in _primitive_to_dtype_dict.items():
 
 @final
 class NumpyType(Type):
+    def copy(self, *, primitive: Type = unset, parameters=unset, typestr=unset) -> Self:
+        return NumpyType(
+            self._primitive if primitive is unset else primitive,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, primitive, *, parameters=None, typestr=None):
         primitive = dtype_to_primitive(primitive_to_dtype(primitive))
         if parameters is not None and not isinstance(parameters, dict):

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import json
 import re

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -5,7 +5,8 @@ from awkward._parameters import (
     parameters_union,
     type_parameters_equal,
 )
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
 from awkward.types.type import Type
@@ -14,6 +15,13 @@ from awkward.types.uniontype import UnionType
 
 @final
 class OptionType(Type):
+    def copy(self, *, content: Type = unset, parameters=unset, typestr=unset) -> Self:
+        return OptionType(
+            self._content if content is unset else content,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, content, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
             raise TypeError(

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from awkward._parameters import (
     parameters_are_equal,

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,12 +7,28 @@ from itertools import permutations
 import awkward as ak
 import awkward._prettyprint
 from awkward._parameters import parameters_are_equal, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 
 @final
 class RecordType(Type):
+    def copy(
+        self,
+        *,
+        contents: list[Type] = unset,
+        fields: list[str] | None = unset,
+        parameters=unset,
+        typestr=unset,
+    ) -> Self:
+        return RecordType(
+            self._contents if contents is unset else contents,
+            self._fields if fields is unset else fields,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, contents, fields, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
             raise TypeError(

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import json
 from collections.abc import Iterable

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,4 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,13 +1,29 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-from awkward._nplikes.shape import unknown_length
+from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 
 @final
 class RegularType(Type):
+    def copy(
+        self,
+        *,
+        content: Type = unset,
+        size: ShapeItem = unset,
+        parameters=unset,
+        typestr=unset,
+    ) -> Self:
+        return RegularType(
+            self._content if content is unset else content,
+            size=self._size if size is unset else size,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, content, size, *, parameters=None, typestr=None):
         if not isinstance(content, Type):
             raise TypeError(

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 import sys
 

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -6,12 +6,17 @@ import sys
 
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._typing import Self
+from awkward._util import unset
 from awkward.types._awkward_datashape_parser import Lark_StandAlone, Transformer
 
 np = NumpyMetadata.instance()
 
 
 class Type:
+    def copy(self, *, parameters=unset, typestr=unset) -> Self:
+        raise NotImplementedError
+
     @property
     def parameters(self):
         if self._parameters is None:  # pylint: disable=E0203

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -4,12 +4,22 @@ from collections.abc import Iterable
 from itertools import permutations
 
 from awkward._parameters import parameters_are_equal, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 
 @final
 class UnionType(Type):
+    def copy(
+        self, *, contents: list[Type] = unset, parameters=unset, typestr=unset
+    ) -> Self:
+        return UnionType(
+            self._contents if contents is unset else contents,
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, contents, *, parameters=None, typestr=None):
         if not isinstance(contents, Iterable):
             raise TypeError(

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from collections.abc import Iterable
 from itertools import permutations

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
 
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -2,12 +2,19 @@
 
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
+from awkward._util import unset
 from awkward.types.type import Type
 
 
 @final
 class UnknownType(Type):
+    def copy(self, *, parameters=unset, typestr=unset) -> Self:
+        return UnknownType(
+            parameters=self._parameters if parameters is unset else parameters,
+            typestr=self._typestr if typestr is unset else typestr,
+        )
+
     def __init__(self, *, parameters=None, typestr=None):
         if parameters is not None:
             deprecate(

--- a/tests/test_2425_forms_from_type.py
+++ b/tests/test_2425_forms_from_type.py
@@ -6,30 +6,17 @@ import awkward as ak
 
 
 def test_from_iter():
-    array = ak.from_iter(
-        [
-            1,
-            2,
-            "hi",
-            [3, 4, {"x": 4}, None],
-            [
-                1j,
-                [
-                    3,
-                    4,
-                    (
-                        False,
-                        True,
-                    ),
-                ],
-            ],
-        ]
-    )[:0]
-    array_round_trip = ak.forms.from_type(array.type.content).length_zero_array()
-    assert array_round_trip.type.is_equal_to(array.type)
+    # We define `from_type` to match ArrayBuilder where possible. We can't
+    # include options inside unions, though, because ArrayBuilder creates `UnmaskedArray`
+    # nodes for the non-indexed option
+    array = ak.to_packed(
+        ak.from_iter([1, 2, "hi", [3, 4, {"x": 4}], {"y": [None, 2]}])[:0]
+    )
+    form_from_type = ak.forms.from_type(array.type.content)
+    assert form_from_type == array.layout.form
 
 
 def test_regular():
     array = ak.to_regular([[1, 2, 3]])[:0]
-    array_round_trip = ak.forms.from_type(array.type.content).length_zero_array()
-    assert array_round_trip.type.is_equal_to(array.type)
+    form_from_type = ak.forms.from_type(array.type.content)
+    assert form_from_type == array.layout.form

--- a/tests/test_2425_forms_from_type.py
+++ b/tests/test_2425_forms_from_type.py
@@ -1,0 +1,35 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_from_iter():
+    array = ak.from_iter(
+        [
+            1,
+            2,
+            "hi",
+            [3, 4, {"x": 4}, None],
+            [
+                1j,
+                [
+                    3,
+                    4,
+                    (
+                        False,
+                        True,
+                    ),
+                ],
+            ],
+        ]
+    )[:0]
+    array_round_trip = ak.forms.from_type(array.type.content).length_zero_array()
+    assert array_round_trip.type.is_equal_to(array.type)
+
+
+def test_regular():
+    array = ak.to_regular([[1, 2, 3]])[:0]
+    array_round_trip = ak.forms.from_type(array.type.content).length_zero_array()
+    assert array_round_trip.type.is_equal_to(array.type)

--- a/tests/test_2425_forms_from_type.py
+++ b/tests/test_2425_forms_from_type.py
@@ -34,3 +34,9 @@ def test_categorical():
     )
     form_from_type = ak.forms.from_type(array.type.content)
     assert form_from_type == array.layout.form
+
+
+def test_categorical_option():
+    array = ak.to_categorical([1, 1, 2, 1, 1, None])
+    form_from_type = ak.forms.from_type(array.type.content)
+    assert form_from_type == array.layout.form

--- a/tests/test_2425_forms_from_type.py
+++ b/tests/test_2425_forms_from_type.py
@@ -20,3 +20,17 @@ def test_regular():
     array = ak.to_regular([[1, 2, 3]])[:0]
     form_from_type = ak.forms.from_type(array.type.content)
     assert form_from_type == array.layout.form
+
+
+def test_categorical():
+    array = ak.to_categorical(
+        [
+            1,
+            1,
+            2,
+            1,
+            1,
+        ]
+    )
+    form_from_type = ak.forms.from_type(array.type.content)
+    assert form_from_type == array.layout.form


### PR DESCRIPTION
Add a new `ak.forms.from_type` function that can convert an `ak.types.Type` object to an `ak.forms.Form` object. As this is a one-to-many function, we choose to build forms that match those of `ArrayBuilder`.

As a part of this PR, `ak.types.Type` objects now implement the `.copy` interface that we have for contents and forms