### PR TITLE
fix: use offsets for starts to handle length-0 arrays

### DIFF
--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -949,10 +949,13 @@ class ByteMaskedArray(Content):
         if not branch and negaxis == depth:
             return out
         else:
-            if out.is_list:
-                out_content = out.content[out.offsets[0] :]
-            elif out.is_regular:
+            if out.is_regular:
                 out_content = out.content
+            elif out.is_list:
+                # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
+                # the list content to start at the first offset.
+                # We know that we don't have any list type other than `ListOffsetArray`
+                out_content = out.content[out.offsets[0] :]
             else:
                 raise ValueError(
                     "reduce_next with unbranching depth > negaxis is only "

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -954,7 +954,6 @@ class ByteMaskedArray(Content):
             elif isinstance(out, ak.contents.ListOffsetArray):
                 # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
                 # the list content to start at the first offset.
-                # We know that we don't have any list type other than `ListOffsetArray`
                 out_content = out.content[out.offsets[0] :]
             else:
                 raise ValueError(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -950,7 +950,7 @@ class ByteMaskedArray(Content):
             return out
         else:
             if out.is_list:
-                out_content = out.content[out.starts[0] :]
+                out_content = out.content[out.offsets[0] :]
             elif out.is_regular:
                 out_content = out.content
             else:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -949,9 +949,9 @@ class ByteMaskedArray(Content):
         if not branch and negaxis == depth:
             return out
         else:
-            if out.is_regular:
+            if isinstance(out, ak.contents.RegularArray):
                 out_content = out.content
-            elif out.is_list:
+            elif isinstance(out, ak.contents.ListOffsetArray):
                 # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
                 # the list content to start at the first offset.
                 # We know that we don't have any list type other than `ListOffsetArray`

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1388,7 +1388,7 @@ class IndexedOptionArray(Content):
             return out
         else:
             if out.is_list:
-                out_content = out.content[out.starts[0] :]
+                out_content = out.content[out.offsets[0] :]
             elif out.is_regular:
                 out_content = out.content
             else:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1392,7 +1392,6 @@ class IndexedOptionArray(Content):
             elif isinstance(out, ak.contents.ListOffsetArray):
                 # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
                 # the list content to start at the first offset.
-                # We know that we don't have any list type other than `ListOffsetArray`
                 out_content = out.content[out.offsets[0] :]
             else:
                 raise AssertionError(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1387,10 +1387,13 @@ class IndexedOptionArray(Content):
         if not branch and negaxis == depth:
             return out
         else:
-            if out.is_list:
-                out_content = out.content[out.offsets[0] :]
-            elif out.is_regular:
+            if out.is_regular:
                 out_content = out.content
+            elif out.is_list:
+                # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
+                # the list content to start at the first offset.
+                # We know that we don't have any list type other than `ListOffsetArray`
+                out_content = out.content[out.offsets[0] :]
             else:
                 raise AssertionError(
                     "reduce_next with unbranching depth > negaxis is only "

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1387,9 +1387,9 @@ class IndexedOptionArray(Content):
         if not branch and negaxis == depth:
             return out
         else:
-            if out.is_regular:
+            if isinstance(out, ak.contents.RegularArray):
                 out_content = out.content
-            elif out.is_list:
+            elif isinstance(out, ak.contents.ListOffsetArray):
                 # The `outindex` that will index into `out_content` is 0-based, so we should ensure that we normalise
                 # the list content to start at the first offset.
                 # We know that we don't have any list type other than `ListOffsetArray`

--- a/tests/test_2484_reduce_starts_empty.py
+++ b/tests/test_2484_reduce_starts_empty.py
@@ -1,0 +1,36 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import numpy as np
+
+import awkward as ak
+
+
+def test():
+    layout = ak.contents.ByteMaskedArray(
+        ak.index.Index8([0]),
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 1]),
+            ak.contents.ByteMaskedArray(
+                ak.index.Index8([1]),
+                ak.contents.ListOffsetArray(
+                    ak.index.Index64([0, 2]), ak.contents.NumpyArray([5, 6])
+                ),
+                valid_when=True,
+            ),
+        ),
+        valid_when=True,
+    )
+    assert ak.almost_equal(
+        ak.any(layout, axis=2),
+        ak.contents.IndexedOptionArray(
+            ak.index.Index64([-1]),
+            ak.contents.ListOffsetArray(
+                ak.index.Index64([0]),
+                ak.contents.IndexedOptionArray(
+                    ak.index.Index64([]),
+                    ak.contents.NumpyArray(np.empty(0, dtype=np.bool_)),
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
Unlike `offsets`, `starts` is not guaranteed to always have at least one element. This kind of bug has been dealt with elsewhere, but these are a few outstanding places.

Fixes #2484