### PR TITLE
feat: add array dispatcher (non-inline)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ env:
   # This will ensure that the hash of the awkward-cpp directory remains
   # constant for unchanged files, meaning that it can be used for caching
   SOURCE_DATE_EPOCH: "1668811211"
-  AWKWARD_CHECK_DISPATCH_SIGNATURES: 1
 
 jobs:
   Windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ env:
   # This will ensure that the hash of the awkward-cpp directory remains
   # constant for unchanged files, meaning that it can be used for caching
   SOURCE_DATE_EPOCH: "1668811211"
+  AWKWARD_CHECK_DISPATCH_SIGNATURES: 1
 
 jobs:
   Windows:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,0 +1,40 @@
+from functools import wraps
+from inspect import signature
+
+from awkward._errors import OperationErrorContext
+from awkward._typing import Callable, Iterator, TypeAlias, TypeVar
+
+DispatcherType: TypeAlias = Iterator
+
+
+T = TypeVar("T", bound=Callable)
+
+
+def high_level_function(dispatcher=None):
+    """Decorate a high-level function such that it may be overloaded by third-party array objects"""
+
+    def decorator(func: T) -> T:
+        # Let's check the signature!
+        if not (dispatcher is None or signature(func) == signature(dispatcher)):
+            raise RuntimeError(
+                f"Array dispatcher for {func.__qualname__} is incompatible with implementation"
+            )
+
+        @wraps(func)
+        def dispatch(*args, **kwargs):
+            # NOTE: this decorator assumes that the operation is exposed under `ak.`
+            with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
+                if dispatcher is not None:
+                    dispatched = tuple(dispatcher(*args, **kwargs))
+                    for arg in dispatched:
+                        try:
+                            custom_impl = arg.__awkward_function__
+                        except AttributeError:
+                            continue
+                        return custom_impl(dispatch, dispatched, args, kwargs)
+
+                return func(*args, **kwargs)
+
+        return dispatch
+
+    return decorator

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,3 +1,4 @@
+import os
 from functools import wraps
 from inspect import signature
 
@@ -14,8 +15,10 @@ def high_level_function(dispatcher=None):
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""
 
     def decorator(func: T) -> T:
-        # Let's check the signature!
-        if not (dispatcher is None or signature(func) == signature(dispatcher)):
+        # Don't always check something that should be correct at author time
+        if "AWKWARD_CHECK_DISPATCH_SIGNATURES" in os.environ and not (
+            dispatcher is None or signature(func) == signature(dispatcher)
+        ):
             raise RuntimeError(
                 f"Array dispatcher for {func.__qualname__} is incompatible with implementation"
             )

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -3,7 +3,7 @@ __all__ = ("all",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def all(
     array,
     axis=None,

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 __all__ = ("almost_equal",)
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
@@ -12,7 +12,21 @@ from awkward.operations.ak_to_layout import to_layout
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    left,
+    right,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+    dtype_exact: bool = True,
+    check_parameters: bool = True,
+    check_regular: bool = True,
+):
+    yield left
+    yield right
+
+
+@high_level_function(_dispatcher)
 def almost_equal(
     left,
     right,
@@ -22,7 +36,7 @@ def almost_equal(
     dtype_exact: bool = True,
     check_parameters: bool = True,
     check_regular: bool = True,
-) -> bool:
+):
     """
     Args:
         left: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -3,7 +3,7 @@ __all__ = ("any",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def any(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -1,10 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argcartesian",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -13,7 +15,23 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    axis=1,
+    *,
+    nested=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def argcartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argcombinations",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,22 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    n,
+    *,
+    replacement=False,
+    axis=1,
+    fields=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argcombinations(
     array,
     n,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -3,7 +3,7 @@ __all__ = ("argmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argmax(
     array,
     axis=None,
@@ -63,7 +75,19 @@ def argmax(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanargmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -3,7 +3,7 @@ __all__ = ("argmin",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argmin(
     array,
     axis=None,
@@ -63,7 +75,19 @@ def argmin(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanargmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -2,7 +2,7 @@
 __all__ = ("argsort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -1,11 +1,15 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("backend",)
 from awkward._backends.dispatch import backend_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
-def backend(*arrays) -> str:
+def _dispatcher(*arrays):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
+def backend(*arrays):
     """
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -5,7 +5,7 @@ from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -13,7 +13,19 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    *arrays,
+    depth_limit=None,
+    broadcast_parameters_rule="one_to_one",
+    left_broadcast=True,
+    right_broadcast=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
 def broadcast_arrays(
     *arrays,
     depth_limit=None,
@@ -126,7 +138,7 @@ def broadcast_arrays(
             output = []
             for inner in outer:
                 output.append(x + inner)
-            yield output
+            yield arrayput
 
     where `x` has the same value for each `inner` in the inner loop.
 

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -4,18 +4,18 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
-def broadcast_fields(
-    *arrays,
-    highlevel=True,
-    behavior=None,
-):
+def _dispatcher(*arrays, highlevel=True, behavior=None):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
+def broadcast_fields(*arrays, highlevel=True, behavior=None):
     """
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -1,10 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("cartesian",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -13,7 +16,23 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    axis=1,
+    *,
+    nested=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def cartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -2,11 +2,15 @@
 __all__ = ("categories",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@with_operation_context
+def _dispatcher(array, highlevel=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def categories(array, highlevel=True):
     """
     Args:

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("combinations",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,22 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    n,
+    *,
+    replacement=False,
+    axis=1,
+    fields=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def combinations(
     array,
     n,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -17,8 +17,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@ak._connect.numpy.implements("concatenate")
-@with_operation_context
+def _dispatcher(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -4,13 +4,17 @@ import copy as _copy
 
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def copy(array):
     """
     Args:

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -2,7 +2,7 @@
 __all__ = ("corr",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,16 +10,14 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def corr(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield y
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the correlation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -2,7 +2,7 @@
 __all__ = ("count",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def count(
     array,
     axis=None,

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -2,7 +2,7 @@
 __all__ = ("count_nonzero",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def count_nonzero(
     array,
     axis=None,

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -2,23 +2,21 @@
 __all__ = ("covar",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def covar(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield y
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -1,7 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("drop_none",)
 import awkward as ak
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +10,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=None, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -6,7 +6,7 @@ __all__ = ("enforce_type",)
 from itertools import permutations
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -17,14 +17,12 @@ from awkward.types.numpytype import primitive_to_dtype
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def enforce_type(
-    array,
-    type,
-    *,
-    highlevel=True,
-    behavior=None,
-):
+def _dispatcher(array, type, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
+def enforce_type(array, type, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -1,13 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("fields",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def fields(array):
     """
     Args:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -6,7 +6,8 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_sized_iterable, regularize_axis
@@ -15,7 +16,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, value, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+    yield value
+
+
+@high_level_function(_dispatcher)
 def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,7 +2,8 @@
 __all__ = ("firsts",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("flatten",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -1,14 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow_schema",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -4,13 +4,13 @@ __all__ = ("from_avro_file",)
 from os import PathLike, fsdecode
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_avro_file(
     file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -2,11 +2,15 @@
 __all__ = ("from_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_cupy",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -5,13 +5,13 @@ from collections.abc import Iterable
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_iter(
     iterable,
     *,

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_jax",)
 from awkward import jax
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_json(
     source,
     *,
@@ -520,11 +520,11 @@ def _yes_schema(
             raise TypeError("JSONSchema type is not concrete: array without items")
 
         instructions.append(["TopLevelArray"])
-        form = build_assembly(schema["items"], container, instructions)
+        form = _build_assembly(schema["items"], container, instructions)
         is_record = False
 
     elif schema.get("type") == "object":
-        form = build_assembly(schema, container, instructions)
+        form = _build_assembly(schema, container, instructions)
         is_record = True
 
     else:
@@ -565,8 +565,7 @@ def _yes_schema(
         return layout
 
 
-@with_operation_context
-def build_assembly(schema, container, instructions):
+def _build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
         raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
 
@@ -712,7 +711,7 @@ def build_assembly(schema, container, instructions):
 
             instructions.append(["FixedLengthList", schema.get("minItems")])
 
-            content = build_assembly(schema["items"], container, instructions)
+            content = _build_assembly(schema["items"], container, instructions)
 
             out = ak.forms.RegularForm(content, size=schema.get("minItems"))
             if is_optional:
@@ -730,7 +729,7 @@ def build_assembly(schema, container, instructions):
             container[offsets + "-offsets"] = None
             instructions.append(["VarLengthList", offsets + "-offsets", "int64"])
 
-            content = build_assembly(schema["items"], container, instructions)
+            content = _build_assembly(schema["items"], container, instructions)
 
             out = ak.forms.ListOffsetForm("i64", content, form_key=offsets)
             if is_optional:
@@ -769,7 +768,7 @@ def build_assembly(schema, container, instructions):
         for keyindex, subschema in enumerate(subschemas):
             # set the "jump_to" instruction position in the KeyTable
             instructions[startkeys + keyindex][2] = len(instructions)
-            contents.append(build_assembly(subschema, container, instructions))
+            contents.append(_build_assembly(subschema, container, instructions))
 
         out = ak.forms.RecordForm(contents, names)
         if is_optional:

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_numpy",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_numpy(
     array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_parquet",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._regularize import is_integer
 
 
-@with_operation_context
+@high_level_function()
 def from_parquet(
     path,
     *,
@@ -76,7 +76,18 @@ def from_parquet(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    path,
+    storage_options=None,
+    row_groups=None,
+    columns=None,
+    ignore_metadata=False,
+    scan_files=True,
+):
+    yield
+
+
+@high_level_function(_dispatcher)
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -1,13 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_rdataframe",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,7 +2,8 @@
 __all__ = ("from_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -3,7 +3,7 @@ __all__ = ("full_like",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import ensure_known_scalar
@@ -12,7 +12,20 @@ from awkward.operations.ak_zeros_like import _ZEROS
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    fill_value,
+    *,
+    dtype=None,
+    including_unknown=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+    yield fill_value
+
+
+@high_level_function(_dispatcher)
 def full_like(
     array,
     fill_value,

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_categorical",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_categorical(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,7 +2,8 @@
 __all__ = ("is_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_tuple",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_tuple(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_valid",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, exception=False):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_valid(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -2,14 +2,21 @@
 __all__ = ("isclose",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
+):
+    yield a
+    yield b
+
+
+@high_level_function(_dispatcher)
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -3,7 +3,7 @@ __all__ = ("linear_fit",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -12,16 +12,12 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def linear_fit(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield from (x, y, weight)
+
+
+@high_level_function(_dispatcher)
+def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the linear fit (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("local_index",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -2,14 +2,19 @@
 __all__ = ("mask",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, mask, *, valid_when=True, highlevel=True, behavior=None):
+    yield array
+    yield mask
+
+
+@high_level_function(_dispatcher)
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -3,7 +3,7 @@ __all__ = ("max",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,20 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def max(
     array,
     axis=None,
@@ -72,7 +85,20 @@ def max(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -3,7 +3,7 @@ __all__ = ("mean",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,15 +11,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def mean(
-    x,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
@@ -85,15 +83,8 @@ def mean(
     return _impl(x, weight, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanmean(
-    x,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-):
+@high_level_function(_dispatcher)
+def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -3,7 +3,8 @@ __all__ = ("merge_option_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -3,7 +3,8 @@ __all__ = ("merge_union_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -3,7 +3,7 @@ __all__ = ("metadata_from_parquet",)
 import collections
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -15,7 +15,7 @@ ParquetMetadata = collections.namedtuple(
 )
 
 
-@with_operation_context
+@high_level_function()
 def metadata_from_parquet(
     path,
     *,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -3,7 +3,7 @@ __all__ = ("min",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,20 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def min(
     array,
     axis=None,
@@ -72,7 +85,20 @@ def min(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -2,23 +2,20 @@
 __all__ = ("moment",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def moment(
-    x,
-    n,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the moment (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -2,14 +2,18 @@
 __all__ = ("nan_to_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -2,14 +2,27 @@
 __all__ = ("nan_to_num",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    copy=True,
+    nan=0.0,
+    posinf=None,
+    neginf=None,
+    *,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nan_to_num(
     array,
     copy=True,

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,7 +2,8 @@
 __all__ = ("num",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -2,13 +2,19 @@
 __all__ = ("ones_like",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ones_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("pad_none",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -6,13 +6,17 @@ import numbers
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def parameters(array):
     """
     Args:

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -3,7 +3,7 @@ __all__ = ("prod",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def prod(
     array,
     axis=None,
@@ -56,7 +68,19 @@ def prod(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanprod(
     array,
     axis=None,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -3,7 +3,7 @@ __all__ = ("ptp",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=None, *, keepdims=False, mask_identity=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -2,14 +2,18 @@
 __all__ = ("ravel",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -13,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def run_lengths(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,7 +2,8 @@
 __all__ = ("singletons",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -2,7 +2,7 @@
 __all__ = ("softmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(x, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+
+
+@high_level_function(_dispatcher)
 def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -2,7 +2,7 @@
 __all__ = ("sort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -3,7 +3,7 @@ __all__ = ("std",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -12,16 +12,15 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def std(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
@@ -68,16 +67,15 @@ def std(
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanstd(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -2,7 +2,7 @@
 __all__ = ("strings_astype",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,7 +11,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, to, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -3,7 +3,7 @@ __all__ = ("sum",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def sum(
     array,
     axis=None,
@@ -200,7 +212,19 @@ def sum(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nansum(
     array,
     axis=None,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -1,13 +1,27 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_arrow",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    *,
+    list_to32=False,
+    string_to32=False,
+    bytestring_to32=False,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_arrow(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -3,13 +3,27 @@ __all__ = ("to_arrow_table",)
 import json
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    *,
+    list_to32=False,
+    string_to32=False,
+    bytestring_to32=False,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_arrow_table(
     array,
     *,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -3,14 +3,18 @@ __all__ = ("to_backend",)
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, backend, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -2,13 +2,26 @@
 __all__ = ("to_buffers",)
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    container=None,
+    buffer_key="{form_key}-{attribute}",
+    form_key="node{id}",
+    *,
+    id_start=0,
+    backend=None,
+    byteorder="<",
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_buffers(
     array,
     container=None,

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,7 +2,7 @@
 __all__ = ("to_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,7 +11,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -2,10 +2,14 @@
 __all__ = ("to_cupy",)
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_cupy(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_dataframe",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -9,9 +9,19 @@ numpy = Numpy.instance()
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _default_levelname(index: int) -> str:
+    return "sub" * index + "entry"
+
+
+def _dispatcher(
+    array, *, how="inner", levelname=_default_levelname, anonymous="values"
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_dataframe(
-    array, *, how="inner", levelname=lambda i: "sub" * i + "entry", anonymous="values"
+    array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):
     """
     Args:

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -2,10 +2,14 @@
 __all__ = ("to_jax",)
 import awkward as ak
 from awkward._backends.jax import JaxBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_jax(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -9,7 +9,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -17,7 +17,24 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    file=None,
+    *,
+    line_delimited=False,
+    num_indent_spaces=None,
+    num_readability_spaces=0,
+    nan_string=None,
+    posinf_string=None,
+    neginf_string=None,
+    complex_record_fields=None,
+    convert_bytes=None,
+    convert_other=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_json(
     array,
     file=None,

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -6,7 +6,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -17,7 +17,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, allow_record=True, allow_other=False, regulararray=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -5,13 +5,17 @@ from collections.abc import Iterable, Mapping
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -2,10 +2,14 @@
 __all__ = ("to_numpy",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, allow_missing=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_numpy(array, *, allow_missing=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -1,14 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_packed",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_packed(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -4,13 +4,43 @@ from collections.abc import Mapping, Sequence
 from os import fsdecode
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 metadata = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    destination,
+    *,
+    list_to32=False,
+    string_to32=True,
+    bytestring_to32=True,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+    compression="zstd",
+    compression_level=None,
+    row_group_size=64 * 1024 * 1024,
+    data_page_size=None,
+    parquet_flavor=None,
+    parquet_version="2.4",
+    parquet_page_version="1.0",
+    parquet_metadata_statistics=True,
+    parquet_dictionary_encoding=False,
+    parquet_byte_stream_split=False,
+    parquet_coerce_timestamps=None,
+    parquet_old_int96_timestamps=None,
+    parquet_compliant_nested=False,  # https://issues.apache.org/jira/browse/ARROW-16348
+    parquet_extra_options=None,
+    storage_options=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_parquet(
     array,
     destination,

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -4,12 +4,16 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(arrays, *, flatlist_as_rvec=True):
+    yield from arrays.values()
+
+
+@high_level_function(_dispatcher)
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,7 +2,8 @@
 __all__ = ("to_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -6,13 +6,33 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    transformation,
+    array,
+    *more_arrays,
+    depth_context=None,
+    lateral_context=None,
+    allow_records=True,
+    broadcast_parameters_rule="intersect",
+    left_broadcast=True,
+    right_broadcast=True,
+    numpy_to_regular=False,
+    regular_to_jagged=False,
+    return_value="simplified",
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+    yield from more_arrays
+
+
+@high_level_function(_dispatcher)
 def transform(
     transformation,
     array,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -7,13 +7,17 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def type(array, *, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -2,7 +2,7 @@
 __all__ = ("unflatten",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -12,7 +12,11 @@ from awkward._regularize import is_integer_like, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, counts, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -2,14 +2,18 @@
 __all__ = ("unzip",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("validity_error",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, exception=False):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def validity_error(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -1,14 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("values_astype",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, to, *, including_unknown=False, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def values_astype(array, to, *, including_unknown=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -3,7 +3,7 @@ __all__ = ("var",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,16 +11,15 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def var(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
@@ -73,16 +72,15 @@ def var(
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanvar(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -12,8 +12,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@ak._connect.numpy.implements("where")
-@with_operation_context
+def _dispatcher(condition, *args, mergebool=True, highlevel=True, behavior=None):
+    yield condition
+    yield from args
+
+
+@high_level_function(_dispatcher)
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -6,7 +6,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_non_string_like_sequence
@@ -17,7 +17,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, what, where=None, *, highlevel=True, behavior=None):
+    yield array
+    yield what
+
+
+@high_level_function(_dispatcher)
 def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -2,14 +2,18 @@
 __all__ = ("with_name",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, name, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -2,14 +2,18 @@
 __all__ = ("with_parameter",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, parameter, value, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -4,14 +4,18 @@ from collections.abc import Sequence
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, where, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def without_field(array, where, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,14 +2,18 @@
 __all__ = ("without_parameters",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -2,7 +2,7 @@
 __all__ = ("zeros_like",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -11,7 +11,13 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
-@with_operation_context
+def _dispatcher(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def zeros_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -1,15 +1,34 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("zip",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    depth_limit=None,
+    *,
+    parameters=None,
+    with_name=None,
+    right_broadcast=False,
+    optiontype_outside_record=False,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def zip(
     arrays,
     depth_limit=None,


### PR DESCRIPTION
## Goal 
It would be helpful for users of `dask-awkward` if we could provide a mechanism to use the `ak.` namespace on these third-party array objects, e.g.
```python
import awkward as ak

import dask_awkward as dak

array = ak.Array([[False, False, True, True], [], [True]])
darray = dak.from_awkward(array, npartitions=3)

dtotal = ak.sum(darray, axis=-1, keepdims=True)
dresult = ak.any(dtotal > 1, axis=-1, keepdims=True)

print(dresult.compute())
```

This PR implements a mechanism similar to NEP-18 for delegating to array objects for the concrete operation implementation. This behaves as follows:
- each high-level function implements a dispatcher that yields possible array-like objects that may implement this protocol
- if _any_ array-like implements the `__awkward_function__` protocol, we return the result of invoking that function
- if multiple arrays implement an `__awkward_function__`, the first as yielded by the `dispatcher` wins. In future we could require that `__awkward_function__` be defined _on the class_ and require that only a single _type_ implement this method.

For `dask-awkward` this function might look as follows:
```python
@classmethod
def __awkward_function__(cls, func, dispatched, args, kwargs):
    assert all(isinstance(x, cls) for x in dispatched)

    import dask_awkward
	name = func.__qualname__
    try:
        impl = getattr(dask_awkward, name)
    except AttributeError:
        raise NotImplementedError from None
    return impl(*args, **kwargs)
```

### Notes
- Unlike NumPy's mechanism, we don't try and support the case that there are multiple third-party arrays. I think this use case fairly unlikely at this stage, so at least for now it is not necessary to cater for it.
- The dispatcher must have an identical signature to the implementation. This avoids the need to use something like `inspect.signature` to prepare the arguments upon each invocation, i.e. a design tradeoff. This is also checked by the decorator upon first invocation. We could also perform such a test at import time, or only in our CI, but I think better to ensure this always runs for an invocation.