### PR TITLE
fix: touch offsets in kernel call

### DIFF
--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -386,6 +386,7 @@ class ListArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
+            offsets.touch_data()
         return ListOffsetArray._broadcast_tooffsets64(self, offsets)
 
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -384,6 +384,8 @@ class ListArray(Content):
         return out
 
     def _broadcast_tooffsets64(self, offsets):
+        if not self.backend.index_nplike.known_data:
+            self._touch_data(recursive=False)
         return ListOffsetArray._broadcast_tooffsets64(self, offsets)
 
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -386,7 +386,7 @@ class ListArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
-            offsets.touch_data()
+            offsets.data.touch_data()
         return ListOffsetArray._broadcast_tooffsets64(self, offsets)
 
     def _getitem_next_jagged(self, slicestarts, slicestops, slicecontent, tail):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2077,11 +2077,15 @@ class ListOffsetArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        offsetsmin = self._offsets[0]
-        offsets = ak.index.Index(
-            self._offsets.data - offsetsmin, nplike=self._backend.index_nplike
-        )
-        content = self._content[offsetsmin : self._offsets[-1]]
+        if self._backend.nplike.known_data:
+            offsetsmin = self._offsets[0]
+            offsets = ak.index.Index(
+                self._offsets.data - offsetsmin, nplike=self._backend.index_nplike
+            )
+            content = self._content[offsetsmin : self._offsets[-1]]
+        else:
+            self._touch_data(recursive=False)
+            offsets, content = self._offsets, self._content
 
         if options["return_array"]:
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -371,7 +371,7 @@ class ListOffsetArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
-            offsets.touch_data()
+            offsets.data.touch_data()
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -371,6 +371,7 @@ class ListOffsetArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
+            offsets.touch_data()
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -369,6 +369,8 @@ class ListOffsetArray(Content):
         return out
 
     def _broadcast_tooffsets64(self, offsets):
+        if not self.backend.index_nplike.known_data:
+            self._touch_data(recursive=False)
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(
@@ -2074,15 +2076,11 @@ class ListOffsetArray(Content):
     def _recursively_apply(
         self, action, behavior, depth, depth_context, lateral_context, options
     ):
-        if self._backend.nplike.known_data:
-            offsetsmin = self._offsets[0]
-            offsets = ak.index.Index(
-                self._offsets.data - offsetsmin, nplike=self._backend.index_nplike
-            )
-            content = self._content[offsetsmin : self._offsets[-1]]
-        else:
-            self._touch_data(recursive=False)
-            offsets, content = self._offsets, self._content
+        offsetsmin = self._offsets[0]
+        offsets = ak.index.Index(
+            self._offsets.data - offsetsmin, nplike=self._backend.index_nplike
+        )
+        content = self._content[offsetsmin : self._offsets[-1]]
 
         if options["return_array"]:
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -392,6 +392,8 @@ class RegularArray(Content):
         return out
 
     def _broadcast_tooffsets64(self, offsets):
+        if not self.backend.index_nplike.known_data:
+            self._touch_data(recursive=False)
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -394,7 +394,7 @@ class RegularArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
-            offsets.touch_data()
+            offsets.data.touch_data()
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -394,6 +394,7 @@ class RegularArray(Content):
     def _broadcast_tooffsets64(self, offsets):
         if not self.backend.index_nplike.known_data:
             self._touch_data(recursive=False)
+            offsets.touch_data()
         if offsets.nplike.known_data and (offsets.length == 0 or offsets[0] != 0):
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with offsets that start at 0, not {}".format(


### PR DESCRIPTION
This kernel reads the values of `offsets`, so it should trigger a touch.

I recall seeing a place in awkward where we didn't make these touches before invoking this function; really, we should perform touches as-close-to the functions that would actually touch the 