### PR TITLE
feat!: remove use of `typestr` in `ak.types.Type`

### DIFF
--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._nplikes import ufuncs
+from awkward._typing import Any
 
 
 def overlay_behavior(behavior: dict | None) -> Mapping:
@@ -125,34 +126,18 @@ def find_ufunc(behavior, signature):
                 return custom
 
 
-def find_typestrs(behavior):
+def find_record_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+    if parameters is None:
+        return None
     behavior = overlay_behavior(behavior)
-    out = {}
-    for key, typestr in behavior.items():
-        if (
-            isinstance(key, tuple)
-            and len(key) == 2
-            and key[0] == "__typestr__"
-            and isinstance(key[1], str)
-            and isinstance(typestr, str)
-        ):
-            out[key[1]] = typestr
-    return out
+    return behavior.get(("__typestr__", parameters.get("__record__")))
 
 
-def find_typestr(parameters, typestrs):
-    if parameters is not None:
-        record = parameters.get("__record__")
-        if record is not None:
-            typestr = typestrs.get(record)
-            if typestr is not None:
-                return typestr
-        array = parameters.get("__array__")
-        if array is not None:
-            typestr = typestrs.get(array)
-            if typestr is not None:
-                return typestr
-    return None
+def find_array_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+    if parameters is None:
+        return None
+    behavior = overlay_behavior(behavior)
+    return behavior.get(("__typestr__", parameters.get("__array__")))
 
 
 def behavior_of(*arrays, **kwargs):

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -126,18 +126,22 @@ def find_ufunc(behavior, signature):
                 return custom
 
 
-def find_record_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+def find_record_typestr(
+    behavior: None | Mapping, parameters: None | Mapping[str, Any], default: str = None
+):
     if parameters is None:
-        return None
+        return default
     behavior = overlay_behavior(behavior)
-    return behavior.get(("__typestr__", parameters.get("__record__")))
+    return behavior.get(("__typestr__", parameters.get("__record__")), default)
 
 
-def find_array_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+def find_array_typestr(
+    behavior: None | Mapping, parameters: None | Mapping[str, Any], default: str = None
+):
     if parameters is None:
-        return None
+        return default
     behavior = overlay_behavior(behavior)
-    return behavior.get(("__typestr__", parameters.get("__array__")))
+    return behavior.get(("__typestr__", parameters.get("__array__")), default)
 
 
 def behavior_of(*arrays, **kwargs):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -141,9 +141,10 @@ class BitMaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
             #
         ).simplify_option_union()

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -144,9 +144,7 @@ class BitMaskedForm(Form):
     @property
     def type(self):
         return ak.types.OptionType(
-            self._content.type,
-            parameters=self._parameters,
-            #
+            self._content.type, parameters=self._parameters
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -146,7 +145,7 @@ class BitMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -122,9 +122,7 @@ class ByteMaskedForm(Form):
     @property
     def type(self):
         return ak.types.OptionType(
-            self._content.type,
-            parameters=self._parameters,
-            #
+            self._content.type, parameters=self._parameters
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -119,9 +119,10 @@ class ByteMaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
             #
         ).simplify_option_union()

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -124,7 +123,7 @@ class ByteMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -47,10 +47,7 @@ class EmptyForm(Form):
 
     @property
     def type(self):
-        return ak.types.UnknownType(
-            parameters=self._parameters,
-            #
-        )
+        return ak.types.UnknownType(parameters=self._parameters)
 
     def __eq__(self, other) -> bool:
         return isinstance(other, EmptyForm) and self._form_key == other._form_key

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._errors import deprecate
 from awkward._typing import final
 from awkward._util import unset
@@ -49,7 +48,7 @@ class EmptyForm(Form):
     def _type(self, typestrs):
         return ak.types.UnknownType(
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         )
 
     def __eq__(self, other) -> bool:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -45,7 +45,8 @@ class EmptyForm(Form):
     def _to_dict_part(self, verbose, toplevel):
         return self._to_dict_extra({"class": "EmptyArray"}, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.UnknownType(
             parameters=self._parameters,
             #

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import find_typestrs
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -377,10 +376,17 @@ class Form:
 
     @property
     def type(self):
-        return self._type({})
+        raise NotImplementedError
 
     def type_from_behavior(self, behavior):
-        return self._type(find_typestrs(behavior))
+        deprecate(
+            "low level types produced by forms do not hold references to behaviors. "
+            "Use a high-level type (e.g. ak.types.ArrayType or ak.types.ScalarType) to"
+            "associate a type with behavior information, or simply access the low-level"
+            "type from Form.type",
+            version="2.4.0",
+        )
+        return self.type
 
     def columns(self, list_indicator=None, column_prefix=()):
         output = []
@@ -423,9 +429,6 @@ class Form:
         raise NotImplementedError
 
     def _to_dict_part(self, verbose, toplevel):
-        raise NotImplementedError
-
-    def _type(self, typestrs):
         raise NotImplementedError
 
     def length_zero_array(

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -106,8 +106,9 @@ class IndexedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
-        out = self._content._type(typestrs)
+    @property
+    def type(self):
+        out = self._content.type
 
         if self._parameters is not None:
             if out._parameters is None:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -109,7 +108,6 @@ class IndexedOptionForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -97,7 +97,8 @@ class IndexedOptionForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         if self.parameter("__array__") == "categorical":
             parameters = dict(self._parameters)
             del parameters["__array__"]
@@ -106,7 +107,7 @@ class IndexedOptionForm(Form):
             parameters = self._parameters
 
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=parameters,
         ).simplify_option_union()
 

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -104,9 +104,10 @@ class ListForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.ListType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -109,7 +108,6 @@ class ListForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -68,7 +67,6 @@ class ListOffsetForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -63,9 +63,10 @@ class ListOffsetForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.ListType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -2,7 +2,6 @@
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
@@ -131,7 +130,6 @@ class NumpyForm(Form):
         out = ak.types.NumpyType(
             self._primitive,
             parameters=None,
-            typestr=find_typestr(self._parameters, typestrs),
         )
         for x in self._inner_shape[::-1]:
             out = ak.types.RegularType(out, x)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -126,7 +126,8 @@ class NumpyForm(Form):
                 out["inner_shape"] = list(self._inner_shape)
             return self._to_dict_extra(out, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         out = ak.types.NumpyType(
             self._primitive,
             parameters=None,

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -3,7 +3,6 @@ import glob
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
@@ -170,7 +169,6 @@ class RecordForm(Form):
             [x._type(typestrs) for x in self._contents],
             self._fields,
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -164,9 +164,10 @@ class RecordForm(Form):
         out["contents"] = contents_tolist
         return self._to_dict_extra(out, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.RecordType(
-            [x._type(typestrs) for x in self._contents],
+            [x.type for x in self._contents],
             self._fields,
             parameters=self._parameters,
         )

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -65,9 +65,10 @@ class RegularForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.RegularType(
-            self._content._type(typestrs),
+            self._content.type,
             self._size,
             parameters=self._parameters,
         )

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
@@ -71,7 +70,6 @@ class RegularForm(Form):
             self._content._type(typestrs),
             self._size,
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -132,9 +132,10 @@ class UnionForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.UnionType(
-            [x._type(typestrs) for x in self._contents],
+            [x.type for x in self._contents],
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -3,7 +3,6 @@ from collections import Counter
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -137,7 +136,6 @@ class UnionForm(Form):
         return ak.types.UnionType(
             [x._type(typestrs) for x in self._contents],
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -82,7 +81,6 @@ class UnmaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -77,9 +77,10 @@ class UnmaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         ).simplify_option_union()
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -436,7 +436,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         wrapped by an #ak.types.ArrayType.
         """
         return ak.types.ArrayType(
-            self._layout.form.type_from_behavior(self._behavior),
+            self._layout.form.type,
             self._layout.length,
             self._behavior,
         )
@@ -1715,9 +1715,7 @@ class Record(NDArrayOperatorsMixin):
         The type of a #ak.record.Record (from #ak.Array.layout) is not
         wrapped by an #ak.types.ScalarType.
         """
-        return ak.types.ScalarType(
-            self._layout.array.form.type_from_behavior(self._behavior), self._behavior
-        )
+        return ak.types.ScalarType(self._layout.array.form.type, self._behavior)
 
     @property
     def typestr(self):
@@ -2320,9 +2318,7 @@ class ArrayBuilder(Sized):
         wrapped by an #ak.types.ArrayType.
         """
         form = ak.forms.from_json(self._layout.form())
-        return ak.types.ArrayType(
-            form.type_from_behavior(self._behavior), len(self._layout)
-        )
+        return ak.types.ArrayType(form.type, len(self._layout), self._behavior)
 
     @property
     def typestr(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -436,7 +436,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         wrapped by an #ak.types.ArrayType.
         """
         return ak.types.ArrayType(
-            self._layout.form.type_from_behavior(self._behavior), self._layout.length
+            self._layout.form.type_from_behavior(self._behavior),
+            self._layout.length,
+            self._behavior,
         )
 
     @property
@@ -1714,7 +1716,7 @@ class Record(NDArrayOperatorsMixin):
         wrapped by an #ak.types.ScalarType.
         """
         return ak.types.ScalarType(
-            self._layout.array.form.type_from_behavior(self._behavior)
+            self._layout.array.form.type_from_behavior(self._behavior), self._behavior
         )
 
     @property

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -85,13 +85,19 @@ def _impl(array, behavior):
 
     if isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array))
+        return ak.types.ArrayType(
+            form.type_from_behavior(behavior), len(array), behavior=behavior
+        )
 
     elif isinstance(array, ak.record.Record):
-        return ak.types.ScalarType(array.array.form.type_from_behavior(behavior))
+        return ak.types.ScalarType(
+            array.array.form.type_from_behavior(behavior), behavior=behavior
+        )
 
     elif isinstance(array, ak.contents.Content):
-        return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
+        return ak.types.ArrayType(
+            array.form.type_from_behavior(behavior), array.length, behavior=behavior
+        )
 
     elif isinstance(array, (np.dtype, np.generic)):
         return ak.types.ScalarType(
@@ -99,22 +105,22 @@ def _impl(array, behavior):
         )
 
     elif isinstance(array, bool):  # np.bool_ in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("bool"))
+        return ak.types.ScalarType(ak.types.NumpyType("bool"), behavior=behavior)
 
     elif isinstance(array, numbers.Integral):
-        return ak.types.ScalarType(ak.types.NumpyType("int64"))
+        return ak.types.ScalarType(ak.types.NumpyType("int64"), behavior=behavior)
 
     elif isinstance(array, numbers.Real):
-        return ak.types.ScalarType(ak.types.NumpyType("float64"))
+        return ak.types.ScalarType(ak.types.NumpyType("float64"), behavior=behavior)
 
     elif isinstance(array, numbers.Complex):
-        return ak.types.ScalarType(ak.types.NumpyType("complex128"))
+        return ak.types.ScalarType(ak.types.NumpyType("complex128"), behavior=behavior)
 
     elif isinstance(array, datetime):  # np.datetime64 in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("datetime64"))
+        return ak.types.ScalarType(ak.types.NumpyType("datetime64"), behavior=behavior)
 
     elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("timedelta"))
+        return ak.types.ScalarType(ak.types.NumpyType("timedelta"), behavior=behavior)
 
     elif isinstance(array, ak.highlevel.ArrayBuilder):
         # Don't go through `to_layout`: we want to avoid snapshotting this array
@@ -123,7 +129,7 @@ def _impl(array, behavior):
     else:
         layout = ak.to_layout(array, allow_other=True, allow_record=True)
         if layout is None:
-            return ak.types.ScalarType(ak.types.UnknownType())
+            return ak.types.ScalarType(ak.types.UnknownType(), behavior=behavior)
 
         elif isinstance(layout, (ak.contents.Content, ak.record.Record)):
             return _impl(layout, behavior)

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -85,19 +85,13 @@ def _impl(array, behavior):
 
     if isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(
-            form.type_from_behavior(behavior), len(array), behavior=behavior
-        )
+        return ak.types.ArrayType(form.type, len(array), behavior=behavior)
 
     elif isinstance(array, ak.record.Record):
-        return ak.types.ScalarType(
-            array.array.form.type_from_behavior(behavior), behavior=behavior
-        )
+        return ak.types.ScalarType(array.array.form.type, behavior=behavior)
 
     elif isinstance(array, ak.contents.Content):
-        return ak.types.ArrayType(
-            array.form.type_from_behavior(behavior), array.length, behavior=behavior
-        )
+        return ak.types.ArrayType(array.form.type, array.length, behavior=behavior)
 
     elif isinstance(array, (np.dtype, np.generic)):
         return ak.types.ScalarType(

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -55,7 +55,7 @@ class ArrayType:
         ]
 
     def __repr__(self):
-        args = [repr(self._content), repr(self._length)]
+        args = [repr(self._content), repr(self._length), repr(self._behavior)]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -47,7 +47,11 @@ class ArrayType:
     def _str(self, indent, compact):
         return [
             f"{self._length} * ",
-            *self._content._str(indent, compact, self._behavior),
+            *self._content._str(
+                indent,
+                compact,
+                ak.behavior if self._behavior is None else self._behavior,
+            ),
         ]
 
     def __repr__(self):

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -9,7 +9,7 @@ from awkward._regularize import is_integer
 
 
 class ArrayType:
-    def __init__(self, content, length):
+    def __init__(self, content, length, behavior=None):
         if not isinstance(content, ak.types.Type):
             raise TypeError(
                 "{} all 'contents' must be Type subclasses, not {}".format(
@@ -24,6 +24,7 @@ class ArrayType:
             )
         self._content = content
         self._length = length
+        self._behavior = behavior
 
     @property
     def content(self):
@@ -33,6 +34,10 @@ class ArrayType:
     def length(self):
         return self._length
 
+    @property
+    def behavior(self):
+        return self._behavior
+
     def __str__(self):
         return "".join(self._str("", True))
 
@@ -40,7 +45,10 @@ class ArrayType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return [f"{self._length} * ", *self._content._str(indent, compact)]
+        return [
+            f"{self._length} * ",
+            *self._content._str(indent, compact, self._behavior),
+        ]
 
     def __repr__(self):
         args = [repr(self._content), repr(self._length)]

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -50,7 +50,7 @@ class ArrayType:
             *self._content._str(
                 indent,
                 compact,
-                ak.behavior if self._behavior is None else self._behavior,
+                self._behavior,
             ),
         ]
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -44,9 +44,11 @@ class ListType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
-
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
         else:
             params = self._str_parameters()
             if params is None:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -43,22 +43,16 @@ class ListType(Type):
     def content(self):
         return self._content
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
-
-        elif self.parameter("__array__") == "string":
-            out = ["string"]
-
-        elif self.parameter("__array__") == "bytestring":
-            out = ["bytes"]
 
         else:
             params = self._str_parameters()
             if params is None:
-                out = ["var * ", *self._content._str(indent, compact)]
+                out = ["var * ", *self._content._str(indent, compact, behavior)]
             else:
-                out = ["[var * ", *self._content._str(indent, compact)] + [
+                out = ["[var * ", *self._content._str(indent, compact, behavior)] + [
                     f", {params}]"
                 ]
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -49,7 +49,7 @@ class ListType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
         else:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -49,10 +49,7 @@ class ListType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
         else:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -44,6 +46,10 @@ class ListType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -130,7 +130,7 @@ class NumpyType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -125,8 +125,11 @@ class NumpyType(Type):
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if self.parameter("__unit__") is not None:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
@@ -130,10 +130,7 @@ class NumpyType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -124,15 +124,9 @@ class NumpyType(Type):
 
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
-
-        elif self.parameter("__array__") == "char":
-            out = ["char"]
-
-        elif self.parameter("__array__") == "byte":
-            out = ["byte"]
 
         else:
             if self.parameter("__unit__") is not None:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 import re
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -125,6 +127,10 @@ class NumpyType(Type):
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -50,14 +50,14 @@ class OptionType(Type):
     def content(self):
         return self._content
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         head = []
         tail = []
         if self._typestr is not None:
             content_out = [self._typestr]
 
         else:
-            content_out = self._content._str(indent, compact)
+            content_out = self._content._str(indent, compact, behavior)
             params = self._str_parameters()
             if params is None:
                 if isinstance(

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -56,7 +56,7 @@ class OptionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
 
         head = []
         tail = []

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import (
     parameters_are_equal,
     parameters_union,
@@ -51,11 +53,16 @@ class OptionType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
-        head = []
-        tail = []
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )
+
+        head = []
+        tail = []
         if typestr is not None:
             content_out = [typestr]
 

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import (
     parameters_are_equal,
@@ -56,10 +56,7 @@ class OptionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
 
         head = []
         tail = []

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -53,8 +53,11 @@ class OptionType(Type):
     def _str(self, indent, compact, behavior):
         head = []
         tail = []
-        if self._typestr is not None:
-            content_out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            content_out = [typestr]
 
         else:
             content_out = self._content._str(indent, compact, behavior)

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,7 +7,7 @@ from itertools import permutations
 
 import awkward as ak
 import awkward._prettyprint
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_record_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -89,10 +89,7 @@ class RecordType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__record__")), self._typestr
-        )
+        typestr = find_record_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -83,7 +83,7 @@ class RecordType(Type):
 
     _str_parameters_exclude = ("__categorical__", "__record__")
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 
@@ -97,14 +97,19 @@ class RecordType(Type):
             for i, x in enumerate(self._contents):
                 if i + 1 < len(self._contents):
                     if compact:
-                        y = [*x._str(indent, compact), ", "]
+                        y = [*x._str(indent, compact, behavior), ", "]
                     else:
-                        y = [*x._str(indent + "    ", compact), ",\n", indent, "    "]
+                        y = [
+                            *x._str(indent + "    ", compact, behavior),
+                            ",\n",
+                            indent,
+                            "    ",
+                        ]
                 else:
                     if compact:
-                        y = x._str(indent, compact)
+                        y = x._str(indent, compact, behavior)
                     else:
-                        y = x._str(indent + "    ", compact)
+                        y = x._str(indent + "    ", compact, behavior)
                 children.append(y)
 
             params = self._str_parameters()

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -91,7 +91,7 @@ class RecordType(Type):
 
         behavior = overlay_behavior(behavior)
         typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
+            ("__typestr__", self.parameter("__record__")), self._typestr
         )
         if typestr is not None:
             out = [typestr]

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,6 +7,8 @@ from itertools import permutations
 
 import awkward as ak
 import awkward._prettyprint
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -84,8 +86,12 @@ class RecordType(Type):
     _str_parameters_exclude = ("__categorical__", "__record__")
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
-            ("__typestr__", self.parameter("__record__")), self._typestr
+            ("__typestr__", self.parameter("__array__")), self._typestr
         )
         if typestr is not None:
             out = [typestr]

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -84,8 +84,11 @@ class RecordType(Type):
     _str_parameters_exclude = ("__categorical__", "__record__")
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__record__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if compact:

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -89,7 +89,7 @@ class RecordType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_record_typestr(behavior, self._parameters)
+        typestr = find_record_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -65,8 +65,11 @@ class RegularType(Type):
         return self._size
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [f"{self._typestr}[{self._size}]"]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [f"{typestr}[{self._size}]"]
 
         else:
             params = self._str_parameters()

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer
@@ -65,6 +67,10 @@ class RegularType(Type):
         return self._size
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -64,27 +64,25 @@ class RegularType(Type):
     def size(self):
         return self._size
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
-            out = [self._typestr]
-
-        elif self.parameter("__array__") == "string":
-            out = [f"string[{self._size}]"]
-
-        elif self.parameter("__array__") == "bytestring":
-            out = [f"bytes[{self._size}]"]
+            out = [f"{self._typestr}[{self._size}]"]
 
         else:
             params = self._str_parameters()
 
             if params is None:
-                out = [str(self._size), " * ", *self._content._str(indent, compact)]
+                out = [
+                    str(self._size),
+                    " * ",
+                    *self._content._str(indent, compact, behavior),
+                ]
             else:
                 out = [
                     "[",
                     str(self._size),
                     " * ",
-                    *self._content._str(indent, compact),
+                    *self._content._str(indent, compact, behavior),
                 ] + [", ", params, "]"]
 
         return [self._str_categorical_begin(), *out] + [self._str_categorical_end()]

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -70,7 +70,7 @@ class RegularType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [f"{typestr}[{self._size}]"]
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
@@ -70,10 +70,7 @@ class RegularType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [f"{typestr}[{self._size}]"]
 

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -39,7 +39,7 @@ class ScalarType:
         )
 
     def __repr__(self):
-        return f"{type(self).__name__}({self._content!r})"
+        return f"{type(self).__name__}({self._content!r}, {self._behavior!r})"
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
         return isinstance(other, type(self)) and self._content.is_equal_to(

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -7,7 +7,7 @@ import awkward as ak
 
 
 class ScalarType:
-    def __init__(self, content):
+    def __init__(self, content, behavior=None):
         if not isinstance(content, ak.types.Type):
             raise TypeError(
                 "{} all 'contents' must be Type subclasses, not {}".format(
@@ -15,10 +15,15 @@ class ScalarType:
                 )
             )
         self._content = content
+        self._behavior = behavior
 
     @property
     def content(self):
         return self._content
+
+    @property
+    def behavior(self):
+        return self._behavior
 
     def __str__(self):
         return "".join(self._str("", True))
@@ -27,7 +32,7 @@ class ScalarType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return self._content._str(indent, compact)
+        return self._content._str(indent, compact, self._behavior)
 
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -32,7 +32,11 @@ class ScalarType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return self._content._str(indent, compact, self._behavior)
+        return self._content._str(
+            indent,
+            compact,
+            ak.behavior if self._behavior is None else self._behavior,
+        )
 
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -35,7 +35,7 @@ class ScalarType:
         return self._content._str(
             indent,
             compact,
-            ak.behavior if self._behavior is None else self._behavior,
+            self._behavior,
         )
 
     def __repr__(self):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -314,8 +314,8 @@ def from_datashape(datashape, highlevel=True):
     the return type is #ak.types.ArrayType, representing an #ak.highlevel.Array.
 
     If `highlevel=True` and the type string starts with a record indicator (e.g. `{`),
-    the return type is #ak.types.RecordType, representing an #ak.highlevel.Record,
-    rather than an array of them.
+    the return type is #ak.types.ScalarType with an #ak.types.RecordType content,
+    representing a scalar #ak.highlevel.Record rather than an array of them.
 
     Other strings (e.g. starting with `var *`, `?`, `option`, etc.) are not compatible
     with `highlevel=True`; an exception would be raised.
@@ -326,6 +326,7 @@ def from_datashape(datashape, highlevel=True):
     from awkward.types.arraytype import ArrayType
     from awkward.types.recordtype import RecordType
     from awkward.types.regulartype import RegularType
+    from awkward.types.scalartype import ScalarType
 
     parser = Lark_StandAlone(transformer=_DataShapeTransformer())
     out = parser.parse(datashape)
@@ -334,7 +335,7 @@ def from_datashape(datashape, highlevel=True):
         if isinstance(out, RegularType):
             return ArrayType(out.content, out.size)
         elif isinstance(out, RecordType):
-            return out
+            return ScalarType(out)
         else:
             raise ValueError(
                 f"type {type(out).__name__!r} is not compatible with highlevel=True"

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -34,9 +34,9 @@ class Type:
         return self._typestr
 
     def __str__(self):
-        return "".join(self._str("", True))
+        return "".join(self._str("", True, None))
 
-    def _str(self, indent: str, compact: bool, behavior) -> list[str]:
+    def _str(self, indent: str, compact: bool, behavior: dict | None) -> list[str]:
         raise NotImplementedError
 
     def show(self, stream=sys.stdout):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -36,8 +36,12 @@ class Type:
     def __str__(self):
         return "".join(self._str("", True))
 
+    def _str(self, indent: str, compact: bool, behavior) -> list[str]:
+        raise NotImplementedError
+
     def show(self, stream=sys.stdout):
-        stream.write("".join([*self._str("", False), "\n"]))
+        # TODO: deprecate lowlevel show
+        stream.write("".join([*self._str("", False, None), "\n"]))
 
     _str_parameters_exclude = ("__categorical__",)
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -63,7 +63,7 @@ class UnionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -57,7 +57,7 @@ class UnionType(Type):
     def contents(self):
         return self._contents
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 
@@ -71,14 +71,19 @@ class UnionType(Type):
             for i, x in enumerate(self._contents):
                 if i + 1 < len(self._contents):
                     if compact:
-                        y = [*x._str(indent, compact), ", "]
+                        y = [*x._str(indent, compact, behavior), ", "]
                     else:
-                        y = [*x._str(indent + "    ", compact), ",\n", indent, "    "]
+                        y = [
+                            *x._str(indent + "    ", compact, behavior),
+                            ",\n",
+                            indent,
+                            "    ",
+                        ]
                 else:
                     if compact:
-                        y = x._str(indent, compact)
+                        y = x._str(indent, compact, behavior)
                     else:
-                        y = x._str(indent + "    ", compact)
+                        y = x._str(indent + "    ", compact, behavior)
                 children.append(y)
 
             flat_children = [y for x in children for y in x]

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from itertools import permutations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -63,10 +63,7 @@ class UnionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from itertools import permutations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -58,6 +60,10 @@ class UnionType(Type):
         return self._contents
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -58,8 +58,11 @@ class UnionType(Type):
         return self._contents
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if compact:

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -36,7 +36,7 @@ class UnknownType(Type):
         self._parameters = parameters
         self._typestr = typestr
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -41,10 +41,7 @@ class UnknownType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -37,6 +38,10 @@ class UnknownType(Type):
         self._typestr = typestr
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -41,7 +41,7 @@ class UnknownType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -37,8 +37,11 @@ class UnknownType(Type):
         self._typestr = typestr
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             params = self._str_parameters()

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -93,7 +93,6 @@ def test_dress():
 
 
 def test_record_name():
-    typestrs = {}
     builder = ak.highlevel.ArrayBuilder()
 
     builder.begin_record("Dummy")
@@ -112,8 +111,8 @@ def test_record_name():
 
     a = builder.snapshot()
 
-    assert str(a.layout.form._type(typestrs)) == "Dummy[one: int64, two: float64]"
-    assert a.layout.form._type(typestrs).parameters == {"__record__": "Dummy"}
+    assert str(a.layout.form.type) == "Dummy[one: int64, two: float64]"
+    assert a.layout.form.type.parameters == {"__record__": "Dummy"}
 
 
 def test_builder_string():

--- a/tests/test_0773_typeparser.py
+++ b/tests/test_0773_typeparser.py
@@ -437,7 +437,7 @@ def test_hardcoded():
 def test_record_highlevel():
     text = "Thingy[x: int64, y: float64]"
     parsedtype = ak.types.from_datashape(text, highlevel=True)
-    assert isinstance(parsedtype, ak.types.RecordType)
+    assert isinstance(parsedtype, ak.types.ScalarType)
     assert str(parsedtype) == text
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -6,6 +6,22 @@ import pytest
 import awkward as ak
 
 
+def assert_overrides_typestr(type_, typestr: str = "override", expected: str = None):
+    # Assume typestr is expected result
+    if expected is None:
+        expected = typestr
+    # Set appropriate array or record parameter
+    if isinstance(type_, ak.types.RecordType):
+        parameters = {**type_.parameters, "__record__": "custom"}
+    else:
+        parameters = {**type_.parameters, "__array__": "custom"}
+    behavior = {("__typestr__", "custom"): typestr}
+    # Build highlevel type with custom behavior
+    with_parameter = type_.copy(parameters=parameters)
+    as_str = "".join(with_parameter._str("", False, behavior))
+    assert as_str == expected
+
+
 def test_UnknownType():
     assert str(ak.types.unknowntype.UnknownType()) == "unknown"
     with pytest.warns(DeprecationWarning):
@@ -13,18 +29,11 @@ def test_UnknownType():
             str(ak.types.unknowntype.UnknownType(parameters={"x": 123}))
             == 'unknown[parameters={"x": 123}]'
         )
-    assert (
-        str(ak.types.unknowntype.UnknownType(parameters=None, typestr="override"))
-        == "override"
-    )
     with pytest.warns(DeprecationWarning):
-        assert (
-            str(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"x": 123}, typestr="override"
-                )
-            )
-            == "override"
+        assert_overrides_typestr(ak.types.unknowntype.UnknownType())
+
+        assert_overrides_typestr(
+            ak.types.unknowntype.UnknownType(parameters={"x": 123})
         )
         assert (
             str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
@@ -38,24 +47,18 @@ def test_UnknownType():
             )
             == 'categorical[type=unknown[parameters={"x": 123}]]'
         )
-        assert (
-            str(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"__categorical__": True}, typestr="override"
-                )
-            )
-            == "categorical[type=override]"
+        assert_overrides_typestr(
+            ak.types.unknowntype.UnknownType(
+                parameters={"__categorical__": True, "x": 123}
+            ),
+            expected="categorical[type=override]",
         )
 
     assert repr(ak.types.unknowntype.UnknownType()) == "UnknownType()"
     with pytest.warns(DeprecationWarning):
         assert (
-            repr(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"__categorical__": True}, typestr="override"
-                )
-            )
-            == "UnknownType(parameters={'__categorical__': True}, typestr='override')"
+            repr(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
+            == "UnknownType(parameters={'__categorical__': True})"
         )
 
 
@@ -87,17 +90,10 @@ def test_NumpyType():
         str(ak.types.numpytype.NumpyType("bool", parameters={"x": 123}))
         == 'bool[parameters={"x": 123}]'
     )
-    assert (
-        str(ak.types.numpytype.NumpyType("bool", parameters=None, typestr="override"))
-        == "override"
-    )
-    assert (
-        str(
-            ak.types.numpytype.NumpyType(
-                "bool", parameters={"x": 123}, typestr="override"
-            )
-        )
-        == "override"
+    assert_overrides_typestr(ak.types.numpytype.NumpyType("bool"))
+
+    assert_overrides_typestr(
+        ak.types.numpytype.NumpyType("bool", parameters={"x": 123})
     )
     assert (
         str(ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}))
@@ -111,13 +107,10 @@ def test_NumpyType():
         )
         == 'categorical[type=bool[parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.numpytype.NumpyType(
-                "bool", parameters={"__categorical__": True}, typestr="override"
-            )
-        )
-        == "categorical[type=override]"
+
+    assert_overrides_typestr(
+        ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}),
+        expected="categorical[type=override]",
     )
     assert str(ak.types.numpytype.NumpyType("datetime64")) == "datetime64"
     assert (
@@ -277,12 +270,10 @@ def test_NumpyType():
     assert (
         repr(
             ak.types.numpytype.NumpyType(
-                primitive="bool",
-                parameters={"__categorical__": True},
-                typestr="override",
+                primitive="bool", parameters={"__categorical__": True}
             )
         )
-        == "NumpyType('bool', parameters={'__categorical__': True}, typestr='override')"
+        == "NumpyType('bool', parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -329,27 +320,19 @@ def test_RegularType():
         )
         == '[10 * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters=None,
-                typestr="override",
-            )
-        )
-        == "override"
+
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+        expected="override[10]",
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters={"x": 123},
-                typestr="override",
-            )
-        )
-        == "override"
+
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(
+            ak.types.unknowntype.UnknownType(),
+            10,
+            parameters={"x": 123},
+        ),
+        expected="override[10]",
     )
     assert (
         str(
@@ -371,16 +354,13 @@ def test_RegularType():
         )
         == 'categorical[type=[10 * unknown, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(
+            ak.types.unknowntype.UnknownType(),
+            10,
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override[10]]",
     )
     assert (
         str(
@@ -417,10 +397,9 @@ def test_RegularType():
                 content=ak.types.unknowntype.UnknownType(),
                 size=10,
                 parameters={"__categorical__": True},
-                typestr="override",
             )
         )
-        == "RegularType(UnknownType(), 10, parameters={'__categorical__': True}, typestr='override')"
+        == "RegularType(UnknownType(), 10, parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -461,23 +440,14 @@ def test_ListType():
         )
         == '[var * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(), parameters=None, typestr="override"
-            )
-        )
-        == "override"
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(ak.types.unknowntype.UnknownType())
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -496,15 +466,12 @@ def test_ListType():
         )
         == 'categorical[type=[var * unknown, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
     assert (
         str(
@@ -534,10 +501,9 @@ def test_ListType():
             ak.types.listtype.ListType(
                 content=ak.types.unknowntype.UnknownType(),
                 parameters={"__categorical__": True},
-                typestr="override",
             )
         )
-        == "ListType(UnknownType(), parameters={'__categorical__': True}, typestr='override')"
+        == "ListType(UnknownType(), parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -614,61 +580,43 @@ def test_RecordType():
         )
         == "Name[x: unknown, y: bool]"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name"},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name"},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name"},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name"},
         )
-        == "override"
     )
     assert (
         str(
@@ -722,61 +670,45 @@ def test_RecordType():
         )
         == 'Name[x: unknown, y: bool, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -830,61 +762,49 @@ def test_RecordType():
         )
         == "categorical[type=Name[x: unknown, y: bool]]"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
     assert (
         str(
@@ -938,61 +858,49 @@ def test_RecordType():
         )
         == 'categorical[type=Name[x: unknown, y: bool, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1028,10 +936,9 @@ def test_RecordType():
                 ],
                 fields=None,
                 parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "RecordType([UnknownType(), NumpyType('bool')], None, parameters={'__record__': 'Name', 'x': 123, '__categorical__': True}, typestr='override')"
+        == "RecordType([UnknownType(), NumpyType('bool')], None, parameters={'__record__': 'Name', 'x': 123, '__categorical__': True})"
     )
     assert (
         repr(
@@ -1055,10 +962,9 @@ def test_RecordType():
                 ],
                 fields=["x", "y"],
                 parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "RecordType([UnknownType(), NumpyType('bool')], ['x', 'y'], parameters={'__record__': 'Name', 'x': 123, '__categorical__': True}, typestr='override')"
+        == "RecordType([UnknownType(), NumpyType('bool')], ['x', 'y'], parameters={'__record__': 'Name', 'x': 123, '__categorical__': True})"
     )
 
 
@@ -1111,67 +1017,39 @@ def test_OptionType():
         )
         == 'option[10 * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(), parameters=None, typestr="override"
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(), parameters=None
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters=None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10)
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -1230,69 +1108,47 @@ def test_OptionType():
         )
         == 'option[categorical[type=10 * unknown], parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1314,10 +1170,9 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 parameters={"x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "OptionType(RegularType(UnknownType(), 10), parameters={'x': 123, '__categorical__': True}, typestr='override')"
+        == "OptionType(RegularType(UnknownType(), 10), parameters={'x': 123, '__categorical__': True})"
     )
 
 
@@ -1345,31 +1200,23 @@ def test_UnionType():
         )
         == 'union[unknown, bool, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters=None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -1395,31 +1242,25 @@ def test_UnionType():
         )
         == 'categorical[type=union[unknown, bool, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1441,10 +1282,9 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 parameters={"x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "UnionType([UnknownType(), NumpyType('bool')], parameters={'x': 123, '__categorical__': True}, typestr='override')"
+        == "UnionType([UnknownType(), NumpyType('bool')], parameters={'x': 123, '__categorical__': True})"
     )
 
 
@@ -1462,10 +1302,8 @@ def test_ArrayType():
 
     # ArrayType should not have these arguments (should not be a Type subclass)
     with pytest.raises(TypeError):
-        ak.types.arraytype.ArrayType(ak.types.unknowntype.UnknownType(), 10, {"x": 123})
-    with pytest.raises(TypeError):
         ak.types.arraytype.ArrayType(
-            ak.types.unknowntype.UnknownType(), 10, None, typestr="override"
+            ak.types.arraytype.ArrayType(ak.types.unknowntype.UnknownType(), 10), 10
         )
 
     assert (
@@ -1475,6 +1313,31 @@ def test_ArrayType():
             )
         )
         == "ArrayType(UnknownType(), 10)"
+    )
+
+    assert (
+        str(
+            ak.types.arraytype.ArrayType(
+                content=ak.types.numpytype.NumpyType(
+                    "int64", parameters={"__array__": "custom"}
+                ),
+                length=10,
+                behavior={("__typestr__", "custom"): "override"},
+            )
+        )
+        == "10 * override"
+    )
+
+    assert (
+        str(
+            ak.types.arraytype.ArrayType(
+                content=ak.types.numpytype.NumpyType(
+                    "int64", parameters={"__array__": "custom"}
+                ),
+                length=10,
+            )
+        )
+        == '10 * int64[parameters={"__array__": "custom"}]'
     )
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -1312,7 +1312,7 @@ def test_ArrayType():
                 content=ak.types.unknowntype.UnknownType(), length=10
             )
         )
-        == "ArrayType(UnknownType(), 10)"
+        == "ArrayType(UnknownType(), 10, None)"
     )
 
     assert (


### PR DESCRIPTION
Awkward associates `("__typestr__", "name")` behavior keys with custom typestrings for named types (records, arrays). Right now, that's implemented using a `typestr` argument. 

This PR drops `typestr` (deprecates), and instead introduces a `behavior` dict on the highlevel type, mirroring what already happens for arrays/records. Custom typestrings are resolved from this dict.

@jpivarski and I discussed this, and I was initially in favour of just building out the `typestr` argument usage. However, it feels to me that passing the behaviour to mirror our array/content implementation seems nicer (and keeps typestrings as contextual properties, rather than an intrinsic part of the type object)

This PR does the following:
- Remove string special casing in typestring resolution
- Simplifies typestring resolution
- Fixes a bug in `ak.types.from_datashape` (doesn't use new `ScalarType`)
- Changes typestring of regular strings to `string[N]` 

I also noticed some quirks that we should raise now:
- Awkward seems to support fixed-length strings (e.g. `ak.to_regular(["hell", "worl"]).type.show()`), but this pathway is never seen as we usually pass in a custom `typestr`.  
  I think the rule here is that typestrings are always used in favour of the type's default format, but the type can embellish that e.g. with fixed-length information?
- `repr(type)` shows custom typestrings. I think this should not be the case; typestrings are an aesthetic thing, not a fundamental part of the representation.

Closes #1945