### PR TITLE
refactor: move responsibility for positional reducers to `Reducer.apply`

### DIFF
--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -54,6 +54,8 @@ class ArgMin(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         raise RuntimeError("Cannot differentiate through argmin")
@@ -78,6 +80,8 @@ class ArgMax(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         raise RuntimeError("Cannot differentiate through argmax")
@@ -102,6 +106,8 @@ class Count(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         raise RuntimeError("Cannot differentiate through count_zero")
@@ -126,6 +132,8 @@ class CountNonzero(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         raise RuntimeError("Cannot differentiate through count_nonzero")
@@ -146,6 +154,8 @@ class Sum(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
@@ -179,6 +189,8 @@ class Prod(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
@@ -214,6 +226,8 @@ class Any(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
@@ -242,6 +256,8 @@ class All(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
@@ -292,6 +308,8 @@ class Min(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
@@ -351,6 +369,8 @@ class Max(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1128,48 +1128,7 @@ class NumpyArray(Content):
         assert self.is_contiguous
         assert self._data.ndim == 1
 
-        out = reducer.apply(self, parents, outlength)
-
-        if reducer.needs_position:
-            if shifts is None:
-                assert (
-                    parents.nplike is self._backend.index_nplike
-                    and starts.nplike is self._backend.index_nplike
-                )
-                self._backend.maybe_kernel_error(
-                    self._backend[
-                        "awkward_NumpyArray_reduce_adjust_starts_64",
-                        out.data.dtype.type,
-                        parents.dtype.type,
-                        starts.dtype.type,
-                    ](
-                        out.data,
-                        outlength,
-                        parents.data,
-                        starts.data,
-                    )
-                )
-            else:
-                assert (
-                    parents.nplike is self._backend.index_nplike
-                    and starts.nplike is self._backend.index_nplike
-                    and shifts.nplike is self._backend.index_nplike
-                )
-                self._backend.maybe_kernel_error(
-                    self._backend[
-                        "awkward_NumpyArray_reduce_adjust_starts_shifts_64",
-                        out.data.dtype.type,
-                        parents.dtype.type,
-                        starts.dtype.type,
-                        shifts.dtype.type,
-                    ](
-                        out.data,
-                        outlength,
-                        parents.data,
-                        starts.data,
-                        shifts.data,
-                    )
-                )
+        out = reducer.apply(self, parents, starts, shifts, outlength)
 
         if mask:
             outmask = ak.index.Index8.empty(outlength, self._backend.index_nplike)


### PR DESCRIPTION
This PR moves the responsibility for "fixing" positional reducers into `_reducers`, such that reducers are self-contained. The same is not done for `RecordArray`, because this is effectively a separate reduction implementation that happens to use the same kernels.