### PR TITLE
feat: canonicalise `union[?X, Y]` into `union[?X, ?Y]`

### DIFF
--- a/tests/test_1125_to_arrow_from_arrow.py
+++ b/tests/test_1125_to_arrow_from_arrow.py
@@ -623,9 +623,11 @@ def test_unionarray(tmp_path, extensionarray):
         ak.index.Index8(np.array([0, 0, 1, 1, 1, 0, 1], dtype=np.int8)),
         ak.index.Index64(np.array([0, 1, 3, 2, 1, 2, 0], dtype=np.int64)),
         [
-            ak.contents.NumpyArray(
-                np.array([0.0, 1.1, 2.2]),
-                parameters={"which": "inner1"},
+            ak.contents.UnmaskedArray(
+                ak.contents.NumpyArray(
+                    np.array([0.0, 1.1, 2.2]),
+                    parameters={"which": "inner1"},
+                )
             ),
             ak.contents.ByteMaskedArray(
                 ak.index.Index8(np.array([False, False, True, False]).view(np.int8)),
@@ -674,8 +676,10 @@ def test_unionarray(tmp_path, extensionarray):
             ak.index.Index8(np.array([0, 0, 1, 1, 1, 0, 1], dtype=np.int8)),
             ak.index.Index64(np.array([0, 1, 3, 2, 1, 2, 0], dtype=np.int64)),
             [
-                ak.contents.NumpyArray(
-                    np.array([0.0, 1.1, 2.2]), parameters={"which": "inner1"}
+                ak.contents.UnmaskedArray(
+                    ak.contents.NumpyArray(
+                        np.array([0.0, 1.1, 2.2]), parameters={"which": "inner1"}
+                    )
                 ),
                 ak.contents.ByteMaskedArray(
                     ak.index.Index8(

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -740,9 +740,11 @@ def test_unionarray(tmp_path, through, extensionarray):
         ak.index.Index8(np.array([0, 0, 1, 1, 1, 0, 1], dtype=np.int8)),
         ak.index.Index64(np.array([0, 1, 3, 2, 1, 2, 0], dtype=np.int64)),
         [
-            ak.contents.NumpyArray(
-                np.array([0.0, 1.1, 2.2]),
-                parameters={"which": "inner1"},
+            ak.contents.UnmaskedArray(
+                ak.contents.NumpyArray(
+                    np.array([0.0, 1.1, 2.2]),
+                    parameters={"which": "inner1"},
+                )
             ),
             ak.contents.ByteMaskedArray(
                 ak.index.Index8(np.array([False, False, True, False]).view(np.int8)),
@@ -801,8 +803,10 @@ def test_unionarray(tmp_path, through, extensionarray):
             ak.index.Index8(np.array([0, 0, 1, 1, 1, 0, 1], dtype=np.int8)),
             ak.index.Index64(np.array([0, 1, 3, 2, 1, 2, 0], dtype=np.int64)),
             [
-                ak.contents.NumpyArray(
-                    np.array([0.0, 1.1, 2.2]), parameters={"which": "inner1"}
+                ak.contents.UnmaskedArray(
+                    ak.contents.NumpyArray(
+                        np.array([0.0, 1.1, 2.2]), parameters={"which": "inner1"}
+                    )
                 ),
                 ak.contents.ByteMaskedArray(
                     ak.index.Index8(

--- a/tests/test_1928_replace_simplify_method_with_classmethod_constructor.py
+++ b/tests/test_1928_replace_simplify_method_with_classmethod_constructor.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
+import pytest
 
 import awkward as ak
 
@@ -40,7 +41,21 @@ def test_indexedoption_of_union():
 
 
 def test_indexedoption_of_union_of_option_1():
-    unionarray = ak.contents.UnionArray(
+    with pytest.raises(
+        TypeError, match=r" must either be comprised of entirely optional contents"
+    ):
+        ak.contents.UnionArray(
+            ak.index.Index8(np.array([0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1], dtype=np.int8)),
+            ak.index.Index64(
+                np.array([0, 1, 0, 2, 1, 2, 3, 3, 4, 5, 4], dtype=np.int64)
+            ),
+            [
+                ak.from_iter([0.0, 1.1, 2.2, 3.3, None, 5.5], highlevel=False),
+                ak.from_iter(["zero", "one", "two", "three", "four"], highlevel=False),
+            ],
+        )
+
+    unionarray = ak.contents.UnionArray.simplified(
         ak.index.Index8(np.array([0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1], dtype=np.int8)),
         ak.index.Index64(np.array([0, 1, 0, 2, 1, 2, 3, 3, 4, 5, 4], dtype=np.int64)),
         [
@@ -66,7 +81,21 @@ def test_indexedoption_of_union_of_option_1():
 
 
 def test_indexedoption_of_union_of_option_2():
-    unionarray = ak.contents.UnionArray(
+    with pytest.raises(
+        TypeError, match=r"must either be comprised of entirely optional contents"
+    ):
+        ak.contents.UnionArray(
+            ak.index.Index8(np.array([0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1], dtype=np.int8)),
+            ak.index.Index64(
+                np.array([0, 1, 0, 2, 1, 2, 3, 3, 4, 5, 4], dtype=np.int64)
+            ),
+            [
+                ak.from_iter([0.0, 1.1, 2.2, 3.3, 4.4, 5.5], highlevel=False),
+                ak.from_iter(["zero", None, "two", "three", "four"], highlevel=False),
+            ],
+        )
+
+    unionarray = ak.contents.UnionArray.simplified(
         ak.index.Index8(np.array([0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1], dtype=np.int8)),
         ak.index.Index64(np.array([0, 1, 0, 2, 1, 2, 3, 3, 4, 5, 4], dtype=np.int64)),
         [

--- a/tests/test_2236_merge_union_of_records_option.py
+++ b/tests/test_2236_merge_union_of_records_option.py
@@ -58,9 +58,11 @@ def test_option():
     assert z.type == ak.types.ArrayType(
         ak.types.UnionType(
             [
-                ak.types.RecordType(
-                    [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
-                    ["a", "b"],
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["a", "b"],
+                    )
                 ),
                 ak.types.OptionType(
                     ak.types.RecordType(
@@ -104,9 +106,11 @@ def test_option_unmasked():
     assert z.type == ak.types.ArrayType(
         ak.types.UnionType(
             [
-                ak.types.RecordType(
-                    [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
-                    ["a", "b"],
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["a", "b"],
+                    )
                 ),
                 ak.types.OptionType(
                     ak.types.RecordType(


### PR DESCRIPTION
Closes #2371 