### PR TITLE
refactor: add internal `with_operation_context`

### DIFF
--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -5,7 +5,7 @@ import builtins
 import sys
 import threading
 import warnings
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping
 from functools import wraps
 
 import numpy  # noqa: TID251
@@ -162,7 +162,7 @@ class ErrorContext:
                 if len(valuestr) > width:
                     valuestr = valuestr[: width - 3] + "..."
 
-        elif isinstance(value, (Sequence, Mapping)) and len(value) < 10000:
+        elif isinstance(value, (Collection, Mapping)) and len(value) < 10000:
             valuestr = repr(value)
             if len(valuestr) > width:
                 valuestr = valuestr[: width - 3] + "..."
@@ -193,7 +193,7 @@ class OperationErrorContext(ErrorContext):
             # Do we not recognise this as an object with a backend?
             if backend is None:
                 # Is this an iterable object, and are we permitted to recurse?
-                if isinstance(obj, Iterable) and depth != depth_limit:
+                if isinstance(obj, Collection) and depth != depth_limit:
                     return self.any_backend_is_delayed(
                         obj, depth=depth + 1, depth_limit=depth_limit
                     )

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -5,14 +5,13 @@ import builtins
 import sys
 import threading
 import warnings
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import wraps
-from inspect import signature
 
 import numpy  # noqa: TID251
 
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward._typing import TypeVar
+from awkward._typing import Any, TypeVar
 
 np = NumpyMetadata.instance()
 
@@ -184,36 +183,65 @@ class ErrorContext:
 class OperationErrorContext(ErrorContext):
     _width = 80 - 8
 
-    def __init__(self, name, arguments):
+    def any_backend_is_delayed(
+        self, iterable: Iterable, *, depth: int = 1, depth_limit: int = 2
+    ) -> bool:
         from awkward._backends.dispatch import backend_of
-        from awkward._backends.numpy import NumpyBackend
 
-        numpy_backend = NumpyBackend.instance()
-        if self.primary() is not None or all(
-            backend_of(x, default=numpy_backend).nplike.is_eager for x in arguments
+        for obj in iterable:
+            backend = backend_of(obj, default=None)
+            # Do we not recognise this as an object with a backend?
+            if backend is None:
+                # Is this an iterable object, and are we permitted to recurse?
+                if isinstance(obj, Iterable) and depth != depth_limit:
+                    return self.any_backend_is_delayed(
+                        obj, depth=depth + 1, depth_limit=depth_limit
+                    )
+                # Assume not delayed!
+                else:
+                    return False
+            # Eager backends aren't delayed!
+            elif backend.nplike.is_eager:
+                continue
+            else:
+                return True
+        return False
+
+    def __init__(self, name, args: Iterable[Any], kwargs: Mapping[str, Any]):
+        if self.primary() is None and (
+            self.any_backend_is_delayed(args)
+            or self.any_backend_is_delayed(kwargs.values())
         ):
+            string_args = self._format_args(args)
+            string_kwargs = self._format_kwargs(kwargs)
+        else:
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays
             # --> in either case, delay string generation
-            string_arguments = PartialFunction(self._string_arguments, arguments)
-        else:
-            string_arguments = self._string_arguments(arguments)
+            string_args = PartialFunction(self._format_args, args)
+            string_kwargs = PartialFunction(self._format_kwargs, kwargs)
 
         super().__init__(
             name=name,
-            arguments=string_arguments,
+            args=string_args,
+            kwargs=string_kwargs,
         )
 
-    def _string_arguments(self, arguments):
+    def _format_args(self, arguments: Iterable) -> list[str]:
+        string_arguments = []
+        for value in arguments:
+            string_arguments.append(self.format_argument(self._width, value))
+
+        return string_arguments
+
+    def _format_kwargs(self, arguments: Mapping[str, Any]) -> dict[str, str]:
         string_arguments = {}
         for key, value in arguments.items():
             if isinstance(key, str):
                 width = self._width - len(key) - 3
             else:
                 width = self._width
-
             string_arguments[key] = self.format_argument(width, value)
-
         return string_arguments
 
     @property
@@ -221,29 +249,39 @@ class OperationErrorContext(ErrorContext):
         return self._kwargs["name"]
 
     @property
-    def arguments(self):
-        out = self._kwargs["arguments"]
+    def args(self) -> list:
+        out = self._kwargs["args"]
         if isinstance(out, PartialFunction):
-            out = self._kwargs["arguments"] = out()
+            out = self._kwargs["args"] = out()
         return out
 
-    def format_exception(self, exception):
+    @property
+    def kwargs(self) -> dict:
+        out = self._kwargs["kwargs"]
+        if isinstance(out, PartialFunction):
+            out = self._kwargs["kwargs"] = out()
+        return out
+
+    def format_exception(self, exception: Exception) -> str:
         return f"{exception}\n{self.note}"
 
     @property
     def note(self) -> str:
         arguments = []
-        for name, valuestr in self.arguments.items():
+        for valuestr in self.args:
+            arguments.append(f"\n        {valuestr}")
+        for name, valuestr in self.kwargs.items():
             if isinstance(name, str):
                 arguments.append(f"\n        {name} = {valuestr}")
             else:
                 arguments.append(f"\n        {valuestr}")
 
         extra_line = "" if len(arguments) == 0 else "\n    "
+        calling_note = f'{self.name}({"".join(arguments)}{extra_line})'
         return f"""
 This error occurred while calling
 
-    {self.name}({"".join(arguments)}{extra_line})"""
+    {calling_note}"""
 
 
 class SlicingErrorContext(ErrorContext):
@@ -389,15 +427,10 @@ T = TypeVar("T", bound=Callable)
 
 
 def with_operation_context(func: T) -> T:
-    sig = signature(func)
-
     @wraps(func)
     def wrapper(*args, **kwargs):
-        bound = sig.bind(*args, **kwargs)
-        bound.apply_defaults()
-
         # NOTE: this decorator assumes that the operation is exposed under `ak.`
-        with OperationErrorContext(f"ak.{func.__qualname__}", bound.arguments):
+        with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
             return func(*args, **kwargs)
 
     return wrapper

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -327,7 +327,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         def __getitem__(self, where):
             with ak._errors.OperationErrorContext(
-                "ak.Array.mask", {0: self._array, 1: where}
+                "ak.Array.mask", args=[self._array, where], kwargs={}
             ):
                 return ak.operations.mask(self._array, where, valid_when=True)
 
@@ -1018,7 +1018,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         with ak._errors.OperationErrorContext(
             "ak.Array.__setitem__",
-            {"self": self, "field_name": where, "field_value": what},
+            (self,),
+            {"where": where, "what": what},
         ):
             if not (
                 isinstance(where, str)
@@ -1049,7 +1050,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         with ak._errors.OperationErrorContext(
             "ak.Array.__delitem__",
-            {"self": self, "field_name": where},
+            (self,),
+            {"where": where},
         ):
             if not (
                 isinstance(where, str)
@@ -1281,11 +1283,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         nested lists in a NumPy `"O"` array are severed from the array and
         cannot be sliced as dimensions.
         """
-        arguments = {0: self}
-        for i, arg in enumerate(args):
-            arguments[i + 1] = arg
-        arguments.update(kwargs)
-        with ak._errors.OperationErrorContext("numpy.asarray", arguments):
+        with ak._errors.OperationErrorContext("numpy.asarray", (self, *args), kwargs):
             return ak._connect.numpy.convert_to_array(self._layout, args, kwargs)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
@@ -1354,11 +1352,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         See also #__array_function__.
         """
         name = f"{type(ufunc).__module__}.{ufunc.__name__}.{method!s}"
-        arguments = {}
-        for i, arg in enumerate(inputs):
-            arguments[i] = arg
-        arguments.update(kwargs)
-        with ak._errors.OperationErrorContext(name, arguments):
+        with ak._errors.OperationErrorContext(name, inputs, kwargs):
             return ak._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
 
     def __array_function__(self, func, types, args, kwargs):
@@ -1787,7 +1781,8 @@ class Record(NDArrayOperatorsMixin):
         """
         with ak._errors.OperationErrorContext(
             "ak.Record.__setitem__",
-            {"self": self, "field_name": where, "field_value": what},
+            (self,),
+            {"where": where, "what": what},
         ):
             if not (
                 isinstance(where, str)
@@ -1819,7 +1814,8 @@ class Record(NDArrayOperatorsMixin):
         """
         with ak._errors.OperationErrorContext(
             "ak.Record.__delitem__",
-            {"self": self, "field_name": where},
+            (self,),
+            {"where": where},
         ):
             if not (
                 isinstance(where, str)
@@ -2030,11 +2026,7 @@ class Record(NDArrayOperatorsMixin):
         See #ak.Array.__array_ufunc__ for a more complete description.
         """
         name = f"{type(ufunc).__module__}.{ufunc.__name__}.{method!s}"
-        arguments = {}
-        for i, arg in enumerate(inputs):
-            arguments[i] = arg
-        arguments.update(kwargs)
-        with ak._errors.OperationErrorContext(name, arguments):
+        with ak._errors.OperationErrorContext(name, inputs, kwargs):
             return ak._connect.numpy.array_ufunc(ufunc, method, inputs, kwargs)
 
     @property
@@ -2376,11 +2368,7 @@ class ArrayBuilder(Sized):
 
         See #ak.Array.__array__ for a more complete description.
         """
-        arguments = {0: self}
-        for i, arg in enumerate(args):
-            arguments[i + 1] = arg
-        arguments.update(kwargs)
-        with ak._errors.OperationErrorContext("numpy.asarray", arguments):
+        with ak._errors.OperationErrorContext("numpy.asarray", (self, *args), kwargs):
             return ak._connect.numpy.convert_to_array(self.snapshot(), args, kwargs)
 
     @property
@@ -2415,7 +2403,7 @@ class ArrayBuilder(Sized):
         formstr, length, container = self._layout.to_buffers()
         form = ak.forms.from_json(formstr)
 
-        with ak._errors.OperationErrorContext("ak.ArrayBuilder.snapshot", {}):
+        with ak._errors.OperationErrorContext("ak.ArrayBuilder.snapshot", [], {}):
             return ak.operations.ak_from_buffers._impl(
                 form,
                 length,

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -3,6 +3,7 @@ __all__ = ("all",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def all(
     array,
     axis=None,
@@ -51,18 +53,7 @@ def all(
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.all",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 __all__ = ("almost_equal",)
-
-
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
@@ -13,6 +12,7 @@ from awkward.operations.ak_to_layout import to_layout
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def almost_equal(
     left,
     right,

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -3,6 +3,7 @@ __all__ = ("any",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def any(
     array,
     axis=None,
@@ -51,18 +53,7 @@ def any(
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.any",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,6 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def argcartesian(
     arrays,
     axis=1,
@@ -88,19 +90,7 @@ def argcartesian(
     All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
     so see the #ak.cartesian documentation for a more complete description.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.argcartesian",
-        {
-            "arrays": arrays,
-            "axis": axis,
-            "nested": nested,
-            "parameters": parameters,
-            "with_name": with_name,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
+    return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argcombinations",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -8,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def argcombinations(
     array,
     n,
@@ -54,31 +56,17 @@ def argcombinations(
     #ak.argcartesian. See #ak.combinations and #ak.argcartesian for a more
     complete description.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.argcombinations",
-        {
-            "array": array,
-            "n": n,
-            "replacement": replacement,
-            "axis": axis,
-            "fields": fields,
-            "parameters": parameters,
-            "with_name": with_name,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            array,
-            n,
-            replacement,
-            axis,
-            fields,
-            parameters,
-            with_name,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        array,
+        n,
+        replacement,
+        axis,
+        fields,
+        parameters,
+        with_name,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -3,6 +3,7 @@ __all__ = ("argmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def argmax(
     array,
     axis=None,
@@ -58,20 +60,10 @@ def argmax(
 
     See also #ak.nanargmax.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.argmax",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
+@with_operation_context
 def nanargmax(
     array,
     axis=None,
@@ -111,20 +103,14 @@ def nanargmax(
 
     See also #ak.argmax.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanargmax",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -3,6 +3,7 @@ __all__ = ("argmin",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def argmin(
     array,
     axis=None,
@@ -58,20 +60,10 @@ def argmin(
 
     See also #ak.nanargmin.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.argmin",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
+@with_operation_context
 def nanargmin(
     array,
     axis=None,
@@ -110,20 +102,14 @@ def nanargmin(
 
     See also #ak.argmin.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanargmin",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -2,6 +2,7 @@
 __all__ = ("argsort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):
@@ -47,18 +49,7 @@ def argsort(
         >>> data[index]
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.argsort",
-        {
-            "array": array,
-            "axis": axis,
-            "ascending": ascending,
-            "stable": stable,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, ascending, stable, highlevel, behavior)
+    return _impl(array, axis, ascending, stable, highlevel, behavior)
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("backend",)
-
-import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def backend(*arrays) -> str:
     """
     Args:
@@ -21,11 +21,7 @@ def backend(*arrays) -> str:
 
     See #ak.to_backend.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.backend",
-        {"*arrays": arrays},
-    ):
-        return _impl(arrays)
+    return _impl(arrays)
 
 
 def _impl(arrays) -> str:

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -5,6 +5,7 @@ from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -12,6 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def broadcast_arrays(
     *arrays,
     depth_limit=None,
@@ -176,27 +178,15 @@ def broadcast_arrays(
          [],
          [[6.6]]]
     """
-    with ak._errors.OperationErrorContext(
-        "ak.broadcast_arrays",
-        {
-            "arrays": arrays,
-            "depth_limit": depth_limit,
-            "broadcast_parameters_rule": broadcast_parameters_rule,
-            "left_broadcast": left_broadcast,
-            "right_broadcast": right_broadcast,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            arrays,
-            depth_limit,
-            broadcast_parameters_rule,
-            left_broadcast,
-            right_broadcast,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        arrays,
+        depth_limit,
+        broadcast_parameters_rule,
+        left_broadcast,
+        right_broadcast,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -4,11 +4,13 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def broadcast_fields(
     *arrays,
     highlevel=True,
@@ -50,15 +52,7 @@ def broadcast_fields(
         }
 
     """
-    with ak._errors.OperationErrorContext(
-        "ak.broadcast_fields",
-        {
-            "arrays": arrays,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(arrays, highlevel, behavior)
+    return _impl(arrays, highlevel, behavior)
 
 
 def _impl(arrays, highlevel, behavior):

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -13,6 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def cartesian(
     arrays,
     axis=1,
@@ -192,19 +193,7 @@ def cartesian(
     #ak.argcartesian form can be particularly useful as nested indexing in
     #ak.Array.__getitem__.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.cartesian",
-        {
-            "arrays": arrays,
-            "axis": axis,
-            "nested": nested,
-            "parameters": parameters,
-            "with_name": with_name,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
+    return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 
 
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -2,9 +2,11 @@
 __all__ = ("categories",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 
 
+@with_operation_context
 def categories(array, highlevel=True):
     """
     Args:
@@ -18,11 +20,7 @@ def categories(array, highlevel=True):
 
     See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.categories",
-        {"array": array, "highlevel": highlevel},
-    ):
-        return _impl(array, highlevel)
+    return _impl(array, highlevel)
 
 
 def _impl(array, highlevel):

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("combinations",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -8,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def combinations(
     array,
     n,
@@ -175,31 +177,17 @@ def combinations(
     The #ak.argcombinations form can be particularly useful as nested indexing
     in #ak.Array.__getitem__.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.combinations",
-        {
-            "array": array,
-            "n": n,
-            "replacement": replacement,
-            "axis": axis,
-            "fields": fields,
-            "parameters": parameters,
-            "with_name": with_name,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            array,
-            n,
-            replacement,
-            axis,
-            fields,
-            parameters,
-            with_name,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        array,
+        n,
+        replacement,
+        axis,
+        fields,
+        parameters,
+        with_name,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -17,6 +18,7 @@ cpu = NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("concatenate")
+@with_operation_context
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """
     Args:
@@ -39,17 +41,7 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
     must have the same lengths and nested lists are each concatenated,
     element for element, and similarly for deeper levels.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.concatenate",
-        {
-            "arrays": arrays,
-            "axis": axis,
-            "mergebool": mergebool,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(arrays, axis, mergebool, highlevel, behavior)
+    return _impl(arrays, axis, mergebool, highlevel, behavior)
 
 
 def _impl(arrays, axis, mergebool, highlevel, behavior):

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -1,15 +1,16 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("copy",)
-
 import copy as _copy
 
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def copy(array):
     """
     Args:
@@ -58,11 +59,7 @@ def copy(array):
     changes, so we don't support it. However, an #ak.Array's data might come from
     a mutable third-party library, so this function allows you to make a true copy.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.fill_none",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -2,6 +2,7 @@
 __all__ = ("corr",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def corr(
     x,
     y,
@@ -57,18 +59,7 @@ def corr(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.corr",
-        {
-            "x": x,
-            "y": y,
-            "weight": weight,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, y, weight, axis, keepdims, mask_identity)
+    return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -2,6 +2,7 @@
 __all__ = ("count",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def count(
     array,
     axis=None,
@@ -93,18 +95,7 @@ def count(
     If it is desirable to exclude NaN ("not a number") values from #ak.count,
     use #ak.nan_to_none to turn them into None, which are not counted.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.count",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -2,6 +2,7 @@
 __all__ = ("count_nonzero",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def count_nonzero(
     array,
     axis=None,
@@ -52,18 +54,7 @@ def count_nonzero(
     count None values. If it is desirable to count them, use #ak.fill_none
     to turn them into something that would be counted.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.count_nonzero",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -2,12 +2,14 @@
 __all__ = ("covar",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def covar(
     x,
     y,
@@ -54,18 +56,7 @@ def covar(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.covar",
-        {
-            "x": x,
-            "y": y,
-            "weight": weight,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, y, weight, axis, keepdims, mask_identity)
+    return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("drop_none",)
 import awkward as ak
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     Args:
@@ -41,11 +42,7 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
         <Array [[[0]], [[None]], [[1]], [[2, None]]] type='4 * var * var * ?int64'>
 
     """
-    with ak._errors.OperationErrorContext(
-        "ak.drop_none",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 # ruff: noqa: B023
 __all__ = ("enforce_type",)
-
-
 from itertools import permutations
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -18,6 +17,7 @@ from awkward.types.numpytype import primitive_to_dtype
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def enforce_type(
     array,
     type,
@@ -227,16 +227,7 @@ def enforce_type(
     given type value. If the conversion is not possible given the layout data, e.g. a conversion from an irregular list
     to a regular type, it will fail.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.enforce_type",
-        {
-            "array": array,
-            "type": type,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, type, highlevel, behavior)
+    return _impl(array, type, highlevel, behavior)
 
 
 def _impl(array, type_, highlevel, behavior):

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -1,12 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("fields",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def fields(array):
     """
     Args:
@@ -23,11 +24,7 @@ def fields(array):
     If the array contains neither tuples nor records, this returns an empty
     list.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.fields",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -6,7 +6,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_sized_iterable, regularize_axis
@@ -15,6 +15,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -59,17 +60,7 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
     The values could be floating-point numbers or strings.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.fill_none",
-        {
-            "array": array,
-            "value": value,
-            "axis": axis,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, value, axis, highlevel, behavior)
+    return _impl(array, value, axis, highlevel, behavior)
 
 
 def _impl(array, value, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,7 +2,7 @@
 __all__ = ("firsts",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -41,11 +42,7 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 
     See #ak.singletons to invert this function.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.firsts",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("flatten",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -8,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -157,11 +159,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
          2.2,
          999]
     """
-    with ak._errors.OperationErrorContext(
-        "ak.flatten",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -1,12 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:
@@ -32,16 +34,7 @@ def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None)
 
     See also #ak.to_arrow, #ak.to_arrow_table, #ak.from_parquet, #ak.from_arrow_schema.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_arrow",
-        {
-            "array": array,
-            "generate_bitmasks": generate_bitmasks,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, generate_bitmasks, highlevel, behavior)
+    return _impl(array, generate_bitmasks, highlevel, behavior)
 
 
 def _impl(array, generate_bitmasks, highlevel, behavior):

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow_schema",)
-
-import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_arrow_schema(schema):
     """
     Args:
@@ -16,11 +16,7 @@ def from_arrow_schema(schema):
 
     See also #ak.to_arrow, #ak.to_arrow_table, #ak.from_arrow, #ak.to_parquet, #ak.from_parquet.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_arrow_schema",
-        {"schema": schema},
-    ):
-        return _impl(schema)
+    return _impl(schema)
 
 
 def _impl(schema):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -1,15 +1,16 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_avro_file",)
-
 # from awkward._typing import Type
 import pathlib
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_avro_file(
     file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):
@@ -30,36 +31,26 @@ def from_avro_file(
     """
     import awkward._connect.avro
 
-    with ak._errors.OperationErrorContext(
-        "ak.from_avro_file",
-        {
-            "file": file,
-            "highlevel": highlevel,
-            "behavior": behavior,
-            "limit_entries": limit_entries,
-            "debug_forth": debug_forth,
-        },
-    ):
-        if isinstance(file, pathlib.Path):
-            file = str(file)
+    if isinstance(file, pathlib.Path):
+        file = str(file)
 
-        if isinstance(file, str):
-            with open(file, "rb") as opened_file:
-                form, length, container = awkward._connect.avro.ReadAvroFT(
-                    opened_file, limit_entries, debug_forth
-                ).outcontents
-                return _impl(form, length, container, highlevel, behavior)
+    if isinstance(file, str):
+        with open(file, "rb") as opened_file:
+            form, length, container = awkward._connect.avro.ReadAvroFT(
+                opened_file, limit_entries, debug_forth
+            ).outcontents
+            return _impl(form, length, container, highlevel, behavior)
 
+    else:
+        if not hasattr(file, "read") or not hasattr(file, "seek"):
+            raise TypeError(
+                "'file' must either be a filename string or be a file-like object with 'read' and 'seek' methods"
+            )
         else:
-            if not hasattr(file, "read") or not hasattr(file, "seek"):
-                raise TypeError(
-                    "'file' must either be a filename string or be a file-like object with 'read' and 'seek' methods"
-                )
-            else:
-                form, length, container = awkward._connect.avro.ReadAvroFT(
-                    file, limit_entries, debug_forth
-                ).outarr
-                return _impl(form, length, container, highlevel, behavior)
+            form, length, container = awkward._connect.avro.ReadAvroFT(
+                file, limit_entries, debug_forth
+            ).outarr
+            return _impl(form, length, container, highlevel, behavior)
 
 
 def _impl(form, length, container, highlevel, behavior):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -30,6 +30,7 @@ def from_avro_file(
     Awkward form and Forth code for that specific Avro file and then reads it.
     """
     import awkward._connect.avro
+
     if isinstance(file, (str, bytes, PathLike)):
         file = fsdecode(file)
         with open(file, "rb") as opened_file:

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 __all__ = ("from_buffers",)
-
 import math
 
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -16,6 +16,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def from_buffers(
     form,
     length,
@@ -73,30 +74,17 @@ def from_buffers(
 
     See #ak.to_buffers for examples.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_buffers",
-        {
-            "form": form,
-            "length": length,
-            "container": container,
-            "buffer_key": buffer_key,
-            "backend": backend,
-            "byteorder": byteorder,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            form,
-            length,
-            container,
-            buffer_key,
-            backend,
-            byteorder,
-            highlevel,
-            behavior,
-            False,
-        )
+    return _impl(
+        form,
+        length,
+        container,
+        buffer_key,
+        backend,
+        byteorder,
+        highlevel,
+        behavior,
+        False,
+    )
 
 
 def _impl(
@@ -175,6 +163,7 @@ def _from_buffer(nplike, buffer, dtype, count, byteorder):
             return array
 
 
+@with_operation_context
 def reconstitute(form, length, container, getkey, backend, byteorder, simplify):
     if isinstance(form, ak.forms.EmptyForm):
         if length != 0:

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -2,9 +2,11 @@
 __all__ = ("from_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 
 
+@with_operation_context
 def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -24,11 +26,7 @@ def from_categorical(array, *, highlevel=True, behavior=None):
     See also #ak.is_categorical, #ak.categories, #ak.to_categorical,
     #ak.from_categorical.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_categorical",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_cupy",)
-import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import from_arraylib, wrap_layout
 
 
+@with_operation_context
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:
@@ -28,17 +29,8 @@ def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_cupy, #ak.from_numpy and #ak.from_jax.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_cupy",
-        {
-            "array": array,
-            "regulararray": regulararray,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return wrap_layout(
-            from_arraylib(array, regulararray, False),
-            highlevel=highlevel,
-            behavior=behavior,
-        )
+    return wrap_layout(
+        from_arraylib(array, regulararray, False),
+        highlevel=highlevel,
+        behavior=behavior,
+    )

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -1,16 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_iter",)
-
 from collections.abc import Iterable
 
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_iter(
     iterable,
     *,
@@ -59,18 +60,7 @@ def from_iter(
 
     See also #ak.to_list.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_iter",
-        {
-            "iterable": iterable,
-            "allow_record": allow_record,
-            "highlevel": highlevel,
-            "behavior": behavior,
-            "initial": initial,
-            "resize": resize,
-        },
-    ):
-        return _impl(iterable, highlevel, behavior, allow_record, initial, resize)
+    return _impl(iterable, highlevel, behavior, allow_record, initial, resize)
 
 
 def _impl(iterable, highlevel, behavior, allow_record, initial, resize):

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,10 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_jax",)
-
 from awkward import _errors, jax
+from awkward._errors import with_operation_context
 from awkward._layout import from_arraylib, wrap_layout
 
 
+@with_operation_context
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_jax",)
-from awkward import _errors, jax
+from awkward import jax
 from awkward._errors import with_operation_context
 from awkward._layout import from_arraylib, wrap_layout
 
@@ -30,18 +30,9 @@ def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
 
     See also #ak.to_jax, #ak.from_numpy and #ak.from_jax.
     """
-    with _errors.OperationErrorContext(
-        "ak.from_jax",
-        {
-            "array": array,
-            "regulararray": regulararray,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        jax.assert_registered()
-        return wrap_layout(
-            from_arraylib(array, regulararray, False),
-            highlevel=highlevel,
-            behavior=behavior,
-        )
+    jax.assert_registered()
+    return wrap_layout(
+        from_arraylib(array, regulararray, False),
+        highlevel=highlevel,
+        behavior=behavior,
+    )

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -17,6 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def from_json(
     source,
     *,
@@ -319,53 +321,36 @@ def from_json(
 
     See also #ak.to_json.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_json",
-        {
-            "source": source,
-            "line_delimited": line_delimited,
-            "schema": schema,
-            "nan_string": nan_string,
-            "posinf_string": posinf_string,
-            "neginf_string": neginf_string,
-            "complex_record_fields": complex_record_fields,
-            "buffersize": buffersize,
-            "initial": initial,
-            "resize": resize,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        if schema is None:
-            return _no_schema(
-                source,
-                line_delimited,
-                nan_string,
-                posinf_string,
-                neginf_string,
-                complex_record_fields,
-                buffersize,
-                initial,
-                resize,
-                highlevel,
-                behavior,
-            )
+    if schema is None:
+        return _no_schema(
+            source,
+            line_delimited,
+            nan_string,
+            posinf_string,
+            neginf_string,
+            complex_record_fields,
+            buffersize,
+            initial,
+            resize,
+            highlevel,
+            behavior,
+        )
 
-        else:
-            return _yes_schema(
-                source,
-                line_delimited,
-                schema,
-                nan_string,
-                posinf_string,
-                neginf_string,
-                complex_record_fields,
-                buffersize,
-                initial,
-                resize,
-                highlevel,
-                behavior,
-            )
+    else:
+        return _yes_schema(
+            source,
+            line_delimited,
+            schema,
+            nan_string,
+            posinf_string,
+            neginf_string,
+            complex_record_fields,
+            buffersize,
+            initial,
+            resize,
+            highlevel,
+            behavior,
+        )
 
 
 class _BytesReader:
@@ -580,6 +565,7 @@ def _yes_schema(
         return layout
 
 
+@with_operation_context
 def build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
         raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_numpy",)
-import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import from_arraylib, wrap_layout
 
 
+@with_operation_context
 def from_numpy(
     array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):
@@ -38,18 +39,8 @@ def from_numpy(
 
     See also #ak.to_numpy and #ak.from_cupy.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_numpy",
-        {
-            "array": array,
-            "regulararray": regulararray,
-            "recordarray": recordarray,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return wrap_layout(
-            from_arraylib(array, regulararray, recordarray),
-            highlevel=highlevel,
-            behavior=behavior,
-        )
+    return wrap_layout(
+        from_arraylib(array, regulararray, recordarray),
+        highlevel=highlevel,
+        behavior=behavior,
+    )

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -1,10 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_parquet",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._regularize import is_integer
 
 
+@with_operation_context
 def from_parquet(
     path,
     *,
@@ -51,44 +53,30 @@ def from_parquet(
 
     See also #ak.to_parquet, #ak.metadata_from_parquet.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_parquet",
-        {
-            "path": path,
-            "columns": columns,
-            "row_groups": row_groups,
-            "storage_options": storage_options,
-            "max_gap": max_gap,
-            "max_block": max_block,
-            "footer_sample_size": footer_sample_size,
-            "generate_bitmasks": generate_bitmasks,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        import awkward._connect.pyarrow  # noqa: F401
+    import awkward._connect.pyarrow  # noqa: F401
 
-        parquet_columns, subform, actual_paths, fs, subrg, row_counts, meta = metadata(
-            path,
-            storage_options,
-            row_groups,
-            columns,
-        )
-        return _load(
-            actual_paths,
-            parquet_columns if columns is not None else None,
-            subrg,
-            max_gap,
-            max_block,
-            footer_sample_size,
-            generate_bitmasks,
-            subform,
-            highlevel,
-            behavior,
-            fs,
-        )
+    parquet_columns, subform, actual_paths, fs, subrg, row_counts, meta = metadata(
+        path,
+        storage_options,
+        row_groups,
+        columns,
+    )
+    return _load(
+        actual_paths,
+        parquet_columns if columns is not None else None,
+        subrg,
+        max_gap,
+        max_block,
+        footer_sample_size,
+        generate_bitmasks,
+        subform,
+        highlevel,
+        behavior,
+        fs,
+    )
 
 
+@with_operation_context
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -1,12 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_rdataframe",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_rdataframe(
     rdf,
     columns,
@@ -45,21 +46,7 @@ def from_rdataframe(
 
     See also #ak.to_rdataframe.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_rdataframe",
-        {
-            "rdf": rdf,
-            "columns": columns,
-            "keep_order": keep_order,
-            "offsets_type": offsets_type,
-            "with_name": with_name,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            rdf, columns, highlevel, behavior, with_name, offsets_type, keep_order
-        )
+    return _impl(rdf, columns, highlevel, behavior, with_name, offsets_type, keep_order)
 
 
 def _impl(

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,7 +2,7 @@
 __all__ = ("from_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -38,11 +39,7 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
 
     See also #ak.to_regular.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.from_regular",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -3,6 +3,7 @@ __all__ = ("full_like",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import ensure_known_scalar
@@ -11,6 +12,7 @@ from awkward.operations.ak_zeros_like import _ZEROS
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def full_like(
     array,
     fill_value,
@@ -78,18 +80,7 @@ def full_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.full_like",
-        {
-            "array": array,
-            "fill_value": fill_value,
-            "dtype": dtype,
-            "including_unknown": including_unknown,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, fill_value, highlevel, behavior, dtype, including_unknown)
+    return _impl(array, fill_value, highlevel, behavior, dtype, including_unknown)
 
 
 def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown):

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_categorical",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def is_categorical(array):
     """
     Args:
@@ -16,11 +17,7 @@ def is_categorical(array):
 
     See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.is_categorical",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,7 +2,7 @@
 __all__ = ("is_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -26,11 +27,7 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
     Returns an array whose value is True where an element of `array` is None;
     False otherwise (at a given `axis` depth).
     """
-    with ak._errors.OperationErrorContext(
-        "ak.is_none",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_tuple",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def is_tuple(array):
     """
     Args:
@@ -12,11 +13,7 @@ def is_tuple(array):
     If `array` is a record, this returns True if the record is a tuple.
     If `array` is an array, this returns True if the outermost record is a tuple.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.is_tuple",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_valid",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def is_valid(array, *, exception=False):
     """
     Args:
@@ -18,11 +19,7 @@ def is_valid(array, *, exception=False):
 
     See also #ak.validity_error.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.is_valid",
-        {"array": array, "exception": exception},
-    ):
-        return _impl(array, exception)
+    return _impl(array, exception)
 
 
 def _impl(array, exception):

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -2,12 +2,14 @@
 __all__ = ("isclose",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):
@@ -27,19 +29,7 @@ def isclose(
     Implements [np.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html)
     for Awkward Arrays.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.isclose",
-        {
-            "a": a,
-            "b": b,
-            "rtol": rtol,
-            "atol": atol,
-            "equal_nan": equal_nan,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(a, b, rtol, atol, equal_nan, highlevel, behavior)
+    return _impl(a, b, rtol, atol, equal_nan, highlevel, behavior)
 
 
 def _impl(a, b, rtol, atol, equal_nan, highlevel, behavior):

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -3,6 +3,7 @@ __all__ = ("linear_fit",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,6 +12,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def linear_fit(
     x,
     y,
@@ -72,18 +74,7 @@ def linear_fit(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.linear_fit",
-        {
-            "x": x,
-            "y": y,
-            "weight": weight,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, y, weight, axis, keepdims, mask_identity)
+    return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 
 def _impl(x, y, weight, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("local_index",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -8,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -72,11 +74,7 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
                        2               8.8
                        3               9.9
     """
-    with ak._errors.OperationErrorContext(
-        "ak.local_index",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -2,12 +2,14 @@
 __all__ = ("mask",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:
@@ -88,17 +90,7 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 
     (which is 5 characters away from simply filtering the `array`).
     """
-    with ak._errors.OperationErrorContext(
-        "ak.mask",
-        {
-            "array": array,
-            "mask": mask,
-            "valid_when": valid_when,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, mask, valid_when, highlevel, behavior)
+    return _impl(array, mask, valid_when, highlevel, behavior)
 
 
 def _impl(array, mask, valid_when, highlevel, behavior):

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -3,6 +3,7 @@ __all__ = ("max",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def max(
     array,
     axis=None,
@@ -59,29 +61,18 @@ def max(
 
     See also #ak.nanmax.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.max",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "initial": initial,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            array,
-            axis,
-            keepdims,
-            initial,
-            mask_identity,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        array,
+        axis,
+        keepdims,
+        initial,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
+@with_operation_context
 def nanmax(
     array,
     axis=None,
@@ -122,29 +113,15 @@ def nanmax(
 
     See also #ak.max.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanmax",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "initial": initial,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(
-            array,
-            axis,
-            keepdims,
-            initial,
-            mask_identity,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        initial,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -3,7 +3,7 @@ __all__ = ("merge_option_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,6 +12,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -34,11 +35,7 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         >>> ak.merge_option_of_records(array)
         <Array [{a: None}, {a: 1}, {a: 2}] type='3 * {a: ?int64}'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.merge_option_of_records",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -3,7 +3,7 @@ __all__ = ("merge_union_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,6 +12,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -44,11 +45,7 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         >>> ak.merge_union_of_records(array)
         <Array [{a: 1, b: None}, {...}, None] type='3 * ?{a: ?int64, b: ?int64}'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.merge_union_of_records",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -1,9 +1,9 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("metadata_from_parquet",)
-
 import collections
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -15,6 +15,7 @@ ParquetMetadata = collections.namedtuple(
 )
 
 
+@with_operation_context
 def metadata_from_parquet(
     path,
     *,
@@ -59,20 +60,13 @@ def metadata_from_parquet(
     """
     import awkward._connect.pyarrow  # noqa: F401
 
-    with ak._errors.OperationErrorContext(
-        "ak.metadata_from_parquet",
-        {
-            "path": path,
-            "storage_options": storage_options,
-        },
-    ):
-        return _impl(
-            path,
-            storage_options,
-            row_groups=row_groups,
-            ignore_metadata=ignore_metadata,
-            scan_files=scan_files,
-        )
+    return _impl(
+        path,
+        storage_options,
+        row_groups=row_groups,
+        ignore_metadata=ignore_metadata,
+        scan_files=scan_files,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -3,6 +3,7 @@ __all__ = ("min",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def min(
     array,
     axis=None,
@@ -59,27 +61,18 @@ def min(
 
     See also #ak.nanmin.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.min",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "initial": initial,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(
-            array,
-            axis,
-            keepdims,
-            initial,
-            mask_identity,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        array,
+        axis,
+        keepdims,
+        initial,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
+@with_operation_context
 def nanmin(
     array,
     axis=None,
@@ -120,29 +113,15 @@ def nanmin(
 
     See also #ak.min.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanmin",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "initial": initial,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(
-            array,
-            axis,
-            keepdims,
-            initial,
-            mask_identity,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        initial,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -2,12 +2,14 @@
 __all__ = ("moment",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def moment(
     x,
     n,
@@ -58,18 +60,7 @@ def moment(
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.moment",
-        {
-            "x": x,
-            "n": n,
-            "weight": weight,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, n, weight, axis, keepdims, mask_identity)
+    return _impl(x, n, weight, axis, keepdims, mask_identity)
 
 
 def _impl(x, n, weight, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -2,12 +2,14 @@
 __all__ = ("nan_to_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -21,15 +23,7 @@ def nan_to_none(array, *, highlevel=True, behavior=None):
 
     See also #ak.nan_to_num to convert NaN or infinity to specified values.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nan_to_none",
-        {
-            "array": array,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -2,12 +2,14 @@
 __all__ = ("nan_to_num",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def nan_to_num(
     array,
     copy=True,
@@ -37,19 +39,7 @@ def nan_to_num(
 
     See also #ak.nan_to_none to convert NaN to None, i.e. missing values with option-type.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nan_to_num",
-        {
-            "array": array,
-            "copy": copy,
-            "nan": nan,
-            "posinf": posinf,
-            "neginf": neginf,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, copy, nan, posinf, neginf, highlevel, behavior)
+    return _impl(array, copy, nan, posinf, neginf, highlevel, behavior)
 
 
 def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,7 +2,7 @@
 __all__ = ("num",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -69,11 +70,7 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
         >>> array.mask[ak.num(array) > 0][:, 0]
         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.num",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -1,13 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("ones_like",)
-
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def ones_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):
@@ -30,17 +31,7 @@ def ones_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.ones_like",
-        {
-            "array": array,
-            "dtype": dtype,
-            "including_unknown": including_unknown,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, highlevel, behavior, dtype, including_unknown)
+    return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 
 def _impl(array, highlevel, behavior, dtype, including_unknown):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("pad_none",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -8,6 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:
@@ -95,18 +97,7 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
         >>> ak.pad_none(array, 2, axis=2, clip=True).type.show()
         3 * var *   2 * ?float64
     """
-    with ak._errors.OperationErrorContext(
-        "ak.pad_none",
-        {
-            "array": array,
-            "target": target,
-            "axis": axis,
-            "clip": clip,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, target, axis, clip, highlevel, behavior)
+    return _impl(array, target, axis, clip, highlevel, behavior)
 
 
 def _impl(array, target, axis, clip, highlevel, behavior):

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -1,17 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("parameters",)
-
 import copy
 import numbers
 
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def parameters(array):
     """
     Args:
@@ -28,11 +29,7 @@ def parameters(array):
     See #ak.Array and #ak.behavior for a more complete description of
     behaviors.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.parameters",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -3,6 +3,7 @@ __all__ = ("prod",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def prod(
     array,
     axis=None,
@@ -51,20 +53,10 @@ def prod(
 
     See also #ak.nanprod.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.prod",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
+@with_operation_context
 def nanprod(
     array,
     axis=None,
@@ -100,20 +92,14 @@ def nanprod(
 
     See also #ak.prod.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanprod",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -3,6 +3,7 @@ __all__ = ("ptp",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
@@ -57,16 +59,7 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.ptp",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity)
+    return _impl(array, axis, keepdims, mask_identity)
 
 
 def _impl(array, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -2,12 +2,14 @@
 __all__ = ("ravel",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -49,11 +51,7 @@ def ravel(array, *, highlevel=True, behavior=None):
     Missing values are not eliminated by flattening. See #ak.flatten with
     `axis=None` for an equivalent function that eliminates the option type.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.ravel",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -12,6 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def run_lengths(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -86,15 +88,7 @@ def run_lengths(array, *, highlevel=True, behavior=None):
 
     See also #ak.num, #ak.argsort, #ak.unflatten.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.run_lengths",
-        {
-            "array": array,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,7 +2,7 @@
 __all__ = ("singletons",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -41,11 +42,7 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
 
     See #ak.firsts to invert this function.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.singletons",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -2,6 +2,7 @@
 __all__ = ("softmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -42,16 +44,7 @@ def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.softmax",
-        {
-            "x": x,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, axis, keepdims, mask_identity)
+    return _impl(x, axis, keepdims, mask_identity)
 
 
 def _impl(x, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -2,6 +2,7 @@
 __all__ = ("sort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:
@@ -34,18 +36,7 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
         >>> ak.sort(ak.Array([[7, 5, 7], [], [2], [8, 2]]))
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.sort",
-        {
-            "array": array,
-            "axis": axis,
-            "ascending": ascending,
-            "stable": stable,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, ascending, stable, highlevel, behavior)
+    return _impl(array, axis, ascending, stable, highlevel, behavior)
 
 
 def _impl(array, axis, ascending, stable, highlevel, behavior):

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -2,6 +2,7 @@
 __all__ = ("strings_astype",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -10,6 +11,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:
@@ -43,11 +45,7 @@ def strings_astype(array, to, *, highlevel=True, behavior=None):
 
     See also #ak.numbers_astype.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.strings_astype",
-        {"array": array, "to": to, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, to, highlevel, behavior)
+    return _impl(array, to, highlevel, behavior)
 
 
 def _impl(array, to, highlevel, behavior):

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -3,6 +3,7 @@ __all__ = ("sum",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def sum(
     array,
     axis=None,
@@ -195,20 +197,10 @@ def sum(
 
     See also #ak.nansum.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.sum",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
+@with_operation_context
 def nansum(
     array,
     axis=None,
@@ -248,20 +240,14 @@ def nansum(
 
     See also #ak.sum.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nansum",
-        {
-            "array": array,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        array = ak.operations.ak_nan_to_none._impl(array, False, None)
-
-        return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(array, False, None),
+        axis,
+        keepdims,
+        mask_identity,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(array, axis, keepdims, mask_identity, highlevel, behavior):

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -1,12 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_arrow",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_arrow(
     array,
     *,
@@ -64,29 +65,16 @@ def to_arrow(
 
     See also #ak.from_arrow, #ak.to_arrow_table, #ak.to_parquet, #ak.from_arrow_schema.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_arrow",
-        {
-            "array": array,
-            "list_to32": list_to32,
-            "string_to32": string_to32,
-            "bytestring_to32": bytestring_to32,
-            "emptyarray_to": emptyarray_to,
-            "categorical_as_dictionary": categorical_as_dictionary,
-            "extensionarray": extensionarray,
-            "count_nulls": count_nulls,
-        },
-    ):
-        return _impl(
-            array,
-            list_to32,
-            string_to32,
-            bytestring_to32,
-            emptyarray_to,
-            categorical_as_dictionary,
-            extensionarray,
-            count_nulls,
-        )
+    return _impl(
+        array,
+        list_to32,
+        string_to32,
+        bytestring_to32,
+        emptyarray_to,
+        categorical_as_dictionary,
+        extensionarray,
+        count_nulls,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -1,14 +1,15 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_arrow_table",)
-
 import json
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_arrow_table(
     array,
     *,
@@ -65,29 +66,16 @@ def to_arrow_table(
 
     See also #ak.from_arrow, #ak.to_arrow, #ak.to_parquet.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_arrow_table",
-        {
-            "array": array,
-            "list_to32": list_to32,
-            "string_to32": string_to32,
-            "bytestring_to32": bytestring_to32,
-            "emptyarray_to": emptyarray_to,
-            "categorical_as_dictionary": categorical_as_dictionary,
-            "extensionarray": extensionarray,
-            "count_nulls": count_nulls,
-        },
-    ):
-        return _impl(
-            array,
-            list_to32,
-            string_to32,
-            bytestring_to32,
-            emptyarray_to,
-            categorical_as_dictionary,
-            extensionarray,
-            count_nulls,
-        )
+    return _impl(
+        array,
+        list_to32,
+        string_to32,
+        bytestring_to32,
+        emptyarray_to,
+        categorical_as_dictionary,
+        extensionarray,
+        count_nulls,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -3,12 +3,14 @@ __all__ = ("to_backend",)
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:
@@ -48,16 +50,7 @@ def to_backend(array, backend, *, highlevel=True, behavior=None):
 
     See #ak.kernels.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_backend",
-        {
-            "array": array,
-            "backend": backend,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, backend, highlevel, behavior)
+    return _impl(array, backend, highlevel, behavior)
 
 
 def _impl(array, backend, highlevel, behavior):

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -1,13 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_buffers",)
-
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_buffers(
     array,
     container=None,
@@ -119,21 +120,7 @@ def to_buffers(
 
     See also #ak.from_buffers and #ak.to_packed.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_buffers",
-        {
-            "array": array,
-            "container": container,
-            "buffer_key": buffer_key,
-            "form_key": form_key,
-            "id_start": id_start,
-            "backend": backend,
-            "byteorder": byteorder,
-        },
-    ):
-        return _impl(
-            array, container, buffer_key, form_key, id_start, backend, byteorder
-        )
+    return _impl(array, container, buffer_key, form_key, id_start, backend, byteorder)
 
 
 def _impl(array, container, buffer_key, form_key, id_start, backend, byteorder):

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,6 +2,7 @@
 __all__ = ("to_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -10,6 +11,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -81,11 +83,7 @@ def to_categorical(array, *, highlevel=True, behavior=None):
 
     See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_categorical",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -1,10 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_cupy",)
-
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def to_cupy(array):
     """
     Args:
@@ -22,11 +23,7 @@ def to_cupy(array):
 
     See also #ak.from_cupy and #ak.to_numpy.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_cupy",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_dataframe",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -9,6 +9,7 @@ numpy = Numpy.instance()
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_dataframe(
     array, *, how="inner", levelname=lambda i: "sub" * i + "entry", anonymous="values"
 ):
@@ -122,16 +123,7 @@ def to_dataframe(
               2         3.0  NaN
               3         4.0  NaN
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_dataframe",
-        {
-            "array": array,
-            "how": how,
-            "levelname": levelname,
-            "anonymous": anonymous,
-        },
-    ):
-        return _impl(array, how, levelname, anonymous)
+    return _impl(array, how, levelname, anonymous)
 
 
 def _impl(array, how, levelname, anonymous):

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -1,10 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_jax",)
-
 import awkward as ak
 from awkward._backends.jax import JaxBackend
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def to_jax(array):
     """
     Args:
@@ -22,11 +23,7 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_jax",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -9,6 +9,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -16,6 +17,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def to_json(
     array,
     file=None,
@@ -111,35 +113,19 @@ def to_json(
 
     See also #ak.from_json.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_json",
-        {
-            "array": array,
-            "file": file,
-            "line_delimited": line_delimited,
-            "num_indent_spaces": num_indent_spaces,
-            "num_readability_spaces": num_readability_spaces,
-            "nan_string": nan_string,
-            "posinf_string": posinf_string,
-            "neginf_string": neginf_string,
-            "complex_record_fields": complex_record_fields,
-            "convert_bytes": convert_bytes,
-            "convert_other": convert_other,
-        },
-    ):
-        return _impl(
-            array,
-            file,
-            line_delimited,
-            num_indent_spaces,
-            num_readability_spaces,
-            nan_string,
-            posinf_string,
-            neginf_string,
-            complex_record_fields,
-            convert_bytes,
-            convert_other,
-        )
+    return _impl(
+        array,
+        file,
+        line_delimited,
+        num_indent_spaces,
+        num_readability_spaces,
+        nan_string,
+        posinf_string,
+        neginf_string,
+        complex_record_fields,
+        convert_bytes,
+        convert_other,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -1,6 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_layout",)
-
 from collections.abc import Iterable
 
 from awkward_cpp.lib import _ext
@@ -8,6 +7,7 @@ from awkward_cpp.lib import _ext
 import awkward as ak
 from awkward import _errors
 from awkward._backends.typetracer import TypeTracerBackend
+from awkward._errors import with_operation_context
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -18,6 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
+@with_operation_context
 def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward import _errors
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._errors import with_operation_context
 from awkward._nplikes.cupy import Cupy
@@ -42,16 +41,7 @@ def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True)
     would rarely be used in a data analysis because #ak.contents.Content and
     #ak.record.Record are lower-level than #ak.Array.
     """
-    with _errors.OperationErrorContext(
-        "ak.to_layout",
-        {
-            "array": array,
-            "allow_record": allow_record,
-            "allow_other": allow_other,
-            "regulararray": regulararray,
-        },
-    ):
-        return _impl(array, allow_record, allow_other, regulararray=regulararray)
+    return _impl(array, allow_record, allow_other, regulararray=regulararray)
 
 
 def _impl(array, allow_record, allow_other, regulararray):

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -1,16 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_list",)
-
 from collections.abc import Iterable, Mapping
 
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_list(array):
     """
     Args:
@@ -38,11 +39,7 @@ def to_list(array):
 
     See also #ak.from_iter and #ak.Array.tolist.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_list",
-        {"array": array},
-    ):
-        return _impl(array)
+    return _impl(array)
 
 
 def _impl(array):

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -2,8 +2,10 @@
 __all__ = ("to_numpy",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def to_numpy(array, *, allow_missing=True):
     """
     Args:
@@ -35,11 +37,7 @@ def to_numpy(array, *, allow_missing=True):
 
     See also #ak.from_numpy and #ak.to_cupy.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_numpy",
-        {"array": array, "allow_missing": allow_missing},
-    ):
-        return _impl(array, allow_missing)
+    return _impl(array, allow_missing)
 
 
 def _impl(array, allow_missing):

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -1,12 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_packed",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_packed(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -65,11 +67,7 @@ def to_packed(array, *, highlevel=True, behavior=None):
 
     See also #ak.to_buffers.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_packed",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -1,14 +1,15 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_parquet",)
-
 from collections.abc import Mapping, Sequence
 
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 metadata = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_parquet(
     array,
     destination,
@@ -318,6 +319,7 @@ def to_parquet(
     return meta
 
 
+@with_operation_context
 def write_metadata(dir_path, fs, *metas, global_metadata=True):
     """Generate metadata file(s) from list of arrow metadata instances"""
     assert metas

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -327,7 +327,6 @@ def to_parquet(
     return meta
 
 
-@with_operation_context
 def write_metadata(dir_path, fs, *metas, global_metadata=True):
     """Generate metadata file(s) from list of arrow metadata instances"""
     assert metas

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -4,10 +4,12 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
+from awkward._errors import with_operation_context
 
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:
@@ -40,14 +42,10 @@ def to_rdataframe(arrays, *, flatlist_as_rvec=True):
 
     See also #ak.from_rdataframe.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_rdataframe",
-        {"arrays": arrays},
-    ):
-        return _impl(
-            arrays,
-            flatlist_as_rvec=flatlist_as_rvec,
-        )
+    return _impl(
+        arrays,
+        flatlist_as_rvec=flatlist_as_rvec,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,7 +2,7 @@
 __all__ = ("to_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
+from awkward._errors import AxisError, with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -51,11 +52,7 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
 
     See also #ak.from_regular.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.to_regular",
-        {"array": array, "axis": axis, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, axis, highlevel, behavior)
+    return _impl(array, axis, highlevel, behavior)
 
 
 def _impl(array, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -6,11 +6,13 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def transform(
     transformation,
     array,
@@ -409,41 +411,22 @@ def transform(
     See also: #ak.is_valid and #ak.valid_when to check the validity of transformed
     outputs.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.transform",
-        {
-            "transformation": transformation,
-            "array": array,
-            "more_arrays": more_arrays,
-            "depth_context": depth_context,
-            "lateral_context": lateral_context,
-            "allow_records": allow_records,
-            "broadcast_parameters_rule": broadcast_parameters_rule,
-            "left_broadcast": left_broadcast,
-            "right_broadcast": right_broadcast,
-            "numpy_to_regular": numpy_to_regular,
-            "regular_to_jagged": regular_to_jagged,
-            "return_value": return_value,
-            "behavior": behavior,
-            "highlevel": highlevel,
-        },
-    ):
-        return _impl(
-            transformation,
-            array,
-            more_arrays,
-            depth_context,
-            lateral_context,
-            allow_records,
-            broadcast_parameters_rule,
-            left_broadcast,
-            right_broadcast,
-            numpy_to_regular,
-            regular_to_jagged,
-            return_value,
-            behavior,
-            highlevel,
-        )
+    return _impl(
+        transformation,
+        array,
+        more_arrays,
+        depth_context,
+        lateral_context,
+        allow_records,
+        broadcast_parameters_rule,
+        left_broadcast,
+        right_broadcast,
+        numpy_to_regular,
+        regular_to_jagged,
+        return_value,
+        behavior,
+        highlevel,
+    )
 
 
 def _impl(

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -7,11 +7,13 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def type(array, *, behavior=None):
     """
     Args:
@@ -73,11 +75,7 @@ def type(array, *, behavior=None):
     similar to existing type-constructors, so it's a plausible addition
     to the language.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.type",
-        {"array": array, "behavior": behavior},
-    ):
-        return _impl(array, behavior)
+    return _impl(array, behavior)
 
 
 def _impl(array, behavior):

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -2,6 +2,7 @@
 __all__ = ("unflatten",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -11,6 +12,7 @@ from awkward._regularize import is_integer_like, regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -74,17 +76,7 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
 
     See also #ak.num and #ak.flatten.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.unflatten",
-        {
-            "array": array,
-            "counts": counts,
-            "axis": axis,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, counts, axis, highlevel, behavior)
+    return _impl(array, counts, axis, highlevel, behavior)
 
 
 def _impl(array, counts, axis, highlevel, behavior):

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -2,12 +2,14 @@
 __all__ = ("unzip",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -34,11 +36,7 @@ def unzip(array, *, highlevel=True, behavior=None):
         >>> y
         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.unzip",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("validity_error",)
-
 import awkward as ak
+from awkward._errors import with_operation_context
 
 
+@with_operation_context
 def validity_error(array, *, exception=False):
     """
     Args:
@@ -19,11 +20,7 @@ def validity_error(array, *, exception=False):
 
     See also #ak.is_valid.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.validity_error",
-        {"array": array, "exception": exception},
-    ):
-        return _impl(array, exception)
+    return _impl(array, exception)
 
 
 def _impl(array, exception):

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -1,12 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("values_astype",)
 import awkward as ak
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def values_astype(array, to, *, including_unknown=False, highlevel=True, behavior=None):
     """
     Args:
@@ -52,17 +54,7 @@ def values_astype(array, to, *, including_unknown=False, highlevel=True, behavio
 
     See also #ak.strings_astype.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.values_astype",
-        {
-            "array": array,
-            "to": to,
-            "including_unknown": including_unknown,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, to, including_unknown, highlevel, behavior)
+    return _impl(array, to, including_unknown, highlevel, behavior)
 
 
 def _impl(array, to, including_unknown, highlevel, behavior):

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -3,6 +3,7 @@ __all__ = ("var",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,6 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def var(
     x,
     weight=None,
@@ -68,20 +70,10 @@ def var(
 
     See also #ak.nanvar.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.var",
-        {
-            "x": x,
-            "weight": weight,
-            "ddof": ddof,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        return _impl(x, weight, ddof, axis, keepdims, mask_identity)
+    return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
+@with_operation_context
 def nanvar(
     x,
     weight=None,
@@ -125,22 +117,17 @@ def nanvar(
 
     See also #ak.var.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.nanvar",
-        {
-            "x": x,
-            "weight": weight,
-            "ddof": ddof,
-            "axis": axis,
-            "keepdims": keepdims,
-            "mask_identity": mask_identity,
-        },
-    ):
-        x = ak.operations.ak_nan_to_none._impl(x, False, None)
-        if weight is not None:
-            weight = ak.operations.ak_nan_to_none._impl(weight, False, None)
+    if weight is not None:
+        weight = ak.operations.ak_nan_to_none._impl(weight, False, None)
 
-        return _impl(x, weight, ddof, axis, keepdims, mask_identity)
+    return _impl(
+        ak.operations.ak_nan_to_none._impl(x, False, None),
+        weight,
+        ddof,
+        axis,
+        keepdims,
+        mask_identity,
+    )
 
 
 def _impl(x, weight, ddof, axis, keepdims, mask_identity):

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -4,6 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -12,6 +13,7 @@ cpu = NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("where")
+@with_operation_context
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:
@@ -44,28 +46,14 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     they are incompatible types, the output will have #ak.type.UnionType.
     """
     if len(args) == 0:
-        with ak._errors.OperationErrorContext(
-            "ak.where",
-            {"condition": condition, "mergebool": mergebool, "highlevel": highlevel},
-        ):
-            return _impl1(condition, mergebool, highlevel, behavior)
+        return _impl1(condition, mergebool, highlevel, behavior)
 
     elif len(args) == 1:
         raise ValueError("either both or neither of x and y should be given")
 
     elif len(args) == 2:
         x, y = args
-        with ak._errors.OperationErrorContext(
-            "ak.where",
-            {
-                "condition": condition,
-                "x": x,
-                "y": y,
-                "mergebool": mergebool,
-                "highlevel": highlevel,
-            },
-        ):
-            return _impl3(condition, x, y, mergebool, highlevel, behavior)
+        return _impl3(condition, x, y, mergebool, highlevel, behavior)
 
     else:
         raise TypeError(

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -6,6 +6,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_non_string_like_sequence
@@ -16,6 +17,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@with_operation_context
 def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:
@@ -39,17 +41,7 @@ def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     #ak.with_field, so performance is not a factor in choosing one over the
     other.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.with_field",
-        {
-            "array": array,
-            "what": what,
-            "where": where,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, what, where, highlevel, behavior)
+    return _impl(array, what, where, highlevel, behavior)
 
 
 def _impl(base, what, where, highlevel, behavior):

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -2,12 +2,14 @@
 __all__ = ("with_name",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:
@@ -31,11 +33,7 @@ def with_name(array, name, *, highlevel=True, behavior=None):
     to the data; see #ak.Array and #ak.behavior for a more complete
     description.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.with_name",
-        {"array": array, "name": name, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, name, highlevel, behavior)
+    return _impl(array, name, highlevel, behavior)
 
 
 def _impl(array, name, highlevel, behavior):

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -2,12 +2,14 @@
 __all__ = ("with_parameter",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:
@@ -28,17 +30,7 @@ def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     You can also remove a single parameter with this function, since setting
     a parameter to None is equivalent to removing it.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.with_parameter",
-        {
-            "array": array,
-            "parameter": parameter,
-            "value": value,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, parameter, value, highlevel, behavior)
+    return _impl(array, parameter, value, highlevel, behavior)
 
 
 def _impl(array, parameter, value, highlevel, behavior):

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -4,12 +4,14 @@ from collections.abc import Sequence
 
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def without_field(array, where, *, highlevel=True, behavior=None):
     """
     Args:
@@ -31,11 +33,7 @@ def without_field(array, where, *, highlevel=True, behavior=None):
     #ak.without_field, so performance is not a factor in choosing one over the
     other.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.without_field",
-        {"array": array, "where": where, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, where, highlevel, behavior)
+    return _impl(array, where, highlevel, behavior)
 
 
 def _impl(base, where, highlevel, behavior):

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,12 +2,14 @@
 __all__ = ("without_parameters",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -23,11 +25,7 @@ def without_parameters(array, *, highlevel=True, behavior=None):
     Note that a "new array" is a lightweight shallow copy, not a duplication
     of large data buffers.
     """
-    with ak._errors.OperationErrorContext(
-        "ak.without_parameters",
-        {"array": array, "highlevel": highlevel, "behavior": behavior},
-    ):
-        return _impl(array, highlevel, behavior)
+    return _impl(array, highlevel, behavior)
 
 
 def _impl(array, highlevel, behavior):

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -1,8 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("zeros_like",)
-
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
+from awkward._errors import with_operation_context
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -11,6 +11,7 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
+@with_operation_context
 def zeros_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):
@@ -33,17 +34,7 @@ def zeros_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
-    with ak._errors.OperationErrorContext(
-        "ak.zeros_like",
-        {
-            "array": array,
-            "dtype": dtype,
-            "including_unknown": including_unknown,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(array, highlevel, behavior, dtype, including_unknown)
+    return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 
 def _impl(array, highlevel, behavior, dtype, including_unknown):

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -2,12 +2,14 @@
 __all__ = ("zip",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import with_operation_context
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
+@with_operation_context
 def zip(
     arrays,
     depth_limit=None,
@@ -131,29 +133,16 @@ def zip(
         >>> ak.zip([one, two], optiontype_outside_record=True)
         <Array [None, (2, 5), None] type='3 * ?(int64, int64)'>
     """
-    with ak._errors.OperationErrorContext(
-        "ak.zip",
-        {
-            "arrays": arrays,
-            "depth_limit": depth_limit,
-            "parameters": parameters,
-            "with_name": with_name,
-            "right_broadcast": right_broadcast,
-            "optiontype_outside_record": optiontype_outside_record,
-            "highlevel": highlevel,
-            "behavior": behavior,
-        },
-    ):
-        return _impl(
-            arrays,
-            depth_limit,
-            parameters,
-            with_name,
-            right_broadcast,
-            optiontype_outside_record,
-            highlevel,
-            behavior,
-        )
+    return _impl(
+        arrays,
+        depth_limit,
+        parameters,
+        with_name,
+        right_broadcast,
+        optiontype_outside_record,
+        highlevel,
+        behavior,
+    )
 
 
 def _impl(


### PR DESCRIPTION
This PR refactors our operations to use a decorator for providing an error context. This makes it easier to add new functions, but also improves readability.

Closes #1839