### PR TITLE
feat!: rework string abstraction

### DIFF
--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -144,10 +144,20 @@ def find_array_typestr(
     return behavior.get(("__typestr__", parameters.get("__array__")), default)
 
 
-def is_subtype(behavior: None | Mapping, type_name: str, supertype_name: str) -> bool:
+def is_subtype(
+    behavior: None | Mapping,
+    type_name: str | None,
+    supertype_names: str | tuple[str, ...],
+) -> bool:
+    if type_name is None:
+        return False
+
+    if isinstance(supertype_names, str):
+        supertype_names = (supertype_names,)
+
     behavior = overlay_behavior(behavior)
     while type_name is not None:
-        if type_name == supertype_name:
+        if type_name in supertype_names:
             return True
         type_name = behavior.get(("__super__", type_name))
     return False

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -71,25 +71,6 @@ def find_custom_cast(obj, behavior):
     return None
 
 
-def find_custom_broadcast(layout, behavior):
-    behavior = overlay_behavior(behavior)
-    custom = layout.parameter("__array__")
-    if not isinstance(custom, str):
-        custom = layout.parameter("__record__")
-    if not isinstance(custom, str):
-        custom = layout.purelist_parameter("__record__")
-    if isinstance(custom, str):
-        for key, fcn in behavior.items():
-            if (
-                isinstance(key, tuple)
-                and len(key) == 2
-                and key[0] == "__broadcast__"
-                and key[1] == custom
-            ):
-                return fcn
-    return None
-
-
 def find_ufunc_generic(ufunc, layout, behavior):
     behavior = overlay_behavior(behavior)
     custom = layout.parameter("__array__")

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._nplikes import ufuncs
+from awkward._typing import Any
 
 
 def overlay_behavior(behavior: dict | None) -> Mapping:
@@ -125,34 +126,18 @@ def find_ufunc(behavior, signature):
                 return custom
 
 
-def find_typestrs(behavior):
+def find_record_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+    if parameters is None:
+        return None
     behavior = overlay_behavior(behavior)
-    out = {}
-    for key, typestr in behavior.items():
-        if (
-            isinstance(key, tuple)
-            and len(key) == 2
-            and key[0] == "__typestr__"
-            and isinstance(key[1], str)
-            and isinstance(typestr, str)
-        ):
-            out[key[1]] = typestr
-    return out
+    return behavior.get(("__typestr__", parameters.get("__record__")))
 
 
-def find_typestr(parameters, typestrs):
-    if parameters is not None:
-        record = parameters.get("__record__")
-        if record is not None:
-            typestr = typestrs.get(record)
-            if typestr is not None:
-                return typestr
-        array = parameters.get("__array__")
-        if array is not None:
-            typestr = typestrs.get(array)
-            if typestr is not None:
-                return typestr
-    return None
+def find_array_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+    if parameters is None:
+        return None
+    behavior = overlay_behavior(behavior)
+    return behavior.get(("__typestr__", parameters.get("__array__")))
 
 
 def behavior_of(*arrays, **kwargs):

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -144,6 +144,20 @@ def find_array_typestr(
     return behavior.get(("__typestr__", parameters.get("__array__")), default)
 
 
+def is_subtype(behavior: None | Mapping, type_name: str, supertype_name: str) -> bool:
+    behavior = overlay_behavior(behavior)
+    while type_name is not None:
+        if type_name == supertype_name:
+            return True
+        type_name = behavior.get(("__super__", type_name))
+    return False
+
+
+def find_supertype(behavior: None | Mapping, type_name: str) -> bool:
+    behavior = overlay_behavior(behavior)
+    return behavior.get(("__super__", type_name))
+
+
 def behavior_of(*arrays, **kwargs):
     from awkward.highlevel import Array, ArrayBuilder, Record
 

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -126,18 +126,22 @@ def find_ufunc(behavior, signature):
                 return custom
 
 
-def find_record_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+def find_record_typestr(
+    behavior: None | Mapping, parameters: None | Mapping[str, Any], default: str = None
+):
     if parameters is None:
-        return None
+        return default
     behavior = overlay_behavior(behavior)
-    return behavior.get(("__typestr__", parameters.get("__record__")))
+    return behavior.get(("__typestr__", parameters.get("__record__")), default)
 
 
-def find_array_typestr(behavior: None | Mapping, parameters: None | Mapping[str, Any]):
+def find_array_typestr(
+    behavior: None | Mapping, parameters: None | Mapping[str, Any], default: str = None
+):
     if parameters is None:
-        return None
+        return default
     behavior = overlay_behavior(behavior)
-    return behavior.get(("__typestr__", parameters.get("__array__")))
+    return behavior.get(("__typestr__", parameters.get("__array__")), default)
 
 
 def behavior_of(*arrays, **kwargs):

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
-from awkward._behavior import find_custom_broadcast
+from awkward._behavior import is_subtype
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -715,45 +715,64 @@ def apply_step(
 
         # General list-handling case: the offsets of each list may be different.
         else:
-            fcns = [
-                find_custom_broadcast(x, behavior) if isinstance(x, Content) else None
-                for x in inputs
-            ]
+            # We have three possible cases here:
+            # 1. all-string (nothing to do)
+            # 2. mixed string-list (strings gain a dimension and broadcast to the non-string offsets)
+            # 3. no strings (all lists broadcast to a single offsets)
+            offsets_content = None
+            all_content_strings = True
+            input_is_string = []
+            for x in inputs:
+                if isinstance(x, Content):
+                    content_is_string = is_subtype(
+                        behavior, x.parameter("__array__"), "stringlike"
+                    )
+                    # Don't try and take offsets from strings
+                    if not content_is_string:
+                        all_content_strings = False
+                        # Take the offsets from the first irregular list
+                        if x.is_list and not x.is_regular and offsets_content is None:
+                            offsets_content = x
+                    input_is_string.append(content_is_string)
+                else:
+                    input_is_string.append(False)
 
-            # Find first list without custom broadcasting which will define the broadcast offsets
-            # Don't consider RegularArray (handle case of 1-sized regular broadcasting)
-            # Do this to prioritise non-custom broadcasting
-            first = None
+            # case (1): user getfunctions should exit before this gets called
+            if all_content_strings:
+                raise ValueError(
+                    "cannot broadcast all strings: {}{}".format(
+                        ", ".join(repr(type(x)) for x in inputs), in_function(options)
+                    )
+                )
 
-            for x, fcn in zip(inputs, fcns):
-                if (
-                    isinstance(x, listtypes)
-                    and not isinstance(x, RegularArray)
-                    and fcn is None
-                ):
-                    first = x
-                    break
-
-            # Did we fail to find a list without custom broadcasting?
-            secondround = False
-            # If we failed to find an irregular, non-custom broadcasting list,
-            # continue search for *any* list.
-            if first is None:
-                secondround = True
-                for x in inputs:
-                    if isinstance(x, listtypes) and not isinstance(x, RegularArray):
-                        first = x
+            # Didn't find a ragged list, try any list!
+            if offsets_content is None:
+                for content in contents:
+                    if content.is_list:
+                        offsets_content = content
                         break
+                else:
+                    raise AssertionError("no list found in list branch!")
 
-            offsets = first._compact_offsets64(True)
+            offsets = offsets_content._compact_offsets64(True)
 
             nextinputs = []
-            for x, fcn in zip(inputs, fcns):
-                if callable(fcn) and not secondround:
-                    nextinputs.append(fcn(x, offsets))
+            for x, x_is_string in zip(inputs, input_is_string):
+                if x_is_string:
+                    offsets_data = backend.index_nplike.asarray(offsets)
+                    counts = offsets_data[1:] - offsets_data[:-1]
+                    if ak._util.win or ak._util.bits32:
+                        counts = index_nplike.astype(counts, dtype=np.int32)
+                    parents = index_nplike.repeat(
+                        index_nplike.arange(counts.size, dtype=counts.dtype), counts
+                    )
+                    nextinputs.append(
+                        ak.contents.IndexedArray(
+                            ak.index.Index64(parents, nplike=index_nplike), x
+                        ).project()
+                    )
                 elif isinstance(x, listtypes):
                     nextinputs.append(x._broadcast_tooffsets64(offsets).content)
-
                 # Handle implicit left-broadcasting (non-NumPy-like broadcasting).
                 elif options["left_broadcast"] and isinstance(x, Content):
                     nextinputs.append(

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -390,7 +390,11 @@ def argsort(
 
 
 def sort(
-    layout: Content, axis: int = -1, ascending: bool = True, stable: bool = False
+    layout: Content,
+    axis: int = -1,
+    ascending: bool = True,
+    stable: bool = False,
+    behavior: dict | None = None,
 ) -> Content:
     negaxis = -axis
     branch, depth = layout.branch_depth
@@ -419,4 +423,4 @@ def sort(
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
     parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.index_nplike)
-    return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
+    return layout._sort_next(negaxis, starts, parents, 1, ascending, stable, behavior)

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -150,7 +150,7 @@ def is_unique(
     return layout._is_unique(negaxis, starts, parents, 1, behavior)
 
 
-def unique(layout: Content, axis=None):
+def unique(layout: Content, axis=None, behavior: dict | None = None):
     if axis == -1 or axis is None:
         negaxis = axis if axis is None else -axis
         if negaxis is not None:
@@ -184,7 +184,7 @@ def unique(layout: Content, axis=None):
             layout.length, nplike=layout._backend.index_nplike
         )
 
-        return layout._unique(negaxis, starts, parents, 1)
+        return layout._unique(negaxis, starts, parents, 1, behavior)
 
     raise AxisError(
         "unique expects axis 'None' or '-1', got axis={} that is not supported yet".format(

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -129,6 +129,7 @@ def combinations(
     axis: Integral = 1,
     fields: list[str] | None = None,
     parameters: dict | None = None,
+    behavior: dict | None = None,
 ):
     if n < 1:
         raise ValueError("in combinations, 'n' must be at least 1")
@@ -138,7 +139,9 @@ def combinations(
         recordlookup = fields
         if len(recordlookup) != n:
             raise ValueError("if provided, the length of 'fields' must be 'n'")
-    return layout._combinations(n, replacement, recordlookup, parameters, axis, 1)
+    return layout._combinations(
+        n, replacement, recordlookup, parameters, axis, 1, behavior
+    )
 
 
 def is_unique(

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -209,6 +209,7 @@ def remove_structure(
     function_name: str | None = None,
     drop_nones: bool = True,
     keepdims: bool = False,
+    behavior: dict | None = None,
 ):
     if isinstance(layout, Record):
         return remove_structure(
@@ -225,6 +226,7 @@ def remove_structure(
             backend = layout._backend
         arrays = layout._remove_structure(
             backend,
+            behavior,
             {
                 "flatten_records": flatten_records,
                 "function_name": function_name,
@@ -271,7 +273,11 @@ def reduce(
 ):
     if axis is None:
         parts = remove_structure(
-            layout, flatten_records=False, drop_nones=False, keepdims=keepdims
+            layout,
+            flatten_records=False,
+            drop_nones=False,
+            keepdims=keepdims,
+            behavior=behavior,
         )
 
         if len(parts) > 1:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -141,11 +141,13 @@ def combinations(
     return layout._combinations(n, replacement, recordlookup, parameters, axis, 1)
 
 
-def is_unique(layout, axis: Integral | None = None) -> bool:
+def is_unique(
+    layout, axis: Integral | None = None, behavior: dict | None = None
+) -> bool:
     negaxis = axis if axis is None else -axis
     starts = ak.index.Index64.zeros(1, nplike=layout._backend.index_nplike)
     parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.index_nplike)
-    return layout._is_unique(negaxis, starts, parents, 1)
+    return layout._is_unique(negaxis, starts, parents, 1, behavior)
 
 
 def unique(layout: Content, axis=None):
@@ -339,8 +341,10 @@ def reduce(
         return next[0]
 
 
-def validity_error(layout: Content, path: str = "layout") -> str:
-    paramcheck = layout._validity_error_parameters(path)
+def validity_error(
+    layout: Content, path: str = "layout", behavior: dict | None = None
+) -> str:
+    paramcheck = layout._validity_error_parameters(path, behavior=behavior)
     if paramcheck != "":
         return paramcheck
     return layout._validity_error(path)

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -355,6 +355,7 @@ def argsort(
     axis: int = -1,
     ascending: bool = True,
     stable: bool = False,
+    behavior: dict | None = None,
 ) -> Content:
     negaxis = -axis
     branch, depth = layout.branch_depth
@@ -384,13 +385,7 @@ def argsort(
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
     parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.index_nplike)
     return layout._argsort_next(
-        negaxis,
-        starts,
-        None,
-        parents,
-        1,
-        ascending,
-        stable,
+        negaxis, starts, None, parents, 1, ascending, stable, behavior
     )
 
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -242,8 +242,10 @@ def flatten(layout: Content, axis: int = 1) -> Content:
     return flattened
 
 
-def numbers_to_type(layout: Content, name: str, including_unknown: bool) -> Content:
-    return layout._numbers_to_type(name, including_unknown)
+def numbers_to_type(
+    layout: Content, name: str, including_unknown: bool, behavior: Mapping
+) -> Content:
+    return layout._numbers_to_type(name, including_unknown, behavior)
 
 
 def fill_none(layout: Content, value: Content) -> Content:

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -277,3 +277,6 @@ def register(behavior):
 
     behavior["__cast__", str] = _cast_bytes_or_str_to_string
     behavior["__cast__", bytes] = _cast_bytes_or_str_to_string
+
+    behavior["__super__", "string"] = "stringlike"
+    behavior["__super__", "bytestring"] = "stringlike"

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -147,20 +147,6 @@ def _string_notequal(one, two):
     return ~_string_equal(one, two)
 
 
-def _string_broadcast(layout, offsets):
-    index_nplike = layout.backend.index_nplike
-    offsets = index_nplike.asarray(offsets)
-    counts = offsets[1:] - offsets[:-1]
-    if ak._util.win or ak._util.bits32:
-        counts = index_nplike.astype(counts, dtype=np.int32)
-    parents = index_nplike.repeat(
-        index_nplike.arange(counts.size, dtype=counts.dtype), counts
-    )
-    return ak.contents.IndexedArray(
-        ak.index.Index64(parents, nplike=index_nplike), layout
-    ).project()
-
-
 def _string_numba_typer(viewtype):
     import numba
 
@@ -267,9 +253,6 @@ def register(behavior):
     behavior[ufuncs.not_equal, "bytestring", "bytestring"] = _string_notequal
     behavior[ufuncs.not_equal, "string", "string"] = _string_notequal
 
-    behavior["__broadcast__", "bytestring"] = _string_broadcast
-    behavior["__broadcast__", "string"] = _string_broadcast
-
     behavior["__numba_typer__", "bytestring"] = _string_numba_typer
     behavior["__numba_lower__", "bytestring"] = _string_numba_lower
     behavior["__numba_typer__", "string"] = _string_numba_typer
@@ -278,5 +261,6 @@ def register(behavior):
     behavior["__cast__", str] = _cast_bytes_or_str_to_string
     behavior["__cast__", bytes] = _cast_bytes_or_str_to_string
 
+    # Define type hierarchy for strings
     behavior["__super__", "string"] = "stringlike"
     behavior["__super__", "bytestring"] = "stringlike"

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -676,9 +676,9 @@ class BitMaskedArray(Content):
     def _pad_none(self, target, axis, depth, clip):
         return self.to_ByteMaskedArray()._pad_none(target, axis, depth, clip)
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         return self.to_ByteMaskedArray()._to_arrow(
-            pyarrow, mask_node, validbytes, length, options
+            pyarrow, mask_node, validbytes, length, options, behavior
         )
 
     def _to_backend_array(self, allow_missing, behavior, backend):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -682,10 +682,10 @@ class BitMaskedArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         return self.to_ByteMaskedArray()._to_backend_array(allow_missing, backend)
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._remove_structure(backend, options)
+            return self.project()._remove_structure(backend, behavior, options)
         else:
             return [self]
 

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -589,11 +589,11 @@ class BitMaskedArray(Content):
     def _numbers_to_type(self, name, including_unknown):
         return self.to_ByteMaskedArray()._numbers_to_type(name, including_unknown)
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._mask.length == 0:
             return True
         return self.to_IndexedOptionArray64()._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -608,10 +608,18 @@ class BitMaskedArray(Content):
             return out._content
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         return self.to_IndexedOptionArray64()._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -629,9 +629,11 @@ class BitMaskedArray(Content):
             negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         return self.to_ByteMaskedArray()._combinations(
-            n, replacement, recordlookup, parameters, axis, depth
+            n, replacement, recordlookup, parameters, axis, depth, behavior
         )
 
     def _reduce_next(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -586,8 +586,10 @@ class BitMaskedArray(Content):
     def _local_index(self, axis, depth):
         return self.to_ByteMaskedArray()._local_index(axis, depth)
 
-    def _numbers_to_type(self, name, including_unknown):
-        return self.to_ByteMaskedArray()._numbers_to_type(name, including_unknown)
+    def _numbers_to_type(self, name, including_unknown, behavior):
+        return self.to_ByteMaskedArray()._numbers_to_type(
+            name, including_unknown, behavior
+        )
 
     def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._mask.length == 0:

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -596,11 +596,11 @@ class BitMaskedArray(Content):
             negaxis, starts, parents, outlength, behavior
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._mask.length == 0:
             return self
         out = self.to_IndexedOptionArray64()._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
         if negaxis is None:
             return out

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -679,8 +679,10 @@ class BitMaskedArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_backend_array(self, allow_missing, backend):
-        return self.to_ByteMaskedArray()._to_backend_array(allow_missing, backend)
+    def _to_backend_array(self, allow_missing, behavior, backend):
+        return self.to_ByteMaskedArray()._to_backend_array(
+            allow_missing, behavior, backend
+        )
 
     def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -622,9 +622,11 @@ class BitMaskedArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         return self.to_IndexedOptionArray64()._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1028,7 +1028,7 @@ class ByteMaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         this_validbytes = self.mask_as_bool(valid_when=True)
 
         return self._content._to_arrow(
@@ -1037,6 +1037,7 @@ class ByteMaskedArray(Content):
             ak._connect.pyarrow.and_validbytes(validbytes, this_validbytes),
             length,
             options,
+            behavior,
         )
 
     def _to_backend_array(self, allow_missing, behavior, backend):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -756,10 +756,10 @@ class ByteMaskedArray(Content):
                 outindex, out, parameters=self._parameters
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.ByteMaskedArray(
             self._mask,
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             self._valid_when,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1042,10 +1042,10 @@ class ByteMaskedArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         return self.to_IndexedOptionArray64()._to_backend_array(allow_missing, backend)
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._remove_structure(backend, options)
+            return self.project()._remove_structure(backend, behavior, options)
         else:
             return [self]
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -793,9 +793,11 @@ class ByteMaskedArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         return self.to_IndexedOptionArray64()._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -764,11 +764,11 @@ class ByteMaskedArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._mask.length == 0:
             return True
         return self.to_IndexedOptionArray64()._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -779,10 +779,18 @@ class ByteMaskedArray(Content):
         )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         return self.to_IndexedOptionArray64()._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -800,7 +800,9 @@ class ByteMaskedArray(Content):
             negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         if n < 1:
             raise ValueError("in combinations, 'n' must be at least 1")
         posaxis = maybe_posaxis(self, axis, depth)
@@ -811,7 +813,7 @@ class ByteMaskedArray(Content):
 
             next = self._content._carry(nextcarry, True)
             out = next._combinations(
-                n, replacement, recordlookup, parameters, axis, depth
+                n, replacement, recordlookup, parameters, axis, depth, behavior
             )
             return ak.contents.IndexedOptionArray.simplified(
                 outindex, out, parameters=parameters

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1039,8 +1039,10 @@ class ByteMaskedArray(Content):
             options,
         )
 
-    def _to_backend_array(self, allow_missing, backend):
-        return self.to_IndexedOptionArray64()._to_backend_array(allow_missing, backend)
+    def _to_backend_array(self, allow_missing, behavior, backend):
+        return self.to_IndexedOptionArray64()._to_backend_array(
+            allow_missing, behavior, backend
+        )
 
     def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -771,11 +771,11 @@ class ByteMaskedArray(Content):
             negaxis, starts, parents, outlength, behavior
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._mask.length == 0:
             return self
         return self.to_IndexedOptionArray64()._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _argsort_next(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1103,7 +1103,7 @@ class Content:
     def _drop_none(self) -> Content:
         raise NotImplementedError
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         raise NotImplementedError
 
     def _recursively_apply(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -826,6 +826,7 @@ class Content:
         outlength: int,
         ascending: bool,
         stable: bool,
+        behavior: dict | None,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1329,7 +1329,9 @@ class Content:
     def _repr(self, indent: str, pre: str, post: str) -> str:
         raise NotImplementedError
 
-    def _numbers_to_type(self, name: str, including_unknown: bool) -> Content:
+    def _numbers_to_type(
+        self, name: str, including_unknown: bool, behavior: Mapping
+    ) -> Content:
         raise NotImplementedError
 
     def _fill_none(self, value: Content) -> Content:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1061,6 +1061,7 @@ class Content:
         extensionarray: bool = True,
         count_nulls: bool = True,
         record_is_scalar: bool = False,
+        behavior: Mapping = None,
     ):
         import awkward._connect.pyarrow
 
@@ -1080,6 +1081,7 @@ class Content:
                 "count_nulls": count_nulls,
                 "record_is_scalar": record_is_scalar,
             },
+            behavior,
         )
 
     def _to_arrow(
@@ -1089,6 +1091,7 @@ class Content:
         validbytes: Any,
         length: int,
         options: dict[str, Any],
+        behavior: Mapping | None,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -923,6 +923,7 @@ class Content:
         parameters: dict[str, Any] | None,
         axis: int,
         depth: int,
+        behavior: dict | None = None,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -838,6 +838,7 @@ class Content:
         outlength: int,
         ascending: bool,
         stable: bool,
+        behavior: dict | None,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -924,9 +924,11 @@ class Content:
     ):
         raise NotImplementedError
 
-    def _validity_error_parameters(self, path: str) -> str:
+    def _validity_error_parameters(
+        self, path: str, behavior: dict | None = None
+    ) -> str:
         if self.parameter("__array__") == "categorical":
-            if not ak._do.is_unique(self._content):
+            if not ak._do.is_unique(self._content, behavior=behavior):
                 return 'at {} ("{}"): __array__ = "categorical" requires contents to be unique'.format(
                     path, type(self)
                 )
@@ -955,6 +957,7 @@ class Content:
         starts: Index,
         parents: Index,
         outlength: int,
+        behavior: dict | None,
     ) -> bool:
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -967,6 +967,7 @@ class Content:
         starts: Index,
         parents: Index,
         outlength: int,
+        behavior: dict | None,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -275,7 +275,7 @@ class EmptyArray(Content):
         else:
             return self
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         return True
 
     def _unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -297,7 +297,9 @@ class EmptyArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -347,7 +347,7 @@ class EmptyArray(Content):
         else:
             return self._pad_none_axis0(target, True)
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         if options["emptyarray_to"] is None:
             return pyarrow.Array.from_buffers(
                 ak._connect.pyarrow.to_awkwardarrow_type(
@@ -371,7 +371,9 @@ class EmptyArray(Content):
                 parameters=self._parameters,
                 backend=self._backend,
             )
-            return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
+            return next._to_arrow(
+                pyarrow, mask_node, validbytes, length, options, behavior
+            )
 
     def _to_backend_array(self, allow_missing, behavior, backend):
         return backend.nplike.empty(0, dtype=np.float64)

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -373,7 +373,7 @@ class EmptyArray(Content):
             )
             return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         return backend.nplike.empty(0, dtype=np.float64)
 
     def _remove_structure(self, backend, behavior, options):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -376,7 +376,7 @@ class EmptyArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         return backend.nplike.empty(0, dtype=np.float64)
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         return [self]
 
     def _recursively_apply(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -302,7 +302,9 @@ class EmptyArray(Content):
     ):
         return self
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         return ak.contents.EmptyArray(
             parameters=self._parameters, backend=self._backend
         )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -269,7 +269,7 @@ class EmptyArray(Content):
         else:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         if including_unknown:
             return self.to_NumpyArray(ak.types.numpytype.primitive_to_dtype(name))
         else:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -282,11 +282,19 @@ class EmptyArray(Content):
         return self
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         as_numpy = self.to_NumpyArray(np.float64)
         return as_numpy._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -278,7 +278,7 @@ class EmptyArray(Content):
     def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         return self
 
     def _argsort_next(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1030,8 +1030,8 @@ class IndexedArray(Content):
             )
             return next2._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-    def _to_backend_array(self, allow_missing, backend):
-        return self.project()._to_backend_array(allow_missing, backend)
+    def _to_backend_array(self, allow_missing, behavior, backend):
+        return self.project()._to_backend_array(allow_missing, behavior, backend)
 
     def _remove_structure(self, backend, behavior, options):
         return self.project()._remove_structure(backend, behavior, options)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -887,11 +887,19 @@ class IndexedArray(Content):
         raise NotImplementedError
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         next = self._content._carry(self._index, False)
         return next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -910,13 +910,15 @@ class IndexedArray(Content):
             negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return self.project()._combinations(
-                n, replacement, recordlookup, parameters, axis, depth
+                n, replacement, recordlookup, parameters, axis, depth, behavior
             )
 
     def _reduce_next(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -744,10 +744,10 @@ class IndexedArray(Content):
 
         return next[0 : length[0]]
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.IndexedArray(
             self._index,
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -751,7 +751,7 @@ class IndexedArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._index.length == 0:
             return True
 
@@ -761,7 +761,7 @@ class IndexedArray(Content):
             return False
 
         next = self._content._carry(nextindex, False)
-        return next._is_unique(negaxis, starts, parents, outlength)
+        return next._is_unique(negaxis, starts, parents, outlength, behavior)
 
     def _unique(self, negaxis, starts, parents, outlength):
         if self._index.length == 0:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -763,7 +763,7 @@ class IndexedArray(Content):
         next = self._content._carry(nextindex, False)
         return next._is_unique(negaxis, starts, parents, outlength, behavior)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._index.length == 0:
             return self
 
@@ -801,12 +801,7 @@ class IndexedArray(Content):
             )
         )
         next = self._content._carry(nextcarry, False)
-        unique = next._unique(
-            negaxis,
-            starts,
-            nextparents,
-            outlength,
-        )
+        unique = next._unique(negaxis, starts, nextparents, outlength, behavior)
 
         if branch or (negaxis is not None and negaxis != depth):
             nextoutindex = ak.index.Index64.empty(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1033,8 +1033,8 @@ class IndexedArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         return self.project()._to_backend_array(allow_missing, backend)
 
-    def _remove_structure(self, backend, options):
-        return self.project()._remove_structure(backend, options)
+    def _remove_structure(self, backend, behavior, options):
+        return self.project()._remove_structure(backend, behavior, options)
 
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -902,9 +902,13 @@ class IndexedArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         next = self._content._carry(self._index, False)
-        return next._sort_next(negaxis, starts, parents, outlength, ascending, stable)
+        return next._sort_next(
+            negaxis, starts, parents, outlength, ascending, stable, behavior
+        )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -981,7 +981,7 @@ class IndexedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         if (
             not options["categorical_as_dictionary"]
             and self.parameter("__array__") == "categorical"
@@ -989,13 +989,15 @@ class IndexedArray(Content):
             next_parameters = dict(self._parameters)
             del next_parameters["__array__"]
             next = IndexedArray(self._index, self._content, parameters=next_parameters)
-            return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
+            return next._to_arrow(
+                pyarrow, mask_node, validbytes, length, options, behavior
+            )
 
         index = self._index.raw(numpy)
 
         if self.parameter("__array__") == "categorical":
             dictionary = self._content._to_arrow(
-                pyarrow, None, None, self._content.length, options
+                pyarrow, None, None, self._content.length, options, behavior
             )
             out = pyarrow.DictionaryArray.from_arrays(
                 index,
@@ -1028,7 +1030,9 @@ class IndexedArray(Content):
             next2 = next.copy(
                 parameters=parameters_union(next._parameters, self._parameters)
             )
-            return next2._to_arrow(pyarrow, mask_node, validbytes, length, options)
+            return next2._to_arrow(
+                pyarrow, mask_node, validbytes, length, options, behavior
+            )
 
     def _to_backend_array(self, allow_missing, behavior, backend):
         return self.project()._to_backend_array(allow_missing, behavior, backend)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1515,7 +1515,7 @@ class IndexedOptionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         index = numpy.asarray(self._index, copy=True)
         this_validbytes = self.mask_as_bool(valid_when=True)
         index[~this_validbytes] = 0
@@ -1536,6 +1536,7 @@ class IndexedOptionArray(Content):
             ak._connect.pyarrow.and_validbytes(validbytes, this_validbytes),
             length,
             options,
+            behavior,
         )
 
     def _to_backend_array(self, allow_missing, behavior, backend):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1538,11 +1538,11 @@ class IndexedOptionArray(Content):
             options,
         )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         nplike = backend.nplike
         index_nplike = backend.index_nplike
 
-        content = self.project()._to_backend_array(allow_missing, backend)
+        content = self.project()._to_backend_array(allow_missing, behavior, backend)
         shape = (self.length, *content.shape[1:])
         data = nplike.empty(shape, dtype=content.dtype)
         mask0 = index_nplike.asarray(self.mask_as_bool(valid_when=False)).view(np.bool_)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1294,7 +1294,9 @@ class IndexedOptionArray(Content):
         else:
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         assert (
             starts.nplike is self._backend.index_nplike
             and parents.nplike is self._backend.index_nplike
@@ -1304,7 +1306,7 @@ class IndexedOptionArray(Content):
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
 
         out = next._sort_next(
-            negaxis, starts, nextparents, outlength, ascending, stable
+            negaxis, starts, nextparents, outlength, ascending, stable, behavior
         )
 
         nextoutindex = ak.index.Index64.empty(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1449,7 +1449,9 @@ class IndexedOptionArray(Content):
                 outoffsets, inner, parameters=self._parameters
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -1457,7 +1459,7 @@ class IndexedOptionArray(Content):
             _, nextcarry, outindex = self._nextcarry_outindex()
             next = self._content._carry(nextcarry, True)
             out = next._combinations(
-                n, replacement, recordlookup, parameters, axis, depth
+                n, replacement, recordlookup, parameters, axis, depth, behavior
             )
             return IndexedOptionArray.simplified(outindex, out, parameters=parameters)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1156,7 +1156,15 @@ class IndexedOptionArray(Content):
         return next, nextparents, numnull, outindex
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         assert (
             starts.nplike is self._backend.index_nplike
@@ -1174,7 +1182,14 @@ class IndexedOptionArray(Content):
             nextshifts = None
 
         out = next._argsort_next(
-            negaxis, starts, nextshifts, nextparents, outlength, ascending, stable
+            negaxis,
+            starts,
+            nextshifts,
+            nextparents,
+            outlength,
+            ascending,
+            stable,
+            behavior,
         )
 
         # `next._argsort_next` is given the non-None values. We choose to

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -908,10 +908,10 @@ class IndexedOptionArray(Content):
                 nextstarts, nextstops, nextstarts.length, False
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.IndexedOptionArray(
             self._index,
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1593,10 +1593,10 @@ class IndexedOptionArray(Content):
             else:
                 return content
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._remove_structure(backend, options)
+            return self.project()._remove_structure(backend, behavior, options)
         else:
             return [self]
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -922,7 +922,7 @@ class IndexedOptionArray(Content):
         projected = self.project()
         return projected._is_unique(negaxis, starts, parents, outlength, behavior)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         branch, depth = self.branch_depth
 
         inject_nones = (
@@ -933,12 +933,7 @@ class IndexedOptionArray(Content):
 
         next, nextparents, numnull, outindex = self._rearrange_prepare_next(parents)
 
-        out = next._unique(
-            negaxis,
-            starts,
-            nextparents,
-            outlength,
-        )
+        out = next._unique(negaxis, starts, nextparents, outlength, behavior)
 
         if branch or (negaxis is not None and negaxis != depth):
             nextoutindex = ak.index.Index64.empty(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -915,12 +915,12 @@ class IndexedOptionArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._index.length is not unknown_length and self._index.length == 0:
             return True
 
         projected = self.project()
-        return projected._is_unique(negaxis, starts, parents, outlength)
+        return projected._is_unique(negaxis, starts, parents, outlength, behavior)
 
     def _unique(self, negaxis, starts, parents, outlength):
         branch, depth = self.branch_depth

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1227,12 +1227,12 @@ class ListArray(Content):
             negaxis, starts, parents, outlength, behavior
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._starts.length is not unknown_length and self._starts.length == 0:
             return self
 
         return self.to_ListOffsetArray64(True)._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _argsort_next(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1236,11 +1236,19 @@ class ListArray(Content):
         )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         next = self.to_ListOffsetArray64(True)
         out = next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
         return out
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1435,9 +1435,9 @@ class ListArray(Content):
                 target, axis, depth, clip=True
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         return self.to_ListOffsetArray64(False)._to_arrow(
-            pyarrow, mask_node, validbytes, length, options
+            pyarrow, mask_node, validbytes, length, options, behavior
         )
 
     def _to_backend_array(self, allow_missing, behavior, backend):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1259,9 +1259,11 @@ class ListArray(Content):
             negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         return ListOffsetArray._combinations(
-            self, n, replacement, recordlookup, parameters, axis, depth
+            self, n, replacement, recordlookup, parameters, axis, depth, behavior
         )
 
     def _reduce_next(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1439,14 +1439,16 @@ class ListArray(Content):
             pyarrow, mask_node, validbytes, length, options
         )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
             # As our array-of-strings _may_ be empty, we should pass the dtype
             dtype = np.str_ if array_param == "string" else np.bytes_
             return backend.nplike.asarray(self.to_list(), dtype=dtype)
         else:
-            return self.to_RegularArray()._to_backend_array(allow_missing, backend)
+            return self.to_RegularArray()._to_backend_array(
+                allow_missing, behavior, backend
+            )
 
     def _remove_structure(self, backend, behavior, options):
         return self.to_ListOffsetArray64(False)._remove_structure(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1219,12 +1219,12 @@ class ListArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._starts.length is not unknown_length and self._starts.length == 0:
             return True
 
         return self.to_ListOffsetArray64(True)._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1448,8 +1448,10 @@ class ListArray(Content):
         else:
             return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
-    def _remove_structure(self, backend, options):
-        return self.to_ListOffsetArray64(False)._remove_structure(backend, options)
+    def _remove_structure(self, backend, behavior, options):
+        return self.to_ListOffsetArray64(False)._remove_structure(
+            backend, behavior, options
+        )
 
     def _drop_none(self):
         return self.to_ListOffsetArray64()._drop_none()

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1252,9 +1252,11 @@ class ListArray(Content):
         )
         return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         return self.to_ListOffsetArray64(True)._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1874,9 +1874,9 @@ class ListOffsetArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        is_string = self.parameter("__array__") == "string"
-        is_bytestring = self.parameter("__array__") == "bytestring"
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
+        is_string = is_subtype(behavior, self.parameter("__array__"), "string")
+        is_bytestring = is_subtype(behavior, self.parameter("__array__"), "bytestring")
         if is_string:
             downsize = options["string_to32"]
         elif is_bytestring:
@@ -1907,7 +1907,7 @@ class ListOffsetArray(Content):
                     parameters=self._parameters,
                 )
                 return next.to_ListOffsetArray64(True)._to_arrow(
-                    pyarrow, mask_node, validbytes, length, options
+                    pyarrow, mask_node, validbytes, length, options, behavior
                 )
 
         if issubclass(npoffsets.dtype.type, np.int64):
@@ -1952,7 +1952,7 @@ class ListOffsetArray(Content):
 
         else:
             paarray = akcontent._to_arrow(
-                pyarrow, None, None, akcontent.length, options
+                pyarrow, None, None, akcontent.length, options, behavior
             )
 
             content_type = pyarrow.list_(paarray.type).value_field.with_nullable(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2015,7 +2015,7 @@ class ListOffsetArray(Content):
         else:
             return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
@@ -2023,7 +2023,7 @@ class ListOffsetArray(Content):
             return [self]
         else:
             content = self._content[self._offsets[0] : self._offsets[-1]]
-            contents = content._remove_structure(backend, options)
+            contents = content._remove_structure(backend, behavior, options)
             if options["keepdims"]:
                 return [
                     ListOffsetArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1029,14 +1029,7 @@ class ListOffsetArray(Content):
             )
 
     def _argsort_next(
-        self,
-        negaxis,
-        starts,
-        shifts,
-        parents,
-        outlength,
-        ascending,
-        stable,
+        self, negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
     ):
         branch, depth = self.branch_depth
 
@@ -1155,6 +1148,7 @@ class ListOffsetArray(Content):
                 nextstarts.length,
                 ascending,
                 stable,
+                behavior,
             )
 
             outcarry = ak.index.Index64.empty(
@@ -1214,6 +1208,7 @@ class ListOffsetArray(Content):
                 self._offsets.length - 1,
                 ascending,
                 stable,
+                behavior,
             )
             outoffsets = self._compact_offsets64(True)
             return ak.contents.ListOffsetArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -920,7 +920,7 @@ class ListOffsetArray(Content):
                 negaxis, starts, nextparents, outlength, behavior
             )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._offsets.length - 1 == 0:
             return self
 
@@ -962,10 +962,7 @@ class ListOffsetArray(Content):
 
             nextcontent = self._content._carry(nextcarry, False)
             outcontent = nextcontent._unique(
-                negaxis - 1,
-                nextstarts,
-                nextparents,
-                maxnextparents[0] + 1,
+                negaxis - 1, nextstarts, nextparents, maxnextparents[0] + 1, behavior
             )
 
             outcarry = ak.index.Index64.empty(
@@ -1020,6 +1017,7 @@ class ListOffsetArray(Content):
                 self._offsets[:-1],
                 nextparents,
                 self._offsets.length - 1,
+                behavior,
             )
 
             if negaxis is None or negaxis == depth - 1:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1215,7 +1215,9 @@ class ListOffsetArray(Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         branch, depth = self.branch_depth
 
         index_nplike = self._backend.index_nplike
@@ -1291,6 +1293,7 @@ class ListOffsetArray(Content):
                 maxnextparents + 1,
                 ascending,
                 stable,
+                behavior,
             )
 
             outcarry = ak.index.Index64.empty(nextcarry.length, index_nplike)
@@ -1343,6 +1346,7 @@ class ListOffsetArray(Content):
                 lenstarts,
                 ascending,
                 stable,
+                behavior,
             )
             outoffsets = self._compact_offsets64(True)
             return ak.contents.ListOffsetArray(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -5,6 +5,7 @@ import copy
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._behavior import is_subtype
 from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
@@ -2006,14 +2007,18 @@ class ListOffsetArray(Content):
                 ),
             )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         array_param = self.parameter("__array__")
-        if array_param in {"bytestring", "string"}:
+        if is_subtype(behavior, array_param, ("string", "bytestring")):
             # As our array-of-strings _may_ be empty, we should pass the dtype
-            dtype = np.str_ if array_param == "string" else np.bytes_
+            dtype = (
+                np.str_ if is_subtype(behavior, array_param, "string") else np.bytes_
+            )
             return backend.nplike.asarray(self.to_list(), dtype=dtype)
         else:
-            return self.to_RegularArray()._to_backend_array(allow_missing, backend)
+            return self.to_RegularArray()._to_backend_array(
+                allow_missing, behavior, backend
+            )
 
     def _remove_structure(self, backend, behavior, options):
         if (

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -861,7 +861,7 @@ class ListOffsetArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._offsets.length - 1 == 0:
             return True
 
@@ -886,10 +886,14 @@ class ListOffsetArray(Content):
                 return out2.length == self.length
 
         if negaxis is None:
-            return self._content._is_unique(negaxis, starts, parents, outlength)
+            return self._content._is_unique(
+                negaxis, starts, parents, outlength, behavior
+            )
 
         if not branch and (negaxis == depth):
-            return self._content._is_unique(negaxis - 1, starts, parents, outlength)
+            return self._content._is_unique(
+                negaxis - 1, starts, parents, outlength, behavior
+            )
         else:
             nextparents = ak.index.Index64.empty(
                 self._offsets[-1] - self._offsets[0], self._backend.index_nplike
@@ -912,7 +916,9 @@ class ListOffsetArray(Content):
             )
             starts = self._offsets[:-1]
 
-            return self._content._is_unique(negaxis, starts, nextparents, outlength)
+            return self._content._is_unique(
+                negaxis, starts, nextparents, outlength, behavior
+            )
 
     def _unique(self, negaxis, starts, parents, outlength):
         if self._offsets.length - 1 == 0:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -855,10 +855,10 @@ class ListOffsetArray(Content):
                 self._offsets, self._content._local_index(axis, depth + 1)
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.ListOffsetArray(
             self._offsets,
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -1353,7 +1353,9 @@ class ListOffsetArray(Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         index_nplike = self._backend.index_nplike
 
         posaxis = maybe_posaxis(self, axis, depth)
@@ -1458,7 +1460,7 @@ class ListOffsetArray(Content):
         else:
             compact = self.to_ListOffsetArray64(True)
             next = compact._content._combinations(
-                n, replacement, recordlookup, parameters, axis, depth + 1
+                n, replacement, recordlookup, parameters, axis, depth + 1, behavior
             )
             return ak.contents.ListOffsetArray(
                 compact.offsets, next, parameters=self._parameters

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -868,10 +868,7 @@ class ListOffsetArray(Content):
 
         branch, depth = self.branch_depth
 
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             if branch or (negaxis is not None and negaxis != depth):
                 raise ValueError(
                     "array with strings can only be checked on uniqueness with axis=-1"
@@ -927,10 +924,7 @@ class ListOffsetArray(Content):
 
         branch, depth = self.branch_depth
 
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             if branch or (negaxis != depth):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
@@ -943,10 +937,7 @@ class ListOffsetArray(Content):
                 )
 
         if not branch and (negaxis == depth):
-            if (
-                self.parameter("__array__") == "string"
-                or self.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
@@ -1034,10 +1025,7 @@ class ListOffsetArray(Content):
     ):
         branch, depth = self.branch_depth
 
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             if branch or (negaxis != depth):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
@@ -1081,10 +1069,7 @@ class ListOffsetArray(Content):
                 )
 
         if not branch and (negaxis == depth):
-            if (
-                self.parameter("__array__") == "string"
-                or self.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
@@ -1223,10 +1208,7 @@ class ListOffsetArray(Content):
 
         index_nplike = self._backend.index_nplike
 
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             if branch or (negaxis != depth):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
@@ -1268,10 +1250,7 @@ class ListOffsetArray(Content):
                 return self._carry(nextcarry, False)
 
         if not branch and (negaxis == depth):
-            if (
-                self.parameter("__array__") == "string"
-                or self.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
                 raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
@@ -1363,10 +1342,7 @@ class ListOffsetArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif posaxis is not None and posaxis + 1 == depth + 1:
-            if (
-                self.parameter("__array__") == "string"
-                or self.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
                 raise ValueError(
                     "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                 )
@@ -2021,10 +1997,7 @@ class ListOffsetArray(Content):
             )
 
     def _remove_structure(self, backend, behavior, options):
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             return [self]
         else:
             content = self._content[self._offsets[0] : self._offsets[-1]]
@@ -2162,7 +2135,8 @@ class ListOffsetArray(Content):
 
         nextcontent = self._content._getitem_range(mini, maxi)
 
-        if self.parameter("__array__") == "bytestring":
+        nominal_type = self.parameter("__array__")
+        if is_subtype(behavior, nominal_type, "bytestring"):
             convert_bytes = (
                 None if json_conversions is None else json_conversions["convert_bytes"]
             )
@@ -2176,7 +2150,7 @@ class ListOffsetArray(Content):
                     out[i] = convert_bytes(content[starts_data[i] : stops_data[i]])
             return out
 
-        elif self.parameter("__array__") == "string":
+        elif is_subtype(behavior, nominal_type, "string"):
             data = nextcontent.data
             if hasattr(data, "tobytes"):
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1064,7 +1064,9 @@ class NumpyArray(Content):
                 backend=self._backend,
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -1072,7 +1074,7 @@ class NumpyArray(Content):
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         else:
             return self.to_RegularArray()._combinations(
-                n, replacement, recordlookup, parameters, axis, depth
+                n, replacement, recordlookup, parameters, axis, depth, behavior
             )
 
     def _reduce_next(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -981,14 +981,16 @@ class NumpyArray(Content):
             out = NumpyArray(nextcarry.data, parameters=None, backend=self._backend)
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         if len(self.shape) == 0:
             raise TypeError(f"{type(self).__name__} attempting to sort a scalar ")
 
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
             return contiguous_self.to_RegularArray()._sort_next(
-                negaxis, starts, parents, outlength, ascending, stable
+                negaxis, starts, parents, outlength, ascending, stable, behavior
             )
 
         else:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1249,7 +1249,7 @@ class NumpyArray(Content):
             ),
         )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         return to_nplike(self.data, backend.nplike, from_nplike=self._backend.nplike)
 
     def _remove_structure(self, backend, behavior, options):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1252,7 +1252,7 @@ class NumpyArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         return to_nplike(self.data, backend.nplike, from_nplike=self._backend.nplike)
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         if options["keepdims"]:
             shape = (1,) * (self._data.ndim - 1) + (-1,)
         else:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -686,13 +686,13 @@ class NumpyArray(Content):
                 negaxis, starts, parents, outlength, behavior
             )
         else:
-            out = self._unique(negaxis, starts, parents, outlength)
+            out = self._unique(negaxis, starts, parents, outlength, behavior)
             if isinstance(out, ak.contents.ListOffsetArray):
                 return out.content.length == self.length
 
             return out.length == self.length
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self.shape[0] == 0:
             return self
 
@@ -753,10 +753,7 @@ class NumpyArray(Content):
         if len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
             return contiguous_self.to_RegularArray()._unique(
-                negaxis,
-                starts,
-                parents,
-                outlength,
+                negaxis, starts, parents, outlength, behavior
             )
         else:
             parents_length = parents.length

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -865,14 +865,22 @@ class NumpyArray(Content):
             )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         if len(self.shape) == 0:
             raise TypeError(f"{type(self).__name__} attempting to argsort a scalar ")
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
             return contiguous_self.to_RegularArray()._argsort_next(
-                negaxis, starts, shifts, parents, outlength, ascending, stable
+                negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
             )
 
         else:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -676,17 +676,14 @@ class NumpyArray(Content):
                 backend=self._backend,
             )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self.length == 0:
             return True
 
         elif len(self.shape) != 1 or not self.is_contiguous:
             contiguous_self = self.to_contiguous()
             return contiguous_self.to_RegularArray()._is_unique(
-                negaxis,
-                starts,
-                parents,
-                outlength,
+                negaxis, starts, parents, outlength, behavior
             )
         else:
             out = self._unique(negaxis, starts, parents, outlength)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1217,10 +1217,10 @@ class NumpyArray(Content):
     def _nbytes_part(self):
         return self.data.nbytes
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         if self._data.ndim != 1:
             return self.to_RegularArray()._to_arrow(
-                pyarrow, mask_node, validbytes, length, options
+                pyarrow, mask_node, validbytes, length, options, behavior
             )
 
         nparray = self._raw(numpy)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -8,6 +8,7 @@ from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
+from awkward._behavior import is_subtype
 from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import to_nplike
@@ -660,12 +661,9 @@ class NumpyArray(Content):
 
         return out2, nextoffsets[: outlength[0]]
 
-    def _numbers_to_type(self, name, including_unknown):
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-            or self.parameter("__array__") == "char"
-            or self.parameter("__array__") == "byte"
+    def _numbers_to_type(self, name, including_unknown, behavior):
+        if is_subtype(
+            behavior, self.parameter("__array__"), ("stringlike", "char", "byte")
         ):
             return self
         else:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -863,7 +863,9 @@ class RecordArray(Content):
             backend=self._backend,
         )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -872,7 +874,7 @@ class RecordArray(Content):
             for content in self._contents:
                 contents.append(
                     content._combinations(
-                        n, replacement, recordlookup, parameters, axis, depth
+                        n, replacement, recordlookup, parameters, axis, depth, behavior
                     )
                 )
             return ak.contents.RecordArray(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -958,10 +958,10 @@ class RecordArray(Content):
                     backend=self._backend,
                 )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         values = [
             (x if x.length == length else x[:length])._to_arrow(
-                pyarrow, mask_node, validbytes, length, options
+                pyarrow, mask_node, validbytes, length, options, behavior
             )
             for x in self._contents
         ]

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -838,7 +838,9 @@ class RecordArray(Content):
     ):
         raise NotImplementedError
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         if self._fields is None or len(self._fields) == 0:
             return ak.contents.NumpyArray(
                 self._backend.nplike.instance().empty(0, dtype=np.int64),
@@ -850,7 +852,7 @@ class RecordArray(Content):
         for content in self._contents:
             contents.append(
                 content._sort_next(
-                    negaxis, starts, parents, outlength, ascending, stable
+                    negaxis, starts, parents, outlength, ascending, stable, behavior
                 )
             )
         return RecordArray(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -816,9 +816,9 @@ class RecordArray(Content):
             backend=self._backend,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         for content in self._contents:
-            if not content._is_unique(negaxis, starts, parents, outlength):
+            if not content._is_unique(negaxis, starts, parents, outlength, behavior):
                 return False
         return True
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -807,7 +807,7 @@ class RecordArray(Content):
     def _numbers_to_type(self, name, including_unknown, behavior):
         contents = []
         for x in self._contents:
-            contents.append(x._numbers_to_type(name, including_unknown))
+            contents.append(x._numbers_to_type(name, including_unknown, behavior))
         return ak.contents.RecordArray(
             contents,
             self._fields,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -804,7 +804,7 @@ class RecordArray(Content):
                 backend=self._backend,
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         contents = []
         for x in self._contents:
             contents.append(x._numbers_to_type(name, including_unknown))

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -988,10 +988,13 @@ class RecordArray(Content):
             children=values,
         )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
+        contents = [
+            x._to_backend_array(allow_missing, behavior, backend)
+            for x in self._contents
+        ]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
         out = backend.nplike.empty(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1014,11 +1014,15 @@ class RecordArray(Content):
 
         return out
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self._length]._remove_structure(backend, options))
+                out.extend(
+                    content[: self._length]._remove_structure(
+                        backend, behavior, options
+                    )
+                )
             return out
         else:
             in_function = ""

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -826,7 +826,15 @@ class RecordArray(Content):
         raise NotImplementedError
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         raise NotImplementedError
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -822,7 +822,7 @@ class RecordArray(Content):
                 return False
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         raise NotImplementedError
 
     def _argsort_next(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -875,7 +875,9 @@ class RegularArray(Content):
 
         return out
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         index_nplike = self._backend.index_nplike
 
         posaxis = maybe_posaxis(self, axis, depth)
@@ -963,7 +965,9 @@ class RegularArray(Content):
             length = self._length * self._size
             next = self._content._getitem_range(
                 0, index_nplike.shape_item_as_index(length)
-            )._combinations(n, replacement, recordlookup, parameters, axis, depth + 1)
+            )._combinations(
+                n, replacement, recordlookup, parameters, axis, depth + 1, behavior
+            )
             return ak.contents.RegularArray(
                 next, self._size, self._length, parameters=self._parameters
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -794,9 +794,9 @@ class RegularArray(Content):
                 self._content._local_index(axis, depth + 1), self._size, self._length
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.RegularArray(
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             self._size,
             self._length,
             parameters=self._parameters,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1236,19 +1236,17 @@ class RegularArray(Content):
                 shape,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         assert self._backend.nplike.known_data
 
-        if self.parameter("__array__") == "string":
+        if is_subtype(behavior, self.parameter("__array__"), "string"):
             return self.to_ListOffsetArray64(False)._to_arrow(
-                pyarrow, mask_node, validbytes, length, options
+                pyarrow, mask_node, validbytes, length, options, behavior
             )
-
-        is_bytestring = self.parameter("__array__") == "bytestring"
 
         akcontent = self._content[: self._length * self._size]
 
-        if is_bytestring:
+        if is_subtype(behavior, self.parameter("__array__"), "bytestring"):
             assert isinstance(akcontent, ak.contents.NumpyArray)
 
             return pyarrow.Array.from_buffers(
@@ -1268,7 +1266,7 @@ class RegularArray(Content):
 
         else:
             paarray = akcontent._to_arrow(
-                pyarrow, None, None, self._length * self._size, options
+                pyarrow, None, None, self._length * self._size, options, behavior
             )
 
             content_type = pyarrow.list_(paarray.type).value_field.with_nullable(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1293,7 +1293,7 @@ class RegularArray(Content):
                 ),
             )
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         if (
             self.parameter("__array__") == "string"
             or self.parameter("__array__") == "bytestring"
@@ -1304,7 +1304,7 @@ class RegularArray(Content):
             content = self._content[
                 : index_nplike.shape_item_as_index(self._length * self._size)
             ]
-            contents = content._remove_structure(backend, options)
+            contents = content._remove_structure(backend, behavior, options)
             if options["keepdims"]:
                 return [
                     RegularArray(c, size=c.length, parameters=self._parameters)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -809,14 +809,11 @@ class RegularArray(Content):
             negaxis, starts, parents, outlength, behavior
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._length == 0:
             return self
         out = self.to_ListOffsetArray64(True)._unique(
-            negaxis,
-            starts,
-            parents,
-            outlength,
+            negaxis, starts, parents, outlength, behavior
         )
 
         if isinstance(out, ak.contents.RegularArray):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -854,9 +854,11 @@ class RegularArray(Content):
 
         return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         out = self.to_ListOffsetArray64(True)._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
         # FIXME

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -828,11 +828,19 @@ class RegularArray(Content):
         return out
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         next = self.to_ListOffsetArray64(True)
         out = next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
         if isinstance(out, ak.contents.RegularArray):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -885,10 +885,7 @@ class RegularArray(Content):
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         elif posaxis is not None and posaxis + 1 == depth + 1:
-            if (
-                self.parameter("__array__") == "string"
-                or self.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
                 raise ValueError(
                     "ak.combinations does not compute combinations of the characters of a string; please split it into lists"
                 )
@@ -1297,10 +1294,7 @@ class RegularArray(Content):
             )
 
     def _remove_structure(self, backend, behavior, options):
-        if (
-            self.parameter("__array__") == "string"
-            or self.parameter("__array__") == "bytestring"
-        ):
+        if is_subtype(behavior, self.parameter("__array__"), "stringlike"):
             return [self]
         else:
             index_nplike = self._backend.index_nplike
@@ -1398,7 +1392,8 @@ class RegularArray(Content):
         if not self._backend.nplike.known_data:
             raise TypeError("cannot convert typetracer arrays to Python lists")
 
-        if self.parameter("__array__") == "bytestring":
+        nominal_type = self.parameter("__array__")
+        if is_subtype(behavior, nominal_type, "bytestring"):
             convert_bytes = (
                 None if json_conversions is None else json_conversions["convert_bytes"]
             )
@@ -1413,7 +1408,7 @@ class RegularArray(Content):
                     out[i] = convert_bytes(content[(i) * size : (i + 1) * size])
             return out
 
-        elif self.parameter("__array__") == "string":
+        elif is_subtype(behavior, nominal_type, "string"):
             data = self._content.data
             if hasattr(data, "tobytes"):
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -801,15 +801,12 @@ class RegularArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._length == 0:
             return True
 
         return self.to_ListOffsetArray64(True)._is_unique(
-            negaxis,
-            starts,
-            parents,
-            outlength,
+            negaxis, starts, parents, outlength, behavior
         )
 
     def _unique(self, negaxis, starts, parents, outlength):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1236,7 +1236,15 @@ class UnionArray(Content):
         return simplified._unique(negaxis, starts, parents, outlength, behavior)
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         simplified = type(self).simplified(
             self._tags,
@@ -1256,7 +1264,7 @@ class UnionArray(Content):
             raise ValueError("cannot argsort an irreducible UnionArray")
 
         return simplified._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1267,7 +1267,9 @@ class UnionArray(Content):
             negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         if self.length == 0:
             return self
 
@@ -1285,7 +1287,7 @@ class UnionArray(Content):
             raise ValueError("cannot sort an irreducible UnionArray")
 
         return simplified._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
     def _reduce_next(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1221,7 +1221,7 @@ class UnionArray(Content):
 
         return simplified._is_unique(negaxis, starts, parents, outlength, behavior)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1233,7 +1233,7 @@ class UnionArray(Content):
         if isinstance(simplified, ak.contents.UnionArray):
             raise ValueError("cannot make a unique irreducible UnionArray")
 
-        return simplified._unique(negaxis, starts, parents, outlength)
+        return simplified._unique(negaxis, starts, parents, outlength, behavior)
 
     def _argsort_next(
         self, negaxis, starts, shifts, parents, outlength, ascending, stable

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1198,7 +1198,7 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         contents = []
         for x in self._contents:
             contents.append(x._numbers_to_type(name, including_unknown))

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1201,7 +1201,7 @@ class UnionArray(Content):
     def _numbers_to_type(self, name, including_unknown, behavior):
         contents = []
         for x in self._contents:
-            contents.append(x._numbers_to_type(name, including_unknown))
+            contents.append(x._numbers_to_type(name, including_unknown, behavior))
         return ak.contents.UnionArray(
             self._tags,
             self._index,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1207,7 +1207,7 @@ class UnionArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1219,7 +1219,7 @@ class UnionArray(Content):
         if isinstance(simplified, ak.contents.UnionArray):
             raise ValueError("cannot check if an irreducible UnionArray is unique")
 
-        return simplified._is_unique(negaxis, starts, parents, outlength)
+        return simplified._is_unique(negaxis, starts, parents, outlength, behavior)
 
     def _unique(self, negaxis, starts, parents, outlength):
         simplified = type(self).simplified(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1490,14 +1490,14 @@ class UnionArray(Content):
 
         return out
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         out = []
         for i in range(len(self._contents)):
             index = self._index[self._tags.data == i]
             out.extend(
                 self._contents[i]
                 ._carry(index, False)
-                ._remove_structure(backend, options)
+                ._remove_structure(backend, behavior, options)
             )
         return out
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1457,13 +1457,13 @@ class UnionArray(Content):
             children=values,
         )
 
-    def _to_backend_array(self, allow_missing, backend):
+    def _to_backend_array(self, allow_missing, behavior, backend):
         ak._errors.deprecate(
             "Conversion of irreducible unions to backend arrays is deprecated.", "2.2.0"
         )
 
         contents = [
-            self.project(i)._to_backend_array(allow_missing, backend)
+            self.project(i)._to_backend_array(allow_missing, behavior, backend)
             for i in range(len(self.contents))
         ]
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1177,7 +1177,9 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
@@ -1186,7 +1188,7 @@ class UnionArray(Content):
             for content in self._contents:
                 contents.append(
                     content._combinations(
-                        n, replacement, recordlookup, parameters, axis, depth
+                        n, replacement, recordlookup, parameters, axis, depth, behavior
                     )
                 )
             return ak.unionarray.UnionArray(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1379,7 +1379,7 @@ class UnionArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
         nptags = self._tags.raw(numpy)
         npindex = self._index.raw(numpy)
         copied_index = False
@@ -1422,7 +1422,7 @@ class UnionArray(Content):
 
             values.append(
                 content._to_arrow(
-                    pyarrow, mask_node, this_validbytes, this_length, options
+                    pyarrow, mask_node, this_validbytes, this_length, options, behavior
                 )
             )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -357,9 +357,9 @@ class UnmaskedArray(Content):
                 self._content._local_index(axis, depth), parameters=self._parameters
             )
 
-    def _numbers_to_type(self, name, including_unknown):
+    def _numbers_to_type(self, name, including_unknown, behavior):
         return ak.contents.UnmaskedArray(
-            self._content._numbers_to_type(name, including_unknown),
+            self._content._numbers_to_type(name, including_unknown, behavior),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -482,10 +482,10 @@ class UnmaskedArray(Content):
         else:
             return content
 
-    def _remove_structure(self, backend, options):
+    def _remove_structure(self, backend, behavior, options):
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:
-            return self.project()._remove_structure(backend, options)
+            return self.project()._remove_structure(backend, behavior, options)
         else:
             return [self]
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -416,14 +416,16 @@ class UnmaskedArray(Content):
         else:
             return out
 
-    def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
+    def _combinations(
+        self, n, replacement, recordlookup, parameters, axis, depth, behavior
+    ):
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
             return self._combinations_axis0(n, replacement, recordlookup, parameters)
         else:
             return ak.contents.UnmaskedArray(
                 self._content._combinations(
-                    n, replacement, recordlookup, parameters, axis, depth
+                    n, replacement, recordlookup, parameters, axis, depth, behavior
                 ),
                 parameters=self._parameters,
             )

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -368,10 +368,10 @@ class UnmaskedArray(Content):
             return True
         return self._content._is_unique(negaxis, starts, parents, outlength, behavior)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, outlength, behavior):
         if self._content.length == 0:
             return self
-        return self._content._unique(negaxis, starts, parents, outlength)
+        return self._content._unique(negaxis, starts, parents, outlength, behavior)
 
     def _argsort_next(
         self, negaxis, starts, shifts, parents, outlength, ascending, stable

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -475,8 +475,8 @@ class UnmaskedArray(Content):
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
         return self._content._to_arrow(pyarrow, self, None, length, options)
 
-    def _to_backend_array(self, allow_missing, backend):
-        content = self.content._to_backend_array(allow_missing, backend)
+    def _to_backend_array(self, allow_missing, behavior, backend):
+        content = self.content._to_backend_array(allow_missing, behavior, backend)
         if allow_missing:
             return backend.nplike.ma.MaskedArray(content)
         else:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -374,10 +374,18 @@ class UnmaskedArray(Content):
         return self._content._unique(negaxis, starts, parents, outlength, behavior)
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self,
+        negaxis,
+        starts,
+        shifts,
+        parents,
+        outlength,
+        ascending,
+        stable,
+        behavior,
     ):
         out = self._content._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, outlength, ascending, stable, behavior
         )
 
         if isinstance(out, ak.contents.RegularArray):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -397,9 +397,11 @@ class UnmaskedArray(Content):
         else:
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, outlength, ascending, stable, behavior
+    ):
         out = self._content._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, outlength, ascending, stable, behavior
         )
 
         if isinstance(out, ak.contents.RegularArray):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -363,10 +363,10 @@ class UnmaskedArray(Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, outlength, behavior: dict | None):
         if self._content.length == 0:
             return True
-        return self._content._is_unique(negaxis, starts, parents, outlength)
+        return self._content._is_unique(negaxis, starts, parents, outlength, behavior)
 
     def _unique(self, negaxis, starts, parents, outlength):
         if self._content.length == 0:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -472,8 +472,8 @@ class UnmaskedArray(Content):
                 parameters=self._parameters,
             )
 
-    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        return self._content._to_arrow(pyarrow, self, None, length, options)
+    def _to_arrow(self, pyarrow, mask_node, validbytes, length, options, behavior):
+        return self._content._to_arrow(pyarrow, self, None, length, options, behavior)
 
     def _to_backend_array(self, allow_missing, behavior, backend):
         content = self.content._to_backend_array(allow_missing, behavior, backend)

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -141,9 +141,10 @@ class BitMaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
             #
         ).simplify_option_union()

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -144,9 +144,7 @@ class BitMaskedForm(Form):
     @property
     def type(self):
         return ak.types.OptionType(
-            self._content.type,
-            parameters=self._parameters,
-            #
+            self._content.type, parameters=self._parameters
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -146,7 +145,7 @@ class BitMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -122,9 +122,7 @@ class ByteMaskedForm(Form):
     @property
     def type(self):
         return ak.types.OptionType(
-            self._content.type,
-            parameters=self._parameters,
-            #
+            self._content.type, parameters=self._parameters
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -119,9 +119,10 @@ class ByteMaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
             #
         ).simplify_option_union()

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -124,7 +123,7 @@ class ByteMaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -47,10 +47,7 @@ class EmptyForm(Form):
 
     @property
     def type(self):
-        return ak.types.UnknownType(
-            parameters=self._parameters,
-            #
-        )
+        return ak.types.UnknownType(parameters=self._parameters)
 
     def __eq__(self, other) -> bool:
         return isinstance(other, EmptyForm) and self._form_key == other._form_key

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._errors import deprecate
 from awkward._typing import final
 from awkward._util import unset
@@ -49,7 +48,7 @@ class EmptyForm(Form):
     def _type(self, typestrs):
         return ak.types.UnknownType(
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
+            #
         )
 
     def __eq__(self, other) -> bool:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -45,7 +45,8 @@ class EmptyForm(Form):
     def _to_dict_part(self, verbose, toplevel):
         return self._to_dict_extra({"class": "EmptyArray"}, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.UnknownType(
             parameters=self._parameters,
             #

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import find_typestrs
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -377,10 +376,17 @@ class Form:
 
     @property
     def type(self):
-        return self._type({})
+        raise NotImplementedError
 
     def type_from_behavior(self, behavior):
-        return self._type(find_typestrs(behavior))
+        deprecate(
+            "low level types produced by forms do not hold references to behaviors. "
+            "Use a high-level type (e.g. ak.types.ArrayType or ak.types.ScalarType) to"
+            "associate a type with behavior information, or simply access the low-level"
+            "type from Form.type",
+            version="2.4.0",
+        )
+        return self.type
 
     def columns(self, list_indicator=None, column_prefix=()):
         output = []
@@ -423,9 +429,6 @@ class Form:
         raise NotImplementedError
 
     def _to_dict_part(self, verbose, toplevel):
-        raise NotImplementedError
-
-    def _type(self, typestrs):
         raise NotImplementedError
 
     def length_zero_array(

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -106,8 +106,9 @@ class IndexedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
-        out = self._content._type(typestrs)
+    @property
+    def type(self):
+        out = self._content.type
 
         if self._parameters is not None:
             if out._parameters is None:

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -109,7 +108,6 @@ class IndexedOptionForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -97,7 +97,8 @@ class IndexedOptionForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         if self.parameter("__array__") == "categorical":
             parameters = dict(self._parameters)
             del parameters["__array__"]
@@ -106,7 +107,7 @@ class IndexedOptionForm(Form):
             parameters = self._parameters
 
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=parameters,
         ).simplify_option_union()
 

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -104,9 +104,10 @@ class ListForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.ListType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -109,7 +108,6 @@ class ListForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -68,7 +67,6 @@ class ListOffsetForm(Form):
         return ak.types.ListType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -63,9 +63,10 @@ class ListOffsetForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.ListType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -2,7 +2,6 @@
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
@@ -131,7 +130,6 @@ class NumpyForm(Form):
         out = ak.types.NumpyType(
             self._primitive,
             parameters=None,
-            typestr=find_typestr(self._parameters, typestrs),
         )
         for x in self._inner_shape[::-1]:
             out = ak.types.RegularType(out, x)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -126,7 +126,8 @@ class NumpyForm(Form):
                 out["inner_shape"] = list(self._inner_shape)
             return self._to_dict_extra(out, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         out = ak.types.NumpyType(
             self._primitive,
             parameters=None,

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -3,7 +3,6 @@ import glob
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
@@ -170,7 +169,6 @@ class RecordForm(Form):
             [x._type(typestrs) for x in self._contents],
             self._fields,
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -164,9 +164,10 @@ class RecordForm(Form):
         out["contents"] = contents_tolist
         return self._to_dict_extra(out, verbose)
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.RecordType(
-            [x._type(typestrs) for x in self._contents],
+            [x.type for x in self._contents],
             self._fields,
             parameters=self._parameters,
         )

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -65,9 +65,10 @@ class RegularForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.RegularType(
-            self._content._type(typestrs),
+            self._content.type,
             self._size,
             parameters=self._parameters,
         )

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
@@ -71,7 +70,6 @@ class RegularForm(Form):
             self._content._type(typestrs),
             self._size,
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -132,9 +132,10 @@ class UnionForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.UnionType(
-            [x._type(typestrs) for x in self._contents],
+            [x.type for x in self._contents],
             parameters=self._parameters,
         )
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -3,7 +3,6 @@ from collections import Counter
 from collections.abc import Iterable
 
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -137,7 +136,6 @@ class UnionForm(Form):
         return ak.types.UnionType(
             [x._type(typestrs) for x in self._contents],
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         )
 
     def __eq__(self, other):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
-from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
 from awkward._util import unset
@@ -82,7 +81,6 @@ class UnmaskedForm(Form):
         return ak.types.OptionType(
             self._content._type(typestrs),
             parameters=self._parameters,
-            typestr=find_typestr(self._parameters, typestrs),
         ).simplify_option_union()
 
     def __eq__(self, other):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -77,9 +77,10 @@ class UnmaskedForm(Form):
             verbose,
         )
 
-    def _type(self, typestrs):
+    @property
+    def type(self):
         return ak.types.OptionType(
-            self._content._type(typestrs),
+            self._content.type,
             parameters=self._parameters,
         ).simplify_option_union()
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -436,7 +436,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         wrapped by an #ak.types.ArrayType.
         """
         return ak.types.ArrayType(
-            self._layout.form.type_from_behavior(self._behavior),
+            self._layout.form.type,
             self._layout.length,
             self._behavior,
         )
@@ -1715,9 +1715,7 @@ class Record(NDArrayOperatorsMixin):
         The type of a #ak.record.Record (from #ak.Array.layout) is not
         wrapped by an #ak.types.ScalarType.
         """
-        return ak.types.ScalarType(
-            self._layout.array.form.type_from_behavior(self._behavior), self._behavior
-        )
+        return ak.types.ScalarType(self._layout.array.form.type, self._behavior)
 
     @property
     def typestr(self):
@@ -2320,9 +2318,7 @@ class ArrayBuilder(Sized):
         wrapped by an #ak.types.ArrayType.
         """
         form = ak.forms.from_json(self._layout.form())
-        return ak.types.ArrayType(
-            form.type_from_behavior(self._behavior), len(self._layout)
-        )
+        return ak.types.ArrayType(form.type, len(self._layout), self._behavior)
 
     @property
     def typestr(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -436,7 +436,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         wrapped by an #ak.types.ArrayType.
         """
         return ak.types.ArrayType(
-            self._layout.form.type_from_behavior(self._behavior), self._layout.length
+            self._layout.form.type_from_behavior(self._behavior),
+            self._layout.length,
+            self._behavior,
         )
 
     @property
@@ -1714,7 +1716,7 @@ class Record(NDArrayOperatorsMixin):
         wrapped by an #ak.types.ScalarType.
         """
         return ak.types.ScalarType(
-            self._layout.array.form.type_from_behavior(self._behavior)
+            self._layout.array.form.type_from_behavior(self._behavior), self._behavior
         )
 
     @property

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -17,7 +17,12 @@ import awkward as ak
 import awkward._connect.hist
 from awkward._backends.dispatch import register_backend_lookup_factory
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import behavior_of, get_array_class, get_record_class
+from awkward._behavior import (
+    behavior_of,
+    get_array_class,
+    get_record_class,
+    overlay_behavior,
+)
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -947,7 +952,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         have the same dimension as the array being indexed.
         """
         with ak._errors.SlicingErrorContext(self, where):
-            out = self._layout[where]
+            out = self._layout._getitem(
+                where, overlay_behavior(behavior_of(self, where))
+            )
             if isinstance(out, ak.contents.NumpyArray):
                 array_param = out.parameter("__array__")
                 if array_param == "byte":

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argsort",)
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._connect.numpy import unsupported
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -62,9 +63,10 @@ def argsort(
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
+    behavior = behavior_of(array, behavior=behavior)
     axis = regularize_axis(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = ak._do.argsort(layout, axis, ascending, stable)
+    out = ak._do.argsort(layout, axis, ascending, stable, behavior=behavior)
     return wrap_layout(out, behavior, highlevel, like=array)
 
 

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -3,7 +3,7 @@ __all__ = ("cartesian",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import behavior_of
+from awkward._behavior import behavior_of, is_subtype
 from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -345,10 +345,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             if depth == posaxis:
                 n_inside = len(array_layouts) - i - 1
                 n_outside = i
-                if (
-                    layout.parameter("__array__") == "string"
-                    or layout.parameter("__array__") == "bytestring"
-                ):
+                if is_subtype(behavior, layout.parameter("__array__"), "stringlike"):
                     raise ValueError(
                         "ak.cartesian does not compute combinations of the "
                         "characters of a string; please split it into lists"

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("combinations",)
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -213,6 +214,7 @@ def _impl(
     if with_name is not None:
         parameters["__record__"] = with_name
 
+    behavior = behavior_of(array, behavior=behavior)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
     out = ak._do.combinations(
         layout,
@@ -221,5 +223,6 @@ def _impl(
         axis=axis,
         fields=fields,
         parameters=parameters,
+        behavior=behavior,
     )
     return wrap_layout(out, behavior, highlevel, like=array)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("flatten",)
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -166,10 +167,13 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
 
 def _impl(array, axis, highlevel, behavior):
     axis = regularize_axis(axis)
+    behavior = behavior_of(array, behavior=behavior)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
     if axis is None:
-        out = ak._do.remove_structure(layout, function_name="ak.flatten")
+        out = ak._do.remove_structure(
+            layout, function_name="ak.flatten", behavior=behavior
+        )
         assert isinstance(out, tuple) and all(
             isinstance(x, ak.contents.Content) for x in out
         )

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -136,7 +136,9 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown):
             else:
                 return None
 
-        elif is_subtype(behavior, layout.parameter("__array__"), ("string", "bytes")):
+        elif is_subtype(
+            behavior, layout.parameter("__array__"), ("string", "bytestring")
+        ):
             nominal_type = layout.parameter("__array__")
             if fill_value is _ZEROS:
                 asbytes = nplike.frombuffer(b"", dtype=np.uint8)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("ravel",)
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._connect.numpy import unsupported
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -57,9 +58,12 @@ def ravel(array, *, highlevel=True, behavior=None):
 
 
 def _impl(array, highlevel, behavior):
+    behavior = behavior_of(array, behavior=behavior)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
 
-    out = ak._do.remove_structure(layout, function_name="ak.ravel", drop_nones=False)
+    out = ak._do.remove_structure(
+        layout, function_name="ak.ravel", drop_nones=False, behavior=behavior
+    )
     assert isinstance(out, tuple) and all(
         isinstance(x, ak.contents.Content) for x in out
     )

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -168,7 +168,9 @@ def _impl(array, highlevel, behavior):
             if not layout.is_list:
                 raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
-            if is_subtype(behavior, layout.parameter("__array__"), "stringlike"):
+            if is_subtype(
+                behavior, layout.content.parameter("__array__"), "stringlike"
+            ):
                 # We also want to trim the _upper_ bound of content,
                 # so we manually convert the list type to zero-based
                 listoffsetarray = layout.to_ListOffsetArray64(False)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -3,7 +3,7 @@ __all__ = ("run_lengths",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import behavior_of
+from awkward._behavior import behavior_of, is_subtype
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -151,10 +151,7 @@ def _impl(array, highlevel, behavior):
             if layout.is_indexed:
                 layout = layout.project()
 
-            if (
-                layout.parameter("__array__") == "string"
-                or layout.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, layout.parameter("__array__"), "stringlike"):
                 nextcontent, _ = lengths_of(ak.highlevel.Array(layout), None)
                 return ak.contents.NumpyArray(nextcontent)
 
@@ -171,10 +168,7 @@ def _impl(array, highlevel, behavior):
             if not layout.is_list:
                 raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
-            if (
-                layout.content.parameter("__array__") == "string"
-                or layout.content.parameter("__array__") == "bytestring"
-            ):
+            if is_subtype(behavior, layout.parameter("__array__"), "stringlike"):
                 # We also want to trim the _upper_ bound of content,
                 # so we manually convert the list type to zero-based
                 listoffsetarray = layout.to_ListOffsetArray64(False)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("sort",)
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._connect.numpy import unsupported
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -49,9 +50,10 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):
+    behavior = behavior_of(array, behavior=behavior)
     axis = regularize_axis(axis)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = ak._do.sort(layout, axis, ascending, stable)
+    out = ak._do.sort(layout, axis, ascending, stable, behavior=behavior)
     return wrap_layout(out, behavior, highlevel, like=array)
 
 

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("strings_astype",)
 import awkward as ak
-from awkward._behavior import behavior_of
+from awkward._behavior import behavior_of, is_subtype
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -54,9 +54,8 @@ def _impl(array, to, highlevel, behavior):
     to_dtype = np.dtype(to)
 
     def action(layout, **kwargs):
-        if layout.is_list and (
-            layout.parameter("__array__") == "string"
-            or layout.parameter("__array__") == "bytestring"
+        if layout.is_list and is_subtype(
+            behavior, layout.parameter("__array__"), "stringlike"
         ):
             layout = ak.operations.without_parameters(
                 layout, highlevel=False, behavior=behavior

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -2,6 +2,7 @@
 __all__ = ("to_arrow",)
 
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -99,6 +100,7 @@ def _impl(
     extensionarray,
     count_nulls,
 ):
+    behavior = behavior_of(array)
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     if isinstance(layout, ak.record.Record):
         layout = layout.array[layout.at : layout.at + 1]
@@ -115,4 +117,5 @@ def _impl(
         extensionarray=extensionarray,
         count_nulls=count_nulls,
         record_is_scalar=record_is_scalar,
+        behavior=behavior,
     )

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -4,6 +4,7 @@ __all__ = ("to_arrow_table",)
 import json
 
 import awkward as ak
+from awkward._behavior import behavior_of
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -102,6 +103,7 @@ def _impl(
 ):
     from awkward._connect.pyarrow import direct_Content_subclass, pyarrow
 
+    behavior = behavior_of(array)
     layout = ak.operations.to_layout(array, allow_record=True, allow_other=False)
     if isinstance(layout, ak.record.Record):
         layout = layout.array[layout.at : layout.at + 1]
@@ -128,6 +130,7 @@ def _impl(
                     extensionarray=extensionarray,
                     count_nulls=count_nulls,
                     record_is_scalar=record_is_scalar,
+                    behavior=behavior,
                 )
             )
             pafields.append(
@@ -156,6 +159,7 @@ def _impl(
                 extensionarray=extensionarray,
                 count_nulls=count_nulls,
                 record_is_scalar=record_is_scalar,
+                behavior=behavior,
             )
         )
         pafields.append(

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -2,6 +2,7 @@
 __all__ = ("to_numpy",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
+from awkward._behavior import behavior_of
 
 
 def to_numpy(array, *, allow_missing=True):
@@ -43,12 +44,15 @@ def to_numpy(array, *, allow_missing=True):
 
 
 def _impl(array, allow_missing):
+    behavior = behavior_of(array)
+    layout = ak.to_layout(array, allow_record=False)
+
     import numpy  # noqa: TID251
 
     with numpy.errstate(invalid="ignore"):
-        layout = ak.to_layout(array, allow_record=False)
-
         backend = NumpyBackend.instance()
         numpy_layout = layout.to_backend(backend)
 
-        return numpy_layout.to_backend_array(allow_missing=allow_missing)
+        return numpy_layout.to_backend_array(
+            allow_missing=allow_missing, behavior=behavior
+        )

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -85,13 +85,19 @@ def _impl(array, behavior):
 
     if isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(form.type_from_behavior(behavior), len(array))
+        return ak.types.ArrayType(
+            form.type_from_behavior(behavior), len(array), behavior=behavior
+        )
 
     elif isinstance(array, ak.record.Record):
-        return ak.types.ScalarType(array.array.form.type_from_behavior(behavior))
+        return ak.types.ScalarType(
+            array.array.form.type_from_behavior(behavior), behavior=behavior
+        )
 
     elif isinstance(array, ak.contents.Content):
-        return ak.types.ArrayType(array.form.type_from_behavior(behavior), array.length)
+        return ak.types.ArrayType(
+            array.form.type_from_behavior(behavior), array.length, behavior=behavior
+        )
 
     elif isinstance(array, (np.dtype, np.generic)):
         return ak.types.ScalarType(
@@ -99,22 +105,22 @@ def _impl(array, behavior):
         )
 
     elif isinstance(array, bool):  # np.bool_ in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("bool"))
+        return ak.types.ScalarType(ak.types.NumpyType("bool"), behavior=behavior)
 
     elif isinstance(array, numbers.Integral):
-        return ak.types.ScalarType(ak.types.NumpyType("int64"))
+        return ak.types.ScalarType(ak.types.NumpyType("int64"), behavior=behavior)
 
     elif isinstance(array, numbers.Real):
-        return ak.types.ScalarType(ak.types.NumpyType("float64"))
+        return ak.types.ScalarType(ak.types.NumpyType("float64"), behavior=behavior)
 
     elif isinstance(array, numbers.Complex):
-        return ak.types.ScalarType(ak.types.NumpyType("complex128"))
+        return ak.types.ScalarType(ak.types.NumpyType("complex128"), behavior=behavior)
 
     elif isinstance(array, datetime):  # np.datetime64 in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("datetime64"))
+        return ak.types.ScalarType(ak.types.NumpyType("datetime64"), behavior=behavior)
 
     elif isinstance(array, timedelta):  # np.timedelta64 in np.generic (above)
-        return ak.types.ScalarType(ak.types.NumpyType("timedelta"))
+        return ak.types.ScalarType(ak.types.NumpyType("timedelta"), behavior=behavior)
 
     elif isinstance(array, ak.highlevel.ArrayBuilder):
         # Don't go through `to_layout`: we want to avoid snapshotting this array
@@ -123,7 +129,7 @@ def _impl(array, behavior):
     else:
         layout = ak.to_layout(array, allow_other=True, allow_record=True)
         if layout is None:
-            return ak.types.ScalarType(ak.types.UnknownType())
+            return ak.types.ScalarType(ak.types.UnknownType(), behavior=behavior)
 
         elif isinstance(layout, (ak.contents.Content, ak.record.Record)):
             return _impl(layout, behavior)

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -85,19 +85,13 @@ def _impl(array, behavior):
 
     if isinstance(array, _ext.ArrayBuilder):
         form = ak.forms.from_json(array.form())
-        return ak.types.ArrayType(
-            form.type_from_behavior(behavior), len(array), behavior=behavior
-        )
+        return ak.types.ArrayType(form.type, len(array), behavior=behavior)
 
     elif isinstance(array, ak.record.Record):
-        return ak.types.ScalarType(
-            array.array.form.type_from_behavior(behavior), behavior=behavior
-        )
+        return ak.types.ScalarType(array.array.form.type, behavior=behavior)
 
     elif isinstance(array, ak.contents.Content):
-        return ak.types.ArrayType(
-            array.form.type_from_behavior(behavior), array.length, behavior=behavior
-        )
+        return ak.types.ArrayType(array.form.type, array.length, behavior=behavior)
 
     elif isinstance(array, (np.dtype, np.generic)):
         return ak.types.ScalarType(

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("values_astype",)
 import awkward as ak
+from awkward._behavior import behavior_of, overlay_behavior
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -66,8 +67,11 @@ def values_astype(array, to, *, including_unknown=False, highlevel=True, behavio
 
 
 def _impl(array, to, including_unknown, highlevel, behavior):
+    behavior = behavior_of(array, behavior=behavior)
     to_dtype = np.dtype(to)
     to_str = ak.types.numpytype.dtype_to_primitive(to_dtype)
     layout = ak.operations.to_layout(array, allow_record=False, allow_other=False)
-    out = ak._do.numbers_to_type(layout, to_str, including_unknown)
+    out = ak._do.numbers_to_type(
+        layout, to_str, including_unknown, overlay_behavior(behavior)
+    )
     return wrap_layout(out, behavior, highlevel, like=array)

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -55,7 +55,7 @@ class ArrayType:
         ]
 
     def __repr__(self):
-        args = [repr(self._content), repr(self._length)]
+        args = [repr(self._content), repr(self._length), repr(self._behavior)]
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -47,7 +47,11 @@ class ArrayType:
     def _str(self, indent, compact):
         return [
             f"{self._length} * ",
-            *self._content._str(indent, compact, self._behavior),
+            *self._content._str(
+                indent,
+                compact,
+                ak.behavior if self._behavior is None else self._behavior,
+            ),
         ]
 
     def __repr__(self):

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -9,7 +9,7 @@ from awkward._regularize import is_integer
 
 
 class ArrayType:
-    def __init__(self, content, length):
+    def __init__(self, content, length, behavior=None):
         if not isinstance(content, ak.types.Type):
             raise TypeError(
                 "{} all 'contents' must be Type subclasses, not {}".format(
@@ -24,6 +24,7 @@ class ArrayType:
             )
         self._content = content
         self._length = length
+        self._behavior = behavior
 
     @property
     def content(self):
@@ -33,6 +34,10 @@ class ArrayType:
     def length(self):
         return self._length
 
+    @property
+    def behavior(self):
+        return self._behavior
+
     def __str__(self):
         return "".join(self._str("", True))
 
@@ -40,7 +45,10 @@ class ArrayType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return [f"{self._length} * ", *self._content._str(indent, compact)]
+        return [
+            f"{self._length} * ",
+            *self._content._str(indent, compact, self._behavior),
+        ]
 
     def __repr__(self):
         args = [repr(self._content), repr(self._length)]

--- a/src/awkward/types/arraytype.py
+++ b/src/awkward/types/arraytype.py
@@ -50,7 +50,7 @@ class ArrayType:
             *self._content._str(
                 indent,
                 compact,
-                ak.behavior if self._behavior is None else self._behavior,
+                self._behavior,
             ),
         ]
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -44,9 +44,11 @@ class ListType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
-
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
         else:
             params = self._str_parameters()
             if params is None:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -43,22 +43,16 @@ class ListType(Type):
     def content(self):
         return self._content
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
-
-        elif self.parameter("__array__") == "string":
-            out = ["string"]
-
-        elif self.parameter("__array__") == "bytestring":
-            out = ["bytes"]
 
         else:
             params = self._str_parameters()
             if params is None:
-                out = ["var * ", *self._content._str(indent, compact)]
+                out = ["var * ", *self._content._str(indent, compact, behavior)]
             else:
-                out = ["[var * ", *self._content._str(indent, compact)] + [
+                out = ["[var * ", *self._content._str(indent, compact, behavior)] + [
                     f", {params}]"
                 ]
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -49,7 +49,7 @@ class ListType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
         else:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -49,10 +49,7 @@ class ListType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
         else:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -44,6 +46,10 @@ class ListType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -130,7 +130,7 @@ class NumpyType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -125,8 +125,11 @@ class NumpyType(Type):
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if self.parameter("__unit__") is not None:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
@@ -130,10 +130,7 @@ class NumpyType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -124,15 +124,9 @@ class NumpyType(Type):
 
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
-
-        elif self.parameter("__array__") == "char":
-            out = ["char"]
-
-        elif self.parameter("__array__") == "byte":
-            out = ["byte"]
 
         else:
             if self.parameter("__unit__") is not None:

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 import re
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -125,6 +127,10 @@ class NumpyType(Type):
     _str_parameters_exclude = ("__categorical__", "__unit__")
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -50,14 +50,14 @@ class OptionType(Type):
     def content(self):
         return self._content
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         head = []
         tail = []
         if self._typestr is not None:
             content_out = [self._typestr]
 
         else:
-            content_out = self._content._str(indent, compact)
+            content_out = self._content._str(indent, compact, behavior)
             params = self._str_parameters()
             if params is None:
                 if isinstance(

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -56,7 +56,7 @@ class OptionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
 
         head = []
         tail = []

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import (
     parameters_are_equal,
     parameters_union,
@@ -51,11 +53,16 @@ class OptionType(Type):
         return self._content
 
     def _str(self, indent, compact, behavior):
-        head = []
-        tail = []
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )
+
+        head = []
+        tail = []
         if typestr is not None:
             content_out = [typestr]
 

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import (
     parameters_are_equal,
@@ -56,10 +56,7 @@ class OptionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
 
         head = []
         tail = []

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -53,8 +53,11 @@ class OptionType(Type):
     def _str(self, indent, compact, behavior):
         head = []
         tail = []
-        if self._typestr is not None:
-            content_out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            content_out = [typestr]
 
         else:
             content_out = self._content._str(indent, compact, behavior)

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,7 +7,7 @@ from itertools import permutations
 
 import awkward as ak
 import awkward._prettyprint
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_record_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -89,10 +89,7 @@ class RecordType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__record__")), self._typestr
-        )
+        typestr = find_record_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -83,7 +83,7 @@ class RecordType(Type):
 
     _str_parameters_exclude = ("__categorical__", "__record__")
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 
@@ -97,14 +97,19 @@ class RecordType(Type):
             for i, x in enumerate(self._contents):
                 if i + 1 < len(self._contents):
                     if compact:
-                        y = [*x._str(indent, compact), ", "]
+                        y = [*x._str(indent, compact, behavior), ", "]
                     else:
-                        y = [*x._str(indent + "    ", compact), ",\n", indent, "    "]
+                        y = [
+                            *x._str(indent + "    ", compact, behavior),
+                            ",\n",
+                            indent,
+                            "    ",
+                        ]
                 else:
                     if compact:
-                        y = x._str(indent, compact)
+                        y = x._str(indent, compact, behavior)
                     else:
-                        y = x._str(indent + "    ", compact)
+                        y = x._str(indent + "    ", compact, behavior)
                 children.append(y)
 
             params = self._str_parameters()

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -91,7 +91,7 @@ class RecordType(Type):
 
         behavior = overlay_behavior(behavior)
         typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
+            ("__typestr__", self.parameter("__record__")), self._typestr
         )
         if typestr is not None:
             out = [typestr]

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -7,6 +7,8 @@ from itertools import permutations
 
 import awkward as ak
 import awkward._prettyprint
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -84,8 +86,12 @@ class RecordType(Type):
     _str_parameters_exclude = ("__categorical__", "__record__")
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
-            ("__typestr__", self.parameter("__record__")), self._typestr
+            ("__typestr__", self.parameter("__array__")), self._typestr
         )
         if typestr is not None:
             out = [typestr]

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -84,8 +84,11 @@ class RecordType(Type):
     _str_parameters_exclude = ("__categorical__", "__record__")
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__record__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if compact:

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -89,7 +89,7 @@ class RecordType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_record_typestr(behavior, self._parameters)
+        typestr = find_record_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -65,8 +65,11 @@ class RegularType(Type):
         return self._size
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [f"{self._typestr}[{self._size}]"]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [f"{typestr}[{self._size}]"]
 
         else:
             params = self._str_parameters()

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer
@@ -65,6 +67,10 @@ class RegularType(Type):
         return self._size
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -64,27 +64,25 @@ class RegularType(Type):
     def size(self):
         return self._size
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
-            out = [self._typestr]
-
-        elif self.parameter("__array__") == "string":
-            out = [f"string[{self._size}]"]
-
-        elif self.parameter("__array__") == "bytestring":
-            out = [f"bytes[{self._size}]"]
+            out = [f"{self._typestr}[{self._size}]"]
 
         else:
             params = self._str_parameters()
 
             if params is None:
-                out = [str(self._size), " * ", *self._content._str(indent, compact)]
+                out = [
+                    str(self._size),
+                    " * ",
+                    *self._content._str(indent, compact, behavior),
+                ]
             else:
                 out = [
                     "[",
                     str(self._size),
                     " * ",
-                    *self._content._str(indent, compact),
+                    *self._content._str(indent, compact, behavior),
                 ] + [", ", params, "]"]
 
         return [self._str_categorical_begin(), *out] + [self._str_categorical_end()]

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -70,7 +70,7 @@ class RegularType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [f"{typestr}[{self._size}]"]
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
@@ -70,10 +70,7 @@ class RegularType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [f"{typestr}[{self._size}]"]
 

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -39,7 +39,7 @@ class ScalarType:
         )
 
     def __repr__(self):
-        return f"{type(self).__name__}({self._content!r})"
+        return f"{type(self).__name__}({self._content!r}, {self._behavior!r})"
 
     def is_equal_to(self, other, *, all_parameters: bool = False) -> bool:
         return isinstance(other, type(self)) and self._content.is_equal_to(

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -7,7 +7,7 @@ import awkward as ak
 
 
 class ScalarType:
-    def __init__(self, content):
+    def __init__(self, content, behavior=None):
         if not isinstance(content, ak.types.Type):
             raise TypeError(
                 "{} all 'contents' must be Type subclasses, not {}".format(
@@ -15,10 +15,15 @@ class ScalarType:
                 )
             )
         self._content = content
+        self._behavior = behavior
 
     @property
     def content(self):
         return self._content
+
+    @property
+    def behavior(self):
+        return self._behavior
 
     def __str__(self):
         return "".join(self._str("", True))
@@ -27,7 +32,7 @@ class ScalarType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return self._content._str(indent, compact)
+        return self._content._str(indent, compact, self._behavior)
 
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -32,7 +32,11 @@ class ScalarType:
         stream.write("".join([*self._str("", False), "\n"]))
 
     def _str(self, indent, compact):
-        return self._content._str(indent, compact, self._behavior)
+        return self._content._str(
+            indent,
+            compact,
+            ak.behavior if self._behavior is None else self._behavior,
+        )
 
     def __repr__(self):
         return f"{type(self).__name__}({self._content!r})"

--- a/src/awkward/types/scalartype.py
+++ b/src/awkward/types/scalartype.py
@@ -35,7 +35,7 @@ class ScalarType:
         return self._content._str(
             indent,
             compact,
-            ak.behavior if self._behavior is None else self._behavior,
+            self._behavior,
         )
 
     def __repr__(self):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -314,8 +314,8 @@ def from_datashape(datashape, highlevel=True):
     the return type is #ak.types.ArrayType, representing an #ak.highlevel.Array.
 
     If `highlevel=True` and the type string starts with a record indicator (e.g. `{`),
-    the return type is #ak.types.RecordType, representing an #ak.highlevel.Record,
-    rather than an array of them.
+    the return type is #ak.types.ScalarType with an #ak.types.RecordType content,
+    representing a scalar #ak.highlevel.Record rather than an array of them.
 
     Other strings (e.g. starting with `var *`, `?`, `option`, etc.) are not compatible
     with `highlevel=True`; an exception would be raised.
@@ -326,6 +326,7 @@ def from_datashape(datashape, highlevel=True):
     from awkward.types.arraytype import ArrayType
     from awkward.types.recordtype import RecordType
     from awkward.types.regulartype import RegularType
+    from awkward.types.scalartype import ScalarType
 
     parser = Lark_StandAlone(transformer=_DataShapeTransformer())
     out = parser.parse(datashape)
@@ -334,7 +335,7 @@ def from_datashape(datashape, highlevel=True):
         if isinstance(out, RegularType):
             return ArrayType(out.content, out.size)
         elif isinstance(out, RecordType):
-            return out
+            return ScalarType(out)
         else:
             raise ValueError(
                 f"type {type(out).__name__!r} is not compatible with highlevel=True"

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -34,9 +34,9 @@ class Type:
         return self._typestr
 
     def __str__(self):
-        return "".join(self._str("", True))
+        return "".join(self._str("", True, None))
 
-    def _str(self, indent: str, compact: bool, behavior) -> list[str]:
+    def _str(self, indent: str, compact: bool, behavior: dict | None) -> list[str]:
         raise NotImplementedError
 
     def show(self, stream=sys.stdout):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -36,8 +36,12 @@ class Type:
     def __str__(self):
         return "".join(self._str("", True))
 
+    def _str(self, indent: str, compact: bool, behavior) -> list[str]:
+        raise NotImplementedError
+
     def show(self, stream=sys.stdout):
-        stream.write("".join([*self._str("", False), "\n"]))
+        # TODO: deprecate lowlevel show
+        stream.write("".join([*self._str("", False, None), "\n"]))
 
     _str_parameters_exclude = ("__categorical__",)
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -63,7 +63,7 @@ class UnionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -57,7 +57,7 @@ class UnionType(Type):
     def contents(self):
         return self._contents
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 
@@ -71,14 +71,19 @@ class UnionType(Type):
             for i, x in enumerate(self._contents):
                 if i + 1 < len(self._contents):
                     if compact:
-                        y = [*x._str(indent, compact), ", "]
+                        y = [*x._str(indent, compact, behavior), ", "]
                     else:
-                        y = [*x._str(indent + "    ", compact), ",\n", indent, "    "]
+                        y = [
+                            *x._str(indent + "    ", compact, behavior),
+                            ",\n",
+                            indent,
+                            "    ",
+                        ]
                 else:
                     if compact:
-                        y = x._str(indent, compact)
+                        y = x._str(indent, compact, behavior)
                     else:
-                        y = x._str(indent + "    ", compact)
+                        y = x._str(indent + "    ", compact, behavior)
                 children.append(y)
 
             flat_children = [y for x in children for y in x]

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from itertools import permutations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -63,10 +63,7 @@ class UnionType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from itertools import permutations
 
+from awkward._behavior import overlay_behavior
+from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import unset
@@ -58,6 +60,10 @@ class UnionType(Type):
         return self._contents
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -58,8 +58,11 @@ class UnionType(Type):
         return self._contents
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             if compact:

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -36,7 +36,7 @@ class UnknownType(Type):
         self._parameters = parameters
         self._typestr = typestr
 
-    def _str(self, indent, compact):
+    def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             out = [self._typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import overlay_behavior
+from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -41,10 +41,7 @@ class UnknownType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        behavior = overlay_behavior(behavior)
-        typestr = behavior.get(
-            ("__typestr__", self.parameter("__array__")), self._typestr
-        )
+        typestr = find_array_typestr(behavior, self._parameters)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from awkward._behavior import overlay_behavior
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
@@ -37,6 +38,10 @@ class UnknownType(Type):
         self._typestr = typestr
 
     def _str(self, indent, compact, behavior):
+        if self._typestr is not None:
+            deprecate("typestr argument is deprecated", "2.4.0")
+
+        behavior = overlay_behavior(behavior)
         typestr = behavior.get(
             ("__typestr__", self.parameter("__array__")), self._typestr
         )

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -41,7 +41,7 @@ class UnknownType(Type):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters)
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
         if typestr is not None:
             out = [typestr]
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -37,8 +37,11 @@ class UnknownType(Type):
         self._typestr = typestr
 
     def _str(self, indent, compact, behavior):
-        if self._typestr is not None:
-            out = [self._typestr]
+        typestr = behavior.get(
+            ("__typestr__", self.parameter("__array__")), self._typestr
+        )
+        if typestr is not None:
+            out = [typestr]
 
         else:
             params = self._str_parameters()

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -93,7 +93,6 @@ def test_dress():
 
 
 def test_record_name():
-    typestrs = {}
     builder = ak.highlevel.ArrayBuilder()
 
     builder.begin_record("Dummy")
@@ -112,8 +111,8 @@ def test_record_name():
 
     a = builder.snapshot()
 
-    assert str(a.layout.form._type(typestrs)) == "Dummy[one: int64, two: float64]"
-    assert a.layout.form._type(typestrs).parameters == {"__record__": "Dummy"}
+    assert str(a.layout.form.type) == "Dummy[one: int64, two: float64]"
+    assert a.layout.form.type.parameters == {"__record__": "Dummy"}
 
 
 def test_builder_string():

--- a/tests/test_0773_typeparser.py
+++ b/tests/test_0773_typeparser.py
@@ -437,7 +437,7 @@ def test_hardcoded():
 def test_record_highlevel():
     text = "Thingy[x: int64, y: float64]"
     parsedtype = ak.types.from_datashape(text, highlevel=True)
-    assert isinstance(parsedtype, ak.types.RecordType)
+    assert isinstance(parsedtype, ak.types.ScalarType)
     assert str(parsedtype) == text
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -6,6 +6,22 @@ import pytest
 import awkward as ak
 
 
+def assert_overrides_typestr(type_, typestr: str = "override", expected: str = None):
+    # Assume typestr is expected result
+    if expected is None:
+        expected = typestr
+    # Set appropriate array or record parameter
+    if isinstance(type_, ak.types.RecordType):
+        parameters = {**type_.parameters, "__record__": "custom"}
+    else:
+        parameters = {**type_.parameters, "__array__": "custom"}
+    behavior = {("__typestr__", "custom"): typestr}
+    # Build highlevel type with custom behavior
+    with_parameter = type_.copy(parameters=parameters)
+    as_str = "".join(with_parameter._str("", False, behavior))
+    assert as_str == expected
+
+
 def test_UnknownType():
     assert str(ak.types.unknowntype.UnknownType()) == "unknown"
     with pytest.warns(DeprecationWarning):
@@ -13,18 +29,11 @@ def test_UnknownType():
             str(ak.types.unknowntype.UnknownType(parameters={"x": 123}))
             == 'unknown[parameters={"x": 123}]'
         )
-    assert (
-        str(ak.types.unknowntype.UnknownType(parameters=None, typestr="override"))
-        == "override"
-    )
     with pytest.warns(DeprecationWarning):
-        assert (
-            str(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"x": 123}, typestr="override"
-                )
-            )
-            == "override"
+        assert_overrides_typestr(ak.types.unknowntype.UnknownType())
+
+        assert_overrides_typestr(
+            ak.types.unknowntype.UnknownType(parameters={"x": 123})
         )
         assert (
             str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
@@ -38,24 +47,18 @@ def test_UnknownType():
             )
             == 'categorical[type=unknown[parameters={"x": 123}]]'
         )
-        assert (
-            str(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"__categorical__": True}, typestr="override"
-                )
-            )
-            == "categorical[type=override]"
+        assert_overrides_typestr(
+            ak.types.unknowntype.UnknownType(
+                parameters={"__categorical__": True, "x": 123}
+            ),
+            expected="categorical[type=override]",
         )
 
     assert repr(ak.types.unknowntype.UnknownType()) == "UnknownType()"
     with pytest.warns(DeprecationWarning):
         assert (
-            repr(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"__categorical__": True}, typestr="override"
-                )
-            )
-            == "UnknownType(parameters={'__categorical__': True}, typestr='override')"
+            repr(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
+            == "UnknownType(parameters={'__categorical__': True})"
         )
 
 
@@ -87,17 +90,10 @@ def test_NumpyType():
         str(ak.types.numpytype.NumpyType("bool", parameters={"x": 123}))
         == 'bool[parameters={"x": 123}]'
     )
-    assert (
-        str(ak.types.numpytype.NumpyType("bool", parameters=None, typestr="override"))
-        == "override"
-    )
-    assert (
-        str(
-            ak.types.numpytype.NumpyType(
-                "bool", parameters={"x": 123}, typestr="override"
-            )
-        )
-        == "override"
+    assert_overrides_typestr(ak.types.numpytype.NumpyType("bool"))
+
+    assert_overrides_typestr(
+        ak.types.numpytype.NumpyType("bool", parameters={"x": 123})
     )
     assert (
         str(ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}))
@@ -111,13 +107,10 @@ def test_NumpyType():
         )
         == 'categorical[type=bool[parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.numpytype.NumpyType(
-                "bool", parameters={"__categorical__": True}, typestr="override"
-            )
-        )
-        == "categorical[type=override]"
+
+    assert_overrides_typestr(
+        ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}),
+        expected="categorical[type=override]",
     )
     assert str(ak.types.numpytype.NumpyType("datetime64")) == "datetime64"
     assert (
@@ -277,12 +270,10 @@ def test_NumpyType():
     assert (
         repr(
             ak.types.numpytype.NumpyType(
-                primitive="bool",
-                parameters={"__categorical__": True},
-                typestr="override",
+                primitive="bool", parameters={"__categorical__": True}
             )
         )
-        == "NumpyType('bool', parameters={'__categorical__': True}, typestr='override')"
+        == "NumpyType('bool', parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -329,27 +320,19 @@ def test_RegularType():
         )
         == '[10 * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters=None,
-                typestr="override",
-            )
-        )
-        == "override"
+
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+        expected="override[10]",
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters={"x": 123},
-                typestr="override",
-            )
-        )
-        == "override"
+
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(
+            ak.types.unknowntype.UnknownType(),
+            10,
+            parameters={"x": 123},
+        ),
+        expected="override[10]",
     )
     assert (
         str(
@@ -371,16 +354,13 @@ def test_RegularType():
         )
         == 'categorical[type=[10 * unknown, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.regulartype.RegularType(
-                ak.types.unknowntype.UnknownType(),
-                10,
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.regulartype.RegularType(
+            ak.types.unknowntype.UnknownType(),
+            10,
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override[10]]",
     )
     assert (
         str(
@@ -417,10 +397,9 @@ def test_RegularType():
                 content=ak.types.unknowntype.UnknownType(),
                 size=10,
                 parameters={"__categorical__": True},
-                typestr="override",
             )
         )
-        == "RegularType(UnknownType(), 10, parameters={'__categorical__': True}, typestr='override')"
+        == "RegularType(UnknownType(), 10, parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -461,23 +440,14 @@ def test_ListType():
         )
         == '[var * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(), parameters=None, typestr="override"
-            )
-        )
-        == "override"
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(ak.types.unknowntype.UnknownType())
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -496,15 +466,12 @@ def test_ListType():
         )
         == 'categorical[type=[var * unknown, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.listtype.ListType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.listtype.ListType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
     assert (
         str(
@@ -534,10 +501,9 @@ def test_ListType():
             ak.types.listtype.ListType(
                 content=ak.types.unknowntype.UnknownType(),
                 parameters={"__categorical__": True},
-                typestr="override",
             )
         )
-        == "ListType(UnknownType(), parameters={'__categorical__': True}, typestr='override')"
+        == "ListType(UnknownType(), parameters={'__categorical__': True})"
     )
     assert (
         repr(
@@ -614,61 +580,43 @@ def test_RecordType():
         )
         == "Name[x: unknown, y: bool]"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name"},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name"},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name"},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name"},
         )
-        == "override"
     )
     assert (
         str(
@@ -722,61 +670,45 @@ def test_RecordType():
         )
         == 'Name[x: unknown, y: bool, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -830,61 +762,49 @@ def test_RecordType():
         )
         == "categorical[type=Name[x: unknown, y: bool]]"
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
     assert (
         str(
@@ -938,61 +858,49 @@ def test_RecordType():
         )
         == 'categorical[type=Name[x: unknown, y: bool, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                None,
-                parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            None,
+            parameters={"__record__": "Name", "x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.recordtype.RecordType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                ["x", "y"],
-                parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.recordtype.RecordType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            ["x", "y"],
+            parameters={"__record__": "Name", "x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1028,10 +936,9 @@ def test_RecordType():
                 ],
                 fields=None,
                 parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "RecordType([UnknownType(), NumpyType('bool')], None, parameters={'__record__': 'Name', 'x': 123, '__categorical__': True}, typestr='override')"
+        == "RecordType([UnknownType(), NumpyType('bool')], None, parameters={'__record__': 'Name', 'x': 123, '__categorical__': True})"
     )
     assert (
         repr(
@@ -1055,10 +962,9 @@ def test_RecordType():
                 ],
                 fields=["x", "y"],
                 parameters={"__record__": "Name", "x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "RecordType([UnknownType(), NumpyType('bool')], ['x', 'y'], parameters={'__record__': 'Name', 'x': 123, '__categorical__': True}, typestr='override')"
+        == "RecordType([UnknownType(), NumpyType('bool')], ['x', 'y'], parameters={'__record__': 'Name', 'x': 123, '__categorical__': True})"
     )
 
 
@@ -1111,67 +1017,39 @@ def test_OptionType():
         )
         == 'option[10 * unknown, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(), parameters=None, typestr="override"
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(), parameters=None
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters=None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10)
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"x": 123},
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -1230,69 +1108,47 @@ def test_OptionType():
         )
         == 'option[categorical[type=10 * unknown], parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.unknowntype.UnknownType(),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.unknowntype.UnknownType(),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.optiontype.OptionType(
-                ak.types.regulartype.RegularType(
-                    ak.types.unknowntype.UnknownType(), 10
-                ),
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.optiontype.OptionType(
+            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1314,10 +1170,9 @@ def test_OptionType():
                     ak.types.unknowntype.UnknownType(), 10
                 ),
                 parameters={"x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "OptionType(RegularType(UnknownType(), 10), parameters={'x': 123, '__categorical__': True}, typestr='override')"
+        == "OptionType(RegularType(UnknownType(), 10), parameters={'x': 123, '__categorical__': True})"
     )
 
 
@@ -1345,31 +1200,23 @@ def test_UnionType():
         )
         == 'union[unknown, bool, parameters={"x": 123}]'
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters=None,
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters=None,
         )
-        == "override"
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"x": 123},
-                typestr="override",
-            )
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"x": 123},
         )
-        == "override"
     )
     assert (
         str(
@@ -1395,31 +1242,25 @@ def test_UnionType():
         )
         == 'categorical[type=union[unknown, bool, parameters={"x": 123}]]'
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
-    assert (
-        str(
-            ak.types.uniontype.UnionType(
-                [
-                    ak.types.unknowntype.UnknownType(),
-                    ak.types.numpytype.NumpyType("bool"),
-                ],
-                parameters={"x": 123, "__categorical__": True},
-                typestr="override",
-            )
-        )
-        == "categorical[type=override]"
+    assert_overrides_typestr(
+        ak.types.uniontype.UnionType(
+            [
+                ak.types.unknowntype.UnknownType(),
+                ak.types.numpytype.NumpyType("bool"),
+            ],
+            parameters={"x": 123, "__categorical__": True},
+        ),
+        expected="categorical[type=override]",
     )
 
     assert (
@@ -1441,10 +1282,9 @@ def test_UnionType():
                     ak.types.numpytype.NumpyType("bool"),
                 ],
                 parameters={"x": 123, "__categorical__": True},
-                typestr="override",
             )
         )
-        == "UnionType([UnknownType(), NumpyType('bool')], parameters={'x': 123, '__categorical__': True}, typestr='override')"
+        == "UnionType([UnknownType(), NumpyType('bool')], parameters={'x': 123, '__categorical__': True})"
     )
 
 
@@ -1462,10 +1302,8 @@ def test_ArrayType():
 
     # ArrayType should not have these arguments (should not be a Type subclass)
     with pytest.raises(TypeError):
-        ak.types.arraytype.ArrayType(ak.types.unknowntype.UnknownType(), 10, {"x": 123})
-    with pytest.raises(TypeError):
         ak.types.arraytype.ArrayType(
-            ak.types.unknowntype.UnknownType(), 10, None, typestr="override"
+            ak.types.arraytype.ArrayType(ak.types.unknowntype.UnknownType(), 10), 10
         )
 
     assert (
@@ -1475,6 +1313,31 @@ def test_ArrayType():
             )
         )
         == "ArrayType(UnknownType(), 10)"
+    )
+
+    assert (
+        str(
+            ak.types.arraytype.ArrayType(
+                content=ak.types.numpytype.NumpyType(
+                    "int64", parameters={"__array__": "custom"}
+                ),
+                length=10,
+                behavior={("__typestr__", "custom"): "override"},
+            )
+        )
+        == "10 * override"
+    )
+
+    assert (
+        str(
+            ak.types.arraytype.ArrayType(
+                content=ak.types.numpytype.NumpyType(
+                    "int64", parameters={"__array__": "custom"}
+                ),
+                length=10,
+            )
+        )
+        == '10 * int64[parameters={"__array__": "custom"}]'
     )
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -1312,7 +1312,7 @@ def test_ArrayType():
                 content=ak.types.unknowntype.UnknownType(), length=10
             )
         )
-        == "ArrayType(UnknownType(), 10)"
+        == "ArrayType(UnknownType(), 10, None)"
     )
 
     assert (

--- a/tests/test_1142_numbers_to_type.py
+++ b/tests/test_1142_numbers_to_type.py
@@ -12,250 +12,250 @@ def test_numbers_to_type():
         ak.highlevel.Array([4, 5]).layout,
     )
 
-    assert np.asarray(ak._do.numbers_to_type(one, "bool", False)).dtype == np.dtype(
-        np.bool_
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "int8", False)).dtype == np.dtype(
-        np.int8
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint8", False)).dtype == np.dtype(
-        np.uint8
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "int16", False)).dtype == np.dtype(
-        np.int16
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint16", False)).dtype == np.dtype(
-        np.uint16
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "int32", False)).dtype == np.dtype(
-        np.int32
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint32", False)).dtype == np.dtype(
-        np.uint32
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "int64", False)).dtype == np.dtype(
-        np.int64
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint64", False)).dtype == np.dtype(
-        np.uint64
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "float32", False)).dtype == np.dtype(
-        np.float32
-    )
-    assert np.asarray(ak._do.numbers_to_type(one, "float64", False)).dtype == np.dtype(
-        np.float64
-    )
     assert np.asarray(
-        ak._do.numbers_to_type(one, "complex64", False)
+        ak.values_astype(one, "bool", including_unknown=False)
+    ).dtype == np.dtype(np.bool_)
+    assert np.asarray(
+        ak.values_astype(one, "int8", including_unknown=False)
+    ).dtype == np.dtype(np.int8)
+    assert np.asarray(
+        ak.values_astype(one, "uint8", including_unknown=False)
+    ).dtype == np.dtype(np.uint8)
+    assert np.asarray(
+        ak.values_astype(one, "int16", including_unknown=False)
+    ).dtype == np.dtype(np.int16)
+    assert np.asarray(
+        ak.values_astype(one, "uint16", including_unknown=False)
+    ).dtype == np.dtype(np.uint16)
+    assert np.asarray(
+        ak.values_astype(one, "int32", including_unknown=False)
+    ).dtype == np.dtype(np.int32)
+    assert np.asarray(
+        ak.values_astype(one, "uint32", including_unknown=False)
+    ).dtype == np.dtype(np.uint32)
+    assert np.asarray(
+        ak.values_astype(one, "int64", including_unknown=False)
+    ).dtype == np.dtype(np.int64)
+    assert np.asarray(
+        ak.values_astype(one, "uint64", including_unknown=False)
+    ).dtype == np.dtype(np.uint64)
+    assert np.asarray(
+        ak.values_astype(one, "float32", including_unknown=False)
+    ).dtype == np.dtype(np.float32)
+    assert np.asarray(
+        ak.values_astype(one, "float64", including_unknown=False)
+    ).dtype == np.dtype(np.float64)
+    assert np.asarray(
+        ak.values_astype(one, "complex64", including_unknown=False)
     ).dtype == np.dtype(np.complex64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "complex128", False)
+        ak.values_astype(one, "complex128", including_unknown=False)
     ).dtype == np.dtype(np.complex128)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64", False)
+        ak.values_astype(one, "datetime64", including_unknown=False)
     ).dtype == np.dtype(np.datetime64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[Y]", False)
+        ak.values_astype(one, "datetime64[Y]", including_unknown=False)
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[M]", False)
+        ak.values_astype(one, "datetime64[M]", including_unknown=False)
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[W]", False)
+        ak.values_astype(one, "datetime64[W]", including_unknown=False)
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[D]", False)
+        ak.values_astype(one, "datetime64[D]", including_unknown=False)
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[h]", False)
+        ak.values_astype(one, "datetime64[h]", including_unknown=False)
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[m]", False)
+        ak.values_astype(one, "datetime64[m]", including_unknown=False)
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[s]", False)
+        ak.values_astype(one, "datetime64[s]", including_unknown=False)
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ms]", False)
+        ak.values_astype(one, "datetime64[ms]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[us]", False)
+        ak.values_astype(one, "datetime64[us]", including_unknown=False)
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ns]", False)
+        ak.values_astype(one, "datetime64[ns]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ps]", False)
+        ak.values_astype(one, "datetime64[ps]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[fs]", False)
+        ak.values_astype(one, "datetime64[fs]", including_unknown=False)
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[as]", False)
+        ak.values_astype(one, "datetime64[as]", including_unknown=False)
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64", False)
+        ak.values_astype(one, "timedelta64", including_unknown=False)
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[Y]", False)
+        ak.values_astype(one, "timedelta64[Y]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[M]", False)
+        ak.values_astype(one, "timedelta64[M]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[W]", False)
+        ak.values_astype(one, "timedelta64[W]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[D]", False)
+        ak.values_astype(one, "timedelta64[D]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[h]", False)
+        ak.values_astype(one, "timedelta64[h]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[m]", False)
+        ak.values_astype(one, "timedelta64[m]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[s]", False)
+        ak.values_astype(one, "timedelta64[s]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ms]", False)
+        ak.values_astype(one, "timedelta64[ms]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[us]", False)
+        ak.values_astype(one, "timedelta64[us]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ns]", False)
+        ak.values_astype(one, "timedelta64[ns]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ps]", False)
+        ak.values_astype(one, "timedelta64[ps]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[fs]", False)
+        ak.values_astype(one, "timedelta64[fs]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[as]", False)
+        ak.values_astype(one, "timedelta64[as]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[as]")
 
-    assert np.asarray(ak._do.numbers_to_type(two, "bool", False)).dtype == np.dtype(
-        np.bool_
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "int8", False)).dtype == np.dtype(
-        np.int8
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint8", False)).dtype == np.dtype(
-        np.uint8
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "int16", False)).dtype == np.dtype(
-        np.int16
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint16", False)).dtype == np.dtype(
-        np.uint16
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "int32", False)).dtype == np.dtype(
-        np.int32
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint32", False)).dtype == np.dtype(
-        np.uint32
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "int64", False)).dtype == np.dtype(
-        np.int64
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint64", False)).dtype == np.dtype(
-        np.uint64
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "float32", False)).dtype == np.dtype(
-        np.float32
-    )
-    assert np.asarray(ak._do.numbers_to_type(two, "float64", False)).dtype == np.dtype(
-        np.float64
-    )
     assert np.asarray(
-        ak._do.numbers_to_type(two, "complex64", False)
+        ak.values_astype(two, "bool", including_unknown=False)
+    ).dtype == np.dtype(np.bool_)
+    assert np.asarray(
+        ak.values_astype(two, "int8", including_unknown=False)
+    ).dtype == np.dtype(np.int8)
+    assert np.asarray(
+        ak.values_astype(two, "uint8", including_unknown=False)
+    ).dtype == np.dtype(np.uint8)
+    assert np.asarray(
+        ak.values_astype(two, "int16", including_unknown=False)
+    ).dtype == np.dtype(np.int16)
+    assert np.asarray(
+        ak.values_astype(two, "uint16", including_unknown=False)
+    ).dtype == np.dtype(np.uint16)
+    assert np.asarray(
+        ak.values_astype(two, "int32", including_unknown=False)
+    ).dtype == np.dtype(np.int32)
+    assert np.asarray(
+        ak.values_astype(two, "uint32", including_unknown=False)
+    ).dtype == np.dtype(np.uint32)
+    assert np.asarray(
+        ak.values_astype(two, "int64", including_unknown=False)
+    ).dtype == np.dtype(np.int64)
+    assert np.asarray(
+        ak.values_astype(two, "uint64", including_unknown=False)
+    ).dtype == np.dtype(np.uint64)
+    assert np.asarray(
+        ak.values_astype(two, "float32", including_unknown=False)
+    ).dtype == np.dtype(np.float32)
+    assert np.asarray(
+        ak.values_astype(two, "float64", including_unknown=False)
+    ).dtype == np.dtype(np.float64)
+    assert np.asarray(
+        ak.values_astype(two, "complex64", including_unknown=False)
     ).dtype == np.dtype(np.complex64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "complex128", False)
+        ak.values_astype(two, "complex128", including_unknown=False)
     ).dtype == np.dtype(np.complex128)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64", False)
+        ak.values_astype(two, "datetime64", including_unknown=False)
     ).dtype == np.dtype(np.datetime64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[Y]", False)
+        ak.values_astype(two, "datetime64[Y]", including_unknown=False)
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[M]", False)
+        ak.values_astype(two, "datetime64[M]", including_unknown=False)
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[W]", False)
+        ak.values_astype(two, "datetime64[W]", including_unknown=False)
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[D]", False)
+        ak.values_astype(two, "datetime64[D]", including_unknown=False)
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[h]", False)
+        ak.values_astype(two, "datetime64[h]", including_unknown=False)
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[m]", False)
+        ak.values_astype(two, "datetime64[m]", including_unknown=False)
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[s]", False)
+        ak.values_astype(two, "datetime64[s]", including_unknown=False)
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ms]", False)
+        ak.values_astype(two, "datetime64[ms]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[us]", False)
+        ak.values_astype(two, "datetime64[us]", including_unknown=False)
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ns]", False)
+        ak.values_astype(two, "datetime64[ns]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ps]", False)
+        ak.values_astype(two, "datetime64[ps]", including_unknown=False)
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[fs]", False)
+        ak.values_astype(two, "datetime64[fs]", including_unknown=False)
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[as]", False)
+        ak.values_astype(two, "datetime64[as]", including_unknown=False)
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64", False)
+        ak.values_astype(two, "timedelta64", including_unknown=False)
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[Y]", False)
+        ak.values_astype(two, "timedelta64[Y]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[M]", False)
+        ak.values_astype(two, "timedelta64[M]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[W]", False)
+        ak.values_astype(two, "timedelta64[W]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[D]", False)
+        ak.values_astype(two, "timedelta64[D]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[h]", False)
+        ak.values_astype(two, "timedelta64[h]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[m]", False)
+        ak.values_astype(two, "timedelta64[m]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[s]", False)
+        ak.values_astype(two, "timedelta64[s]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ms]", False)
+        ak.values_astype(two, "timedelta64[ms]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[us]", False)
+        ak.values_astype(two, "timedelta64[us]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ns]", False)
+        ak.values_astype(two, "timedelta64[ns]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ps]", False)
+        ak.values_astype(two, "timedelta64[ps]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[fs]", False)
+        ak.values_astype(two, "timedelta64[fs]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[as]", False)
+        ak.values_astype(two, "timedelta64[as]", including_unknown=False)
     ).dtype == np.dtype("timedelta64[as]")

--- a/tests/test_2456_string_like.py
+++ b/tests/test_2456_string_like.py
@@ -1,0 +1,64 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_string_slice():
+    fields = ak.Array(["x"])
+    array = ak.Array([{"x": 1, "y": 2}])
+    assert array[fields].to_list() == [{"x": 1}]
+
+
+def test_stringlike_slice():
+    behavior = {("__super__", "my-string"): "string"}
+    fields = ak.with_parameter(["x"], "__array__", "my-string", behavior=behavior)
+    array = ak.Array([{"x": 1, "y": 2}])
+    assert array[fields].to_list() == [{"x": 1}]
+
+
+@pytest.mark.skip(reason="test needs more work")
+def test_stringlike_tolist():
+    behavior = {("__super__", "my-string"): "string"}
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
+    )
+    assert array.to_list() == ["bish", "bash", "bosh"]
+
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-other-string", behavior=behavior
+    )
+    assert array.to_list() != ["bish", "bash", "bosh"]
+
+
+def test_stringlike_flatten():
+    behavior = {("__super__", "my-string"): "string"}
+
+    # axis=None
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
+    )
+    assert ak.flatten(array, axis=None).type.is_equal_to(
+        ak.types.ArrayType(
+            ak.types.ListType(
+                ak.types.NumpyType("uint8", parameters={"__array__": "char"}),
+                parameters={"__array__": "my-string"},
+            ),
+            3,
+            None,
+        )
+    )
+
+    # axis=1
+    with pytest.raises(np.AxisError):
+        ak.flatten(array, axis=1)
+
+
+def test_stringlike_backend_array():
+    behavior = {("__super__", "my-string"): "string"}
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
+    )
+    assert ak.to_numpy(array).tolist() == ["bish", "bash", "bosh"]

--- a/tests/test_2456_string_like.py
+++ b/tests/test_2456_string_like.py
@@ -92,3 +92,42 @@ def test_stringlike_to_arrow_table():
         table.schema.to_string()
         == ": large_list<item: uint8 not null> not null\n  child 0, item: uint8 not null"
     )
+
+
+def test_string_broadcasting():
+    result = ak.broadcast_arrays(["he", "lo"], ["w", "orld"])
+    assert result[0].tolist() == ["he", "lo"]
+    assert result[1].tolist() == ["w", "orld"]
+
+    with pytest.raises(ValueError):
+        ak.broadcast_arrays(["he", "lo"], [1, 2, 3])
+
+    result = ak.broadcast_arrays(["he", "lo"], [[1, 2, 3], [4]])
+    assert result[0].tolist() == [["he", "he", "he"], ["lo"]]
+    assert result[1].tolist() == [[1, 2, 3], [4]]
+
+
+def test_stringlike_broadcasting():
+    behavior = {("__super__", "my-string"): "string"}
+    result = ak.broadcast_arrays(
+        ak.with_parameter(["he", "lo"], "__array__", "my-string"),
+        ak.with_parameter(["w", "orld"], "__array__", "my-string"),
+        behavior=behavior,
+    )
+    assert result[0].tolist() == ["he", "lo"]
+    assert result[1].tolist() == ["w", "orld"]
+
+    with pytest.raises(ValueError):
+        ak.broadcast_arrays(
+            ak.with_parameter(["he", "lo"], "__array__", "my-string"),
+            [1, 2, 3],
+            behavior=behavior,
+        )
+
+    result = ak.broadcast_arrays(
+        ak.with_parameter(["he", "lo"], "__array__", "my-string"),
+        [[1, 2, 3], [4]],
+        behavior=behavior,
+    )
+    assert result[0].tolist() == [["he", "he", "he"], ["lo"]]
+    assert result[1].tolist() == [[1, 2, 3], [4]]

--- a/tests/test_2456_string_like.py
+++ b/tests/test_2456_string_like.py
@@ -62,3 +62,33 @@ def test_stringlike_backend_array():
         ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
     )
     assert ak.to_numpy(array).tolist() == ["bish", "bash", "bosh"]
+
+
+def test_stringlike_values_astype():
+    behavior = {("__super__", "my-string"): "string"}
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
+    )
+    assert ak.values_astype(array, np.int64).tolist() == ["bish", "bash", "bosh"]
+
+    array = ak.with_parameter(["bish", "bash", "bosh"], "__array__", "my-other-string")
+    assert ak.values_astype(array, np.float32).tolist() == ["bish", "bash", "bosh"]
+
+
+def test_stringlike_to_arrow_table():
+    behavior = {("__super__", "my-string"): "string"}
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-string", behavior=behavior
+    )
+    table = ak.to_arrow_table(array, extensionarray=False)
+
+    # Fails
+    assert table.schema.to_string() == ": large_string not null"
+    array = ak.with_parameter(
+        ["bish", "bash", "bosh"], "__array__", "my-other-string", behavior=behavior
+    )
+    table = ak.to_arrow_table(array, extensionarray=False)
+    assert (
+        table.schema.to_string()
+        == ": large_list<item: uint8 not null> not null\n  child 0, item: uint8 not null"
+    )


### PR DESCRIPTION
Closes #2432 

- [x] Support for string-likes in `getitem`
- [x] Support for string-likes in `_remove_structure`
- [x] Support for string-likes in `_to_backend_array`
- [x] Support for string-likes in `_combinations`
- [x] Support for string-likes in `_argsort_next`
- [x] Support for string-likes in `_sort_next`
- [x] Support for string-likes in `_unique`
- [x] Support for string-likes in `_is_unique`
- [x] Support for string-likes in `_numbers_to_type`
- [x] Support for string-likes in `_to_arrow`
- [x] Support for string-likes in `_reduce_next`
- [ ] Validity error for string-likes (list of numpy invariant) [^1]
- [ ] Figure out whether to make `behavior: Mapping` internally 

[^1]: should we allow overloading validity error for any type name?