### PR TITLE
fix!: raise error when flattening strings

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -718,6 +718,15 @@ class ListOffsetArray(Content):
             raise AxisError("axis=0 not allowed for flatten")
 
         elif posaxis is not None and posaxis + 1 == depth + 1:
+            if (
+                self.parameter("__array__") == "string"
+                or self.parameter("__array__") == "bytestring"
+            ):
+                raise ValueError(
+                    "array of strings cannot be directly flattened. "
+                    'To flatten this array, drop the `"__array__"="string"` parameter using '
+                    "`ak.enforce_type`, `ak.with_parameter`, or `ak.without_parameters`/"
+                )
             listoffsetarray = self.to_ListOffsetArray64(True)
             stop = listoffsetarray.offsets[-1]
             content = listoffsetarray.content._getitem_range(0, stop)

--- a/tests/test_2471_flatten_string.py
+++ b/tests/test_2471_flatten_string.py
@@ -1,0 +1,26 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array(
+        ["is", "this", "real", "life", "or", "is", "this", "just", "fantasy"]
+    )
+    with pytest.raises(ValueError, match=r"strings cannot be directly flattened"):
+        ak.flatten(array, axis=1)
+
+    array = ak.Array(
+        ["is", "this", "real", "life", "or", "is", "this", "just", "fantasy"]
+    )
+    assert ak.to_layout(array) == ak.flatten(array, axis=0, highlevel=False)
+
+    array_ragged = ak.Array(
+        [["is", "this", "real", "life"], ["or", "is", "this", "just", "fantasy"]]
+    )
+    assert ak.almost_equal(array, ak.flatten(array_ragged, axis=1))
+
+    with pytest.raises(ValueError, match=r"strings cannot be directly flattened"):
+        ak.flatten(array_ragged, axis=2)


### PR DESCRIPTION
We consider strings to be a relatively strong abstraction, so we should error when trying to flatten them at axis=0. To be able to flatten these arrays, users should change their type, e.g. with `ak.ensure_type`

```python
>>> import awkward as ak
>>> ak.flatten(["this", "and", "that"], axis=1)
ValueError: array of strings cannot be directly flattened. To flatten this array, drop the `"__array__"="string"` parameter using `ak.enforce_type`, `ak.with_parameter`, or `ak.without_parameters`/

This error occurred while calling

    ak.flatten(
        array = ['this', 'and', 'that']
        axis = 1
        highlevel = True
        behavior = None
    )
>>> ak.flatten(
...     ak.enforce_type(["this", "and", "that"], "var * char"),
... axis=1)
'thisandthat'
```


Fixes #2455 