### PR TITLE
fix: `is_equal_to` bug in `UnionArray`

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1583,7 +1583,7 @@ class UnionArray(Content):
 
     def _is_equal_to(self, other, index_dtype, numpyarray):
         return (
-            self.tags == other.tags
+            self.tags.is_equal_to(other.tags)
             and self.index.is_equal_to(other.index, index_dtype, numpyarray)
             and len(self.contents) == len(other.contents)
             and all(

--- a/tests/test_2426_is_equal_to.py
+++ b/tests/test_2426_is_equal_to.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_equal_union():
+    union_1 = ak.from_iter([1, None, {"x": 2}], highlevel=False)
+    union_2 = ak.from_iter([1, None, {"x": 2}], highlevel=False)
+
+    assert union_1.is_equal_to(union_2)
+
+
+def test_unequal_union():
+    union_1 = ak.from_iter([1, None, {"x": 2}, 3], highlevel=False)
+    union_2 = ak.from_iter([1, None, {"x": 2}, 2], highlevel=False)
+
+    assert not union_1.is_equal_to(union_2)


### PR DESCRIPTION
The tags were being compared by identity, not equality.