### PR TITLE
feat: add `__subclass__` parameter for high-precedence non-record nominal types

### DIFF
--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -23,6 +23,8 @@ def overlay_behavior(behavior: Mapping | None) -> Mapping:
 
 
 def get_array_name(parameters: JSONMapping | None) -> str | None:
+    if parameters is None:
+        return None
     for param in "__name__", "__array__":
         name = parameters.get(param)
         if name is not None:
@@ -31,6 +33,8 @@ def get_array_name(parameters: JSONMapping | None) -> str | None:
 
 
 def get_record_name(parameters: JSONMapping | None) -> str | None:
+    if parameters is None:
+        return None
     return parameters.get("__record__")
 
 

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -59,12 +59,10 @@ def get_array_class(layout, behavior: Mapping | None) -> type:
             continue
         # Did the user register a behavior class?
         cls = behavior.get(name)
-        if cls is None:
-            continue
         # Is the behavior class valid?
         if isinstance(cls, type) and issubclass(cls, Array):
             return cls
-        else:
+        elif cls is not None:
             raise TypeError(
                 f"a non ak.Array subclass was encountered when resolving the array class for {name}"
             )
@@ -74,12 +72,12 @@ def get_array_class(layout, behavior: Mapping | None) -> type:
         purelist_name = layout.purelist_parameter("__record__")
         if purelist_name is not None:
             cls = behavior.get(("*", purelist_name))
-            if not (isinstance(cls, type) and issubclass(cls, Array)):
+            if isinstance(cls, type) and issubclass(cls, Array):
+                return cls
+            elif cls is not None:
                 raise TypeError(
                     f"a non ak.Array subclass was encountered when resolving the array class for {name}"
                 )
-            else:
-                return cls
     return Array
 
 

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -25,7 +25,7 @@ def overlay_behavior(behavior: Mapping | None) -> Mapping:
 def get_array_name(parameters: JSONMapping | None) -> str | None:
     if parameters is None:
         return None
-    for param in ".__subclass__", "__array__":
+    for param in "__subclass__", "__array__":
         name = parameters.get(param)
         if name is not None:
             return name
@@ -52,7 +52,7 @@ def get_array_class(layout, behavior: Mapping | None) -> type:
 
     # __array__ is a fallback for __name__. If one of these parameters is set, we should return a registered behavior
     # class, or the default array type
-    for param in ".__subclass__", "__array__":
+    for param in "__subclass__", "__array__":
         # Did the user specify a nominal parameter?
         name = layout.parameter(param)
         if name is None:

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -25,7 +25,7 @@ def overlay_behavior(behavior: Mapping | None) -> Mapping:
 def get_array_name(parameters: JSONMapping | None) -> str | None:
     if parameters is None:
         return None
-    for param in "__name__", "__array__":
+    for param in ".__subclass__", "__array__":
         name = parameters.get(param)
         if name is not None:
             return name
@@ -52,7 +52,7 @@ def get_array_class(layout, behavior: Mapping | None) -> type:
 
     # __array__ is a fallback for __name__. If one of these parameters is set, we should return a registered behavior
     # class, or the default array type
-    for param in "__name__", "__array__":
+    for param in ".__subclass__", "__array__":
         # Did the user specify a nominal parameter?
         name = layout.parameter(param)
         if name is None:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -16,7 +16,7 @@ from awkward._behavior import (
     find_custom_cast,
     find_ufunc,
     find_ufunc_generic,
-    get_nominal_type,
+    get_layout_name,
 )
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
@@ -197,7 +197,7 @@ def _array_ufunc_signature(ufunc, inputs):
     signature = [ufunc]
     for x in inputs:
         if isinstance(x, ak.contents.Content):
-            nominal_type = get_nominal_type(x)
+            nominal_type = get_layout_name(x)
             if nominal_type is not None:
                 signature.append(nominal_type)
             elif isinstance(x, NumpyArray):
@@ -270,14 +270,14 @@ def array_ufunc(ufunc, method, inputs, kwargs):
                         return out
 
         if all(
-            get_nominal_type(x) is not None
+            get_layout_name(x) is not None
             for x in inputs
             if isinstance(x, ak.contents.Content)
         ):
             error_message = []
             for x in inputs:
                 if isinstance(x, ak.contents.Content):
-                    nominal_type = get_nominal_type(x)
+                    nominal_type = get_layout_name(x)
                     if nominal_type is not None:
                         error_message.append(nominal_type)
                     else:

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -4,6 +4,8 @@ from collections.abc import Collection
 
 from awkward._typing import JSONMapping, JSONSerializable
 
+NOMINAL_PARAMETERS = ("__array__", "__name__", "__categorical__", "__record__")
+
 
 def type_parameters_equal(
     one: JSONMapping | None, two: JSONMapping | None, *, allow_missing: bool = False
@@ -14,19 +16,19 @@ def type_parameters_equal(
     elif one is None:
         # NB: __categorical__ is currently a type-only parameter, but
         # we check it here as types check this too.
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if two.get(key) is not None:
                 return allow_missing
         return True
 
     elif two is None:
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if one.get(key) is not None:
                 return allow_missing
         return True
 
     else:
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if one.get(key) != two.get(key):
                 return False
         return True
@@ -41,7 +43,7 @@ def parameters_are_equal(
         if only_array_record:
             # NB: __categorical__ is currently a type-only parameter, but
             # we check it here as types check this too.
-            for key in ("__array__", "__record__", "__categorical__"):
+            for key in NOMINAL_PARAMETERS:
                 if two.get(key) is not None:
                     return False
             return True
@@ -53,7 +55,7 @@ def parameters_are_equal(
 
     elif two is None:
         if only_array_record:
-            for key in ("__array__", "__record__", "__categorical__"):
+            for key in NOMINAL_PARAMETERS:
                 if one.get(key) is not None:
                     return False
             return True
@@ -65,7 +67,7 @@ def parameters_are_equal(
 
     else:
         if only_array_record:
-            keys = ("__array__", "__record__", "__categorical__")
+            keys = NOMINAL_PARAMETERS
         else:
             keys = set(one.keys()).union(two.keys())
         for key in keys:

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 
 from awkward._typing import JSONMapping, JSONSerializable
 
-NOMINAL_PARAMETERS = ("__array__", ".__subclass__", "__categorical__", "__record__")
+NOMINAL_PARAMETERS = ("__array__", "__subclass__", "__categorical__", "__record__")
 
 
 def type_parameters_equal(

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 
 from awkward._typing import JSONMapping, JSONSerializable
 
-NOMINAL_PARAMETERS = ("__array__", "__name__", "__categorical__", "__record__")
+NOMINAL_PARAMETERS = ("__array__", ".__subclass__", "__categorical__", "__record__")
 
 
 def type_parameters_equal(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -14,7 +14,6 @@ from awkward._backends.dispatch import (
     regularize_backend,
 )
 from awkward._behavior import get_array_class, get_record_class
-from awkward._errors import deprecate
 from awkward._kernels import KernelError
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
@@ -105,21 +104,6 @@ class Content:
         else:
             if parameters.get("__array__") is not None:
                 array_name = parameters["__array__"]
-
-                if array_name not in {
-                    "string",
-                    "bytestring",
-                    "char",
-                    "byte",
-                    "categorical",
-                    "sorted_map",
-                }:
-                    deprecate(
-                        'use of parameters["__array__"] for non built-in array types is deprecated. '
-                        "Please use the `__name__` parameter instead",
-                        version="2.4.0",
-                    )
-
                 # Validate string-likes
                 if not self.is_list and array_name in ("string", "bytestring"):
                     raise TypeError(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -898,7 +898,7 @@ class RecordArray(Content):
         keepdims,
         behavior,
     ):
-        reducer_recordclass = find_record_reducer(reducer, self, behavior)
+        reducer_recordclass = find_record_reducer(reducer, self._parameters, behavior)
         if reducer_recordclass is None:
             raise TypeError(
                 "no ak.{} overloads for custom types: {}".format(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1178,7 +1178,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         import awkward._prettyprint
 
         try:
-            pytype = super().__getattribute__("__name__")
+            pytype = super().__getattribute__(".__subclass__")
         except AttributeError:
             pytype = type(self).__name__
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1178,7 +1178,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         import awkward._prettyprint
 
         try:
-            pytype = super().__getattribute__(".__subclass__")
+            pytype = super().__getattribute__("__subclass__")
         except AttributeError:
             pytype = type(self).__name__
 

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -13,43 +13,43 @@ def test_types_with_parameters():
     assert t.parameters == {}
 
     with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
-        assert t.parameters == {"__array__": ["val", "ue"]}
+        t = ak.types.UnknownType(parameters={"__name__": ["val", "ue"]})
+        assert t.parameters == {"__name__": ["val", "ue"]}
 
-    t = ak.types.NumpyType("int32", parameters={"__array__": ["val", "ue"]})
-    assert t.parameters == {"__array__": ["val", "ue"]}
-    t = ak.types.NumpyType("float64", parameters={"__array__": ["val", "ue"]})
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    t = ak.types.NumpyType("int32", parameters={"__name__": ["val", "ue"]})
+    assert t.parameters == {"__name__": ["val", "ue"]}
+    t = ak.types.NumpyType("float64", parameters={"__name__": ["val", "ue"]})
+    assert t.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.ArrayType(
-        ak.types.NumpyType("int32", parameters={"__array__": ["val", "ue"]}), 100
+        ak.types.NumpyType("int32", parameters={"__name__": ["val", "ue"]}), 100
     )
-    assert t.content.parameters == {"__array__": ["val", "ue"]}
+    assert t.content.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.ListType(
-        ak.types.NumpyType("int32"), parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"__name__": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.RegularType(
-        ak.types.NumpyType("int32"), 5, parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), 5, parameters={"__name__": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.OptionType(
-        ak.types.NumpyType("int32"), parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"__name__": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.UnionType(
         (ak.types.NumpyType("int32"), ak.types.NumpyType("float64")),
-        parameters={"__array__": ["val", "ue"]},
+        parameters={"__name__": ["val", "ue"]},
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"__name__": ["val", "ue"]}
     t = ak.types.RecordType(
         [
             ak.types.NumpyType("int32"),
             ak.types.NumpyType("float64"),
         ],
         fields=["one", "two"],
-        parameters={"__array__": ["val", "ue"]},
+        parameters={"__name__": ["val", "ue"]},
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"__name__": ["val", "ue"]}
 
     with pytest.warns(DeprecationWarning):
         t = ak.types.UnknownType(
@@ -60,7 +60,7 @@ def test_types_with_parameters():
         assert t == ak.types.UnknownType(
             parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
         )
-        assert t != ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
+        assert t != ak.types.UnknownType(parameters={"__name__": ["val", "ue"]})
 
 
 def test_dress():
@@ -71,14 +71,14 @@ def test_dress():
     ns = {"Dummy": Dummy}
 
     x = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    x.parameters["__array__"] = "Dummy"
+    x.parameters["__name__"] = "Dummy"
     a = ak.highlevel.Array(x, behavior=ns, check_valid=True)
     assert str(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
 
     x2 = ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 3, 5], dtype=np.int64)),
         ak.contents.NumpyArray(
-            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={"__array__": "Dummy"}
+            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={"__name__": "Dummy"}
         ),
     )
     a2 = ak.highlevel.Array(x2, behavior=ns, check_valid=True)

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -13,43 +13,43 @@ def test_types_with_parameters():
     assert t.parameters == {}
 
     with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(parameters={".__subclass__": ["val", "ue"]})
-        assert t.parameters == {".__subclass__": ["val", "ue"]}
+        t = ak.types.UnknownType(parameters={"__subclass__": ["val", "ue"]})
+        assert t.parameters == {"__subclass__": ["val", "ue"]}
 
-    t = ak.types.NumpyType("int32", parameters={".__subclass__": ["val", "ue"]})
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
-    t = ak.types.NumpyType("float64", parameters={".__subclass__": ["val", "ue"]})
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    t = ak.types.NumpyType("int32", parameters={"__subclass__": ["val", "ue"]})
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
+    t = ak.types.NumpyType("float64", parameters={"__subclass__": ["val", "ue"]})
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.ArrayType(
-        ak.types.NumpyType("int32", parameters={".__subclass__": ["val", "ue"]}), 100
+        ak.types.NumpyType("int32", parameters={"__subclass__": ["val", "ue"]}), 100
     )
-    assert t.content.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.content.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.ListType(
-        ak.types.NumpyType("int32"), parameters={".__subclass__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.RegularType(
-        ak.types.NumpyType("int32"), 5, parameters={".__subclass__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), 5, parameters={"__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.OptionType(
-        ak.types.NumpyType("int32"), parameters={".__subclass__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.UnionType(
         (ak.types.NumpyType("int32"), ak.types.NumpyType("float64")),
-        parameters={".__subclass__": ["val", "ue"]},
+        parameters={"__subclass__": ["val", "ue"]},
     )
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
     t = ak.types.RecordType(
         [
             ak.types.NumpyType("int32"),
             ak.types.NumpyType("float64"),
         ],
         fields=["one", "two"],
-        parameters={".__subclass__": ["val", "ue"]},
+        parameters={"__subclass__": ["val", "ue"]},
     )
-    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    assert t.parameters == {"__subclass__": ["val", "ue"]}
 
     with pytest.warns(DeprecationWarning):
         t = ak.types.UnknownType(
@@ -60,7 +60,7 @@ def test_types_with_parameters():
         assert t == ak.types.UnknownType(
             parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
         )
-        assert t != ak.types.UnknownType(parameters={".__subclass__": ["val", "ue"]})
+        assert t != ak.types.UnknownType(parameters={"__subclass__": ["val", "ue"]})
 
 
 def test_dress():
@@ -71,14 +71,14 @@ def test_dress():
     ns = {"Dummy": Dummy}
 
     x = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    x.parameters[".__subclass__"] = "Dummy"
+    x.parameters["__subclass__"] = "Dummy"
     a = ak.highlevel.Array(x, behavior=ns, check_valid=True)
     assert str(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
 
     x2 = ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 3, 5], dtype=np.int64)),
         ak.contents.NumpyArray(
-            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={".__subclass__": "Dummy"}
+            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={"__subclass__": "Dummy"}
         ),
     )
     a2 = ak.highlevel.Array(x2, behavior=ns, check_valid=True)

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -13,43 +13,43 @@ def test_types_with_parameters():
     assert t.parameters == {}
 
     with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(parameters={"__name__": ["val", "ue"]})
-        assert t.parameters == {"__name__": ["val", "ue"]}
+        t = ak.types.UnknownType(parameters={".__subclass__": ["val", "ue"]})
+        assert t.parameters == {".__subclass__": ["val", "ue"]}
 
-    t = ak.types.NumpyType("int32", parameters={"__name__": ["val", "ue"]})
-    assert t.parameters == {"__name__": ["val", "ue"]}
-    t = ak.types.NumpyType("float64", parameters={"__name__": ["val", "ue"]})
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    t = ak.types.NumpyType("int32", parameters={".__subclass__": ["val", "ue"]})
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
+    t = ak.types.NumpyType("float64", parameters={".__subclass__": ["val", "ue"]})
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.ArrayType(
-        ak.types.NumpyType("int32", parameters={"__name__": ["val", "ue"]}), 100
+        ak.types.NumpyType("int32", parameters={".__subclass__": ["val", "ue"]}), 100
     )
-    assert t.content.parameters == {"__name__": ["val", "ue"]}
+    assert t.content.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.ListType(
-        ak.types.NumpyType("int32"), parameters={"__name__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={".__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.RegularType(
-        ak.types.NumpyType("int32"), 5, parameters={"__name__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), 5, parameters={".__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.OptionType(
-        ak.types.NumpyType("int32"), parameters={"__name__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={".__subclass__": ["val", "ue"]}
     )
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.UnionType(
         (ak.types.NumpyType("int32"), ak.types.NumpyType("float64")),
-        parameters={"__name__": ["val", "ue"]},
+        parameters={".__subclass__": ["val", "ue"]},
     )
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
     t = ak.types.RecordType(
         [
             ak.types.NumpyType("int32"),
             ak.types.NumpyType("float64"),
         ],
         fields=["one", "two"],
-        parameters={"__name__": ["val", "ue"]},
+        parameters={".__subclass__": ["val", "ue"]},
     )
-    assert t.parameters == {"__name__": ["val", "ue"]}
+    assert t.parameters == {".__subclass__": ["val", "ue"]}
 
     with pytest.warns(DeprecationWarning):
         t = ak.types.UnknownType(
@@ -60,7 +60,7 @@ def test_types_with_parameters():
         assert t == ak.types.UnknownType(
             parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
         )
-        assert t != ak.types.UnknownType(parameters={"__name__": ["val", "ue"]})
+        assert t != ak.types.UnknownType(parameters={".__subclass__": ["val", "ue"]})
 
 
 def test_dress():
@@ -71,14 +71,14 @@ def test_dress():
     ns = {"Dummy": Dummy}
 
     x = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    x.parameters["__name__"] = "Dummy"
+    x.parameters[".__subclass__"] = "Dummy"
     a = ak.highlevel.Array(x, behavior=ns, check_valid=True)
     assert str(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
 
     x2 = ak.contents.ListOffsetArray(
         ak.index.Index64(np.array([0, 3, 3, 5], dtype=np.int64)),
         ak.contents.NumpyArray(
-            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={"__name__": "Dummy"}
+            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={".__subclass__": "Dummy"}
         ),
     )
     a2 = ak.highlevel.Array(x2, behavior=ns, check_valid=True)

--- a/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
+++ b/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
@@ -6,17 +6,18 @@ import pytest  # noqa: F401
 import awkward as ak
 
 # https://github.com/scikit-hep/awkward-1.0/issues/459#issuecomment-694941328
+# https://github.com/scikit-hep/awkward/pull/2540
 #
 # So the rules would be,
-#    * if arrays have different `__array__` or `__record__` parameters, they are not equal;
+#    * if arrays have different `__array__`, "__name__", or `__record__` parameters, they are not equal;
 #    * if they otherwise have different parameters, the types can be equal, but merging
 #      (concatenation, option-simplify, or union-simplify) removes parameters other than
-#      `__array__` and `__record__`.
+#      `__array__`, "__name__", and `__record__`.
 
 
 def test_0459_types():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__array__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, "__name__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -25,10 +26,10 @@ def test_0459_types():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__array__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__name__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__array__": "zoinks",
+        "__name__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -49,12 +50,12 @@ def test_0459_types():
     assert ak.operations.type(plain_isdoc) != ak.operations.type(array_isdoc)
     assert ak.operations.type(array_isdoc) != ak.operations.type(plain_isdoc)
 
-    assert array_plain.layout.parameters == {"__array__": "zoinks"}
+    assert array_plain.layout.parameters == {"__name__": "zoinks"}
     assert ak.operations.without_parameters(array_plain).layout.parameters == {}
     assert plain_isdoc.layout.parameters == {"__doc__": "This is a zoink."}
     assert ak.operations.without_parameters(plain_isdoc).layout.parameters == {}
     assert array_isdoc.layout.parameters == {
-        "__array__": "zoinks",
+        "__name__": "zoinks",
         "__doc__": "This is a zoink.",
     }
     assert ak.operations.without_parameters(array_isdoc).layout.parameters == {}
@@ -62,7 +63,7 @@ def test_0459_types():
 
 def test_0459():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__array__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, "__name__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -71,10 +72,10 @@ def test_0459():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__array__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__name__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__array__": "zoinks",
+        "__name__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -84,14 +85,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_plain])
-    ) == {"__array__": "zoinks"}
+    ) == {"__name__": "zoinks"}
     assert ak.operations.parameters(
         ak.operations.concatenate([plain_isdoc, plain_isdoc])
     ) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_isdoc])
     ) == {
-        "__array__": "zoinks",
+        "__name__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -152,14 +153,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_isdoc])
-    ) == {"__array__": "zoinks"}
+    ) == {"__name__": "zoinks"}
     assert (
         ak.operations.parameters(ak.operations.concatenate([plain_isdoc, plain_plain]))
         == {}
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_plain])
-    ) == {"__array__": "zoinks"}
+    ) == {"__name__": "zoinks"}
 
     assert isinstance(
         ak.operations.concatenate([plain_plain, plain_isdoc]).layout,

--- a/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
+++ b/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
@@ -9,15 +9,15 @@ import awkward as ak
 # https://github.com/scikit-hep/awkward/pull/2540
 #
 # So the rules would be,
-#    * if arrays have different `__array__`, ".__subclass__", or `__record__` parameters, they are not equal;
+#    * if arrays have different `__array__`, "__subclass__", or `__record__` parameters, they are not equal;
 #    * if they otherwise have different parameters, the types can be equal, but merging
 #      (concatenation, option-simplify, or union-simplify) removes parameters other than
-#      `__array__`, ".__subclass__", and `__record__`.
+#      `__array__`, "__subclass__", and `__record__`.
 
 
 def test_0459_types():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, ".__subclass__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, "__subclass__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -26,10 +26,10 @@ def test_0459_types():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {".__subclass__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__subclass__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        ".__subclass__": "zoinks",
+        "__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -50,12 +50,12 @@ def test_0459_types():
     assert ak.operations.type(plain_isdoc) != ak.operations.type(array_isdoc)
     assert ak.operations.type(array_isdoc) != ak.operations.type(plain_isdoc)
 
-    assert array_plain.layout.parameters == {".__subclass__": "zoinks"}
+    assert array_plain.layout.parameters == {"__subclass__": "zoinks"}
     assert ak.operations.without_parameters(array_plain).layout.parameters == {}
     assert plain_isdoc.layout.parameters == {"__doc__": "This is a zoink."}
     assert ak.operations.without_parameters(plain_isdoc).layout.parameters == {}
     assert array_isdoc.layout.parameters == {
-        ".__subclass__": "zoinks",
+        "__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
     assert ak.operations.without_parameters(array_isdoc).layout.parameters == {}
@@ -63,7 +63,7 @@ def test_0459_types():
 
 def test_0459():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, ".__subclass__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, "__subclass__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -72,10 +72,10 @@ def test_0459():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {".__subclass__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__subclass__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        ".__subclass__": "zoinks",
+        "__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -85,14 +85,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_plain])
-    ) == {".__subclass__": "zoinks"}
+    ) == {"__subclass__": "zoinks"}
     assert ak.operations.parameters(
         ak.operations.concatenate([plain_isdoc, plain_isdoc])
     ) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_isdoc])
     ) == {
-        ".__subclass__": "zoinks",
+        "__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -153,14 +153,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_isdoc])
-    ) == {".__subclass__": "zoinks"}
+    ) == {"__subclass__": "zoinks"}
     assert (
         ak.operations.parameters(ak.operations.concatenate([plain_isdoc, plain_plain]))
         == {}
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_plain])
-    ) == {".__subclass__": "zoinks"}
+    ) == {"__subclass__": "zoinks"}
 
     assert isinstance(
         ak.operations.concatenate([plain_plain, plain_isdoc]).layout,

--- a/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
+++ b/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
@@ -9,15 +9,15 @@ import awkward as ak
 # https://github.com/scikit-hep/awkward/pull/2540
 #
 # So the rules would be,
-#    * if arrays have different `__array__`, "__name__", or `__record__` parameters, they are not equal;
+#    * if arrays have different `__array__`, ".__subclass__", or `__record__` parameters, they are not equal;
 #    * if they otherwise have different parameters, the types can be equal, but merging
 #      (concatenation, option-simplify, or union-simplify) removes parameters other than
-#      `__array__`, "__name__", and `__record__`.
+#      `__array__`, ".__subclass__", and `__record__`.
 
 
 def test_0459_types():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__name__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, ".__subclass__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -26,10 +26,10 @@ def test_0459_types():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__name__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {".__subclass__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__name__": "zoinks",
+        ".__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -50,12 +50,12 @@ def test_0459_types():
     assert ak.operations.type(plain_isdoc) != ak.operations.type(array_isdoc)
     assert ak.operations.type(array_isdoc) != ak.operations.type(plain_isdoc)
 
-    assert array_plain.layout.parameters == {"__name__": "zoinks"}
+    assert array_plain.layout.parameters == {".__subclass__": "zoinks"}
     assert ak.operations.without_parameters(array_plain).layout.parameters == {}
     assert plain_isdoc.layout.parameters == {"__doc__": "This is a zoink."}
     assert ak.operations.without_parameters(plain_isdoc).layout.parameters == {}
     assert array_isdoc.layout.parameters == {
-        "__name__": "zoinks",
+        ".__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
     assert ak.operations.without_parameters(array_isdoc).layout.parameters == {}
@@ -63,7 +63,7 @@ def test_0459_types():
 
 def test_0459():
     plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__name__", "zoinks")
+    array_plain = ak.operations.with_parameter(plain_plain, ".__subclass__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -72,10 +72,10 @@ def test_0459():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__name__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {".__subclass__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__name__": "zoinks",
+        ".__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -85,14 +85,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_plain])
-    ) == {"__name__": "zoinks"}
+    ) == {".__subclass__": "zoinks"}
     assert ak.operations.parameters(
         ak.operations.concatenate([plain_isdoc, plain_isdoc])
     ) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_isdoc])
     ) == {
-        "__name__": "zoinks",
+        ".__subclass__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -153,14 +153,14 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_isdoc])
-    ) == {"__name__": "zoinks"}
+    ) == {".__subclass__": "zoinks"}
     assert (
         ak.operations.parameters(ak.operations.concatenate([plain_isdoc, plain_plain]))
         == {}
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_plain])
-    ) == {"__name__": "zoinks"}
+    ) == {".__subclass__": "zoinks"}
 
     assert isinstance(
         ak.operations.concatenate([plain_plain, plain_isdoc]).layout,

--- a/tests/test_1762_jax_behavior_support.py
+++ b/tests/test_1762_jax_behavior_support.py
@@ -24,8 +24,10 @@ def test():
     tangent = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
 
     behavior = {"grad": GradBehavior}
-    primal_grad = ak.with_parameter(primal, "__name__", "grad", behavior=behavior)
-    tangent_grad = ak.with_parameter(tangent, "__name__", "grad", behavior=behavior)
+    primal_grad = ak.with_parameter(primal, ".__subclass__", "grad", behavior=behavior)
+    tangent_grad = ak.with_parameter(
+        tangent, ".__subclass__", "grad", behavior=behavior
+    )
     value_jvp_grad, jvp_grad_grad = jax.jvp(
         square_fifth_entry, (primal_grad,), (tangent_grad,)
     )

--- a/tests/test_1762_jax_behavior_support.py
+++ b/tests/test_1762_jax_behavior_support.py
@@ -24,10 +24,8 @@ def test():
     tangent = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
 
     behavior = {"grad": GradBehavior}
-    primal_grad = ak.with_parameter(primal, ".__subclass__", "grad", behavior=behavior)
-    tangent_grad = ak.with_parameter(
-        tangent, ".__subclass__", "grad", behavior=behavior
-    )
+    primal_grad = ak.with_parameter(primal, "__subclass__", "grad", behavior=behavior)
+    tangent_grad = ak.with_parameter(tangent, "__subclass__", "grad", behavior=behavior)
     value_jvp_grad, jvp_grad_grad = jax.jvp(
         square_fifth_entry, (primal_grad,), (tangent_grad,)
     )

--- a/tests/test_1762_jax_behavior_support.py
+++ b/tests/test_1762_jax_behavior_support.py
@@ -24,8 +24,8 @@ def test():
     tangent = ak.Array(np.arange(10, dtype=np.float64), backend="jax")
 
     behavior = {"grad": GradBehavior}
-    primal_grad = ak.with_parameter(primal, "__array__", "grad", behavior=behavior)
-    tangent_grad = ak.with_parameter(tangent, "__array__", "grad", behavior=behavior)
+    primal_grad = ak.with_parameter(primal, "__name__", "grad", behavior=behavior)
+    tangent_grad = ak.with_parameter(tangent, "__name__", "grad", behavior=behavior)
     value_jvp_grad, jvp_grad_grad = jax.jvp(
         square_fifth_entry, (primal_grad,), (tangent_grad,)
     )


### PR DESCRIPTION
This PR closes #2432 by making it possible to define custom types for strings (and categoricals). Now, `__array__` represents _both_ nominal type and implementation type (string, categorical), and a new `__subclass__` parameter represents a higher-precedence nominal type.