### PR TITLE
refactor: reorganise sentinel definitions

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -7,7 +7,7 @@ from awkward._backends.backend import Backend
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._typing import Callable, TypeAlias, TypeVar
-from awkward._util import unset
+from awkward._util import UNSET
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -69,7 +69,7 @@ def common_backend(backends: Iterable[Backend]) -> Backend:
             )
 
 
-def _backend_of(obj, default: D = unset) -> Backend | D:
+def _backend_of(obj, default: D = UNSET) -> Backend | D:
     cls = type(obj)
     try:
         lookup = _type_to_backend_lookup[cls]
@@ -80,7 +80,7 @@ def _backend_of(obj, default: D = unset) -> Backend | D:
             if maybe_lookup is not None:
                 break
         else:
-            if default is unset:
+            if default is UNSET:
                 raise TypeError(f"cannot find nplike for {cls.__name__}")
             else:
                 return default
@@ -88,7 +88,7 @@ def _backend_of(obj, default: D = unset) -> Backend | D:
         return maybe_lookup(obj)
 
 
-def backend_of(*objects, default: D = unset) -> Backend | D:
+def backend_of(*objects, default: D = UNSET) -> Backend | D:
     """
     Args:
         objects: objects for which to find a suitable backend
@@ -104,7 +104,7 @@ def backend_of(*objects, default: D = unset) -> Backend | D:
 
     if backends:
         return common_backend(backends)
-    elif default is unset:
+    elif default is UNSET:
         raise ValueError("could not find backend for", objects)
     else:
         return default

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -20,7 +20,7 @@ from awkward._parameters import (
     parameters_intersect,
 )
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
-from awkward._util import Sentinel, unset
+from awkward._util import UNSET, Sentinel
 from awkward.contents.bitmaskedarray import BitMaskedArray
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
@@ -426,10 +426,10 @@ def apply_step(
         if not options["allow_records"]:
             raise ValueError(f"cannot broadcast records {in_function(options)}")
 
-        fields, length, istuple = unset, unset, unset
+        fields, length, istuple = UNSET, UNSET, UNSET
         for x in contents:
             if x.is_record:
-                if fields is unset:
+                if fields is UNSET:
                     fields = x.fields
                 elif set(fields) != set(x.fields):
                     raise ValueError(
@@ -440,7 +440,7 @@ def apply_step(
                             ", ".join(sorted(x.fields)),
                         )
                     )
-                if length is unset:
+                if length is UNSET:
                     length = x.length
                 elif length != x.length:
                     raise ValueError(
@@ -450,7 +450,7 @@ def apply_step(
                         )
                     )
                 # Records win over tuples
-                if istuple is unset or not x.is_tuple:
+                if istuple is UNSET or not x.is_tuple:
                     istuple = False
 
         outcontents, numoutputs = [], None

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -20,7 +20,7 @@ from awkward._parameters import (
     parameters_intersect,
 )
 from awkward._typing import Any, Callable, Dict, List, TypeAlias, Union
-from awkward._util import unset
+from awkward._util import Sentinel, unset
 from awkward.contents.bitmaskedarray import BitMaskedArray
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
@@ -173,21 +173,6 @@ def all_same_offsets(backend: Backend, inputs: list) -> bool:
             return False
 
     return True
-
-
-# TODO: move to _util or another module
-class Sentinel:
-    """A class for implementing sentinel types"""
-
-    def __init__(self, name, module=None):
-        self._name = name
-        self._module = module
-
-    def __repr__(self):
-        if self._module is not None:
-            return f"{self._module}.{self._name}"
-        else:
-            return f"{self._name}"
 
 
 NO_PARAMETERS = Sentinel("NO_PARAMETERS", __name__)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -20,7 +20,7 @@ from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
 from awkward._regularize import is_non_string_like_iterable
 from awkward._typing import Iterator
-from awkward._util import numpy_at_least
+from awkward._util import Sentinel, numpy_at_least
 from awkward.contents.numpyarray import NumpyArray
 
 # NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work, which
@@ -30,13 +30,7 @@ if not numpy_at_least("1.13.1"):
     raise ImportError("NumPy 1.13.1 or later required")
 
 
-# FIXME: introduce sentinel type for this
-class _Unsupported:
-    def __repr__(self):
-        return f"{__name__}.unsupported"
-
-
-unsupported = _Unsupported()
+UNSUPPORTED = Sentinel("UNSUPPORTED", __name__)
 
 
 def convert_to_array(layout, args, kwargs):
@@ -124,7 +118,7 @@ def implements(numpy_function):
     def decorator(function):
         signature = inspect.signature(function)
         unsupported_names = {
-            p.name for p in signature.parameters.values() if p.default is unsupported
+            p.name for p in signature.parameters.values() if p.default is UNSUPPORTED
         }
 
         @functools.wraps(function)

--- a/src/awkward/_nplikes/dispatch.py
+++ b/src/awkward/_nplikes/dispatch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from awkward._nplikes.numpylike import NumpyLike
 from awkward._typing import TypeVar
-from awkward._util import unset
+from awkward._util import UNSET
 
 D = TypeVar("D")
 
@@ -19,7 +19,7 @@ def register_nplike(cls: N) -> N:
     return cls
 
 
-def nplike_of(obj, *, default: D = unset) -> NumpyLike | D:
+def nplike_of(obj, *, default: D = UNSET) -> NumpyLike | D:
     """
     Args:
         *arrays: iterable of possible array objects
@@ -41,7 +41,7 @@ def nplike_of(obj, *, default: D = unset) -> NumpyLike | D:
                 nplike = nplike_cls.instance()
                 break
         else:
-            if default is unset:
+            if default is UNSET:
                 raise TypeError(f"cannot find nplike for {cls.__name__}")
             else:
                 return default

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -2,18 +2,16 @@
 from __future__ import annotations
 
 import os
+import struct
 import sys
 from collections.abc import Collection
 
 import packaging.version
 
-from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import TypeVar
 
-np = NumpyMetadata.instance()
-
 win = os.name == "nt"
-bits32 = np.iinfo(np.intp).bits == 32
+bits32 = struct.calcsize("P") * 8 == 32
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -80,18 +80,21 @@ def identifier_hash(str):
     )
 
 
-# FIXME: introduce sentinel type for this
-class _Unset:
+class Sentinel:
+    """A class for implementing sentinel types"""
+
+    def __init__(self, name, module=None):
+        self._name = name
+        self._module = module
+
     def __repr__(self):
-        return f"{__name__}.unset"
+        if self._module is not None:
+            return f"{self._module}.{self._name}"
+        else:
+            return f"{self._name}"
 
 
-unset = _Unset()
-
-
-# Sentinel object for catching pass-through values
-class Unspecified:
-    pass
+unset = Sentinel("UNSET", __name__)
 
 
 T = TypeVar("T")

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+import base64
 import os
 import struct
 import sys
@@ -66,9 +67,6 @@ def native_to_byteorder(array, byteorder: str):
 
 
 def identifier_hash(str):
-    import base64
-    import struct
-
     return (
         base64.encodebytes(struct.pack("q", hash(str)))
         .rstrip(b"=\n")

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -94,7 +94,7 @@ class Sentinel:
             return f"{self._name}"
 
 
-unset = Sentinel("UNSET", __name__)
+UNSET = Sentinel("UNSET", __name__)
 
 
 T = TypeVar("T")

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -17,7 +17,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
 from awkward.forms.bitmaskedform import BitMaskedForm
@@ -205,21 +205,21 @@ class BitMaskedArray(Content):
 
     def copy(
         self,
-        mask=unset,
-        content=unset,
-        valid_when=unset,
-        length=unset,
-        lsb_order=unset,
+        mask=UNSET,
+        content=UNSET,
+        valid_when=UNSET,
+        length=UNSET,
+        lsb_order=UNSET,
         *,
-        parameters=unset,
+        parameters=UNSET,
     ):
         return BitMaskedArray(
-            self._mask if mask is unset else mask,
-            self._content if content is unset else content,
-            self._valid_when if valid_when is unset else valid_when,
-            self._length if length is unset else length,
-            self._lsb_order if lsb_order is unset else lsb_order,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._mask if mask is UNSET else mask,
+            self._content if content is UNSET else content,
+            self._valid_when if valid_when is UNSET else valid_when,
+            self._length if length is UNSET else length,
+            self._lsb_order if lsb_order is UNSET else lsb_order,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -20,7 +20,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.index import Index
@@ -147,12 +147,12 @@ class ByteMaskedArray(Content):
 
     form_cls: Final = ByteMaskedForm
 
-    def copy(self, mask=unset, content=unset, valid_when=unset, *, parameters=unset):
+    def copy(self, mask=UNSET, content=UNSET, valid_when=UNSET, *, parameters=UNSET):
         return ByteMaskedArray(
-            self._mask if mask is unset else mask,
-            self._content if content is unset else content,
-            self._valid_when if valid_when is unset else valid_when,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._mask if mask is UNSET else mask,
+            self._content if content is UNSET else content,
+            self._valid_when if valid_when is UNSET else valid_when,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -37,7 +37,7 @@ from awkward._typing import (
     TypeAlias,
     TypedDict,
 )
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 from awkward.index import Index, Index64
 
@@ -902,13 +902,13 @@ class Content:
             )
         )
         contents = []
-        length = ak._util.unset
+        length = ak._util.UNSET
         for ptr in tocarry:
             contents.append(
                 ak.contents.IndexedArray.simplified(ptr, self, parameters=None)
             )
             length = contents[-1].length
-        assert not (length is ak._util.unset and self._backend.nplike.known_data)
+        assert not (length is ak._util.UNSET and self._backend.nplike.known_data)
         return ak.contents.RecordArray(
             contents, recordlookup, length, parameters=parameters, backend=self._backend
         )
@@ -1312,7 +1312,7 @@ class Content:
     def _fill_none(self, value: Content) -> Content:
         raise NotImplementedError
 
-    def copy(self, *, parameters: JSONMapping | None = unset) -> Self:
+    def copy(self, *, parameters: JSONMapping | None = UNSET) -> Self:
         raise NotImplementedError
 
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -14,7 +14,7 @@ from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.emptyform import EmptyForm
 from awkward.index import Index
@@ -79,16 +79,16 @@ class EmptyArray(Content):
     def copy(
         self,
         *,
-        parameters=unset,
-        backend=unset,
+        parameters=UNSET,
+        backend=UNSET,
     ):
-        if not (parameters is unset or parameters is None or len(parameters) == 0):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             deprecate(
                 f"{type(self).__name__} cannot contain parameters", version="2.2.0"
             )
         return EmptyArray(
-            parameters=self._parameters if parameters is unset else parameters,
-            backend=self._backend if backend is unset else backend,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            backend=self._backend if backend is UNSET else backend,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -18,7 +18,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
@@ -128,11 +128,11 @@ class IndexedArray(Content):
 
     form_cls: Final = IndexedForm
 
-    def copy(self, index=unset, content=unset, *, parameters=unset):
+    def copy(self, index=UNSET, content=UNSET, *, parameters=UNSET):
         return IndexedArray(
-            self._index if index is unset else index,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._index if index is UNSET else index,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -19,7 +19,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
@@ -126,11 +126,11 @@ class IndexedOptionArray(Content):
 
     form_cls: Final = IndexedOptionForm
 
-    def copy(self, index=unset, content=unset, *, parameters=unset):
+    def copy(self, index=UNSET, content=UNSET, *, parameters=UNSET):
         return IndexedOptionArray(
-            self._index if index is unset else index,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._index if index is UNSET else index,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -16,7 +16,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
 from awkward.forms.listform import ListForm
@@ -172,12 +172,12 @@ class ListArray(Content):
 
     form_cls: Final = ListForm
 
-    def copy(self, starts=unset, stops=unset, content=unset, *, parameters=unset):
+    def copy(self, starts=UNSET, stops=UNSET, content=UNSET, *, parameters=UNSET):
         return ListArray(
-            self._starts if starts is unset else starts,
-            self._stops if stops is unset else stops,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._starts if starts is UNSET else starts,
+            self._stops if stops is UNSET else stops,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -17,7 +17,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index
@@ -150,11 +150,11 @@ class ListOffsetArray(Content):
 
     form_cls: Final = ListOffsetForm
 
-    def copy(self, offsets=unset, content=unset, *, parameters=unset):
+    def copy(self, offsets=UNSET, content=UNSET, *, parameters=UNSET):
         return ListOffsetArray(
-            self._offsets if offsets is unset else offsets,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._offsets if offsets is UNSET else offsets,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -22,7 +22,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.numpyform import NumpyForm
 from awkward.index import Index
@@ -128,15 +128,15 @@ class NumpyArray(Content):
 
     def copy(
         self,
-        data=unset,
+        data=UNSET,
         *,
-        parameters=unset,
-        backend=unset,
+        parameters=UNSET,
+        backend=UNSET,
     ):
         return NumpyArray(
-            self._data if data is unset else data,
-            parameters=self._parameters if parameters is unset else parameters,
-            backend=self._backend if backend is unset else backend,
+            self._data if data is UNSET else data,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            backend=self._backend if backend is UNSET else backend,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -22,7 +22,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.recordform import RecordForm
 from awkward.index import Index
@@ -260,19 +260,19 @@ class RecordArray(Content):
 
     def copy(
         self,
-        contents=unset,
-        fields=unset,
-        length=unset,
+        contents=UNSET,
+        fields=UNSET,
+        length=UNSET,
         *,
-        parameters=unset,
-        backend=unset,
+        parameters=UNSET,
+        backend=UNSET,
     ):
         return RecordArray(
-            self._contents if contents is unset else contents,
-            self._fields if fields is unset else fields,
-            self._length if length is unset else length,
-            parameters=self._parameters if parameters is unset else parameters,
-            backend=self._backend if backend is unset else backend,
+            self._contents if contents is UNSET else contents,
+            self._fields if fields is UNSET else fields,
+            self._length if length is UNSET else length,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            backend=self._backend if backend is UNSET else backend,
         )
 
     def __copy__(self):
@@ -742,13 +742,13 @@ class RecordArray(Content):
                     )
 
         nextcontents = []
-        minlength = ak._util.unset
+        minlength = ak._util.UNSET
         for forfield in for_each_field:
             merged = forfield[0]._mergemany(forfield[1:])
 
             nextcontents.append(merged)
 
-            if minlength is ak._util.unset or (
+            if minlength is ak._util.UNSET or (
                 not (merged.length is unknown_length or minlength is unknown_length)
                 and merged.length < minlength
             ):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -17,7 +17,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.regularform import RegularForm
 from awkward.index import Index
@@ -175,12 +175,12 @@ class RegularArray(Content):
 
     form_cls: Final = RegularForm
 
-    def copy(self, content=unset, size=unset, zeros_length=unset, *, parameters=unset):
+    def copy(self, content=UNSET, size=UNSET, zeros_length=UNSET, *, parameters=UNSET):
         return RegularArray(
-            self._content if content is unset else content,
-            self._size if size is unset else size,
-            self._length if zeros_length is unset else zeros_length,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._content if content is UNSET else content,
+            self._size if size is UNSET else size,
+            self._length if zeros_length is UNSET else zeros_length,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):
@@ -940,11 +940,11 @@ class RegularArray(Content):
                 )
 
             contents = []
-            length = unset
+            length = UNSET
             for ptr in tocarry:
                 contents.append(self._content._carry(ptr, True))
                 length = contents[-1].length
-            assert length is not unset
+            assert length is not UNSET
             recordarray = ak.contents.RecordArray(
                 contents,
                 recordlookup,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -19,7 +19,7 @@ from awkward._parameters import parameters_intersect, parameters_union
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
@@ -188,17 +188,17 @@ class UnionArray(Content):
 
     def copy(
         self,
-        tags=unset,
-        index=unset,
-        contents=unset,
+        tags=UNSET,
+        index=UNSET,
+        contents=UNSET,
         *,
-        parameters=unset,
+        parameters=UNSET,
     ):
         return UnionArray(
-            self._tags if tags is unset else tags,
-            self._index if index is unset else index,
-            self._contents if contents is unset else contents,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._tags if tags is UNSET else tags,
+            self._index if index is UNSET else index,
+            self._contents if contents is UNSET else contents,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -19,7 +19,7 @@ from awkward._parameters import (
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Final, Self, SupportsIndex, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.index import Index
@@ -89,10 +89,10 @@ class UnmaskedArray(Content):
 
     form_cls: Final = UnmaskedForm
 
-    def copy(self, content=unset, *, parameters=unset):
+    def copy(self, content=UNSET, *, parameters=UNSET):
         return UnmaskedArray(
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
         )
 
     def __copy__(self):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -70,21 +70,21 @@ class BitMaskedForm(Form):
 
     def copy(
         self,
-        mask=unset,
-        content=unset,
-        valid_when=unset,
-        lsb_order=unset,
+        mask=UNSET,
+        content=UNSET,
+        valid_when=UNSET,
+        lsb_order=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return BitMaskedForm(
-            self._mask if mask is unset else mask,
-            self._content if content is unset else content,
-            self._valid_when if valid_when is unset else valid_when,
-            self._lsb_order if lsb_order is unset else lsb_order,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._mask if mask is UNSET else mask,
+            self._content if content is UNSET else content,
+            self._valid_when if valid_when is UNSET else valid_when,
+            self._lsb_order if lsb_order is UNSET else lsb_order,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -58,19 +58,19 @@ class ByteMaskedForm(Form):
 
     def copy(
         self,
-        mask=unset,
-        content=unset,
-        valid_when=unset,
+        mask=UNSET,
+        content=UNSET,
+        valid_when=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return ByteMaskedForm(
-            self._mask if mask is unset else mask,
-            self._content if content is unset else content,
-            self._valid_when if valid_when is unset else valid_when,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._mask if mask is UNSET else mask,
+            self._content if content is UNSET else content,
+            self._valid_when if valid_when is UNSET else valid_when,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -5,7 +5,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._errors import deprecate
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form, JSONMapping
 
 
@@ -22,15 +22,15 @@ class EmptyForm(Form):
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
-        self, *, parameters: JSONMapping | None = unset, form_key=unset
+        self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
-        if not (parameters is unset or parameters is None or len(parameters) == 0):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             deprecate(
                 f"{type(self).__name__} cannot contain parameters", version="2.2.0"
             )
         return EmptyForm(
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -3,7 +3,7 @@
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -46,17 +46,17 @@ class IndexedForm(Form):
 
     def copy(
         self,
-        index=unset,
-        content=unset,
+        index=UNSET,
+        content=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return IndexedForm(
-            self._index if index is unset else index,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._index if index is UNSET else index,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -47,17 +47,17 @@ class IndexedOptionForm(Form):
 
     def copy(
         self,
-        index=unset,
-        content=unset,
+        index=UNSET,
+        content=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return IndexedOptionForm(
-            self._index if index is unset else index,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._index if index is UNSET else index,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -58,19 +58,19 @@ class ListForm(Form):
 
     def copy(
         self,
-        starts=unset,
-        stops=unset,
-        content=unset,
+        starts=UNSET,
+        stops=UNSET,
+        content=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return ListForm(
-            self._starts if starts is unset else starts,
-            self._stops if stops is unset else stops,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._starts if starts is UNSET else starts,
+            self._stops if stops is UNSET else stops,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -33,17 +33,17 @@ class ListOffsetForm(Form):
 
     def copy(
         self,
-        offsets=unset,
-        content=unset,
+        offsets=UNSET,
+        content=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return ListOffsetForm(
-            self._offsets if offsets is unset else offsets,
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._offsets if offsets is UNSET else offsets,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -6,7 +6,7 @@ from awkward._behavior import find_typestr
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 np = NumpyMetadata.instance()
@@ -73,17 +73,17 @@ class NumpyForm(Form):
 
     def copy(
         self,
-        primitive=unset,
-        inner_shape=unset,
+        primitive=UNSET,
+        inner_shape=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return NumpyForm(
-            self._primitive if primitive is unset else primitive,
-            self._inner_shape if inner_shape is unset else inner_shape,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._primitive if primitive is UNSET else primitive,
+            self._inner_shape if inner_shape is UNSET else inner_shape,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -7,7 +7,7 @@ from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -60,17 +60,17 @@ class RecordForm(Form):
 
     def copy(
         self,
-        contents=unset,
-        fields=unset,
+        contents=UNSET,
+        fields=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return RecordForm(
-            self._contents if contents is unset else contents,
-            self._fields if fields is unset else fields,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._contents if contents is UNSET else contents,
+            self._fields if fields is UNSET else fields,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -5,7 +5,7 @@ from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -40,12 +40,12 @@ class RegularForm(Form):
     def size(self):
         return self._size
 
-    def copy(self, content=unset, size=unset, *, parameters=unset, form_key=unset):
+    def copy(self, content=UNSET, size=UNSET, *, parameters=UNSET, form_key=UNSET):
         return RegularForm(
-            self._content if content is unset else content,
-            self._size if size is unset else size,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._content if content is UNSET else content,
+            self._size if size is UNSET else size,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -6,7 +6,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -68,19 +68,19 @@ class UnionForm(Form):
 
     def copy(
         self,
-        tags=unset,
-        index=unset,
-        contents=unset,
+        tags=UNSET,
+        index=UNSET,
+        contents=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return UnionForm(
-            self._tags if tags is unset else tags,
-            self._index if index is unset else index,
-            self._contents if contents is unset else contents,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._tags if tags is UNSET else tags,
+            self._index if index is UNSET else index,
+            self._contents if contents is UNSET else contents,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._behavior import find_typestr
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.forms.form import Form
 
 
@@ -34,15 +34,15 @@ class UnmaskedForm(Form):
 
     def copy(
         self,
-        content=unset,
+        content=UNSET,
         *,
-        parameters=unset,
-        form_key=unset,
+        parameters=UNSET,
+        form_key=UNSET,
     ):
         return UnmaskedForm(
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            form_key=self._form_key if form_key is unset else form_key,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -2,7 +2,7 @@
 __all__ = ("all",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -86,5 +86,5 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("all")
-def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False, *, where=unsupported):
+def _nep_18_impl(a, axis=None, out=UNSUPPORTED, keepdims=False, *, where=UNSUPPORTED):
     return all(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -2,7 +2,7 @@
 __all__ = ("any",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -86,5 +86,5 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("any")
-def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False, *, where=unsupported):
+def _nep_18_impl(a, axis=None, out=UNSUPPORTED, keepdims=False, *, where=UNSUPPORTED):
     return any(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -2,7 +2,7 @@
 __all__ = ("argmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -148,10 +148,10 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("argmax")
-def _nep_18_impl_argmax(a, axis=None, out=unsupported, *, keepdims=False):
+def _nep_18_impl_argmax(a, axis=None, out=UNSUPPORTED, *, keepdims=False):
     return argmax(a, axis=axis, keepdims=keepdims)
 
 
 @ak._connect.numpy.implements("nanargmax")
-def _nep_18_impl_nanargmax(a, axis=None, out=unsupported, *, keepdims=False):
+def _nep_18_impl_nanargmax(a, axis=None, out=UNSUPPORTED, *, keepdims=False):
     return nanargmax(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -2,7 +2,7 @@
 __all__ = ("argmin",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -147,10 +147,10 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("argmin")
-def _nep_18_impl_argmin(a, axis=None, out=unsupported, *, keepdims=False):
+def _nep_18_impl_argmin(a, axis=None, out=UNSUPPORTED, *, keepdims=False):
     return argmin(a, axis=axis, keepdims=keepdims)
 
 
 @ak._connect.numpy.implements("nanargmin")
-def _nep_18_impl_nanargmin(a, axis=None, out=unsupported, *, keepdims=False):
+def _nep_18_impl_nanargmin(a, axis=None, out=UNSUPPORTED, *, keepdims=False):
     return nanargmin(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argsort",)
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -69,7 +69,7 @@ def _impl(array, axis, ascending, stable, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("argsort")
-def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
+def _nep_18_impl(a, axis=-1, kind=None, order=UNSUPPORTED):
     if kind is None:
         stable = False
     elif kind in ("stable", "mergesort"):

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -249,5 +249,5 @@ def _impl(
 
 
 @ak._connect.numpy.implements("broadcast_arrays")
-def _nep_18_impl(*args, subok=unsupported):
+def _nep_18_impl(*args, subok=UNSUPPORTED):
     return broadcast_arrays(*args)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -4,7 +4,7 @@ __all__ = ("copy",)
 import copy as _copy
 
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -70,5 +70,5 @@ def _impl(array):
 
 
 @ak._connect.numpy.implements("copy")
-def _nep_18_impl(a, order=unsupported, subok=unsupported):
+def _nep_18_impl(a, order=UNSUPPORTED, subok=UNSUPPORTED):
     return copy(a)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -2,7 +2,7 @@
 __all__ = ("full_like",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import ensure_known_scalar
@@ -213,6 +213,6 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown):
 
 @ak._connect.numpy.implements("full_like")
 def _nep_18_impl(
-    a, fill_value, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+    a, fill_value, dtype=None, order=UNSUPPORTED, subok=UNSUPPORTED, shape=UNSUPPORTED
 ):
     return full_like(a, fill_value=fill_value, dtype=dtype)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -2,7 +2,7 @@
 __all__ = ("max",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -169,13 +169,13 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
 
 @ak._connect.numpy.implements("amax")
 def _nep_18_impl_amax(
-    a, axis=None, out=unsupported, keepdims=False, initial=None, where=unsupported
+    a, axis=None, out=UNSUPPORTED, keepdims=False, initial=None, where=UNSUPPORTED
 ):
     return max(a, axis=axis, keepdims=keepdims, initial=initial)
 
 
 @ak._connect.numpy.implements("nanmax")
 def _nep_18_impl_nanmax(
-    a, axis=None, out=unsupported, keepdims=False, initial=None, where=unsupported
+    a, axis=None, out=UNSUPPORTED, keepdims=False, initial=None, where=UNSUPPORTED
 ):
     return nanmax(a, axis=axis, keepdims=keepdims, initial=initial)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -2,7 +2,7 @@
 __all__ = ("mean",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -218,11 +218,11 @@ def _impl(x, weight, axis, keepdims, mask_identity):
 def _nep_18_impl_mean(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return mean(a, axis=axis, keepdims=keepdims)
 
@@ -231,10 +231,10 @@ def _nep_18_impl_mean(
 def _nep_18_impl_nanmean(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return nanmean(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -2,7 +2,7 @@
 __all__ = ("min",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -169,10 +169,10 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):
 def _nep_18_impl_amin(
     a,
     axis=None,
-    out=unsupported,
+    out=UNSUPPORTED,
     keepdims=False,
     initial=None,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return min(a, axis=axis, keepdims=keepdims, initial=initial)
 
@@ -181,9 +181,9 @@ def _nep_18_impl_amin(
 def _nep_18_impl_nanmin(
     a,
     axis=None,
-    out=unsupported,
+    out=UNSUPPORTED,
     keepdims=False,
     initial=None,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return nanmin(a, axis=axis, keepdims=keepdims, initial=initial)

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -2,7 +2,7 @@
 __all__ = ("ones_like",)
 
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -51,6 +51,6 @@ def _impl(array, highlevel, behavior, dtype, including_unknown):
 
 @ak._connect.numpy.implements("ones_like")
 def _nep_18_impl(
-    a, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+    a, dtype=None, order=UNSUPPORTED, subok=UNSUPPORTED, shape=UNSUPPORTED
 ):
     return ones_like(a, dtype=dtype)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -2,7 +2,7 @@
 __all__ = ("prod",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -140,11 +140,11 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 def _nep_18_impl_prod(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
-    initial=unsupported,
-    where=unsupported,
+    initial=UNSUPPORTED,
+    where=UNSUPPORTED,
 ):
     return prod(a, axis=axis, keepdims=keepdims)
 
@@ -153,10 +153,10 @@ def _nep_18_impl_prod(
 def _nep_18_impl_nanprod(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
-    initial=unsupported,
-    where=unsupported,
+    initial=UNSUPPORTED,
+    where=UNSUPPORTED,
 ):
     return nanprod(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -2,7 +2,7 @@
 __all__ = ("ptp",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -113,5 +113,5 @@ def _impl(array, axis, keepdims, mask_identity):
 
 
 @ak._connect.numpy.implements("ptp")
-def _nep_18_impl(a, axis=None, out=unsupported, keepdims=False):
+def _nep_18_impl(a, axis=None, out=UNSUPPORTED, keepdims=False):
     return ptp(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("ravel",)
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -70,5 +70,5 @@ def _impl(array, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("ravel")
-def _nep_18_impl(a, order=unsupported):
+def _nep_18_impl(a, order=UNSUPPORTED):
     return ravel(a)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("sort",)
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -56,7 +56,7 @@ def _impl(array, axis, ascending, stable, highlevel, behavior):
 
 
 @ak._connect.numpy.implements("sort")
-def _nep_18_impl(a, axis=-1, kind=None, order=unsupported):
+def _nep_18_impl(a, axis=-1, kind=None, order=UNSUPPORTED):
     if kind is None:
         stable = False
     elif kind in ("stable", "mergesort"):

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -2,7 +2,7 @@
 __all__ = ("std",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -181,12 +181,12 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
 def _nep_18_impl_std(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     ddof=0,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return std(a, axis=axis, keepdims=keepdims, ddof=ddof)
 
@@ -195,11 +195,11 @@ def _nep_18_impl_std(
 def _nep_18_impl_nanstd(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     ddof=0,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return nanstd(a, axis=axis, keepdims=keepdims, ddof=ddof)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -2,7 +2,7 @@
 __all__ = ("sum",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -288,11 +288,11 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):
 def _nep_18_impl_sum(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
-    initial=unsupported,
-    where=unsupported,
+    initial=UNSUPPORTED,
+    where=UNSUPPORTED,
 ):
     return sum(a, axis=axis, keepdims=keepdims)
 
@@ -301,10 +301,10 @@ def _nep_18_impl_sum(
 def _nep_18_impl_nansum(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     keepdims=False,
-    initial=unsupported,
-    where=unsupported,
+    initial=UNSUPPORTED,
+    where=UNSUPPORTED,
 ):
     return nansum(a, axis=axis, keepdims=keepdims)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -2,7 +2,7 @@
 __all__ = ("var",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -217,12 +217,12 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity):
 def _nep_18_impl_var(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     ddof=0,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return var(a, axis=axis, keepdims=keepdims, ddof=ddof)
 
@@ -231,11 +231,11 @@ def _nep_18_impl_var(
 def _nep_18_impl_nanvar(
     a,
     axis=None,
-    dtype=unsupported,
-    out=unsupported,
+    dtype=UNSUPPORTED,
+    out=UNSUPPORTED,
     ddof=0,
     keepdims=False,
     *,
-    where=unsupported,
+    where=UNSUPPORTED,
 ):
     return nanvar(a, axis=axis, keepdims=keepdims, ddof=ddof)

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -2,7 +2,7 @@
 __all__ = ("zeros_like",)
 
 import awkward as ak
-from awkward._connect.numpy import unsupported
+from awkward._connect.numpy import UNSUPPORTED
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -58,6 +58,6 @@ def _impl(array, highlevel, behavior, dtype, including_unknown):
 
 @ak._connect.numpy.implements("zeros_like")
 def _nep_18_impl(
-    a, dtype=None, order=unsupported, subok=unsupported, shape=unsupported
+    a, dtype=None, order=UNSUPPORTED, subok=UNSUPPORTED, shape=UNSUPPORTED
 ):
     return zeros_like(a, dtype=dtype)

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -16,7 +16,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer
 from awkward._typing import Self
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.contents.content import Content
 
 np = NumpyMetadata.instance()
@@ -244,9 +244,9 @@ class Record:
     def __deepcopy__(self, memo):
         return Record(copy.deepcopy(self._array, memo), self._at)
 
-    def copy(self, array=unset, at=unset) -> Self:
+    def copy(self, array=UNSET, at=UNSET) -> Self:
         return Record(
-            self._array if array is unset else array, self._at if at is unset else at
+            self._array if array is UNSET else array, self._at if at is UNSET else at
         )
 
 

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 
 @final
 class ListType(Type):
-    def copy(self, *, content: Type = unset, parameters=unset, typestr=unset) -> Self:
+    def copy(self, *, content: Type = UNSET, parameters=UNSET, typestr=UNSET) -> Self:
         return ListType(
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, content, *, parameters=None, typestr=None):

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -7,7 +7,7 @@ import re
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 np = NumpyMetadata.instance()
@@ -93,11 +93,11 @@ for primitive, dtype in _primitive_to_dtype_dict.items():
 
 @final
 class NumpyType(Type):
-    def copy(self, *, primitive: Type = unset, parameters=unset, typestr=unset) -> Self:
+    def copy(self, *, primitive: Type = UNSET, parameters=UNSET, typestr=UNSET) -> Self:
         return NumpyType(
-            self._primitive if primitive is unset else primitive,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._primitive if primitive is UNSET else primitive,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, primitive, *, parameters=None, typestr=None):

--- a/src/awkward/types/optiontype.py
+++ b/src/awkward/types/optiontype.py
@@ -7,7 +7,7 @@ from awkward._parameters import (
     type_parameters_equal,
 )
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.listtype import ListType
 from awkward.types.regulartype import RegularType
 from awkward.types.type import Type
@@ -16,11 +16,11 @@ from awkward.types.uniontype import UnionType
 
 @final
 class OptionType(Type):
-    def copy(self, *, content: Type = unset, parameters=unset, typestr=unset) -> Self:
+    def copy(self, *, content: Type = UNSET, parameters=UNSET, typestr=UNSET) -> Self:
         return OptionType(
-            self._content if content is unset else content,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._content if content is UNSET else content,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, content, *, parameters=None, typestr=None):

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -9,7 +9,7 @@ import awkward as ak
 import awkward._prettyprint
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 
@@ -18,16 +18,16 @@ class RecordType(Type):
     def copy(
         self,
         *,
-        contents: list[Type] = unset,
-        fields: list[str] | None = unset,
-        parameters=unset,
-        typestr=unset,
+        contents: list[Type] = UNSET,
+        fields: list[str] | None = UNSET,
+        parameters=UNSET,
+        typestr=UNSET,
     ) -> Self:
         return RecordType(
-            self._contents if contents is unset else contents,
-            self._fields if fields is unset else fields,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._contents if contents is UNSET else contents,
+            self._fields if fields is UNSET else fields,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, contents, fields, *, parameters=None, typestr=None):

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -5,7 +5,7 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 
@@ -14,16 +14,16 @@ class RegularType(Type):
     def copy(
         self,
         *,
-        content: Type = unset,
-        size: ShapeItem = unset,
-        parameters=unset,
-        typestr=unset,
+        content: Type = UNSET,
+        size: ShapeItem = UNSET,
+        parameters=UNSET,
+        typestr=UNSET,
     ) -> Self:
         return RegularType(
-            self._content if content is unset else content,
-            size=self._size if size is unset else size,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._content if content is UNSET else content,
+            size=self._size if size is UNSET else size,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, content, size, *, parameters=None, typestr=None):

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -7,14 +7,14 @@ import sys
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import Self
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types._awkward_datashape_parser import Lark_StandAlone, Transformer
 
 np = NumpyMetadata.instance()
 
 
 class Type:
-    def copy(self, *, parameters=unset, typestr=unset) -> Self:
+    def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
         raise NotImplementedError
 
     @property

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -6,19 +6,19 @@ from itertools import permutations
 
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 
 @final
 class UnionType(Type):
     def copy(
-        self, *, contents: list[Type] = unset, parameters=unset, typestr=unset
+        self, *, contents: list[Type] = UNSET, parameters=UNSET, typestr=UNSET
     ) -> Self:
         return UnionType(
-            self._contents if contents is unset else contents,
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            self._contents if contents is UNSET else contents,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, contents, *, parameters=None, typestr=None):

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 from awkward._errors import deprecate
 from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
-from awkward._util import unset
+from awkward._util import UNSET
 from awkward.types.type import Type
 
 
 @final
 class UnknownType(Type):
-    def copy(self, *, parameters=unset, typestr=unset) -> Self:
+    def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
         return UnknownType(
-            parameters=self._parameters if parameters is unset else parameters,
-            typestr=self._typestr if typestr is unset else typestr,
+            parameters=self._parameters if parameters is UNSET else parameters,
+            typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, *, parameters=None, typestr=None):


### PR DESCRIPTION
For a while we've wanted a `Sentinel` class, but it's not been clear where to put it such that our imports don't tangle. After #2131 and friends, we have much leaner modules, and it's safe to put this in `ak._util`.

Also, generally PEP8 encourages uppercase constants, which I consider sentinels to be.