### PR TITLE
feat!: deprecate `to_NumpyForm`'s ``dtype` argument

### DIFF
--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -446,7 +446,7 @@ namespace awkward {{
 
 def togenerator(form, flatlist_as_rvec):
     if isinstance(form, ak.forms.EmptyForm):
-        return togenerator(form.to_NumpyForm(np.dtype(np.float64)), flatlist_as_rvec)
+        return togenerator(form.to_NumpyForm(primitive="float64"), flatlist_as_rvec)
 
     elif isinstance(form, ak.forms.NumpyForm):
         if len(form.inner_shape) == 0:

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -106,7 +106,7 @@ def code_to_function(code, function_name, externals=None, debug=False):
 
 def to_numbatype(form):
     if isinstance(form, ak.forms.EmptyForm):
-        return to_numbatype(form.to_NumpyForm(np.dtype(np.float64)))
+        return to_numbatype(form.to_NumpyForm(primitive="float64"))
 
     elif isinstance(form, ak.forms.NumpyForm):
         if len(form.inner_shape) == 0:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+from inspect import signature
+
 import awkward as ak
 from awkward._errors import deprecate
 from awkward._typing import final
@@ -52,8 +54,34 @@ class EmptyForm(Form):
     def __eq__(self, other) -> bool:
         return isinstance(other, EmptyForm) and self._form_key == other._form_key
 
-    def to_NumpyForm(self, dtype):
-        return ak.forms.numpyform.from_dtype(dtype, parameters=self._parameters)
+    def to_NumpyForm(self, *args, **kwargs):
+        def legacy_impl(dtype):
+            deprecate(
+                f"the `dtype` parameter in {type(self).__name__}.to_NumpyForm is deprecated, "
+                f"in favour of a new `primitive` argument. Pass `primitive` by keyword to opt-in to the new behavior.",
+                version="2.4.0",
+            )
+            return ak.forms.numpyform.from_dtype(dtype, parameters=self._parameters)
+
+        def new_impl(*, primitive):
+            return ak.forms.numpyform.NumpyForm(primitive, parameters=self._parameters)
+
+        dispatch_table = [
+            new_impl,
+            legacy_impl,
+        ]
+        for func in dispatch_table:
+            sig = signature(func)
+            try:
+                bound_arguments = sig.bind(*args, **kwargs)
+            except TypeError:
+                continue
+            else:
+                return func(*bound_arguments.args, **bound_arguments.kwargs)
+        raise AssertionError(
+            f"{type(self).__name__}.to_NumpyForm accepts either the new `primitive` argument as a keyword-only "
+            f"argument, or the legacy `dtype` argument as positional or keyword"
+        )
 
     def purelist_parameter(self, key):
         if self._parameters is None or key not in self._parameters:

--- a/tests/test_2503_deprecate_to_numpyform.py
+++ b/tests/test_2503_deprecate_to_numpyform.py
@@ -1,0 +1,22 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_dtype_deprecated():
+    form = ak.forms.EmptyForm()
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"the `dtype` parameter in EmptyForm\.to_NumpyForm is deprecated",
+    ):
+        next_form = form.to_NumpyForm(dtype=np.dtype(np.int64))
+    assert next_form.primitive == "int64"
+
+
+def test_primitive():
+    form = ak.forms.EmptyForm()
+    next_form = form.to_NumpyForm(primitive="int64")
+    assert next_form.primitive == "int64"


### PR DESCRIPTION
Whilst refactoring I noticed that we accept a `dtype` argument in `EmptyForm`. I propose we deprecate this form, in favour of `primitive`. This is not a big change, but I think it would be sensible.