### PR TITLE
fix: typetracer `nplike.repeat` & `ak.with_field`

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1118,7 +1118,25 @@ class TypeTracer(NumpyLike):
     ) -> TypeTracerArray:
         try_touch_data(x)
         try_touch_data(repeats)
-        raise NotImplementedError
+
+        if axis is None:
+            size = x.size
+            if isinstance(repeats, TypeTracerArray) and repeats.ndim > 0:
+                raise NotImplementedError
+            elif is_unknown_scalar(repeats):
+                size = size * self.index_as_shape_item(repeats)
+            else:
+                size = size * repeats
+            return TypeTracerArray._new(x.dtype, (size,))
+        else:
+            shape = list(x.shape)
+            if isinstance(repeats, TypeTracerArray) and repeats.ndim > 0:
+                raise NotImplementedError
+            elif is_unknown_scalar(repeats):
+                shape[axis] = shape[axis] * self.index_as_shape_item(repeats)
+            else:
+                shape[axis] = shape[axis] * repeats
+            return TypeTracerArray._new(x.dtype, shape=tuple(shape))
 
     def tile(self, x: ArrayLike, reps: int) -> TypeTracerArray:
         try_touch_data(x)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1123,19 +1123,15 @@ class TypeTracer(NumpyLike):
             size = x.size
             if isinstance(repeats, TypeTracerArray) and repeats.ndim > 0:
                 raise NotImplementedError
-            elif is_unknown_scalar(repeats):
-                size = size * self.index_as_shape_item(repeats)
             else:
-                size = size * repeats
+                size = size * self.index_as_shape_item(repeats)
             return TypeTracerArray._new(x.dtype, (size,))
         else:
             shape = list(x.shape)
             if isinstance(repeats, TypeTracerArray) and repeats.ndim > 0:
                 raise NotImplementedError
-            elif is_unknown_scalar(repeats):
-                shape[axis] = shape[axis] * self.index_as_shape_item(repeats)
             else:
-                shape[axis] = shape[axis] * repeats
+                shape[axis] = shape[axis] * self.index_as_shape_item(repeats)
             return TypeTracerArray._new(x.dtype, shape=tuple(shape))
 
     def tile(self, x: ArrayLike, reps: int) -> TypeTracerArray:

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -120,11 +120,17 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
             )
             if not isinstance(left, ak.contents.Content):
                 left = ak.contents.NumpyArray(
-                    backend.nplike.repeat(backend.nplike.asarray(left), tags.length)
+                    backend.nplike.repeat(
+                        backend.nplike.asarray(left),
+                        backend.nplike.shape_item_as_index(tags.length),
+                    )
                 )
             if not isinstance(right, ak.contents.Content):
                 right = ak.contents.NumpyArray(
-                    backend.nplike.repeat(backend.nplike.asarray(right), tags.length)
+                    backend.nplike.repeat(
+                        backend.nplike.asarray(right),
+                        backend.nplike.shape_item_as_index(tags.length),
+                    )
                 )
             return (
                 ak.contents.UnionArray.simplified(

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -119,10 +119,12 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
                 nplike=backend.index_nplike,
             )
             if not isinstance(left, ak.contents.Content):
-                left = ak.contents.NumpyArray(backend.nplike.repeat(left, tags.length))
+                left = ak.contents.NumpyArray(
+                    backend.nplike.repeat(backend.nplike.asarray(left), tags.length)
+                )
             if not isinstance(right, ak.contents.Content):
                 right = ak.contents.NumpyArray(
-                    backend.nplike.repeat(right, tags.length)
+                    backend.nplike.repeat(backend.nplike.asarray(right), tags.length)
                 )
             return (
                 ak.contents.UnionArray.simplified(

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -124,7 +124,7 @@ def _impl(base, what, where, highlevel, behavior):
                     )
                 elif not isinstance(what, ak.contents.Content):
                     what = ak.contents.NumpyArray(
-                        backend.nplike.repeat(what, len(base))
+                        backend.nplike.repeat(backend.nplike.asarray(what), len(base))
                     )
                 if base.is_tuple:
                     # Preserve tuple-ness

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -117,14 +117,14 @@ def _impl(base, what, where, highlevel, behavior):
                 if what is None:
                     what = ak.contents.IndexedOptionArray(
                         ak.index.Index64(
-                            backend.index_nplike.full(len(base), -1, dtype=np.int64),
+                            backend.index_nplike.full(base.length, -1, dtype=np.int64),
                             nplike=backend.index_nplike,
                         ),
                         ak.contents.EmptyArray(),
                     )
                 elif not isinstance(what, ak.contents.Content):
                     what = ak.contents.NumpyArray(
-                        backend.nplike.repeat(backend.nplike.asarray(what), len(base))
+                        backend.nplike.repeat(backend.nplike.asarray(what), base.length)
                     )
                 if base.is_tuple:
                     # Preserve tuple-ness

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -124,7 +124,10 @@ def _impl(base, what, where, highlevel, behavior):
                     )
                 elif not isinstance(what, ak.contents.Content):
                     what = ak.contents.NumpyArray(
-                        backend.nplike.repeat(backend.nplike.asarray(what), base.length)
+                        backend.nplike.repeat(
+                            backend.nplike.asarray(what),
+                            backend.nplike.shape_item_as_index(base.length),
+                        )
                     )
                 if base.is_tuple:
                     # Preserve tuple-ness


### PR DESCRIPTION
This PR fixes a set of miscellaneous typetracer bugs. It doesn't implement a full `repeat` implementation, but it's a start.