### PR TITLE
fix: don't project records during broadcasting; push index down

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -934,7 +934,10 @@ def apply_step(
         )
 
     def broadcast_any_indexed():
-        nextinputs = [x.project() if isinstance(x, IndexedArray) else x for x in inputs]
+        nextinputs = [
+            x._push_inside_record_or_project() if isinstance(x, IndexedArray) else x
+            for x in inputs
+        ]
         return apply_step(
             backend,
             nextinputs,

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -934,6 +934,9 @@ def apply_step(
         )
 
     def broadcast_any_indexed():
+        # The `apply` function may exit at the level of a `RecordArray`. We can avoid projection
+        # of the record array in such cases, in favour of a deferred carry. This can be done by
+        # "pushing" the `IndexedArray` _into_ the record (i.e., wrapping each `content`).
         nextinputs = [
             x._push_inside_record_or_project() if isinstance(x, IndexedArray) else x
             for x in inputs

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1150,4 +1150,4 @@ class IndexedArray(Content):
                 parameters=parameters_union(self.content._parameters, self._parameters),
             )
         else:
-            return self
+            return self.project()

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1136,3 +1136,18 @@ class IndexedArray(Content):
         return self.index.is_equal_to(
             other.index, index_dtype, numpyarray
         ) and self.content.is_equal_to(other.content, index_dtype, numpyarray)
+
+    def _push_inside_record_or_project(self) -> Self | ak.contents.RecordArray:
+        if self.content.is_record:
+            return ak.contents.RecordArray(
+                contents=[
+                    ak.contents.IndexedArray.simplified(self._index, c)
+                    for c in self.content.contents
+                ],
+                fields=self.content._fields,
+                length=self.length,
+                backend=self._backend,
+                parameters=parameters_union(self.content._parameters, self._parameters),
+            )
+        else:
+            return self


### PR DESCRIPTION
The `broadcast_and_apply` logic currently `project()`s `IndexedArray`s during recursion. This is more expensive than necessary; caller-provided callback may exit early, avoiding the need for a projection. Instead, we can just push the indexed node into the contents of the `RecordArray`.

For `dask-awkward` the existing behaviour has more serious consequence; a much greater number of contents are touched during typetracer time. This PR changes the best-case behavior of operations that encounter an `IndexedArray` of `RecordArray` during broadcasting (e.g. `with_field` after an advanced index) from touching _everything_ in the record to touching only the offsets _above_ the record. In practice, the presence of option-types within the record array will lead to additional touching of those buffers.