### PR TITLE
fix: handle indexed nodes in `ak.almost_equal`

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -68,8 +68,14 @@ def almost_equal(
         # Enforce super-canonicalisation rules
         if left.is_option:
             left = left.to_IndexedOptionArray64()
+        # Project out indexed-of-record (comes from e.g. `RegularArray.to_ListOffsetArray64()`)
+        elif left.is_indexed:
+            left = left.project()
         if right.is_option:
             right = right.to_IndexedOptionArray64()
+        # Project out indexed-of-record
+        elif right.is_indexed:
+            right = right.project()
 
         if type(left) is not type(right):
             if not check_regular and (

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -84,7 +84,7 @@ def almost_equal(
         # Simplify regular NumPy types
         if left.is_numpy and left.purelist_depth > 1:
             left = left.to_RegularArray()
-        if right.is_regular and right.purelist_depth > 1:
+        if right.is_numpy and right.purelist_depth > 1:
             right = right.to_RegularArray()
 
         # Different lengths aren't equal!
@@ -111,12 +111,12 @@ def almost_equal(
         elif left.is_list and right.is_list:
             # Mixed regular-var
             if left.is_regular and not right.is_regular:
-                return check_regular and visitor(
+                return (not check_regular) and visitor(
                     left.content,
                     packed_list_content(right),
                 )
             elif right.is_regular and not left.is_regular:
-                return check_regular and visitor(
+                return (not check_regular) and visitor(
                     packed_list_content(left),
                     right.content,
                 )

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -80,7 +80,7 @@ def almost_equal(
         # Simplify regular NumPy types
         if left.is_numpy and left.purelist_depth > 1:
             left = left.to_RegularArray()
-        if right.is_regular and left.purelist_depth > 1:
+        if right.is_regular and right.purelist_depth > 1:
             right = right.to_RegularArray()
 
         # Different lengths aren't equal!

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -149,3 +149,19 @@ def test_typetracer():
     array = ak.Array([[[1, 2, 3]], [[5, 4]]], backend="typetracer")
     with pytest.raises(NotImplementedError):
         ak.almost_equal(array, 2 * array)
+
+
+def test_indexed():
+    assert ak.almost_equal(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 2, 4, 8]),
+            ak.contents.IndexedArray(
+                ak.index.Index64([0, 1, 2, 3, 2, 1, 0, 5]),
+                ak.contents.NumpyArray(np.arange(6, dtype=np.int64)),
+            ),
+        ),
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 2, 4, 8]),
+            ak.contents.NumpyArray(np.array([0, 1, 2, 3, 2, 1, 0, 5], dtype=np.int64)),
+        ),
+    )


### PR DESCRIPTION
This PR:
- Adds handling of `IndexedArray` nodes to `ak.almost_equal` (these come from carrying a `RecordArray`)
- Replaces use of `layout.to_packed()` with explicit packing logic

(2) makes our code more predictable; there are exemptions to packing rules that make it more of an obfuscation than code re-use to rely on `to_packed()`.

By simplifying the switch case, we now don't explicitly catch non-implemented cases. I think, however, this logic is already exhaustive in the valid combinations (`list-list`, `option-option`, etc.)