### PR TITLE
fix: improve performance of `Form.select_columns`

### DIFF
--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -197,15 +197,23 @@ class BitMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return BitMaskedForm(
-            self._mask,
-            self._content._select_columns(match_specifier),
-            self._valid_when,
-            self._lsb_order,
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return BitMaskedForm(
+                self._mask,
+                next_content,
+                self._valid_when,
+                self._lsb_order,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -197,10 +197,10 @@ class BitMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return BitMaskedForm(
             self._mask,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             self._valid_when,
             self._lsb_order,
             parameters=self._parameters,

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -197,8 +197,8 @@ class BitMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -197,12 +197,8 @@ class BitMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -214,6 +210,16 @@ class BitMaskedForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return BitMaskedForm(
+            self._mask,
+            self._content._select_columns(match_specifier),
+            self._valid_when,
+            self._lsb_order,
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -174,10 +174,10 @@ class ByteMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return ByteMaskedForm(
             self._mask,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             self._valid_when,
             parameters=self._parameters,
             form_key=self._form_key,

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -174,14 +174,22 @@ class ByteMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._select_columns(match_specifier),
-            self._valid_when,
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return ByteMaskedForm(
+                self._mask,
+                next_content,
+                self._valid_when,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -174,8 +174,8 @@ class ByteMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -174,12 +174,8 @@ class ByteMaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -190,6 +186,15 @@ class ByteMaskedForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return ByteMaskedForm(
+            self._mask,
+            self._content._select_columns(match_specifier),
+            self._valid_when,
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -6,7 +6,7 @@ from inspect import signature
 import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import Iterator, final
+from awkward._typing import Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, JSONMapping
 
@@ -125,9 +125,10 @@ class EmptyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
+    def _select_columns(self, match_specifier):
+        return self
+
+    def _prune_columns(self, is_inside_record: bool) -> Self:
         return self
 
     def _column_types(self) -> tuple[str, ...]:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -128,7 +128,7 @@ class EmptyForm(Form):
     def _select_columns(self, match_specifier):
         return self
 
-    def _prune_columns(self, is_inside_record: bool) -> Self:
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self:
         return self
 
     def _column_types(self) -> tuple[str, ...]:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -125,9 +125,7 @@ class EmptyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, index, specifier, matches, output):
-        if any(match and index >= len(item) for item, match in zip(specifier, matches)):
-            output.append(None)
+    def _select_columns(self, match_specifier):
         return self
 
     def _column_types(self) -> tuple[str, ...]:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -125,7 +125,9 @@ class EmptyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
         return self
 
     def _column_types(self) -> tuple[str, ...]:

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -280,7 +280,7 @@ class _SpecifierMatcher:
         fixed_strings = set()
         patterns = set()
         # And then map these unique strings to their child specifiers
-        match_to_next_specifiers = defaultdict[str, list[list[str]]](list)
+        match_to_next_specifiers: defaultdict[str, list[list[str]]] = defaultdict(list)
 
         # For each specifier, categorise it as a fixed-string or pattern,
         # and build the next-specifier table

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import re
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from fnmatch import fnmatchcase
 from glob import escape as escape_glob
 
@@ -273,7 +273,9 @@ def _expand_braces(text, seen=None):
 
 
 class _SpecifierMatcher:
-    def __init__(self, specifiers: list[list[str]], *, match_if_empty: bool = False):
+    def __init__(
+        self, specifiers: Iterable[list[str]], *, match_if_empty: bool = False
+    ):
         # We'll build two sets of unique fixed-strings and patterns
         fixed_strings = set()
         patterns = set()

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -456,7 +456,9 @@ class Form:
         self._columns(column_prefix, output, list_indicator)
         return output
 
-    def select_columns(self, specifier, expand_braces=True):
+    def select_columns(
+        self, specifier, expand_braces=True, *, prune_interior_leaves: bool = True
+    ):
         if isinstance(specifier, str):
             specifier = {specifier}
 
@@ -480,7 +482,7 @@ class Form:
 
         specifier = [[] if item == "" else item.split(".") for item in set(specifier)]
         match_specifier = _SpecifierMatcher(specifier, match_if_empty=False)
-        return self._select_columns(match_specifier)
+        return self._select_columns(match_specifier, prune_interior_leaves, False)
 
     def column_types(self):
         return self._column_types()
@@ -488,7 +490,9 @@ class Form:
     def _columns(self, path, output, list_indicator):
         raise NotImplementedError
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ) -> Form | None:
         raise NotImplementedError
 
     def _column_types(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -494,7 +494,7 @@ class Form:
     def _columns(self, path, output, list_indicator):
         raise NotImplementedError
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
         raise NotImplementedError
 
     def _select_columns(self, match_specifier) -> Self | None:

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -482,7 +482,11 @@ class Form:
 
         specifier = [[] if item == "" else item.split(".") for item in set(specifier)]
         match_specifier = _SpecifierMatcher(specifier, match_if_empty=False)
-        return self._select_columns(match_specifier, prune_interior_leaves, False)
+        selection = self._select_columns(match_specifier)
+        if prune_interior_leaves:
+            return selection._prune_columns(False)
+        else:
+            return selection
 
     def column_types(self):
         return self._column_types()
@@ -490,9 +494,10 @@ class Form:
     def _columns(self, path, output, list_indicator):
         raise NotImplementedError
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ) -> Form | None:
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        raise NotImplementedError
+
+    def _select_columns(self, match_specifier) -> Self | None:
         raise NotImplementedError
 
     def _column_types(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import itertools
 import json
 import re
+from collections import defaultdict
 from collections.abc import Mapping
+from fnmatch import fnmatchcase
+from glob import escape as escape_glob
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
@@ -12,7 +15,7 @@ from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_union
-from awkward._typing import Final, JSONMapping, JSONSerializable
+from awkward._typing import Final, JSONMapping, JSONSerializable, Self
 
 np = NumpyMetadata.instance()
 numpy_backend = NumpyBackend.instance()
@@ -269,6 +272,68 @@ def _expand_braces(text, seen=None):
             yield from _expand_braces("".join(replaced), seen)
 
 
+class _SpecifierMatcher:
+    def __init__(self, specifiers: list[list[str]]):
+        # We'll build two sets of unique fixed-strings and patterns
+        fixed_strings = set()
+        patterns = set()
+        # And then map these unique strings to their child specifiers
+        match_to_next_specifiers = defaultdict[str, list[list[str]]](list)
+
+        # For each specifier, categorise it as a fixed-string or pattern,
+        # and build the next-specifier table
+        parent: str
+        child: list[str]
+        for item in specifiers:
+            parent, *child = item
+
+            if escape_glob(parent) == parent:
+                fixed_strings.add(parent)
+            else:
+                patterns.add(parent)
+
+            # Only include child specifier list if it is non-empty
+            if child:
+                match_to_next_specifiers[parent].append(child)
+
+        self._match_to_next_specifiers = match_to_next_specifiers
+        self._fixed_strings = fixed_strings
+        self._patterns = patterns
+
+    @property
+    def is_identity(self) -> bool:
+        """
+        The identity specifier matcher will always return itself for any given field, indicating
+        that the specifier list has been exhausted.
+        """
+        return not (self._patterns or self._fixed_strings)
+
+    def __call__(self, field: str) -> Self | None:
+        # When we run out of specifiers, we always return the identity
+        if self.is_identity:
+            return self
+
+        has_matched = False
+
+        # Fixed-strings are an O(log n) lookup
+        next_specifiers = []
+        if field in self._fixed_strings:
+            has_matched = True
+            next_specifiers.extend(self._match_to_next_specifiers[field])
+
+        # Fixed-strings are an O(n) lookup
+        for pattern in self._patterns:
+            if fnmatchcase(field, pattern):
+                has_matched = True
+                next_specifiers.extend(self._match_to_next_specifiers[pattern])
+
+        if has_matched:
+            return _SpecifierMatcher(next_specifiers)
+        # Return None if we didn't match anything, distinct from "there are no child specifiers"
+        else:
+            return
+
+
 class Form:
     is_numpy = False
     is_unknown = False
@@ -395,12 +460,19 @@ class Form:
 
     def select_columns(self, specifier, expand_braces=True):
         if isinstance(specifier, str):
-            specifier = [specifier]
+            specifier = {specifier}
+        else:
+            specifier = set(specifier)
 
+        # Only take unique specifiers
         for item in specifier:
             if not isinstance(item, str):
                 raise TypeError(
-                    "a column-selection specifier must be a list of strings"
+                    "a column-selection specifier must be a list of non-empty strings"
+                )
+            if not item:
+                raise ValueError(
+                    "a column-selection specifier must be a list of non-empty strings"
                 )
 
         if expand_braces:
@@ -411,10 +483,8 @@ class Form:
             specifier = next_specifier
 
         specifier = [[] if item == "" else item.split(".") for item in set(specifier)]
-        matches = [True] * len(specifier)
-
-        output = []
-        return self._select_columns(0, specifier, matches, output)
+        match_specifier = _SpecifierMatcher(specifier)
+        return self._select_columns(match_specifier)
 
     def column_types(self):
         return self._column_types()
@@ -422,7 +492,7 @@ class Form:
     def _columns(self, path, output, list_indicator):
         raise NotImplementedError
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         raise NotImplementedError
 
     def _column_types(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -457,7 +457,7 @@ class Form:
         return output
 
     def select_columns(
-        self, specifier, expand_braces=True, *, prune_interior_leaves: bool = True
+        self, specifier, expand_braces=True, *, prune_unions_and_records: bool = True
     ):
         if isinstance(specifier, str):
             specifier = {specifier}
@@ -483,7 +483,7 @@ class Form:
         specifier = [[] if item == "" else item.split(".") for item in set(specifier)]
         match_specifier = _SpecifierMatcher(specifier, match_if_empty=False)
         selection = self._select_columns(match_specifier)
-        if prune_interior_leaves:
+        if prune_unions_and_records:
             return selection._prune_columns(False)
         else:
             return selection

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -457,8 +457,6 @@ class Form:
     def select_columns(self, specifier, expand_braces=True):
         if isinstance(specifier, str):
             specifier = {specifier}
-        else:
-            specifier = set(specifier)
 
         # Only take unique specifiers
         for item in specifier:

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -182,12 +182,8 @@ class IndexedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -197,6 +193,14 @@ class IndexedForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return IndexedForm(
+            self._index,
+            self._content._select_columns(match_specifier),
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -182,13 +182,21 @@ class IndexedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return IndexedForm(
-            self._index,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return IndexedForm(
+                self._index,
+                next_content,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -182,8 +182,8 @@ class IndexedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -182,10 +182,10 @@ class IndexedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return IndexedForm(
             self._index,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             parameters=self._parameters,
             form_key=self._form_key,
         )

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -163,13 +163,21 @@ class IndexedOptionForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return IndexedOptionForm(
-            self._index,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return IndexedOptionForm(
+                self._index,
+                next_content,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -163,12 +163,8 @@ class IndexedOptionForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -178,6 +174,14 @@ class IndexedOptionForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return IndexedOptionForm(
+            self._index,
+            self._content._select_columns(match_specifier),
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -163,10 +163,10 @@ class IndexedOptionForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return IndexedOptionForm(
             self._index,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             parameters=self._parameters,
             form_key=self._form_key,
         )

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -163,8 +163,8 @@ class IndexedOptionForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -180,14 +180,22 @@ class ListForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves
         )
+        if next_content is None:
+            return None
+        else:
+            return ListForm(
+                self._starts,
+                self._stops,
+                next_content,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -180,8 +180,8 @@ class ListForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool):
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool):
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -180,12 +180,8 @@ class ListForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves
-        )
+    def _prune_columns(self, is_inside_record: bool):
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -196,6 +192,15 @@ class ListForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return ListForm(
+            self._starts,
+            self._stops,
+            self._content._select_columns(match_specifier),
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -180,11 +180,11 @@ class ListForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return ListForm(
             self._starts,
             self._stops,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             parameters=self._parameters,
             form_key=self._form_key,
         )

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -147,8 +147,8 @@ class ListOffsetForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool):
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool):
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -147,12 +147,8 @@ class ListOffsetForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool):
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -162,6 +158,14 @@ class ListOffsetForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return ListOffsetForm(
+            self._offsets,
+            self._content._select_columns(match_specifier),
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -147,10 +147,10 @@ class ListOffsetForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return ListOffsetForm(
             self._offsets,
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             parameters=self._parameters,
             form_key=self._form_key,
         )

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -147,13 +147,21 @@ class ListOffsetForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return ListOffsetForm(
-            self._offsets,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return ListOffsetForm(
+                self._offsets,
+                next_content,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -212,9 +212,7 @@ class NumpyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, index, specifier, matches, output):
-        if any(match and index >= len(item) for item, match in zip(specifier, matches)):
-            output.append(None)
+    def _select_columns(self, match_specifier):
         return self
 
     def _column_types(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -212,7 +212,9 @@ class NumpyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
         return self
 
     def _column_types(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -215,7 +215,7 @@ class NumpyForm(Form):
     def _select_columns(self, match_specifier):
         return self
 
-    def _prune_columns(self, is_inside_record: bool) -> Self:
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self:
         return self
 
     def _column_types(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,7 +5,7 @@ import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -212,9 +212,10 @@ class NumpyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
+    def _select_columns(self, match_specifier):
+        return self
+
+    def _prune_columns(self, is_inside_record: bool) -> Self:
         return self
 
     def _column_types(self):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -240,7 +240,7 @@ class RecordForm(Form):
         for content, field in zip(self._contents, self.fields):
             content._columns((*path, field), output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool):
+    def _prune_columns(self, is_inside_record_or_union: bool):
         contents = []
         fields = []
         for content, field in zip(self._contents, self.fields):
@@ -250,7 +250,7 @@ class RecordForm(Form):
             contents.append(next_content)
             fields.append(field)
 
-        if fields or not is_inside_record:
+        if fields or not is_inside_record_or_union:
             return RecordForm(
                 contents,
                 fields,

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -241,28 +241,33 @@ class RecordForm(Form):
             content._columns((*path, field), output, list_indicator)
 
     def _select_columns(self, match_specifier):
-        contents = []
-        fields = []
-        for content, field in zip(self._contents, self.fields):
-            # Try and match this field
-            next_match_specifier = match_specifier(field)
-            if next_match_specifier is None:
-                continue
+        if match_specifier.is_identity:
+            return RecordForm(
+                [], [], parameters=self._parameters, form_key=self._form_key
+            )
+        else:
+            contents = []
+            fields = []
+            for content, field in zip(self._contents, self.fields):
+                # Try and match this field
+                next_match_specifier = match_specifier(field)
+                if next_match_specifier is None:
+                    continue
 
-            if next_match_specifier.is_identity:
-                next_content = content
-            # Do we need to proceed in selection?
-            else:
-                next_content = content._select_columns(next_match_specifier)
-            contents.append(next_content)
-            fields.append(field)
+                if next_match_specifier.is_identity:
+                    next_content = content
+                # Do we need to proceed in selection?
+                else:
+                    next_content = content._select_columns(next_match_specifier)
+                contents.append(next_content)
+                fields.append(field)
 
-        return RecordForm(
-            contents,
-            fields,
-            parameters=self._parameters,
-            form_key=self._form_key,
-        )
+            return RecordForm(
+                contents,
+                fields,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return sum((x._column_types() for x in self._contents), ())

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -1,6 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-import glob
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from fnmatch import fnmatchcase
+from functools import partial
+from glob import escape as escape_glob
 
 import awkward as ak
 from awkward._parameters import type_parameters_equal
@@ -241,14 +243,38 @@ class RecordForm(Form):
         for content, field in zip(self._contents, self.fields):
             content._columns((*path, field), output, list_indicator)
 
+    def _build_pattern_matchers(
+        self, specifier: list[list[str]], index: int
+    ) -> list[Callable[[str], bool]]:
+        specifier_matchers = []
+        fixed_string_patterns = set()
+
+        def matches_fixed_string_patterns(field):
+            return field in fixed_string_patterns
+
+        for _i, components in enumerate(specifier):
+            if index >= len(components):
+                specifier_matchers.append(lambda y: True)
+            else:
+                this_item = components[index]
+
+                # Is the pattern a trivial fixed string?
+                if escape_glob(this_item) == this_item:
+                    fixed_string_patterns.add(this_item)
+                    specifier_matchers.append(matches_fixed_string_patterns)
+                else:
+                    specifier_matchers.append(partial(fnmatchcase, pat=this_item))
+        return specifier_matchers
+
     def _select_columns(self, index, specifier, matches, output):
+        specifier_matchers = self._build_pattern_matchers(specifier, index)
+
         contents = []
         fields = []
         for content, field in zip(self._contents, self.fields):
             next_matches = [
-                matches[i]
-                and (index >= len(item) or glob.fnmatch.fnmatchcase(field, item[index]))
-                for i, item in enumerate(specifier)
+                matches[i] and matcher(field)
+                for i, matcher in enumerate(specifier_matchers)
             ]
             if any(next_matches):
                 len_output = len(output)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -141,9 +141,9 @@ class RegularForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return RegularForm(
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             self._size,
             parameters=self._parameters,
             form_key=self._form_key,

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -141,13 +141,21 @@ class RegularForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return RegularForm(
-            self._content._select_columns(match_specifier),
-            self._size,
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return RegularForm(
+                next_content,
+                self._size,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -141,8 +141,8 @@ class RegularForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool):
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool):
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -141,12 +141,8 @@ class RegularForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool):
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -156,6 +152,14 @@ class RegularForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return RegularForm(
+            self._content._select_columns(match_specifier),
+            self._size,
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -231,14 +231,23 @@ class UnionForm(Form):
         for content, field in zip(self._contents, self.fields):
             content._columns((*path, field), output, list_indicator)
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
         contents = []
         for content in self._contents:
-            next_content = content._select_columns(match_specifier)
+            next_content = content._select_columns(
+                match_specifier, prune_interior_leaves, is_inside_record
+            )
+            if next_content is None:
+                continue
             contents.append(next_content)
 
         if len(contents) == 0:
-            return ak.forms.EmptyForm(form_key=self._form_key)
+            if prune_interior_leaves and is_inside_record:
+                return None
+            else:
+                return ak.forms.EmptyForm(form_key=self._form_key)
         elif len(contents) == 1:
             return contents[0]
         else:

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -231,13 +231,11 @@ class UnionForm(Form):
         for content, field in zip(self._contents, self.fields):
             content._columns((*path, field), output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         contents = []
         for content in self._contents:
-            len_output = len(output)
-            next_content = content._select_columns(index, specifier, matches, output)
-            if len_output != len(output):
-                contents.append(next_content)
+            next_content = content._select_columns(match_specifier)
+            contents.append(next_content)
 
         if len(contents) == 0:
             return ak.forms.EmptyForm(form_key=self._form_key)

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -231,16 +231,20 @@ class UnionForm(Form):
         for content, field in zip(self._contents, self.fields):
             content._columns((*path, field), output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
         contents = []
         for content in self._contents:
-            next_content = content._prune_columns(is_inside_record)
+            next_content = content._prune_columns(True)
             if next_content is None:
                 continue
             contents.append(next_content)
 
         if len(contents) == 0:
-            return None
+            if is_inside_record_or_union:
+                return None
+            else:
+                # outermost unions should return an EmptyForm instead
+                return ak.forms.EmptyForm(form_key=self._form_key)
         elif len(contents) == 1:
             return contents[0]
         else:

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import final
+from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -135,12 +135,8 @@ class UnmaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(
-        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
-    ):
-        next_content = self._content._select_columns(
-            match_specifier, prune_interior_leaves, is_inside_record
-        )
+    def _prune_columns(self, is_inside_record: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record)
         if next_content is None:
             return None
         else:
@@ -149,6 +145,13 @@ class UnmaskedForm(Form):
                 parameters=self._parameters,
                 form_key=self._form_key,
             )
+
+    def _select_columns(self, match_specifier):
+        return UnmaskedForm(
+            self._content._select_columns(match_specifier),
+            parameters=self._parameters,
+            form_key=self._form_key,
+        )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -135,12 +135,20 @@ class UnmaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, match_specifier):
-        return UnmaskedForm(
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
+    def _select_columns(
+        self, match_specifier, prune_interior_leaves: bool, is_inside_record: bool
+    ):
+        next_content = self._content._select_columns(
+            match_specifier, prune_interior_leaves, is_inside_record
         )
+        if next_content is None:
+            return None
+        else:
+            return UnmaskedForm(
+                next_content,
+                parameters=self._parameters,
+                form_key=self._form_key,
+            )
 
     def _column_types(self):
         return self._content._column_types()

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -135,9 +135,9 @@ class UnmaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _select_columns(self, index, specifier, matches, output):
+    def _select_columns(self, match_specifier):
         return UnmaskedForm(
-            self._content._select_columns(index, specifier, matches, output),
+            self._content._select_columns(match_specifier),
             parameters=self._parameters,
             form_key=self._form_key,
         )

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -135,8 +135,8 @@ class UnmaskedForm(Form):
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record: bool) -> Self | None:
-        next_content = self._content._prune_columns(is_inside_record)
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
+        next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:

--- a/tests/test_2356_select_columns.py
+++ b/tests/test_2356_select_columns.py
@@ -1,0 +1,84 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    form = ak.Array(
+        [
+            {
+                "x": [
+                    {
+                        "y": {
+                            "z": [1, 2, 3],
+                            "w": 4,
+                        }
+                    }
+                ]
+            }
+        ]
+    ).layout.form
+
+    assert form.select_columns(["*"]) == form
+    assert form.select_columns(["x"]) == form
+    assert form.select_columns(["x.y"]) == form
+    assert form.select_columns(["x.*"]) == form
+    assert form.select_columns(["x.y.*"]) == form
+    assert form.select_columns(["x.y.z", "x.y.w"]) == form
+    assert form.select_columns(["x.y.z"]) == ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": ["x"],
+            "contents": [
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "RecordArray",
+                        "fields": ["y"],
+                        "contents": [
+                            {
+                                "class": "RecordArray",
+                                "fields": [
+                                    "z",
+                                ],
+                                "contents": [
+                                    {
+                                        "class": "ListOffsetArray",
+                                        "offsets": "i64",
+                                        "content": "int64",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    assert form.select_columns(["x.y.q"]) == ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": ["x"],
+            "contents": [
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "RecordArray",
+                        "fields": ["y"],
+                        "contents": [
+                            {
+                                "class": "RecordArray",
+                                "fields": [],
+                                "contents": [],
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    assert form.select_columns([]) == form

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -84,3 +84,44 @@ def test():
     assert form.select_columns([]) == ak.forms.from_dict(
         {"class": "RecordArray", "fields": [], "contents": []}
     )
+
+
+def test_very_large_record():
+    form = ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": [f"x_{i}" for i in range(10_000)],
+            "contents": ["int64"] * 10_000,
+        }
+    )
+    assert form.select_columns(["*"]) == form
+    assert form.select_columns(["x*"]) == form
+    assert form.select_columns(["x_[0-9]"]) == ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": [
+                "x_0",
+                "x_1",
+                "x_2",
+                "x_3",
+                "x_4",
+                "x_5",
+                "x_6",
+                "x_7",
+                "x_8",
+                "x_9",
+            ],
+            "contents": [
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+                "int64",
+            ],
+        }
+    )

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -5,7 +5,7 @@ import pytest  # noqa: F401
 import awkward as ak
 
 
-def test():
+def test_no_prune():
     form = ak.Array(
         [
             {
@@ -21,11 +21,11 @@ def test():
         ]
     ).layout.form
 
-    assert form.select_columns(["*"]) == form
-    assert form.select_columns(["x"]) == form
-    assert form.select_columns(["x.y"]) == form
-    assert form.select_columns(["x.*"]) == form
-    assert form.select_columns(["x.y.z", "x.y.w"]) == form
+    assert form.select_columns(["*"], prune_interior_leaves=False) == form
+    assert form.select_columns(["x"], prune_interior_leaves=False) == form
+    assert form.select_columns(["x.y"], prune_interior_leaves=False) == form
+    assert form.select_columns(["x.*"], prune_interior_leaves=False) == form
+    assert form.select_columns(["x.y.z", "x.y.w"], prune_interior_leaves=False) == form
     assert (
         form.select_columns(["x.y.z"])
         == form.select_columns(["x.y.z*"])
@@ -61,7 +61,9 @@ def test():
             }
         )
     )
-    assert form.select_columns(["x.y.q"]) == ak.forms.from_dict(
+    assert form.select_columns(
+        ["x.y.q"], prune_interior_leaves=False
+    ) == ak.forms.from_dict(
         {
             "class": "RecordArray",
             "fields": ["x"],
@@ -84,8 +86,35 @@ def test():
             ],
         }
     )
-    assert form.select_columns([]) == ak.forms.from_dict(
+    assert form.select_columns([], prune_interior_leaves=False) == ak.forms.from_dict(
         {"class": "RecordArray", "fields": [], "contents": []}
+    )
+
+
+def test_prune():
+    form = ak.Array(
+        [
+            {
+                "x": [
+                    {
+                        "y": {
+                            "z": [1, 2, 3],
+                            "w": 4,
+                        }
+                    }
+                ]
+            }
+        ]
+    ).layout.form
+
+    assert form.select_columns(
+        ["x.y.q"], prune_interior_leaves=True
+    ) == ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": [],
+            "contents": [],
+        }
     )
 
 

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -25,38 +25,41 @@ def test():
     assert form.select_columns(["x"]) == form
     assert form.select_columns(["x.y"]) == form
     assert form.select_columns(["x.*"]) == form
-    assert form.select_columns(["x.y.*"]) == form
     assert form.select_columns(["x.y.z", "x.y.w"]) == form
-    assert form.select_columns(["x.y.z"]) == ak.forms.from_dict(
-        {
-            "class": "RecordArray",
-            "fields": ["x"],
-            "contents": [
-                {
-                    "class": "ListOffsetArray",
-                    "offsets": "i64",
-                    "content": {
-                        "class": "RecordArray",
-                        "fields": ["y"],
-                        "contents": [
-                            {
-                                "class": "RecordArray",
-                                "fields": [
-                                    "z",
-                                ],
-                                "contents": [
-                                    {
-                                        "class": "ListOffsetArray",
-                                        "offsets": "i64",
-                                        "content": "int64",
-                                    }
-                                ],
-                            }
-                        ],
-                    },
-                }
-            ],
-        }
+    assert (
+        form.select_columns(["x.y.z"])
+        == form.select_columns(["x.y.z*"])
+        == ak.forms.from_dict(
+            {
+                "class": "RecordArray",
+                "fields": ["x"],
+                "contents": [
+                    {
+                        "class": "ListOffsetArray",
+                        "offsets": "i64",
+                        "content": {
+                            "class": "RecordArray",
+                            "fields": ["y"],
+                            "contents": [
+                                {
+                                    "class": "RecordArray",
+                                    "fields": [
+                                        "z",
+                                    ],
+                                    "contents": [
+                                        {
+                                            "class": "ListOffsetArray",
+                                            "offsets": "i64",
+                                            "content": "int64",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
     )
     assert form.select_columns(["x.y.q"]) == ak.forms.from_dict(
         {

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -21,11 +21,13 @@ def test_no_prune():
         ]
     ).layout.form
 
-    assert form.select_columns(["*"], prune_interior_leaves=False) == form
-    assert form.select_columns(["x"], prune_interior_leaves=False) == form
-    assert form.select_columns(["x.y"], prune_interior_leaves=False) == form
-    assert form.select_columns(["x.*"], prune_interior_leaves=False) == form
-    assert form.select_columns(["x.y.z", "x.y.w"], prune_interior_leaves=False) == form
+    assert form.select_columns(["*"], prune_unions_and_records=False) == form
+    assert form.select_columns(["x"], prune_unions_and_records=False) == form
+    assert form.select_columns(["x.y"], prune_unions_and_records=False) == form
+    assert form.select_columns(["x.*"], prune_unions_and_records=False) == form
+    assert (
+        form.select_columns(["x.y.z", "x.y.w"], prune_unions_and_records=False) == form
+    )
     assert (
         form.select_columns(["x.y.z"])
         == form.select_columns(["x.y.z*"])
@@ -62,7 +64,7 @@ def test_no_prune():
         )
     )
     assert form.select_columns(
-        ["x.y.q"], prune_interior_leaves=False
+        ["x.y.q"], prune_unions_and_records=False
     ) == ak.forms.from_dict(
         {
             "class": "RecordArray",
@@ -86,8 +88,33 @@ def test_no_prune():
             ],
         }
     )
-    assert form.select_columns([], prune_interior_leaves=False) == ak.forms.from_dict(
-        {"class": "RecordArray", "fields": [], "contents": []}
+    assert form.select_columns(
+        [], prune_unions_and_records=False
+    ) == ak.forms.from_dict({"class": "RecordArray", "fields": [], "contents": []})
+
+    union_form = ak.forms.from_dict(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {"class": "RecordArray", "fields": ["x"], "contents": ["int64"]},
+                {"class": "RecordArray", "fields": ["y"], "contents": ["int64"]},
+            ],
+        }
+    )
+    assert union_form.select_columns(
+        "z", prune_unions_and_records=False
+    ) == ak.forms.from_dict(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {"class": "RecordArray", "fields": [], "contents": []},
+                {"class": "RecordArray", "fields": [], "contents": []},
+            ],
+        }
     )
 
 
@@ -108,13 +135,29 @@ def test_prune():
     ).layout.form
 
     assert form.select_columns(
-        ["x.y.q"], prune_interior_leaves=True
+        ["x.y.q"], prune_unions_and_records=True
     ) == ak.forms.from_dict(
         {
             "class": "RecordArray",
             "fields": [],
             "contents": [],
         }
+    )
+
+    union_form = ak.forms.from_dict(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {"class": "RecordArray", "fields": ["x"], "contents": ["int64"]},
+                {"class": "RecordArray", "fields": ["y"], "contents": ["int64"]},
+            ],
+        }
+    )
+    assert (
+        union_form.select_columns("z", prune_unions_and_records=True)
+        == ak.forms.EmptyForm()
     )
 
 

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -81,4 +81,6 @@ def test():
             ],
         }
     )
-    assert form.select_columns([]) == form
+    assert form.select_columns([]) == ak.forms.from_dict(
+        {"class": "RecordArray", "fields": [], "contents": []}
+    )


### PR DESCRIPTION
Fixes #2535

In `RecordForm._select_columns`, we perform an `N * M` iteration to test for matches. Previously, we were invoking `fnmatch.fnmatchcase`, which uses a 256-wide cache to compile & translate the regex pattern (IIRC `re.compile` also caches, with 512-wide, so that's likely our true effective cache size for the `compile` part). This means that in an `N * M` loop where `N` and `M` are greater than 256, the cache fails to improve performance. This PR identifies the pathological case of `N * M` containing mostly fixed strings, and replaces the calls to `fnmatchcase` with `string in set_of_strings`.

We could just implement our own version of `fnmatchcase` (3 lines) with a bigger cache, but that just defers the problem.

In practice, we know that if the specifiers given are _unique_ fixed strings, we can reduce this loop to `N` iterations. For now, I've not imposed this optimisation, and instead just made the `* M` loop much faster by leveraging the `item in set` time complexity.