### PR TITLE
docs: add `broadcast_fields` to toctree

### DIFF
--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -135,6 +135,7 @@
     :caption: Broadcasting
 
     generated/ak.broadcast_arrays
+    generated/ak.broadcast_fields
 
 .. toctree::
     :caption: Combinatorics ("for loop" replacements)


### PR DESCRIPTION
This was forgotten about when adding `ak.broadcast_fields` in #2267 