### PR TITLE
refactor: cleanup and type hints

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -274,6 +274,9 @@ class ArrayModuleNumpyLike(NumpyLike):
     def broadcast_to(self, x: ArrayLike, shape: tuple[ShapeItem, ...]) -> ArrayLike:
         return self._module.broadcast_to(x, shape)
 
+    def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
+        return x.strides
+
     ############################ ufuncs
 
     def add(

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -5,6 +5,7 @@ import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpylike import ArrayLike
+from awkward._nplikes.shape import ShapeItem
 from awkward._typing import Final
 
 
@@ -74,3 +75,10 @@ class Jax(ArrayModuleNumpyLike):
 
     def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
         return x
+
+    def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
+        x.touch_shape()
+        out = (x._dtype.itemsize,)
+        for item in reversed(x._shape):
+            out = (item * out[0], *out)
+        return out

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -45,11 +45,6 @@ class ArrayLike(Protocol):
 
     @property
     @abstractmethod
-    def strides(self) -> tuple[ShapeItem, ...]:
-        ...
-
-    @property
-    @abstractmethod
     def size(self) -> ShapeItem:
         ...
 
@@ -481,6 +476,10 @@ class NumpyLike(Singleton, Protocol):
         count: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLike:
+        ...
+
+    @abstractmethod
+    def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
         ...
 
     ############################ ufuncs

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -45,6 +45,11 @@ class ArrayLike(Protocol):
 
     @property
     @abstractmethod
+    def strides(self) -> tuple[ShapeItem, ...]:
+        ...
+
+    @property
+    @abstractmethod
     def size(self) -> ShapeItem:
         ...
 

--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -17,7 +17,7 @@ class _UnknownLength:
 
     def __new__(cls, *args, **kwargs):
         raise TypeError(
-            "internal_error: the `TypeTracer` nplike's `TypeTracerArray` object should never be directly instantiated"
+            "internal_error: the _UnknownLength class should never be directly instantiated"
         )
 
     def __add__(self, other) -> Self | NotImplemented:

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -242,10 +242,10 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
             self._report.touch_data(self._form_key)
 
     @property
-    def strides(self):
+    def strides(self) -> tuple[ShapeItem, ...]:
         self.touch_shape()
         out = (self._dtype.itemsize,)
-        for x in self._shape[:0:-1]:
+        for x in reversed(self._shape):
             out = (x * out[0], *out)
         return out
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -198,7 +198,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         return self._dtype
 
     @property
@@ -214,21 +214,21 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return self._shape
 
     @property
-    def form_key(self):
+    def form_key(self) -> str | None:
         return self._form_key
 
     @form_key.setter
-    def form_key(self, value):
+    def form_key(self, value: str | None):
         if value is not None and not isinstance(value, str):
             raise TypeError("form_key must be None or a string")
         self._form_key = value
 
     @property
-    def report(self):
+    def report(self) -> TypeTracerReport | None:
         return self._report
 
     @report.setter
-    def report(self, value):
+    def report(self, value: TypeTracerReport | None):
         if value is not None and not isinstance(value, TypeTracerReport):
             raise TypeError("report must be None or a TypeTracerReport")
         self._report = value
@@ -294,7 +294,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     @property
-    def itemsize(self):
+    def itemsize(self) -> int:
         return self._dtype.itemsize
 
     class _CTypes:
@@ -316,7 +316,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         | Ellipsis
         | tuple[SupportsIndex | slice | Ellipsis | ArrayLike, ...]
         | ArrayLike,
-    ) -> Self:
+    ) -> Self | int | float | bool | complex:
         if not isinstance(key, tuple):
             key = (key,)
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -242,14 +242,6 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
             self._report.touch_data(self._form_key)
 
     @property
-    def strides(self) -> tuple[ShapeItem, ...]:
-        self.touch_shape()
-        out = (self._dtype.itemsize,)
-        for x in reversed(self._shape):
-            out = (x * out[0], *out)
-        return out
-
-    @property
     def nplike(self) -> TypeTracer:
         return TypeTracer.instance()
 
@@ -1128,6 +1120,13 @@ class TypeTracer(NumpyLike):
     ) -> TypeTracerArray:
         try_touch_data(x)
         raise NotImplementedError
+
+    def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
+        x.touch_shape()
+        out = (x._dtype.itemsize,)
+        for item in reversed(x._shape):
+            out = (item * out[0], *out)
+        return out
 
     ############################ ufuncs
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -156,11 +156,11 @@ class NumpyArray(Content):
         return cls(data, parameters=parameters, backend=backend)
 
     @property
-    def shape(self) -> tuple[ShapeItem, ...]:
+    def shape(self) -> tuple[int, ...]:
         return self._data.shape
 
     @property
-    def inner_shape(self) -> tuple[ShapeItem, ...]:
+    def inner_shape(self) -> tuple[int, ...]:
         return self._data.shape[1:]
 
     @property

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -165,7 +165,7 @@ class NumpyArray(Content):
 
     @property
     def strides(self) -> tuple[ShapeItem, ...]:
-        return self._data.strides
+        return self._backend.nplike.strides(self._data)
 
     @property
     def dtype(self) -> np.dtype:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -156,15 +156,15 @@ class NumpyArray(Content):
         return cls(data, parameters=parameters, backend=backend)
 
     @property
-    def shape(self) -> tuple[int, ...]:
+    def shape(self) -> tuple[ShapeItem, ...]:
         return self._data.shape
 
     @property
-    def inner_shape(self) -> tuple[int, ...]:
+    def inner_shape(self) -> tuple[ShapeItem, ...]:
         return self._data.shape[1:]
 
     @property
-    def strides(self) -> tuple[int, ...]:
+    def strides(self) -> tuple[ShapeItem, ...]:
         return self._data.strides
 
     @property

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1389,7 +1389,6 @@ class NumpyArray(Content):
             return (
                 self._backend.nplike.array_equal(self.data, other.data)
                 and self.dtype == other.dtype
-                and self.is_contiguous == other.is_contiguous
                 and self.shape == other.shape
             )
         else:


### PR DESCRIPTION
This PR is a bag of changes:
- Add some additional type hints
- Refactor logic that depends upon `NumpyArray.is_contiguous` (to be more explicit).
- Replace use of `.strides` with nplike method