### PR TITLE
fix: `ak.concatenate` for typetracer

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -269,10 +269,6 @@ class ArrayModuleNumpyLike(NumpyLike):
         assert not isinstance(repeats, PlaceholderArray)
         return self._module.repeat(x, repeats=repeats, axis=axis)
 
-    def tile(self, x: ArrayLike, reps: int) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
-        return self._module.tile(x, reps)
-
     def stack(
         self,
         arrays: list[ArrayLike] | tuple[ArrayLike, ...],

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -445,10 +445,6 @@ class NumpyLike(Singleton, Protocol):
         ...
 
     @abstractmethod
-    def tile(self, x: ArrayLike, reps: int) -> ArrayLike:
-        ...
-
-    @abstractmethod
     def stack(
         self,
         arrays: list[ArrayLike] | tuple[ArrayLike, ...],

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1125,11 +1125,6 @@ class TypeTracer(NumpyLike):
                 shape[axis] = shape[axis] * self.index_as_shape_item(repeats)
             return TypeTracerArray._new(x.dtype, shape=tuple(shape))
 
-    def tile(self, x: ArrayLike, reps: int) -> TypeTracerArray:
-        assert not isinstance(x, PlaceholderArray)
-        try_touch_data(x)
-        raise NotImplementedError
-
     def stack(
         self,
         arrays: list[ArrayLike] | tuple[ArrayLike, ...],

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -190,7 +190,14 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     prototype[start : start + size] = tag
                     start += size
 
-                tags = ak.index.Index8(backend.index_nplike.tile(prototype, length))
+                tags = ak.index.Index8(
+                    backend.index_nplike.reshape(
+                        backend.index_nplike.broadcast_to(
+                            prototype, (length, prototype.size)
+                        ),
+                        (-1,),
+                    )
+                )
                 index = ak.contents.UnionArray.regular_index(tags, backend=backend)
                 inner = ak.contents.UnionArray.simplified(
                     tags,
@@ -199,7 +206,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                     mergebool=mergebool,
                 )
 
-                return (ak.contents.RegularArray(inner, len(prototype)),)
+                return (ak.contents.RegularArray(inner, prototype.size),)
 
             elif depth == posaxis and all(
                 isinstance(x, ak.contents.Content)

--- a/tests/test_2495_concatenate_typetracer.py
+++ b/tests/test_2495_concatenate_typetracer.py
@@ -1,0 +1,49 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+
+def test_mixed_known_lengths():
+    first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
+    first_tt = first.to_typetracer(forget_length=False)
+
+    second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
+    second_tt = second.to_typetracer(forget_length=True)
+
+    result_tt = ak.concatenate((first_tt, second_tt), axis=1)
+    result = ak.concatenate((first, second), axis=1)
+
+    assert result_tt.layout.form == result.layout.form
+    assert result_tt.layout.length == result.layout.length == 3
+
+
+def test_known_lengths():
+    first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
+    first_tt = first.to_typetracer(forget_length=False)
+
+    second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
+    second_tt = second.to_typetracer(forget_length=False)
+
+    result_tt = ak.concatenate((first_tt, second_tt), axis=1)
+    result = ak.concatenate((first, second), axis=1)
+
+    assert result_tt.layout.form == result.layout.form
+    assert result_tt.layout.length == result.layout.length == 3
+
+
+def test_unknown_lengths():
+    first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
+    first_tt = first.to_typetracer(forget_length=True)
+
+    second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
+    second_tt = second.to_typetracer(forget_length=True)
+
+    result_tt = ak.concatenate((first_tt, second_tt), axis=1)
+    result = ak.concatenate((first, second), axis=1)
+
+    assert result_tt.layout.form == result.layout.form
+    assert result_tt.layout.length is unknown_length


### PR DESCRIPTION
This PR closes #2495, changing the code-style for readability.