### PR TITLE
feat!: drop string broadcasting overloading

### DIFF
--- a/docs/reference/ak.behavior.md
+++ b/docs/reference/ak.behavior.md
@@ -570,50 +570,6 @@ so that
 3 * string
 ```
 
-## Custom broadcasting
-
-In situations where we want to think about lists as objects, such as strings,
-we may even need to override the broadcasting rules. For instance, given
-
-```python
-ak.Array(["HAL"]) + ak.Array([[1, 1, 1, 1, 1]])
-```
-
-we might expect `"HAL"` to broadcast to each `1`, like
-
-```python
-[[[73, 66, 77], [73, 66, 77], [73, 66, 77], [73, 66, 77], [73, 66, 77]]]
-```
-
-but (without custom broadcasting) instead it raises a broadcasting for any
-length of `1` list other than 3:
-
-```python
->>> # without custom broadcasting
->>> print(ak.Array(["HAL"]) + ak.Array([[1, 1, 1, 1, 1]]))
-ValueError: in ListOffsetArray64, cannot broadcast nested list
->>> print(ak.Array(["HAL"]) + ak.Array([[1, 1, 1]]))
-[[73, 66, 77]]
-```
-
-It's matching each character of `"HAL"` with a number from the list, but we
-want the string to be taken as an object. That is fixed (in
-`ak.behaviors.string`) with a custom broadcasting rule:
-
-```python
-def _string_broadcast(layout, offsets):
-    # layout:  an ak.layout.Content object
-    # offsets: an ak.layout.Index of offsets to match
-    #
-    # should return: an ak.layout.Content object of the broadcasted result
-    ...
-
-awkward.behavior["__broadcast__", "string"] = _string_broadcast
-```
-
-Very few applications would need to do this, but the {data}`ak.behavior` object
-provides a lot of room for customization hooks like this.
-
 ## Overriding behavior in Numba
 
 Awkward Arrays can be arguments and return values of functions compiled with

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -67,19 +67,6 @@ def find_custom_cast(obj, behavior):
     return None
 
 
-def find_custom_broadcast(layout, behavior):
-    behavior = overlay_behavior(behavior)
-    custom = layout.parameter("__array__")
-    if custom is None:
-        custom = layout.parameter("__record__")
-    if custom is None:
-        custom = layout.purelist_parameter("__record__")
-    if isinstance(custom, str):
-        return behavior.get(("__broadcast__", custom))
-    else:
-        return None
-
-
 def find_ufunc_generic(ufunc, layout, behavior):
     behavior = overlay_behavior(behavior)
     custom = layout.parameter("__array__")

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
-from awkward._behavior import is_subtype
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -709,9 +708,10 @@ def apply_step(
             input_is_string = []
             for x in inputs:
                 if isinstance(x, Content):
-                    content_is_string = is_subtype(
-                        behavior, x.parameter("__array__"), "stringlike"
-                    )
+                    content_is_string = x.parameter("__array__") in {
+                        "string",
+                        "bytestring",
+                    }
                     # Don't try and take offsets from strings
                     if not content_is_string:
                         all_content_strings = False

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -147,20 +147,6 @@ def _string_notequal(one, two):
     return ~_string_equal(one, two)
 
 
-def _string_broadcast(layout, offsets):
-    index_nplike = layout.backend.index_nplike
-    offsets = index_nplike.asarray(offsets)
-    counts = offsets[1:] - offsets[:-1]
-    if ak._util.win or ak._util.bits32:
-        counts = index_nplike.astype(counts, dtype=np.int32)
-    parents = index_nplike.repeat(
-        index_nplike.arange(counts.size, dtype=counts.dtype), counts
-    )
-    return ak.contents.IndexedArray(
-        ak.index.Index64(parents, nplike=index_nplike), layout
-    ).project()
-
-
 def _string_numba_typer(viewtype):
     import numba
 
@@ -266,9 +252,6 @@ def register(behavior):
     behavior[ufuncs.equal, "string", "string"] = _string_equal
     behavior[ufuncs.not_equal, "bytestring", "bytestring"] = _string_notequal
     behavior[ufuncs.not_equal, "string", "string"] = _string_notequal
-
-    behavior["__broadcast__", "bytestring"] = _string_broadcast
-    behavior["__broadcast__", "string"] = _string_broadcast
 
     behavior["__numba_typer__", "bytestring"] = _string_numba_typer
     behavior["__numba_lower__", "bytestring"] = _string_numba_lower


### PR DESCRIPTION
We are planning to remove this feature and replace it with more string-focussed customisation. This PR removes the custom broadcasting in anticipation for that change.

Partially addresses #2432