### PR TITLE
feat!: deprecate string behavior classes

### DIFF
--- a/docs/user-guide/how-to-convert-python.md
+++ b/docs/user-guide/how-to-convert-python.md
@@ -314,7 +314,7 @@ ak.Array([b"one", b"two", b"three", b"four"]).to_list()
 Advanced topic: the rest of this section may be skipped if you don't care about internal representations.
 ```
 
-Awkward's strings and bytestrings are not distinct types, but specializations of variable-length lists. Whereas a list might be internally represented by a {class}`ak.contents.ListArray` or a {class}`ak.contents.ListOffsetArray`,
+Awkward's strings and bytestrings are _specializations_ of variable-length lists. Whereas a list might be internally represented by a {class}`ak.contents.ListArray` or a {class}`ak.contents.ListOffsetArray`,
 
 ```{code-cell} ipython3
 ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).layout
@@ -342,13 +342,6 @@ ak.Array(["one", "two", "three", "four"]) == ak.Array(
 
 Special behaviors for strings are implemented using the same {data}`ak.behavior` mechanism that you might use to give special behaviors to Arrays and Records.
 
-```{code-cell} ipython3
-ak.behavior["string"]
-```
-
-```{code-cell} ipython3
-ak.behavior["bytestring"]
-```
 
 ```{code-cell} ipython3
 ak.behavior[np.equal, "string", "string"]

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._errors import deprecate
 from awkward._layout import wrap_layout
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,6 +12,11 @@ np = NumpyMetadata.instance()
 
 class ByteBehavior(Array):
     __name__ = "Array"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
 
     def __bytes__(self):
         tmp = self.layout.backend.nplike.asarray(self.layout)
@@ -53,6 +59,11 @@ class ByteBehavior(Array):
 class CharBehavior(Array):
     __name__ = "Array"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+
     def __bytes__(self):
         tmp = self.layout.backend.nplike.asarray(self.layout)
         if hasattr(tmp, "tobytes"):
@@ -94,6 +105,11 @@ class CharBehavior(Array):
 class ByteStringBehavior(Array):
     __name__ = "Array"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+
     def __iter__(self):
         for x in super().__iter__():
             yield x.__bytes__()
@@ -101,6 +117,11 @@ class ByteStringBehavior(Array):
 
 class StringBehavior(Array):
     __name__ = "Array"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
 
     def __iter__(self):
         for x in super().__iter__():
@@ -238,14 +259,10 @@ def _cast_bytes_or_str_to_string(string):
 
 
 def register(behavior):
-    behavior["byte"] = ByteBehavior
     behavior["__typestr__", "byte"] = "byte"
-    behavior["char"] = CharBehavior
     behavior["__typestr__", "char"] = "char"
 
-    behavior["bytestring"] = ByteStringBehavior
     behavior["__typestr__", "bytestring"] = "bytes"
-    behavior["string"] = StringBehavior
     behavior["__typestr__", "string"] = "string"
 
     behavior[ufuncs.equal, "bytestring", "bytestring"] = _string_equal

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -267,6 +267,9 @@ def _cast_bytes_or_str_to_string(string):
 
 
 def register(behavior):
+    behavior["byte"] = ByteBehavior
+    behavior["char"] = CharBehavior
+
     behavior["__typestr__", "byte"] = "byte"
     behavior["__typestr__", "char"] = "char"
 

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -122,10 +122,6 @@ class ByteStringBehavior(Array):
             version="2.4.0",
         )
 
-    def __iter__(self):
-        for x in super().__iter__():
-            yield x.__bytes__()
-
 
 class StringBehavior(Array):
     __name__ = "Array"
@@ -138,10 +134,6 @@ class StringBehavior(Array):
             f"provided by Awkward Array, rather than an extension.",
             version="2.4.0",
         )
-
-    def __iter__(self):
-        for x in super().__iter__():
-            yield x.__str__()
 
 
 def _string_equal(one, two):

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -16,7 +16,11 @@ class ByteBehavior(Array):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+        deprecate(
+            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"provided by Awkward Array, rather than an extension.",
+            version="2.4.0",
+        )
 
     def __bytes__(self):
         tmp = self.layout.backend.nplike.asarray(self.layout)
@@ -62,7 +66,11 @@ class CharBehavior(Array):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+        deprecate(
+            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"provided by Awkward Array, rather than an extension.",
+            version="2.4.0",
+        )
 
     def __bytes__(self):
         tmp = self.layout.backend.nplike.asarray(self.layout)
@@ -108,7 +116,11 @@ class ByteStringBehavior(Array):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+        deprecate(
+            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"provided by Awkward Array, rather than an extension.",
+            version="2.4.0",
+        )
 
     def __iter__(self):
         for x in super().__iter__():
@@ -121,7 +133,11 @@ class StringBehavior(Array):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        deprecate(f"{type(self).__name__} is deprecated", version="2.4.0")
+        deprecate(
+            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"provided by Awkward Array, rather than an extension.",
+            version="2.4.0",
+        )
 
     def __iter__(self):
         for x in super().__iter__():


### PR DESCRIPTION
As discussed in #2432, we don't appear to use these behavior classes anywhere. This PR deprecates them, and removes them from the global behavior dictionary.

This PR _doesn't_ remove the behavior classes for `byte` and `char`, because these _are_ used, including for `==` overloads.

- [x] Deprecate `string` and `bytestring` behavior classes