### PR TITLE
feat: add array dispatcher (inline)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ env:
   # This will ensure that the hash of the awkward-cpp directory remains
   # constant for unchanged files, meaning that it can be used for caching
   SOURCE_DATE_EPOCH: "1668811211"
-  AWKWARD_CHECK_DISPATCH_SIGNATURES: 1
 
 jobs:
   Windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ env:
   # This will ensure that the hash of the awkward-cpp directory remains
   # constant for unchanged files, meaning that it can be used for caching
   SOURCE_DATE_EPOCH: "1668811211"
+  AWKWARD_CHECK_DISPATCH_SIGNATURES: 1
 
 jobs:
   Windows:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -29,7 +29,14 @@ def high_level_function(func: T) -> T:
                     except AttributeError:
                         continue
                     else:
-                        return custom_impl(dispatch, array_likes, args, kwargs)
+                        result = custom_impl(dispatch, array_likes, args, kwargs)
+
+                        # Future proof the implementation by permitting the `__awkward_function__` to return `NotImplemented`
+                        # This may later be used to signal that another overload should be used.
+                        if result is NotImplemented:
+                            raise NotImplementedError
+                        else:
+                            return result
 
                 # Failed to find a custom overload, so resume the original function
                 try:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -30,6 +30,6 @@ def high_level_function(func: T) -> T:
                 except StopIteration as err:
                     return err.value
 
-            return func(*args, **kwargs)
+            return gen_or_result
 
     return dispatch

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,0 +1,40 @@
+from functools import wraps
+from inspect import signature
+
+from awkward._errors import OperationErrorContext
+from awkward._typing import Callable, Iterator, TypeAlias, TypeVar
+
+DispatcherType: TypeAlias = Iterator
+
+
+T = TypeVar("T", bound=Callable)
+
+
+def high_level_function(dispatcher=None):
+    """Decorate a high-level function such that it may be overloaded by third-party array objects"""
+
+    def decorator(func: T) -> T:
+        # Let's check the signature!
+        if not (dispatcher is None or signature(func) == signature(dispatcher)):
+            raise RuntimeError(
+                f"Array dispatcher for {func.__qualname__} is incompatible with implementation"
+            )
+
+        @wraps(func)
+        def dispatch(*args, **kwargs):
+            # NOTE: this decorator assumes that the operation is exposed under `ak.`
+            with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
+                if dispatcher is not None:
+                    dispatched = tuple(dispatcher(*args, **kwargs))
+                    for arg in dispatched:
+                        try:
+                            custom_impl = arg.__awkward_function__
+                        except AttributeError:
+                            continue
+                        return custom_impl(dispatch, dispatched, args, kwargs)
+
+                return func(*args, **kwargs)
+
+        return dispatch
+
+    return decorator

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,16 +1,16 @@
+from collections.abc import Callable, Collection, Generator
 from functools import wraps
 from inspect import isgenerator
 
 from awkward._errors import OperationErrorContext
-from awkward._typing import Callable, Iterator, TypeAlias, TypeVar
+from awkward._typing import Any, TypeAlias, TypeVar
 
-DispatcherType: TypeAlias = Iterator
+T = TypeVar("T")
+DispatcherType: TypeAlias = "Callable[..., Generator[Collection[Any], None, T]]"
+HighLevelType: TypeAlias = "Callable[..., T]"
 
 
-T = TypeVar("T", bound=Callable)
-
-
-def high_level_function(func: T) -> T:
+def high_level_function(func: DispatcherType) -> HighLevelType:
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""
 
     @wraps(func)

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from inspect import signature
+from inspect import isgenerator
 
 from awkward._errors import OperationErrorContext
 from awkward._typing import Callable, Iterator, TypeAlias, TypeVar
@@ -10,38 +10,26 @@ DispatcherType: TypeAlias = Iterator
 T = TypeVar("T", bound=Callable)
 
 
-def high_level_function(dispatcher=None):
+def high_level_function(func: T) -> T:
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""
 
-    def decorator(func: T) -> T:
-        signatures_validated = False
-
-        @wraps(func)
-        def dispatch(*args, **kwargs):
-            nonlocal signatures_validated
-
-            # Don't always check something that should be correct at author time
-            if not (signatures_validated or dispatcher is None):
-                if signature(func) == signature(dispatcher):
-                    signatures_validated = True
-                else:
-                    raise RuntimeError(
-                        f"Array dispatcher for {func.__qualname__} is incompatible with implementation"
-                    )
-
-            # NOTE: this decorator assumes that the operation is exposed under `ak.`
-            with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
-                if dispatcher is not None:
-                    dispatched = tuple(dispatcher(*args, **kwargs))
-                    for arg in dispatched:
+    @wraps(func)
+    def dispatch(*args, **kwargs):
+        # NOTE: this decorator assumes that the operation is exposed under `ak.`
+        with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
+            gen_or_result = func(*args, **kwargs)
+            if isgenerator(gen_or_result):
+                try:
+                    while True:
+                        arg = next(gen_or_result)
                         try:
                             custom_impl = arg.__awkward_function__
                         except AttributeError:
                             continue
-                        return custom_impl(dispatch, dispatched, args, kwargs)
+                        return custom_impl(dispatch, args, kwargs)
+                except StopIteration as err:
+                    return err.value
 
-                return func(*args, **kwargs)
+            return func(*args, **kwargs)
 
-        return dispatch
-
-    return decorator
+    return dispatch

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -1,3 +1,4 @@
+import os
 from functools import wraps
 from inspect import signature
 
@@ -14,8 +15,10 @@ def high_level_function(dispatcher=None):
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""
 
     def decorator(func: T) -> T:
-        # Let's check the signature!
-        if not (dispatcher is None or signature(func) == signature(dispatcher)):
+        # Don't always check something that should be correct at author time
+        if "AWKWARD_CHECK_DISPATCH_SIGNATURES" in os.environ and not (
+            dispatcher is None or signature(func) == signature(dispatcher)
+        ):
             raise RuntimeError(
                 f"Array dispatcher for {func.__qualname__} is incompatible with implementation"
             )

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -20,7 +20,7 @@ def high_level_function(func: DispatcherType) -> HighLevelType:
             gen_or_result = func(*args, **kwargs)
             if isgenerator(gen_or_result):
                 array_likes = next(gen_or_result)
-                assert isinstance(array_likes, tuple)
+                assert isinstance(array_likes, Collection)
 
                 # Permit a third-party array object to intercept the invocation
                 for array_like in array_likes:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -43,6 +43,10 @@ def high_level_function(func: DispatcherType) -> HighLevelType:
                     next(gen_or_result)
                 except StopIteration as err:
                     return err.value
+                else:
+                    raise AssertionError(
+                        "high-level functions should only implement a single yield statement"
+                    )
 
             return gen_or_result
 

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -19,14 +19,21 @@ def high_level_function(func: T) -> T:
         with OperationErrorContext(f"ak.{func.__qualname__}", args, kwargs):
             gen_or_result = func(*args, **kwargs)
             if isgenerator(gen_or_result):
+                array_likes = next(gen_or_result)
+                assert isinstance(array_likes, tuple)
+
+                # Permit a third-party array object to intercept the invocation
+                for array_like in array_likes:
+                    try:
+                        custom_impl = array_like.__awkward_function__
+                    except AttributeError:
+                        continue
+                    else:
+                        return custom_impl(dispatch, array_likes, args, kwargs)
+
+                # Failed to find a custom overload, so resume the original function
                 try:
-                    while True:
-                        arg = next(gen_or_result)
-                        try:
-                            custom_impl = arg.__awkward_function__
-                        except AttributeError:
-                            continue
-                        return custom_impl(dispatch, args, kwargs)
+                    next(gen_or_result)
                 except StopIteration as err:
                     return err.value
 

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -3,7 +3,7 @@ __all__ = ("all",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def all(
     array,
     axis=None,

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def all(
     array,
     axis=None,
@@ -65,6 +53,10 @@ def all(
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -54,7 +54,7 @@ def all(
     value (None) handling in reducers.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -46,8 +46,7 @@ def almost_equal(
     be compared.
     """
     # Dispatch
-    yield left
-    yield right
+    yield left, right
 
     # Implementation
     left_behavior = behavior_of(left)

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -12,21 +12,7 @@ from awkward.operations.ak_to_layout import to_layout
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    left,
-    right,
-    *,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
-    dtype_exact: bool = True,
-    check_parameters: bool = True,
-    check_regular: bool = True,
-):
-    yield left
-    yield right
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def almost_equal(
     left,
     right,
@@ -59,6 +45,11 @@ def almost_equal(
     TypeTracer arrays are not supported, as there is very little information to
     be compared.
     """
+    # Dispatch
+    yield left
+    yield right
+
+    # Implementation
     left_behavior = behavior_of(left)
     right_behavior = behavior_of(right)
 

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 __all__ = ("almost_equal",)
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of, get_array_class, get_record_class
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
@@ -12,7 +12,21 @@ from awkward.operations.ak_to_layout import to_layout
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    left,
+    right,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+    dtype_exact: bool = True,
+    check_parameters: bool = True,
+    check_regular: bool = True,
+):
+    yield left
+    yield right
+
+
+@high_level_function(_dispatcher)
 def almost_equal(
     left,
     right,
@@ -22,7 +36,7 @@ def almost_equal(
     dtype_exact: bool = True,
     check_parameters: bool = True,
     check_regular: bool = True,
-) -> bool:
+):
     """
     Args:
         left: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -3,7 +3,7 @@ __all__ = ("any",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def any(
     array,
     axis=None,

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -54,7 +54,7 @@ def any(
     value (None) handling in reducers.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def any(
     array,
     axis=None,
@@ -65,6 +53,10 @@ def any(
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -1,10 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argcartesian",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -13,7 +15,23 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    axis=1,
+    *,
+    nested=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def argcartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -15,23 +15,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(
-    arrays,
-    axis=1,
-    *,
-    nested=None,
-    parameters=None,
-    with_name=None,
-    highlevel=True,
-    behavior=None,
-):
-    if isinstance(arrays, Mapping):
-        yield from arrays.values()
-    else:
-        yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def argcartesian(
     arrays,
     axis=1,
@@ -108,6 +92,13 @@ def argcartesian(
     All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
     so see the #ak.cartesian documentation for a more complete description.
     """
+    # Dispatch
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+    # Implementation
     return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -94,9 +94,9 @@ def argcartesian(
     """
     # Dispatch
     if isinstance(arrays, Mapping):
-        yield from arrays.values()
+        yield arrays.values()
     else:
-        yield from arrays
+        yield arrays
 
     # Implementation
     return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -9,22 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    n,
-    *,
-    replacement=False,
-    axis=1,
-    fields=None,
-    parameters=None,
-    with_name=None,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def argcombinations(
     array,
     n,
@@ -71,6 +56,10 @@ def argcombinations(
     #ak.argcartesian. See #ak.combinations and #ak.argcartesian for a more
     complete description.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         n,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -57,7 +57,7 @@ def argcombinations(
     complete description.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("argcombinations",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,22 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    n,
+    *,
+    replacement=False,
+    axis=1,
+    fields=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argcombinations(
     array,
     n,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def argmax(
     array,
     axis=None,
@@ -72,22 +60,14 @@ def argmax(
 
     See also #ak.nanargmax.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nanargmax(
     array,
     axis=None,
@@ -127,6 +107,10 @@ def nanargmax(
 
     See also #ak.argmax.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -3,7 +3,7 @@ __all__ = ("argmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argmax(
     array,
     axis=None,
@@ -63,7 +75,19 @@ def argmax(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanargmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -61,7 +61,7 @@ def argmax(
     See also #ak.nanargmax.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -108,7 +108,7 @@ def nanargmax(
     See also #ak.argmax.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -3,7 +3,7 @@ __all__ = ("argmin",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argmin(
     array,
     axis=None,
@@ -63,7 +75,19 @@ def argmin(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanargmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def argmin(
     array,
     axis=None,
@@ -72,22 +60,14 @@ def argmin(
 
     See also #ak.nanargmin.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nanargmin(
     array,
     axis=None,
@@ -126,6 +106,10 @@ def nanargmin(
 
     See also #ak.argmin.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -61,7 +61,7 @@ def argmin(
     See also #ak.nanargmin.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -107,7 +107,7 @@ def nanargmin(
     See also #ak.argmin.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -10,13 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):
@@ -55,6 +49,10 @@ def argsort(
         >>> data[index]
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, ascending, stable, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -50,7 +50,7 @@ def argsort(
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, ascending, stable, highlevel, behavior)

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -2,7 +2,7 @@
 __all__ = ("argsort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -4,11 +4,7 @@ from awkward._backends.dispatch import backend_of
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(*arrays):
-    yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def backend(*arrays):
     """
     Args:
@@ -25,6 +21,10 @@ def backend(*arrays):
 
     See #ak.to_backend.
     """
+    # Dispatch
+    yield from arrays
+
+    # Implementation
     return _impl(arrays)
 
 

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -22,7 +22,7 @@ def backend(*arrays):
     See #ak.to_backend.
     """
     # Dispatch
-    yield from arrays
+    yield arrays
 
     # Implementation
     return _impl(arrays)

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -1,11 +1,15 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("backend",)
 from awkward._backends.dispatch import backend_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
-def backend(*arrays) -> str:
+def _dispatcher(*arrays):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
+def backend(*arrays):
     """
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -126,7 +126,7 @@ def broadcast_arrays(
             output = []
             for inner in outer:
                 output.append(x + inner)
-            yield arrayput
+            yield output
 
     where `x` has the same value for each `inner` in the inner loop.
 
@@ -179,7 +179,7 @@ def broadcast_arrays(
          [[6.6]]]
     """
     # Dispatch
-    yield from arrays
+    yield arrays
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -5,7 +5,7 @@ from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -13,7 +13,19 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    *arrays,
+    depth_limit=None,
+    broadcast_parameters_rule="one_to_one",
+    left_broadcast=True,
+    right_broadcast=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
 def broadcast_arrays(
     *arrays,
     depth_limit=None,
@@ -126,7 +138,7 @@ def broadcast_arrays(
             output = []
             for inner in outer:
                 output.append(x + inner)
-            yield output
+            yield arrayput
 
     where `x` has the same value for each `inner` in the inner loop.
 

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -13,19 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(
-    *arrays,
-    depth_limit=None,
-    broadcast_parameters_rule="one_to_one",
-    left_broadcast=True,
-    right_broadcast=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def broadcast_arrays(
     *arrays,
     depth_limit=None,
@@ -190,6 +178,10 @@ def broadcast_arrays(
          [],
          [[6.6]]]
     """
+    # Dispatch
+    yield from arrays
+
+    # Implementation
     return _impl(
         arrays,
         depth_limit,

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -10,11 +10,7 @@ from awkward._layout import wrap_layout
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(*arrays, highlevel=True, behavior=None):
-    yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def broadcast_fields(*arrays, highlevel=True, behavior=None):
     """
     Args:
@@ -52,6 +48,10 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None):
         }
 
     """
+    # Dispatch
+    yield from arrays
+
+    # Implementation
     return _impl(arrays, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -49,7 +49,7 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None):
 
     """
     # Dispatch
-    yield from arrays
+    yield arrays
 
     # Implementation
     return _impl(arrays, highlevel, behavior)

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -4,18 +4,18 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
-def broadcast_fields(
-    *arrays,
-    highlevel=True,
-    behavior=None,
-):
+def _dispatcher(*arrays, highlevel=True, behavior=None):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
+def broadcast_fields(*arrays, highlevel=True, behavior=None):
     """
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -16,23 +16,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(
-    arrays,
-    axis=1,
-    *,
-    nested=None,
-    parameters=None,
-    with_name=None,
-    highlevel=True,
-    behavior=None,
-):
-    if isinstance(arrays, Mapping):
-        yield from arrays.values()
-    else:
-        yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def cartesian(
     arrays,
     axis=1,
@@ -212,6 +196,13 @@ def cartesian(
     #ak.argcartesian form can be particularly useful as nested indexing in
     #ak.Array.__getitem__.
     """
+    # Dispatch
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+    # Implementation
     return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -198,9 +198,9 @@ def cartesian(
     """
     # Dispatch
     if isinstance(arrays, Mapping):
-        yield from arrays.values()
+        yield arrays.values()
     else:
-        yield from arrays
+        yield arrays
 
     # Implementation
     return _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -1,10 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("cartesian",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -13,7 +16,23 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    axis=1,
+    *,
+    nested=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def cartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -21,7 +21,7 @@ def categories(array, highlevel=True):
     See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel)

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -6,11 +6,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-def _dispatcher(array, highlevel=True):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def categories(array, highlevel=True):
     """
     Args:
@@ -24,6 +20,10 @@ def categories(array, highlevel=True):
 
     See also #ak.is_categorical, #ak.to_categorical, #ak.from_categorical.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel)
 
 

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -2,11 +2,15 @@
 __all__ = ("categories",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@with_operation_context
+def _dispatcher(array, highlevel=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def categories(array, highlevel=True):
     """
     Args:

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -178,7 +178,7 @@ def combinations(
     in #ak.Array.__getitem__.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("combinations",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,22 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    n,
+    *,
+    replacement=False,
+    axis=1,
+    fields=None,
+    parameters=None,
+    with_name=None,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def combinations(
     array,
     n,

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -9,22 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    n,
-    *,
-    replacement=False,
-    axis=1,
-    fields=None,
-    parameters=None,
-    with_name=None,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def combinations(
     array,
     n,
@@ -192,6 +177,10 @@ def combinations(
     The #ak.argcombinations form can be particularly useful as nested indexing
     in #ak.Array.__getitem__.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         n,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -41,7 +41,14 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
     element for element, and similarly for deeper levels.
     """
     # Dispatch
-    yield arrays
+    if (
+        # Is an array with a known backend
+        backend_of(arrays, default=None)
+        is not None
+    ):
+        yield (arrays,)
+    else:
+        yield arrays
 
     # Implementation
     return _impl(arrays, axis, mergebool, highlevel, behavior)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -41,7 +41,7 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
     element for element, and similarly for deeper levels.
     """
     # Dispatch
-    yield from arrays
+    yield arrays
 
     # Implementation
     return _impl(arrays, axis, mergebool, highlevel, behavior)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -17,11 +17,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
-    yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """
     Args:
@@ -44,6 +40,10 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
     must have the same lengths and nested lists are each concatenated,
     element for element, and similarly for deeper levels.
     """
+    # Dispatch
+    yield from arrays
+
+    # Implementation
     return _impl(arrays, axis, mergebool, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -17,8 +17,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@ak._connect.numpy.implements("concatenate")
-@with_operation_context
+def _dispatcher(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
+    yield from arrays
+
+
+@high_level_function(_dispatcher)
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -4,13 +4,17 @@ import copy as _copy
 
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def copy(array):
     """
     Args:

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -10,11 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def copy(array):
     """
     Args:
@@ -63,6 +59,10 @@ def copy(array):
     changes, so we don't support it. However, an #ak.Array's data might come from
     a mutable third-party library, so this function allows you to make a true copy.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -60,7 +60,7 @@ def copy(array):
     a mutable third-party library, so this function allows you to make a true copy.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -2,7 +2,7 @@
 __all__ = ("corr",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,16 +10,14 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def corr(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield y
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the correlation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -52,9 +52,7 @@ def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     non-reducer.
     """
     # Dispatch
-    yield x
-    yield y
-    yield weight
+    yield x, y, weight
 
     # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -10,13 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
-    yield x
-    yield y
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -57,6 +51,12 @@ def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
+    # Dispatch
+    yield x
+    yield y
+    yield weight
+
+    # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -10,19 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def count(
     array,
     axis=None,
@@ -107,6 +95,10 @@ def count(
     If it is desirable to exclude NaN ("not a number") values from #ak.count,
     use #ak.nan_to_none to turn them into None, which are not counted.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -2,7 +2,7 @@
 __all__ = ("count",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def count(
     array,
     axis=None,

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -96,7 +96,7 @@ def count(
     use #ak.nan_to_none to turn them into None, which are not counted.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -55,7 +55,7 @@ def count_nonzero(
     to turn them into something that would be counted.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -10,19 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def count_nonzero(
     array,
     axis=None,
@@ -66,6 +54,10 @@ def count_nonzero(
     count None values. If it is desirable to count them, use #ak.fill_none
     to turn them into something that would be counted.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -2,7 +2,7 @@
 __all__ = ("count_nonzero",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def count_nonzero(
     array,
     axis=None,

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -2,23 +2,21 @@
 __all__ = ("covar",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def covar(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield y
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -49,9 +49,7 @@ def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     non-reducer.
     """
     # Dispatch
-    yield x
-    yield y
-    yield weight
+    yield x, y, weight
 
     # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -9,13 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
-    yield x
-    yield y
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -54,6 +48,12 @@ def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
+    # Dispatch
+    yield x
+    yield y
+    yield weight
+
+    # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -1,7 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("drop_none",)
 import awkward as ak
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +10,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=None, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -44,7 +44,7 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
 
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -10,11 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=None, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     Args:
@@ -47,6 +43,10 @@ def drop_none(array, axis=None, highlevel=True, behavior=None):
         <Array [[[0]], [[None]], [[1]], [[2, None]]] type='4 * var * var * ?int64'>
 
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -17,11 +17,7 @@ from awkward.types.numpytype import primitive_to_dtype
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, type, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def enforce_type(array, type, *, highlevel=True, behavior=None):
     """
     Args:
@@ -225,6 +221,10 @@ def enforce_type(array, type, *, highlevel=True, behavior=None):
     given type value. If the conversion is not possible given the layout data, e.g. a conversion from an irregular list
     to a regular type, it will fail.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, type, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -6,7 +6,7 @@ __all__ = ("enforce_type",)
 from itertools import permutations
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -17,14 +17,12 @@ from awkward.types.numpytype import primitive_to_dtype
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def enforce_type(
-    array,
-    type,
-    *,
-    highlevel=True,
-    behavior=None,
-):
+def _dispatcher(array, type, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
+def enforce_type(array, type, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -222,7 +222,7 @@ def enforce_type(array, type, *, highlevel=True, behavior=None):
     to a regular type, it will fail.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, type, highlevel, behavior)

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -7,11 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def fields(array):
     """
     Args:
@@ -28,6 +24,10 @@ def fields(array):
     If the array contains neither tuples nor records, this returns an empty
     list.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -25,7 +25,7 @@ def fields(array):
     list.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -1,13 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("fields",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def fields(array):
     """
     Args:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -16,12 +16,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(array, value, axis=-1, *, highlevel=True, behavior=None):
-    yield array
-    yield value
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -66,6 +61,11 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
 
     The values could be floating-point numbers or strings.
     """
+    # Dispatch
+    yield array
+    yield value
+
+    # Implementation
     return _impl(array, value, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -6,7 +6,8 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_sized_iterable, regularize_axis
@@ -15,7 +16,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, value, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+    yield value
+
+
+@high_level_function(_dispatcher)
 def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -62,8 +62,7 @@ def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     The values could be floating-point numbers or strings.
     """
     # Dispatch
-    yield array
-    yield value
+    yield array, value
 
     # Implementation
     return _impl(array, value, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -11,11 +11,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -47,6 +43,10 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
 
     See #ak.singletons to invert this function.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -2,7 +2,8 @@
 __all__ = ("firsts",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -44,7 +44,7 @@ def firsts(array, axis=1, *, highlevel=True, behavior=None):
     See #ak.singletons to invert this function.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -9,11 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -163,6 +159,10 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
          2.2,
          999]
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("flatten",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -160,7 +160,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None):
          999]
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -1,14 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -6,7 +6,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_arrow_schema",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -4,13 +4,13 @@ __all__ = ("from_avro_file",)
 from os import PathLike, fsdecode
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_avro_file(
     file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_avro_file(
     file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -16,7 +16,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_buffers(
     form,
     length,

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -6,11 +6,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -30,6 +26,10 @@ def from_categorical(array, *, highlevel=True, behavior=None):
     See also #ak.is_categorical, #ak.categories, #ak.to_categorical,
     #ak.from_categorical.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -2,11 +2,15 @@
 __all__ = ("from_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -27,7 +27,7 @@ def from_categorical(array, *, highlevel=True, behavior=None):
     #ak.from_categorical.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_cupy",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -4,7 +4,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function()
+@high_level_function
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_iter(
     iterable,
     *,

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -5,13 +5,13 @@ from collections.abc import Iterable
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_iter(
     iterable,
     *,

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_jax",)
 from awkward import jax
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -5,7 +5,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function()
+@high_level_function
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_json(
     source,
     *,

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_json(
     source,
     *,
@@ -520,11 +520,11 @@ def _yes_schema(
             raise TypeError("JSONSchema type is not concrete: array without items")
 
         instructions.append(["TopLevelArray"])
-        form = build_assembly(schema["items"], container, instructions)
+        form = _build_assembly(schema["items"], container, instructions)
         is_record = False
 
     elif schema.get("type") == "object":
-        form = build_assembly(schema, container, instructions)
+        form = _build_assembly(schema, container, instructions)
         is_record = True
 
     else:
@@ -565,8 +565,7 @@ def _yes_schema(
         return layout
 
 
-@with_operation_context
-def build_assembly(schema, container, instructions):
+def _build_assembly(schema, container, instructions):
     if not isinstance(schema, dict):
         raise TypeError(f"unrecognized JSONSchema: expected dict, got {schema!r}")
 
@@ -712,7 +711,7 @@ def build_assembly(schema, container, instructions):
 
             instructions.append(["FixedLengthList", schema.get("minItems")])
 
-            content = build_assembly(schema["items"], container, instructions)
+            content = _build_assembly(schema["items"], container, instructions)
 
             out = ak.forms.RegularForm(content, size=schema.get("minItems"))
             if is_optional:
@@ -730,7 +729,7 @@ def build_assembly(schema, container, instructions):
             container[offsets + "-offsets"] = None
             instructions.append(["VarLengthList", offsets + "-offsets", "int64"])
 
-            content = build_assembly(schema["items"], container, instructions)
+            content = _build_assembly(schema["items"], container, instructions)
 
             out = ak.forms.ListOffsetForm("i64", content, form_key=offsets)
             if is_optional:
@@ -769,7 +768,7 @@ def build_assembly(schema, container, instructions):
         for keyindex, subschema in enumerate(subschemas):
             # set the "jump_to" instruction position in the KeyTable
             instructions[startkeys + keyindex][2] = len(instructions)
-            contents.append(build_assembly(subschema, container, instructions))
+            contents.append(_build_assembly(subschema, container, instructions))
 
         out = ak.forms.RecordForm(contents, names)
         if is_optional:

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -1,10 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_numpy",)
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@with_operation_context
+@high_level_function()
 def from_numpy(
     array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -4,7 +4,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function()
+@high_level_function
 def from_numpy(
     array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -1,12 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_parquet",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._regularize import is_integer
 
 
-@with_operation_context
+@high_level_function()
 def from_parquet(
     path,
     *,
@@ -76,7 +76,18 @@ def from_parquet(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    path,
+    storage_options=None,
+    row_groups=None,
+    columns=None,
+    ignore_metadata=False,
+    scan_files=True,
+):
+    yield
+
+
+@high_level_function(_dispatcher)
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -6,7 +6,7 @@ from awkward._layout import wrap_layout
 from awkward._regularize import is_integer
 
 
-@high_level_function()
+@high_level_function
 def from_parquet(
     path,
     *,
@@ -76,18 +76,7 @@ def from_parquet(
     )
 
 
-def _dispatcher(
-    path,
-    storage_options=None,
-    row_groups=None,
-    columns=None,
-    ignore_metadata=False,
-    scan_files=True,
-):
-    yield
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -7,7 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -1,13 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_rdataframe",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+@high_level_function()
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,7 +2,8 @@
 __all__ = ("from_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -11,11 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -44,6 +40,10 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
 
     See also #ak.to_regular.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -41,7 +41,7 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     See also #ak.to_regular.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -81,8 +81,7 @@ def full_like(
     are immutable.)
     """
     # Dispatch
-    yield array
-    yield fill_value
+    yield array, fill_value
 
     # Implementation
     return _impl(array, fill_value, highlevel, behavior, dtype, including_unknown)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -3,7 +3,7 @@ __all__ = ("full_like",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.typetracer import ensure_known_scalar
@@ -12,7 +12,20 @@ from awkward.operations.ak_zeros_like import _ZEROS
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    fill_value,
+    *,
+    dtype=None,
+    including_unknown=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+    yield fill_value
+
+
+@high_level_function(_dispatcher)
 def full_like(
     array,
     fill_value,

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -12,20 +12,7 @@ from awkward.operations.ak_zeros_like import _ZEROS
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    fill_value,
-    *,
-    dtype=None,
-    including_unknown=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-    yield fill_value
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def full_like(
     array,
     fill_value,
@@ -93,6 +80,11 @@ def full_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
+    # Dispatch
+    yield array
+    yield fill_value
+
+    # Implementation
     return _impl(array, fill_value, highlevel, behavior, dtype, including_unknown)
 
 

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -18,7 +18,7 @@ def is_categorical(array):
     See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -4,11 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def is_categorical(array):
     """
     Args:
@@ -21,6 +17,10 @@ def is_categorical(array):
 
     See also #ak.categories, #ak.to_categorical, #ak.from_categorical.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_categorical",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_categorical(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -29,7 +29,7 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
     False otherwise (at a given `axis` depth).
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -2,7 +2,8 @@
 __all__ = ("is_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -11,11 +11,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -32,6 +28,10 @@ def is_none(array, axis=0, *, highlevel=True, behavior=None):
     Returns an array whose value is True where an element of `array` is None;
     False otherwise (at a given `axis` depth).
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_tuple",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_tuple(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -14,7 +14,7 @@ def is_tuple(array):
     If `array` is an array, this returns True if the outermost record is a tuple.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -4,11 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def is_tuple(array):
     """
     Args:
@@ -17,6 +13,10 @@ def is_tuple(array):
     If `array` is a record, this returns True if the record is a tuple.
     If `array` is an array, this returns True if the outermost record is a tuple.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -20,7 +20,7 @@ def is_valid(array, *, exception=False):
     See also #ak.validity_error.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, exception)

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -4,11 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array, *, exception=False):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def is_valid(array, *, exception=False):
     """
     Args:
@@ -23,6 +19,10 @@ def is_valid(array, *, exception=False):
 
     See also #ak.validity_error.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, exception)
 
 

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("is_valid",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, exception=False):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def is_valid(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -30,8 +30,7 @@ def isclose(
     for Awkward Arrays.
     """
     # Dispatch
-    yield a
-    yield b
+    yield a, b
 
     # Implementation
     return _impl(a, b, rtol, atol, equal_nan, highlevel, behavior)

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -9,14 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
-):
-    yield a
-    yield b
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):
@@ -36,6 +29,11 @@ def isclose(
     Implements [np.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html)
     for Awkward Arrays.
     """
+    # Dispatch
+    yield a
+    yield b
+
+    # Implementation
     return _impl(a, b, rtol, atol, equal_nan, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -2,14 +2,21 @@
 __all__ = ("isclose",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
+):
+    yield a
+    yield b
+
+
+@high_level_function(_dispatcher)
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -3,7 +3,7 @@ __all__ = ("linear_fit",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -12,16 +12,12 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def linear_fit(
-    x,
-    y,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield from (x, y, weight)
+
+
+@high_level_function(_dispatcher)
+def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: One coordinate to use in the linear fit (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -12,11 +12,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
-    yield from (x, y, weight)
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -70,6 +66,10 @@ def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=Fa
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
+    # Dispatch
+    yield from (x, y, weight)
+
+    # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -67,7 +67,7 @@ def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=Fa
     non-reducer.
     """
     # Dispatch
-    yield from (x, y, weight)
+    yield x, y, weight
 
     # Implementation
     return _impl(x, y, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -9,11 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -78,6 +74,10 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
                        2               8.8
                        3               9.9
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("local_index",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -75,7 +75,7 @@ def local_index(array, axis=-1, *, highlevel=True, behavior=None):
                        3               9.9
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -91,8 +91,7 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     (which is 5 characters away from simply filtering the `array`).
     """
     # Dispatch
-    yield array
-    yield mask
+    yield array, mask
 
     # Implementation
     return _impl(array, mask, valid_when, highlevel, behavior)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -9,12 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, mask, *, valid_when=True, highlevel=True, behavior=None):
-    yield array
-    yield mask
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:
@@ -95,6 +90,11 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 
     (which is 5 characters away from simply filtering the `array`).
     """
+    # Dispatch
+    yield array
+    yield mask
+
+    # Implementation
     return _impl(array, mask, valid_when, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -2,14 +2,19 @@
 __all__ = ("mask",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, mask, *, valid_when=True, highlevel=True, behavior=None):
+    yield array
+    yield mask
+
+
+@high_level_function(_dispatcher)
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -3,7 +3,7 @@ __all__ = ("max",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,20 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def max(
     array,
     axis=None,
@@ -72,7 +85,20 @@ def max(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -62,7 +62,7 @@ def max(
     See also #ak.nanmax.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(
@@ -118,7 +118,7 @@ def nanmax(
     See also #ak.max.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -11,20 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    initial=None,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def max(
     array,
     axis=None,
@@ -74,6 +61,10 @@ def max(
 
     See also #ak.nanmax.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         axis,
@@ -85,20 +76,7 @@ def max(
     )
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    initial=None,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nanmax(
     array,
     axis=None,
@@ -139,6 +117,10 @@ def nanmax(
 
     See also #ak.max.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -76,8 +76,7 @@ def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     See also #ak.nanmean.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     return _impl(x, weight, axis, keepdims, mask_identity)
@@ -117,8 +116,7 @@ def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
     See also #ak.mean.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     if weight is not None:
         weight = ak.operations.ak_nan_to_none._impl(weight, False, None)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -11,12 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
-    yield x
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -80,10 +75,15 @@ def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
 
     See also #ak.nanmean.
     """
+    # Dispatch
+    yield x
+    yield weight
+
+    # Implementation
     return _impl(x, weight, axis, keepdims, mask_identity)
 
 
-@high_level_function(_dispatcher)
+@high_level_function
 def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
@@ -116,6 +116,10 @@ def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
 
     See also #ak.mean.
     """
+    # Dispatch
+    yield x
+    yield weight
+
     if weight is not None:
         weight = ak.operations.ak_nan_to_none._impl(weight, False, None)
 

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -3,7 +3,7 @@ __all__ = ("mean",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,15 +11,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def mean(
-    x,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
@@ -85,15 +83,8 @@ def mean(
     return _impl(x, weight, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanmean(
-    x,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
-):
+@high_level_function(_dispatcher)
+def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -37,7 +37,7 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         <Array [{a: None}, {a: 1}, {a: 2}] type='3 * {a: ?int64}'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -3,7 +3,8 @@ __all__ = ("merge_option_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -13,11 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -40,6 +36,10 @@ def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         >>> ak.merge_option_of_records(array)
         <Array [{a: None}, {a: 1}, {a: 2}] type='3 * {a: ?int64}'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -13,11 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -50,6 +46,10 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         >>> ak.merge_union_of_records(array)
         <Array [{a: 1, b: None}, {...}, None] type='3 * ?{a: ?int64, b: ?int64}'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -3,7 +3,8 @@ __all__ = ("merge_union_of_records",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -12,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=-1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -47,7 +47,7 @@ def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
         <Array [{a: 1, b: None}, {...}, None] type='3 * ?{a: ?int64, b: ?int64}'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -15,7 +15,7 @@ ParquetMetadata = collections.namedtuple(
 )
 
 
-@high_level_function()
+@high_level_function
 def metadata_from_parquet(
     path,
     *,

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -3,7 +3,7 @@ __all__ = ("metadata_from_parquet",)
 import collections
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -15,7 +15,7 @@ ParquetMetadata = collections.namedtuple(
 )
 
 
-@with_operation_context
+@high_level_function()
 def metadata_from_parquet(
     path,
     *,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -62,7 +62,7 @@ def min(
     See also #ak.nanmin.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(
@@ -118,7 +118,7 @@ def nanmin(
     See also #ak.min.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -11,20 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    initial=None,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def min(
     array,
     axis=None,
@@ -74,6 +61,10 @@ def min(
 
     See also #ak.nanmin.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         axis,
@@ -85,20 +76,7 @@ def min(
     )
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    initial=None,
-    mask_identity=True,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nanmin(
     array,
     axis=None,
@@ -139,6 +117,10 @@ def nanmin(
 
     See also #ak.min.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -3,7 +3,7 @@ __all__ = ("min",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,20 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def min(
     array,
     axis=None,
@@ -72,7 +85,20 @@ def min(
     )
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    initial=None,
+    mask_identity=True,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -9,12 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
-    yield x
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -57,6 +52,11 @@ def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False)
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
+    # Dispatch
+    yield x
+    yield weight
+
+    # Implementation
     return _impl(x, n, weight, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -2,23 +2,20 @@
 __all__ = ("moment",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def moment(
-    x,
-    n,
-    weight=None,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-):
+def _dispatcher(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the moment (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -53,8 +53,7 @@ def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False)
     non-reducer.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     return _impl(x, n, weight, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -27,6 +23,10 @@ def nan_to_none(array, *, highlevel=True, behavior=None):
 
     See also #ak.nan_to_num to convert NaN or infinity to specified values.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -2,14 +2,18 @@
 __all__ = ("nan_to_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -24,7 +24,7 @@ def nan_to_none(array, *, highlevel=True, behavior=None):
     See also #ak.nan_to_num to convert NaN or infinity to specified values.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -9,20 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    copy=True,
-    nan=0.0,
-    posinf=None,
-    neginf=None,
-    *,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nan_to_num(
     array,
     copy=True,
@@ -52,6 +39,10 @@ def nan_to_num(
 
     See also #ak.nan_to_none to convert NaN to None, i.e. missing values with option-type.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, copy, nan, posinf, neginf, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -2,14 +2,27 @@
 __all__ = ("nan_to_num",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    copy=True,
+    nan=0.0,
+    posinf=None,
+    neginf=None,
+    *,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nan_to_num(
     array,
     copy=True,

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -40,7 +40,7 @@ def nan_to_num(
     See also #ak.nan_to_none to convert NaN to None, i.e. missing values with option-type.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, copy, nan, posinf, neginf, highlevel, behavior)

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -72,7 +72,7 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -2,7 +2,8 @@
 __all__ = ("num",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -11,11 +11,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -75,6 +71,10 @@ def num(array, axis=1, *, highlevel=True, behavior=None):
         >>> array.mask[ak.num(array) > 0][:, 0]
         <Array [[1.1, 2.2, 3.3], None, [7.7]] type='3 * option[var * float64]'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -8,13 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def ones_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):
@@ -37,6 +31,10 @@ def ones_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -32,7 +32,7 @@ def ones_like(
     are immutable.)
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior, dtype, including_unknown)

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -2,13 +2,19 @@
 __all__ = ("ones_like",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ones_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -98,7 +98,7 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
         3 * var *   2 * ?float64
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, target, axis, clip, highlevel, behavior)

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -9,11 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:
@@ -101,6 +97,10 @@ def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None
         >>> ak.pad_none(array, 2, axis=2, clip=True).type.show()
         3 * var *   2 * ?float64
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, target, axis, clip, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("pad_none",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -9,7 +9,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -30,7 +30,7 @@ def parameters(array):
     behaviors.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -12,11 +12,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def parameters(array):
     """
     Args:
@@ -33,6 +29,10 @@ def parameters(array):
     See #ak.Array and #ak.behavior for a more complete description of
     behaviors.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -6,13 +6,17 @@ import numbers
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def parameters(array):
     """
     Args:

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -54,7 +54,7 @@ def prod(
     See also #ak.nanprod.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -97,7 +97,7 @@ def nanprod(
     See also #ak.prod.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def prod(
     array,
     axis=None,
@@ -65,22 +53,14 @@ def prod(
 
     See also #ak.nanprod.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nanprod(
     array,
     axis=None,
@@ -116,6 +96,10 @@ def nanprod(
 
     See also #ak.prod.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -3,7 +3,7 @@ __all__ = ("prod",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def prod(
     array,
     axis=None,
@@ -56,7 +68,19 @@ def prod(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nanprod(
     array,
     axis=None,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -11,11 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=None, *, keepdims=False, mask_identity=True):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
@@ -63,6 +59,10 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     See #ak.sum for a more complete description of nested list and missing
     value (None) handling in reducers.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -60,7 +60,7 @@ def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     value (None) handling in reducers.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -3,7 +3,7 @@ __all__ = ("ptp",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=None, *, keepdims=False, mask_identity=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -52,7 +52,7 @@ def ravel(array, *, highlevel=True, behavior=None):
     `axis=None` for an equivalent function that eliminates the option type.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -55,6 +51,10 @@ def ravel(array, *, highlevel=True, behavior=None):
     Missing values are not eliminated by flattening. See #ak.flatten with
     `axis=None` for an equivalent function that eliminates the option type.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -2,14 +2,18 @@
 __all__ = ("ravel",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -13,7 +13,11 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def run_lengths(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -89,7 +89,7 @@ def run_lengths(array, *, highlevel=True, behavior=None):
     See also #ak.num, #ak.argsort, #ak.unflatten.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -13,11 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def run_lengths(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -92,6 +88,10 @@ def run_lengths(array, *, highlevel=True, behavior=None):
 
     See also #ak.num, #ak.argsort, #ak.unflatten.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -11,11 +11,7 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -47,6 +43,10 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
 
     See #ak.firsts to invert this function.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -2,7 +2,8 @@
 __all__ = ("singletons",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import is_integer, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -44,7 +44,7 @@ def singletons(array, axis=0, *, highlevel=True, behavior=None):
     See #ak.firsts to invert this function.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -2,7 +2,7 @@
 __all__ = ("softmax",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(x, axis=None, *, keepdims=False, mask_identity=False):
+    yield x
+
+
+@high_level_function(_dispatcher)
 def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -10,11 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(x, axis=None, *, keepdims=False, mask_identity=False):
-    yield x
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -48,6 +44,10 @@ def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     missing values (None) in reducers, and #ak.mean for an example with another
     non-reducer.
     """
+    # Dispatch
+    yield x
+
+    # Implementation
     return _impl(x, axis, keepdims, mask_identity)
 
 

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -45,7 +45,7 @@ def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     non-reducer.
     """
     # Dispatch
-    yield x
+    yield (x,)
 
     # Implementation
     return _impl(x, axis, keepdims, mask_identity)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -37,7 +37,7 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, ascending, stable, highlevel, behavior)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -10,13 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:
@@ -42,6 +36,10 @@ def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavio
         >>> ak.sort(ak.Array([[7, 5, 7], [], [2], [8, 2]]))
         <Array [[5, 7, 7], [], [2], [2, 8]] type='4 * var * int64'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, ascending, stable, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -2,7 +2,7 @@
 __all__ = ("sort",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +10,13 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -12,14 +12,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
-):
-    yield x
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -64,17 +57,15 @@ def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
 
     See also #ak.nanstd.
     """
-    return _impl(x, weight, ddof, axis, keepdims, mask_identity)
-
-
-def _dispatcher(
-    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
-):
+    # Dispatch
     yield x
     yield weight
 
+    # Implementation
+    return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
-@high_level_function(_dispatcher)
+
+@high_level_function
 def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
@@ -110,6 +101,11 @@ def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=T
 
     See also #ak.std.
     """
+    # Dispatch
+    yield x
+    yield weight
+
+    # Implementation
     if weight is not None:
         weight = ak.operations.ak_nan_to_none._impl(weight, False, None)
 

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -58,8 +58,7 @@ def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
     See also #ak.nanstd.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
@@ -102,8 +101,7 @@ def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=T
     See also #ak.std.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     if weight is not None:

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -3,7 +3,7 @@ __all__ = ("std",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -12,16 +12,15 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def std(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
@@ -68,16 +67,15 @@ def std(
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanstd(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -46,7 +46,7 @@ def strings_astype(array, to, *, highlevel=True, behavior=None):
     See also #ak.numbers_astype.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, to, highlevel, behavior)

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -11,11 +11,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-def _dispatcher(array, to, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:
@@ -49,6 +45,10 @@ def strings_astype(array, to, *, highlevel=True, behavior=None):
 
     See also #ak.numbers_astype.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, to, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -2,7 +2,7 @@
 __all__ = ("strings_astype",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,7 +11,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, to, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -11,19 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def sum(
     array,
     axis=None,
@@ -209,22 +197,14 @@ def sum(
 
     See also #ak.nansum.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-def _dispatcher(
-    array,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def nansum(
     array,
     axis=None,
@@ -264,6 +244,10 @@ def nansum(
 
     See also #ak.sum.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         ak.operations.ak_nan_to_none._impl(array, False, None),
         axis,

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -198,7 +198,7 @@ def sum(
     See also #ak.nansum.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
@@ -245,7 +245,7 @@ def nansum(
     See also #ak.sum.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -3,7 +3,7 @@ __all__ = ("sum",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,7 +11,19 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def sum(
     array,
     axis=None,
@@ -200,7 +212,19 @@ def sum(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    axis=None,
+    *,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def nansum(
     array,
     axis=None,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -1,13 +1,27 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_arrow",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    *,
+    list_to32=False,
+    string_to32=False,
+    bytestring_to32=False,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_arrow(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -66,7 +66,7 @@ def to_arrow(
     See also #ak.from_arrow, #ak.to_arrow_table, #ak.to_parquet, #ak.from_arrow_schema.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -7,21 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    *,
-    list_to32=False,
-    string_to32=False,
-    bytestring_to32=False,
-    emptyarray_to=None,
-    categorical_as_dictionary=False,
-    extensionarray=True,
-    count_nulls=True,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_arrow(
     array,
     *,
@@ -79,6 +65,10 @@ def to_arrow(
 
     See also #ak.from_arrow, #ak.to_arrow_table, #ak.to_parquet, #ak.from_arrow_schema.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         list_to32,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -67,7 +67,7 @@ def to_arrow_table(
     See also #ak.from_arrow, #ak.to_arrow, #ak.to_parquet.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -3,13 +3,27 @@ __all__ = ("to_arrow_table",)
 import json
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    *,
+    list_to32=False,
+    string_to32=False,
+    bytestring_to32=False,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_arrow_table(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -9,21 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    *,
-    list_to32=False,
-    string_to32=False,
-    bytestring_to32=False,
-    emptyarray_to=None,
-    categorical_as_dictionary=False,
-    extensionarray=True,
-    count_nulls=True,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_arrow_table(
     array,
     *,
@@ -80,6 +66,10 @@ def to_arrow_table(
 
     See also #ak.from_arrow, #ak.to_arrow, #ak.to_parquet.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         list_to32,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -3,14 +3,18 @@ __all__ = ("to_backend",)
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, backend, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -10,11 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, backend, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:
@@ -54,6 +50,10 @@ def to_backend(array, backend, *, highlevel=True, behavior=None):
 
     See #ak.kernels.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, backend, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -51,7 +51,7 @@ def to_backend(array, backend, *, highlevel=True, behavior=None):
     See #ak.kernels.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, backend, highlevel, behavior)

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -121,7 +121,7 @@ def to_buffers(
     See also #ak.from_buffers and #ak.to_packed.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, container, buffer_key, form_key, id_start, backend, byteorder)

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -8,20 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    container=None,
-    buffer_key="{form_key}-{attribute}",
-    form_key="node{id}",
-    *,
-    id_start=0,
-    backend=None,
-    byteorder="<",
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_buffers(
     array,
     container=None,
@@ -133,6 +120,10 @@ def to_buffers(
 
     See also #ak.from_buffers and #ak.to_packed.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, container, buffer_key, form_key, id_start, backend, byteorder)
 
 

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -2,13 +2,26 @@
 __all__ = ("to_buffers",)
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    container=None,
+    buffer_key="{form_key}-{attribute}",
+    form_key="node{id}",
+    *,
+    id_start=0,
+    backend=None,
+    byteorder="<",
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_buffers(
     array,
     container=None,

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -11,11 +11,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -87,6 +83,10 @@ def to_categorical(array, *, highlevel=True, behavior=None):
 
     See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,7 +2,7 @@
 __all__ = ("to_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -11,7 +11,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -84,7 +84,7 @@ def to_categorical(array, *, highlevel=True, behavior=None):
     See also #ak.is_categorical, #ak.categories, #ak.from_categorical.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -2,10 +2,14 @@
 __all__ = ("to_cupy",)
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_cupy(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -5,11 +5,7 @@ from awkward._backends.cupy import CupyBackend
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_cupy(array):
     """
     Args:
@@ -27,6 +23,10 @@ def to_cupy(array):
 
     See also #ak.from_cupy and #ak.to_numpy.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -24,7 +24,7 @@ def to_cupy(array):
     See also #ak.from_cupy and #ak.to_numpy.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -13,13 +13,7 @@ def _default_levelname(index: int) -> str:
     return "sub" * index + "entry"
 
 
-def _dispatcher(
-    array, *, how="inner", levelname=_default_levelname, anonymous="values"
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_dataframe(
     array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):
@@ -133,6 +127,10 @@ def to_dataframe(
               2         3.0  NaN
               3         4.0  NaN
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, how, levelname, anonymous)
 
 

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_dataframe",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -9,9 +9,19 @@ numpy = Numpy.instance()
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _default_levelname(index: int) -> str:
+    return "sub" * index + "entry"
+
+
+def _dispatcher(
+    array, *, how="inner", levelname=_default_levelname, anonymous="values"
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_dataframe(
-    array, *, how="inner", levelname=lambda i: "sub" * i + "entry", anonymous="values"
+    array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):
     """
     Args:

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -128,7 +128,7 @@ def to_dataframe(
               3         4.0  NaN
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, how, levelname, anonymous)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -24,7 +24,7 @@ def to_jax(array):
     See also #ak.from_jax and #ak.to_numpy.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -2,10 +2,14 @@
 __all__ = ("to_jax",)
 import awkward as ak
 from awkward._backends.jax import JaxBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_jax(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -5,11 +5,7 @@ from awkward._backends.jax import JaxBackend
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_jax(array):
     """
     Args:
@@ -27,6 +23,10 @@ def to_jax(array):
 
     See also #ak.from_jax and #ak.to_numpy.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -17,24 +17,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-def _dispatcher(
-    array,
-    file=None,
-    *,
-    line_delimited=False,
-    num_indent_spaces=None,
-    num_readability_spaces=0,
-    nan_string=None,
-    posinf_string=None,
-    neginf_string=None,
-    complex_record_fields=None,
-    convert_bytes=None,
-    convert_other=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_json(
     array,
     file=None,
@@ -130,6 +113,10 @@ def to_json(
 
     See also #ak.from_json.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(
         array,
         file,

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -9,7 +9,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -17,7 +17,24 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    file=None,
+    *,
+    line_delimited=False,
+    num_indent_spaces=None,
+    num_readability_spaces=0,
+    nan_string=None,
+    posinf_string=None,
+    neginf_string=None,
+    complex_record_fields=None,
+    convert_bytes=None,
+    convert_other=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_json(
     array,
     file=None,

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -114,7 +114,7 @@ def to_json(
     See also #ak.from_json.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -17,11 +17,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-def _dispatcher(array, *, allow_record=True, allow_other=False, regulararray=True):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True):
     """
     Args:
@@ -45,6 +41,10 @@ def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True)
     would rarely be used in a data analysis because #ak.contents.Content and
     #ak.record.Record are lower-level than #ak.Array.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, allow_record, allow_other, regulararray=regulararray)
 
 

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -42,7 +42,7 @@ def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True)
     #ak.record.Record are lower-level than #ak.Array.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, allow_record, allow_other, regulararray=regulararray)

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -6,7 +6,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -17,7 +17,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, allow_record=True, allow_other=False, regulararray=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -11,11 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_list(array):
     """
     Args:
@@ -43,6 +39,10 @@ def to_list(array):
 
     See also #ak.from_iter and #ak.Array.tolist.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array)
 
 

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -5,13 +5,17 @@ from collections.abc import Iterable, Mapping
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -40,7 +40,7 @@ def to_list(array):
     See also #ak.from_iter and #ak.Array.tolist.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array)

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -5,11 +5,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array, *, allow_missing=True):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_numpy(array, *, allow_missing=True):
     """
     Args:
@@ -41,6 +37,10 @@ def to_numpy(array, *, allow_missing=True):
 
     See also #ak.from_numpy and #ak.to_cupy.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, allow_missing)
 
 

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -2,10 +2,14 @@
 __all__ = ("to_numpy",)
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, allow_missing=True):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_numpy(array, *, allow_missing=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -38,7 +38,7 @@ def to_numpy(array, *, allow_missing=True):
     See also #ak.from_numpy and #ak.to_cupy.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, allow_missing)

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -8,11 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_packed(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -71,6 +67,10 @@ def to_packed(array, *, highlevel=True, behavior=None):
 
     See also #ak.to_buffers.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -68,7 +68,7 @@ def to_packed(array, *, highlevel=True, behavior=None):
     See also #ak.to_buffers.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -1,14 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_packed",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_packed(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -172,7 +172,7 @@ def to_parquet(
     See also #ak.to_arrow, which is used as an intermediate step.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     import awkward._connect.pyarrow

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -10,37 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 metadata = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    array,
-    destination,
-    *,
-    list_to32=False,
-    string_to32=True,
-    bytestring_to32=True,
-    emptyarray_to=None,
-    categorical_as_dictionary=False,
-    extensionarray=True,
-    count_nulls=True,
-    compression="zstd",
-    compression_level=None,
-    row_group_size=64 * 1024 * 1024,
-    data_page_size=None,
-    parquet_flavor=None,
-    parquet_version="2.4",
-    parquet_page_version="1.0",
-    parquet_metadata_statistics=True,
-    parquet_dictionary_encoding=False,
-    parquet_byte_stream_split=False,
-    parquet_coerce_timestamps=None,
-    parquet_old_int96_timestamps=None,
-    parquet_compliant_nested=False,  # https://issues.apache.org/jira/browse/ARROW-16348
-    parquet_extra_options=None,
-    storage_options=None,
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_parquet(
     array,
     destination,
@@ -201,6 +171,10 @@ def to_parquet(
 
     See also #ak.to_arrow, which is used as an intermediate step.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     import awkward._connect.pyarrow
 
     data = array

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -4,13 +4,43 @@ from collections.abc import Mapping, Sequence
 from os import fsdecode
 
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 metadata = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    array,
+    destination,
+    *,
+    list_to32=False,
+    string_to32=True,
+    bytestring_to32=True,
+    emptyarray_to=None,
+    categorical_as_dictionary=False,
+    extensionarray=True,
+    count_nulls=True,
+    compression="zstd",
+    compression_level=None,
+    row_group_size=64 * 1024 * 1024,
+    data_page_size=None,
+    parquet_flavor=None,
+    parquet_version="2.4",
+    parquet_page_version="1.0",
+    parquet_metadata_statistics=True,
+    parquet_dictionary_encoding=False,
+    parquet_byte_stream_split=False,
+    parquet_coerce_timestamps=None,
+    parquet_old_int96_timestamps=None,
+    parquet_compliant_nested=False,  # https://issues.apache.org/jira/browse/ARROW-16348
+    parquet_extra_options=None,
+    storage_options=None,
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_parquet(
     array,
     destination,

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -43,7 +43,7 @@ def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     See also #ak.from_rdataframe.
     """
     # Dispatch
-    yield from arrays.values()
+    yield arrays.values()
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -4,12 +4,16 @@ from collections.abc import Mapping
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(arrays, *, flatlist_as_rvec=True):
+    yield from arrays.values()
+
+
+@high_level_function(_dispatcher)
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -9,11 +9,7 @@ from awkward._dispatch import high_level_function
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(arrays, *, flatlist_as_rvec=True):
-    yield from arrays.values()
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:
@@ -46,6 +42,10 @@ def to_rdataframe(arrays, *, flatlist_as_rvec=True):
 
     See also #ak.from_rdataframe.
     """
+    # Dispatch
+    yield from arrays.values()
+
+    # Implementation
     return _impl(
         arrays,
         flatlist_as_rvec=flatlist_as_rvec,

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,7 +2,8 @@
 __all__ = ("to_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError, with_operation_context
+from awkward._dispatch import high_level_function
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -10,7 +11,11 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -54,7 +54,7 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     See also #ak.from_regular.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -11,11 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, axis=1, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:
@@ -57,6 +53,10 @@ def to_regular(array, axis=1, *, highlevel=True, behavior=None):
 
     See also #ak.from_regular.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -412,8 +412,7 @@ def transform(
     outputs.
     """
     # Dispatch
-    yield array
-    yield from more_arrays
+    yield (array, *more_arrays)
 
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -12,27 +12,7 @@ from awkward._layout import wrap_layout
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(
-    transformation,
-    array,
-    *more_arrays,
-    depth_context=None,
-    lateral_context=None,
-    allow_records=True,
-    broadcast_parameters_rule="intersect",
-    left_broadcast=True,
-    right_broadcast=True,
-    numpy_to_regular=False,
-    regular_to_jagged=False,
-    return_value="simplified",
-    highlevel=True,
-    behavior=None,
-):
-    yield array
-    yield from more_arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def transform(
     transformation,
     array,
@@ -431,6 +411,11 @@ def transform(
     See also: #ak.is_valid and #ak.valid_when to check the validity of transformed
     outputs.
     """
+    # Dispatch
+    yield array
+    yield from more_arrays
+
+    # Implementation
     return _impl(
         transformation,
         array,

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -6,13 +6,33 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    transformation,
+    array,
+    *more_arrays,
+    depth_context=None,
+    lateral_context=None,
+    allow_records=True,
+    broadcast_parameters_rule="intersect",
+    left_broadcast=True,
+    right_broadcast=True,
+    numpy_to_regular=False,
+    regular_to_jagged=False,
+    return_value="simplified",
+    highlevel=True,
+    behavior=None,
+):
+    yield array
+    yield from more_arrays
+
+
+@high_level_function(_dispatcher)
 def transform(
     transformation,
     array,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -76,7 +76,7 @@ def type(array, *, behavior=None):
     to the language.)
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, behavior)

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -13,11 +13,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def type(array, *, behavior=None):
     """
     Args:
@@ -79,6 +75,10 @@ def type(array, *, behavior=None):
     similar to existing type-constructors, so it's a plausible addition
     to the language.)
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, behavior)
 
 

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -7,13 +7,17 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def type(array, *, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -12,11 +12,7 @@ from awkward._regularize import is_integer_like, regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, counts, axis=0, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:
@@ -80,6 +76,10 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
 
     See also #ak.num and #ak.flatten.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, counts, axis, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -77,7 +77,7 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     See also #ak.num and #ak.flatten.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, counts, axis, highlevel, behavior)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -2,7 +2,7 @@
 __all__ = ("unflatten",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -12,7 +12,11 @@ from awkward._regularize import is_integer_like, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, counts, axis=0, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -2,14 +2,18 @@
 __all__ = ("unzip",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -40,6 +36,10 @@ def unzip(array, *, highlevel=True, behavior=None):
         >>> y
         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -37,7 +37,7 @@ def unzip(array, *, highlevel=True, behavior=None):
         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -4,11 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-def _dispatcher(array, *, exception=False):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def validity_error(array, *, exception=False):
     """
     Args:
@@ -24,6 +20,10 @@ def validity_error(array, *, exception=False):
 
     See also #ak.is_valid.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, exception)
 
 

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -1,10 +1,14 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("validity_error",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 
 
-@with_operation_context
+def _dispatcher(array, *, exception=False):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def validity_error(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -21,7 +21,7 @@ def validity_error(array, *, exception=False):
     See also #ak.is_valid.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, exception)

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -8,11 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, to, *, including_unknown=False, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def values_astype(array, to, *, including_unknown=False, highlevel=True, behavior=None):
     """
     Args:
@@ -58,6 +54,10 @@ def values_astype(array, to, *, including_unknown=False, highlevel=True, behavio
 
     See also #ak.strings_astype.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, to, including_unknown, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -1,14 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("values_astype",)
 import awkward as ak
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, to, *, including_unknown=False, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def values_astype(array, to, *, including_unknown=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -55,7 +55,7 @@ def values_astype(array, to, *, including_unknown=False, highlevel=True, behavio
     See also #ak.strings_astype.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, to, including_unknown, highlevel, behavior)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -63,8 +63,7 @@ def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
     See also #ak.nanvar.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
@@ -107,8 +106,7 @@ def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=T
     See also #ak.var.
     """
     # Dispatch
-    yield x
-    yield weight
+    yield x, weight
 
     # Implementation
     if weight is not None:

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -3,7 +3,7 @@ __all__ = ("var",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -11,16 +11,15 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
-def var(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=False,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
@@ -73,16 +72,15 @@ def var(
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@with_operation_context
-def nanvar(
-    x,
-    weight=None,
-    ddof=0,
-    axis=None,
-    *,
-    keepdims=False,
-    mask_identity=True,
+def _dispatcher(
+    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
 ):
+    yield x
+    yield weight
+
+
+@high_level_function(_dispatcher)
+def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -11,14 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False
-):
-    yield x
-    yield weight
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -69,17 +62,15 @@ def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
 
     See also #ak.nanvar.
     """
-    return _impl(x, weight, ddof, axis, keepdims, mask_identity)
-
-
-def _dispatcher(
-    x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True
-):
+    # Dispatch
     yield x
     yield weight
 
+    # Implementation
+    return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
-@high_level_function(_dispatcher)
+
+@high_level_function
 def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:
@@ -115,6 +106,11 @@ def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=T
 
     See also #ak.var.
     """
+    # Dispatch
+    yield x
+    yield weight
+
+    # Implementation
     if weight is not None:
         weight = ak.operations.ak_nan_to_none._impl(weight, False, None)
 

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -45,8 +45,7 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     they are incompatible types, the output will have #ak.type.UnionType.
     """
     # Dispatch
-    yield condition
-    yield from args
+    yield (*args, condition)
 
     # Implementation
     if len(args) == 0:

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -12,8 +12,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@ak._connect.numpy.implements("where")
-@with_operation_context
+def _dispatcher(condition, *args, mergebool=True, highlevel=True, behavior=None):
+    yield condition
+    yield from args
+
+
+@high_level_function(_dispatcher)
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -12,12 +12,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(condition, *args, mergebool=True, highlevel=True, behavior=None):
-    yield condition
-    yield from args
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:
@@ -49,6 +44,11 @@ def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     for all `i`. The structure of `x` and `y` do not need to be the same; if
     they are incompatible types, the output will have #ak.type.UnionType.
     """
+    # Dispatch
+    yield condition
+    yield from args
+
+    # Implementation
     if len(args) == 0:
         return _impl1(condition, mergebool, highlevel, behavior)
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -42,8 +42,7 @@ def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     other.)
     """
     # Dispatch
-    yield array
-    yield what
+    yield array, what
 
     # Implementation
     return _impl(array, what, where, highlevel, behavior)

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -6,7 +6,7 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_non_string_like_sequence
@@ -17,7 +17,12 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@with_operation_context
+def _dispatcher(array, what, where=None, *, highlevel=True, behavior=None):
+    yield array
+    yield what
+
+
+@high_level_function(_dispatcher)
 def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -17,12 +17,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-def _dispatcher(array, what, where=None, *, highlevel=True, behavior=None):
-    yield array
-    yield what
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:
@@ -46,6 +41,11 @@ def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     #ak.with_field, so performance is not a factor in choosing one over the
     other.)
     """
+    # Dispatch
+    yield array
+    yield what
+
+    # Implementation
     return _impl(array, what, where, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, name, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:
@@ -37,6 +33,10 @@ def with_name(array, name, *, highlevel=True, behavior=None):
     to the data; see #ak.Array and #ak.behavior for a more complete
     description.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, name, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -34,7 +34,7 @@ def with_name(array, name, *, highlevel=True, behavior=None):
     description.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, name, highlevel, behavior)

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -2,14 +2,18 @@
 __all__ = ("with_name",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, name, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -2,14 +2,18 @@
 __all__ = ("with_parameter",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, parameter, value, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, parameter, value, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:
@@ -34,6 +30,10 @@ def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     You can also remove a single parameter with this function, since setting
     a parameter to None is equivalent to removing it.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, parameter, value, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -31,7 +31,7 @@ def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     a parameter to None is equivalent to removing it.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, parameter, value, highlevel, behavior)

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -4,14 +4,18 @@ from collections.abc import Sequence
 
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, where, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def without_field(array, where, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -34,7 +34,7 @@ def without_field(array, where, *, highlevel=True, behavior=None):
     other.)
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, where, highlevel, behavior)

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -11,11 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, where, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def without_field(array, where, *, highlevel=True, behavior=None):
     """
     Args:
@@ -37,6 +33,10 @@ def without_field(array, where, *, highlevel=True, behavior=None):
     #ak.without_field, so performance is not a factor in choosing one over the
     other.)
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, where, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -26,7 +26,7 @@ def without_parameters(array, *, highlevel=True, behavior=None):
     of large data buffers.
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior)

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -9,11 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(array, *, highlevel=True, behavior=None):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:
@@ -29,6 +25,10 @@ def without_parameters(array, *, highlevel=True, behavior=None):
     Note that a "new array" is a lightweight shallow copy, not a duplication
     of large data buffers.
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior)
 
 

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,14 +2,18 @@
 __all__ = ("without_parameters",)
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(array, *, highlevel=True, behavior=None):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -2,7 +2,7 @@
 __all__ = ("zeros_like",)
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
@@ -11,7 +11,13 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
-@with_operation_context
+def _dispatcher(
+    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
+):
+    yield array
+
+
+@high_level_function(_dispatcher)
 def zeros_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -11,13 +11,7 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
-def _dispatcher(
-    array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
-):
-    yield array
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def zeros_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):
@@ -40,6 +34,10 @@ def zeros_like(
     (There is no equivalent of NumPy's `np.empty_like` because Awkward Arrays
     are immutable.)
     """
+    # Dispatch
+    yield array
+
+    # Implementation
     return _impl(array, highlevel, behavior, dtype, including_unknown)
 
 

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -35,7 +35,7 @@ def zeros_like(
     are immutable.)
     """
     # Dispatch
-    yield array
+    yield (array,)
 
     # Implementation
     return _impl(array, highlevel, behavior, dtype, including_unknown)

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -11,24 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-def _dispatcher(
-    arrays,
-    depth_limit=None,
-    *,
-    parameters=None,
-    with_name=None,
-    right_broadcast=False,
-    optiontype_outside_record=False,
-    highlevel=True,
-    behavior=None,
-):
-    if isinstance(arrays, Mapping):
-        yield from arrays.values()
-    else:
-        yield from arrays
-
-
-@high_level_function(_dispatcher)
+@high_level_function
 def zip(
     arrays,
     depth_limit=None,
@@ -152,6 +135,13 @@ def zip(
         >>> ak.zip([one, two], optiontype_outside_record=True)
         <Array [None, (2, 5), None] type='3 * ?(int64, int64)'>
     """
+    # Dispatch
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+    # Implementation
     return _impl(
         arrays,
         depth_limit,

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -1,15 +1,34 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("zip",)
+from collections.abc import Mapping
+
 import awkward as ak
 from awkward._behavior import behavior_of
-from awkward._errors import with_operation_context
+from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 np = NumpyMetadata.instance()
 
 
-@with_operation_context
+def _dispatcher(
+    arrays,
+    depth_limit=None,
+    *,
+    parameters=None,
+    with_name=None,
+    right_broadcast=False,
+    optiontype_outside_record=False,
+    highlevel=True,
+    behavior=None,
+):
+    if isinstance(arrays, Mapping):
+        yield from arrays.values()
+    else:
+        yield from arrays
+
+
+@high_level_function(_dispatcher)
 def zip(
     arrays,
     depth_limit=None,

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -137,9 +137,9 @@ def zip(
     """
     # Dispatch
     if isinstance(arrays, Mapping):
-        yield from arrays.values()
+        yield arrays.values()
     else:
-        yield from arrays
+        yield arrays
 
     # Implementation
     return _impl(


### PR DESCRIPTION
This PR is an alternative to #2530. It moves the dispatch mechanism _into_ the implementation, which perhaps improves readability. 

Here's an example of `broadcast_arrays` with this dispatch mechanism variant:

```python

@high_level_function
def broadcast_arrays(
    *arrays,
    depth_limit=None,
    broadcast_parameters_rule="one_to_one",
    left_broadcast=True,
    right_broadcast=True,
    highlevel=True,
    behavior=None,
):
    # Dispatch
    yield arrays

    # Implementation
    return _impl(
        arrays,
        depth_limit,
        broadcast_parameters_rule,
        left_broadcast,
        right_broadcast,
        highlevel,
        behavior,
    )
```

Third-party arrays can define the `__awkward_function__` method to intercept `ak.XXX` functions, e.g.
```python
@classmethod
def __awkward_function__(cls, func, array_likes, args, kwargs):
    import dask_awkward
	name = func.__qualname__   

    try:
        impl = getattr(dask_awkward, name)
    except AttributeError:
        return NotImplemented

    return impl(*args, **kwargs)
```

### Limitations
1. High-level function results cannot be generators if they are decorated with `high_level_function`. In this case, the bare error-handler context manager should be used. 
