### PR TITLE
fix: make starts and stops return length-1 arrays for empty lists

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -175,11 +175,17 @@ class ListOffsetArray(Content):
 
     @property
     def starts(self) -> Index:
-        return self._offsets[:-1]
+        if self._offsets.length is unknown_length or self._offsets.length > 1:
+            return self._offsets[:-1]
+        else:
+            return self._offsets[:1]
 
     @property
-    def stops(self):
-        return self._offsets[1:]
+    def stops(self) -> Index:
+        if self._offsets.length is unknown_length or self._offsets.length > 1:
+            return self._offsets[-1:]
+        else:
+            return self._offsets[:1]
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> ListOffsetForm:
         form_key = getkey(self)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -205,11 +205,19 @@ class RegularArray(Content):
 
     @property
     def starts(self) -> Index:
-        return self._compact_offsets64(True)[:-1]
+        offsets = self._compact_offsets64(True)
+        if offsets.length is unknown_length or offsets.length > 1:
+            return offsets[:-1]
+        else:
+            return offsets[:1]
 
     @property
-    def stops(self):
-        return self._compact_offsets64(True)[1:]
+    def stops(self) -> Index:
+        offsets = self._compact_offsets64(True)
+        if offsets.length is unknown_length or offsets.length > 1:
+            return offsets[-1:]
+        else:
+            return offsets[:1]
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> RegularForm:
         form_key = getkey(self)

--- a/tests/test_2484_starts_stops.py
+++ b/tests/test_2484_starts_stops.py
@@ -1,0 +1,52 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_listoffsetarray():
+    layout = ak.contents.ListOffsetArray(
+        ak.index.Index64([0]), ak.contents.NumpyArray([0, 1, 2, 3])
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [0]
+
+    layout = ak.contents.ListOffsetArray(
+        ak.index.Index64([0, 2]), ak.contents.NumpyArray([0, 1, 2, 3])
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [2]
+
+
+def test_listarray():
+    layout = ak.contents.ListArray(
+        ak.index.Index64([0]),
+        ak.index.Index64([0]),
+        ak.contents.NumpyArray([0, 1, 2, 3]),
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [0]
+
+    layout = ak.contents.ListArray(
+        ak.index.Index64([0]),
+        ak.index.Index64([2]),
+        ak.contents.NumpyArray([0, 1, 2, 3]),
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [2]
+
+
+def test_regulararray():
+    layout = ak.contents.RegularArray(
+        ak.contents.NumpyArray(np.arange(0, dtype=np.int64)), size=2
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [0]
+
+    layout = ak.contents.RegularArray(
+        ak.contents.NumpyArray(np.arange(2, dtype=np.int64)), size=2
+    )
+    assert layout.starts.data.tolist() == [0]
+    assert layout.stops.data.tolist() == [2]


### PR DESCRIPTION
This PR brings `ListOffsetArray.starts` and `stops` in line with `ListArray.starts`, by returning length-1 arrays if the list is empty. 

Fixes #2484