### PR TITLE
feat!: canonicalise `union` of `indexed`

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1276,7 +1276,7 @@ class Content:
         return (
             self.__class__ is other.__class__
             and len(self) == len(other)
-            and type_parameters_equal(self.parameters, other.parameters)
+            and type_parameters_equal(self._parameters, other._parameters)
             and self._is_equal_to(other, index_dtype, numpyarray)
         )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -835,7 +835,6 @@ class IndexedOptionArray(Content):
             index,
             contents,
             parameters=self._parameters,
-            merge=True,
             mergebool=True,
         )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1155,7 +1155,10 @@ class UnionArray(Content):
 
             # This pathway is covered by `.simplified`, but we can avoid an extra array operation
             # by performing this now
-            elif isinstance(array, ak.contents.IndexedArray):
+            elif (
+                isinstance(array, ak.contents.IndexedArray)
+                and array.parameter("__array__") != "categorical"
+            ):
                 assert nexttags.nplike is index_nplike
                 self._backend.maybe_kernel_error(
                     self._backend[

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -135,6 +135,13 @@ class UnionArray(Content):
                 )
             elif content.is_option:
                 n_seen_options += 1
+            elif content.is_indexed and content.parameter("__array__") != "categorical":
+                raise TypeError(
+                    (
+                        "{0} cannot contain non-categorical indexed-types in its 'contents' ({1}); "
+                        "try {0}.simplified instead"
+                    ).format(type(self).__name__, type(content).__name__)
+                )
 
         if n_seen_options not in {0, len(contents)}:
             raise TypeError(
@@ -1172,7 +1179,7 @@ class UnionArray(Content):
                 nextcontents.append(
                     array.content.copy(
                         parameters=parameters_union(
-                            array.content.parameters, array.parameters
+                            array.content._parameters, array._parameters
                         )
                     )
                 )

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1284,7 +1284,6 @@ class UnionArray(Content):
             self._index,
             self._contents,
             parameters=self._parameters,
-            merge=True,
             mergebool=True,
         )
         if isinstance(simplified, ak.contents.UnionArray):
@@ -1298,7 +1297,6 @@ class UnionArray(Content):
             self._index,
             self._contents,
             parameters=self._parameters,
-            merge=True,
             mergebool=True,
         )
         if isinstance(simplified, ak.contents.UnionArray):

--- a/tests/test_2192_union_absorb_indexed.py
+++ b/tests/test_2192_union_absorb_indexed.py
@@ -30,6 +30,35 @@ def test_simplified_indexed():
     )
 
 
+def test_simplified_indexed_categorical():
+    numbers = ak.contents.IndexedArray(
+        ak.index.Index64([0, 2, 3]),
+        ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+        parameters={"__array__": "categorical"},
+    )
+    records = ak.contents.RecordArray(
+        [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))], ["x"]
+    )
+    result = ak.concatenate((numbers, records), highlevel=False)
+    assert result.is_equal_to(
+        ak.contents.UnionArray(
+            ak.index.Index8([0, 0, 0, 1, 1, 1]),
+            ak.index.Index64([0, 1, 2, 0, 1, 2]),
+            [
+                ak.contents.IndexedArray(
+                    ak.index.Index64([0, 2, 3]),
+                    ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+                    parameters={"__array__": "categorical"},
+                ),
+                ak.contents.RecordArray(
+                    [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))],
+                    ["x"],
+                ),
+            ],
+        )
+    )
+
+
 def test_merge_indexed():
     records = ak.contents.IndexedArray(
         ak.index.Index64([0, 2, 3]),
@@ -81,3 +110,67 @@ def test_merge_indexed():
     # This test might be a bit strict; any code that views `layout.parameters` will change this result to `{}`
     assert result.contents[0]._parameters is None
     assert result.contents[1]._parameters == {"outer": "foo", "inner": "bar"}
+
+
+def test_merge_indexed_categorical():
+    records = ak.contents.IndexedArray(
+        ak.index.Index64([0, 2, 3]),
+        ak.contents.RecordArray(
+            [
+                ak.contents.NumpyArray(
+                    np.array([4.0, 3.0, 1.0, 9.0, 8.0, 7.0], dtype=np.int64)
+                )
+            ],
+            ["x"],
+            parameters={"inner": "bar", "drop": "this"},
+        ),
+        parameters={"outer": "foo", "ignore": "me", "__array__": "categorical"},
+    )
+    union = ak.contents.UnionArray(
+        ak.index.Index8([0, 0, 0, 1, 1, 1]),
+        ak.index.Index64([0, 1, 2, 0, 1, 2]),
+        [
+            ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+            ak.contents.IndexedArray(
+                ak.index.Index64([0, 1, 2]),
+                ak.contents.RecordArray(
+                    [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))],
+                    ["x"],
+                    parameters={"inner": "bar"},
+                ),
+                parameters={"outer": "foo", "__array__": "categorical"},
+            ),
+        ],
+    )
+    result = ak.concatenate((union, records), highlevel=False)
+    assert result.is_equal_to(
+        ak.contents.UnionArray(
+            ak.index.Index8([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            ak.index.Index64([0, 1, 2, 0, 1, 2, 3, 4, 5]),
+            [
+                ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+                ak.contents.IndexedArray(
+                    ak.index.Index64([0, 1, 2, 3, 5, 6]),
+                    ak.contents.RecordArray(
+                        [
+                            ak.contents.NumpyArray(
+                                np.array(
+                                    [4.0, 3.0, 1.0, 4.0, 3.0, 1.0, 9.0, 8.0, 7.0],
+                                    dtype=np.int64,
+                                )
+                            )
+                        ],
+                        ["x"],
+                    ),
+                    parameters={"__array__": "categorical"},
+                ),
+            ],
+        )
+    )
+    # This test might be a bit strict; any code that views `layout.parameters` will change this result to `{}`
+    assert result.contents[0]._parameters is None
+    assert result.contents[1]._parameters == {
+        "__array__": "categorical",
+        "outer": "foo",
+    }
+    assert result.contents[1].content._parameters == {"inner": "bar"}

--- a/tests/test_2192_union_absorb_indexed.py
+++ b/tests/test_2192_union_absorb_indexed.py
@@ -1,0 +1,83 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_simplified_indexed():
+    numbers = ak.contents.IndexedArray(
+        ak.index.Index64([0, 2, 3]),
+        ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+    )
+    records = ak.contents.RecordArray(
+        [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))], ["x"]
+    )
+    result = ak.concatenate((numbers, records), highlevel=False)
+    assert result.is_equal_to(
+        ak.contents.UnionArray(
+            ak.index.Index8([0, 0, 0, 1, 1, 1]),
+            ak.index.Index64([0, 2, 3, 0, 1, 2]),
+            [
+                ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+                ak.contents.RecordArray(
+                    [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))],
+                    ["x"],
+                ),
+            ],
+        )
+    )
+
+
+def test_merge_indexed():
+    records = ak.contents.IndexedArray(
+        ak.index.Index64([0, 2, 3]),
+        ak.contents.RecordArray(
+            [
+                ak.contents.NumpyArray(
+                    np.array([4.0, 3.0, 1.0, 9.0, 8.0, 7.0], dtype=np.int64)
+                )
+            ],
+            ["x"],
+            parameters={"inner": "bar", "drop": "this"},
+        ),
+        parameters={"outer": "foo", "ignore": "me"},
+    )
+    union = ak.contents.UnionArray(
+        ak.index.Index8([0, 0, 0, 1, 1, 1]),
+        ak.index.Index64([0, 1, 2, 0, 1, 2]),
+        [
+            ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+            ak.contents.RecordArray(
+                [ak.contents.NumpyArray(np.array([4.0, 3.0, 1.0], dtype=np.int64))],
+                ["x"],
+                parameters={"outer": "foo", "inner": "bar"},
+            ),
+        ],
+    )
+    result = ak.concatenate((union, records), highlevel=False)
+
+    assert result.is_equal_to(
+        ak.contents.UnionArray(
+            ak.index.Index8([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            ak.index.Index64([0, 1, 2, 0, 1, 2, 3, 5, 6]),
+            [
+                ak.contents.NumpyArray(np.arange(10, dtype=np.int64)),
+                ak.contents.RecordArray(
+                    [
+                        ak.contents.NumpyArray(
+                            np.array(
+                                [4.0, 3.0, 1.0, 4.0, 3.0, 1.0, 9.0, 8.0, 7.0],
+                                dtype=np.int64,
+                            )
+                        )
+                    ],
+                    ["x"],
+                ),
+            ],
+        )
+    )
+    # This test might be a bit strict; any code that views `layout.parameters` will change this result to `{}`
+    assert result.contents[0]._parameters is None
+    assert result.contents[1]._parameters == {"outer": "foo", "inner": "bar"}


### PR DESCRIPTION
This PR:
- Deprecates the `merge` argument to `UnionArray.simplified` — since the previous introduction of canonicalisation checks, this argument can no longer be meaningfully `False` in contexts where layouts are mergeable.
- Add a new rule for the simplification of `IndexedArray`s inside unions.

Closes #2192 