### PR TITLE
fix: formatting error message (missing space).

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -106,7 +106,7 @@ def in_function(options):
     if options["function_name"] is None:
         return ""
     else:
-        return "in " + options["function_name"]
+        return " in " + options["function_name"]
 
 
 def checklength(inputs, options):


### PR DESCRIPTION
This is a tiny, easy fix. I was looking at error messages like

```
ValueError: cannot broadcast NumpyArray of length 14 with NumpyArray of length 2in equal
```

which clearly need a space between the `2` and the `in`. Go ahead and merge after review, @agoose77—I'm done!