### PR TITLE
fix(do not merge / example): do not touch data in complex slices

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -382,7 +382,6 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
                     or is_unknown_integer(item)
                     or is_unknown_array(item)
                 ):
-
                     if is_unknown_scalar(item):
                         item = self.nplike.promote_scalar(item)
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -382,8 +382,6 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
                     or is_unknown_integer(item)
                     or is_unknown_array(item)
                 ):
-                    try_touch_data(item)
-                    try_touch_data(self)
 
                     if is_unknown_scalar(item):
                         item = self.nplike.promote_scalar(item)


### PR DESCRIPTION
It turns out that removing these two lines fixes the overtouching problem in the example complex analysis attached below (where you can run `dask.compute(output)` and have it succeed using prior versions of dask_awkward/awkward with far fewer read columns).

With the this PR applied the `necessary_columns` returns to previous the previous list.

The rest of https://github.com/scikit-hep/awkward/commit/19f62aaac1f77c8d8096730f56dead782260d400 seems to be perfectly fine.

@douglasdavis @martindurant @jpivarski @agoose77 