### PR TITLE
ci: publish to PyPI with OIDC

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -166,6 +166,10 @@ jobs:
     needs: [build_wheels, build_alt_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: inputs.publish-pypi
+    permissions:
+      id-token: write
+    environment:
+      name: "deploy-cpp-pypi"
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -173,5 +177,3 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        password: ${{ secrets.PYPI_PASSWORD_CPP }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,10 @@ jobs:
     needs: [build, check-requirements, check-cpp-on-pypi]
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && github.event.action == 'published') || inputs.publish-pypi
+    permissions:
+      id-token: write
+    environment:
+      name: "deploy-pypi"
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -109,8 +113,6 @@ jobs:
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        password: ${{ secrets.PYPI_PASSWORD }}
 
   publish-headers:
     name: "Publish header-only libraries alongside release"


### PR DESCRIPTION
This PR introduces two new environments for releasing packages on PyPI. There's no strong reason to use multiple environments, but in general it's better to avoid sharing any kind of state / credentials between unrelated workflows.

Leverages [new PyPI Trusted Publishers feature](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/).