### PR TITLE
wip: add units implementation

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -411,7 +411,7 @@ def apply_step(
     # This whole function is one big switch statement.
     def broadcast_any_record():
         if not options["allow_records"]:
-            raise ValueError(f"cannot broadcast records {in_function(options)}")
+            raise TypeError(f"cannot broadcast records{in_function(options)}")
 
         fields, length, istuple = UNSET, UNSET, UNSET
         nextparameters = []

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -470,7 +470,6 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
 
             return (NumpyArray(result, backend=backend, parameters=parameters),)
 
-
         # If we aren't at the leaves, and we have any records, broadcasting will subsequently fail
         # Let's present a nicer error message
         elif all(x.is_record for x in inputs if isinstance(x, ak.contents.Content)):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -101,36 +101,43 @@ class Content:
                     type(self).__name__, repr(parameters)
                 )
             )
-        # Validate built-in `__array__`
-        elif parameters.get("__array__") is not None:
-            array_name = parameters["__array__"]
-            if not self.is_list and array_name in (
-                "string",
-                "bytestring",
-            ):
-                raise TypeError(
-                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                        type(self).__name__, parameters["__array__"]
+        else:
+            # Validate built-in `__array__`
+            if parameters.get("__array__") is not None:
+                array_name = parameters["__array__"]
+                if not self.is_list and array_name in (
+                    "string",
+                    "bytestring",
+                ):
+                    raise TypeError(
+                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                            type(self).__name__, parameters["__array__"]
+                        )
                     )
-                )
-            if not isinstance(self, ak.contents.NumpyArray) and parameters.get(
-                "__array__"
-            ) in ("char", "byte"):
-                raise TypeError(
-                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                        type(self).__name__, parameters["__array__"]
+                if not isinstance(self, ak.contents.NumpyArray) and parameters.get(
+                    "__array__"
+                ) in ("char", "byte"):
+                    raise TypeError(
+                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                            type(self).__name__, parameters["__array__"]
+                        )
                     )
-                )
-            if not self.is_indexed and array_name == "categorical":
-                raise TypeError(
-                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                        type(self).__name__, parameters["__array__"]
+                if not self.is_indexed and array_name == "categorical":
+                    raise TypeError(
+                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                            type(self).__name__, parameters["__array__"]
+                        )
                     )
-                )
-            if not self.is_record and array_name == "sorted_map":
+                if not self.is_record and array_name == "sorted_map":
+                    raise TypeError(
+                        '{} is not allowed to have parameters["__array__"] = "{}"'.format(
+                            type(self).__name__, parameters["__array__"]
+                        )
+                    )
+            if not self.is_numpy and parameters.get("__units__") is not None:
                 raise TypeError(
-                    '{} is not allowed to have parameters["__array__"] = "{}"'.format(
-                        type(self).__name__, parameters["__array__"]
+                    '{} is not allowed to have parameters["__units__"] != None'.format(
+                        type(self).__name__,
                     )
                 )
         # TODO: enable this once we can guarantee this doesn't happen during broadcasting

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -900,11 +900,19 @@ class RecordArray(Content):
     ):
         reducer_recordclass = find_record_reducer(reducer, self, behavior)
         if reducer_recordclass is None:
-            raise TypeError(
-                "no ak.{} overloads for custom types: {}".format(
-                    reducer.name, ", ".join(self.fields)
+            nominal_type = self.parameter("__record__")
+            if nominal_type is None:
+                raise TypeError(
+                    "no ak.{} overloads for unnamed record type: {}".format(
+                        reducer.name, str(self.form.type)
+                    )
                 )
-            )
+            else:
+                raise TypeError(
+                    "no ak.{} overloads for record named {!r}".format(
+                        reducer.name, nominal_type
+                    )
+                )
         else:
             # Positional reducers ultimately need to do more work when rebuilding the result
             # so asking for a mask doesn't help us!

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -38,6 +38,7 @@ from awkward.operations.ak_from_jax import *
 from awkward.operations.ak_from_json import *
 from awkward.operations.ak_from_numpy import *
 from awkward.operations.ak_from_parquet import *
+from awkward.operations.ak_from_pint import *
 from awkward.operations.ak_from_rdataframe import *
 from awkward.operations.ak_from_regular import *
 from awkward.operations.ak_full_like import *
@@ -86,6 +87,7 @@ from awkward.operations.ak_to_list import *
 from awkward.operations.ak_to_numpy import *
 from awkward.operations.ak_to_packed import *
 from awkward.operations.ak_to_parquet import *
+from awkward.operations.ak_to_pint import *
 from awkward.operations.ak_to_rdataframe import *
 from awkward.operations.ak_to_regular import *
 from awkward.operations.ak_transform import *

--- a/src/awkward/operations/ak_from_pint.py
+++ b/src/awkward/operations/ak_from_pint.py
@@ -1,0 +1,56 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+__all__ = ("from_pint",)
+from awkward._dispatch import high_level_function
+from awkward._do import recursively_apply
+from awkward._layout import from_arraylib, wrap_layout
+from awkward.operations.ak_with_parameter import with_parameter
+
+
+@high_level_function
+def from_pint(
+    array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
+):
+    """
+    Args:
+        array (pint.Quantity): The Pint array to convert into an Awkward Array.
+            This Quantity can contain np.ma.MaskedArray.
+        regulararray (bool): If True and the array is multidimensional,
+            the dimensions are represented by nested #ak.contents.RegularArray
+            nodes; if False and the array is multidimensional, the dimensions
+            are represented by a multivalued #ak.contents.NumpyArray.shape.
+            If the array is one-dimensional, this has no effect.
+        recordarray (bool): If True and the wrapped array is a NumPy structured array
+            (dtype.names is not None), the fields are represented by an
+            #ak.contents.RecordArray; if False and the array is a structured
+            array, the structure is left in the #ak.contents.NumpyArray `format`,
+            which some functions do not recognize.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Converts a Pint.Quantity array into an Awkward Array.
+
+    The resulting layout can only involve the following #ak.contents.Content types:
+
+    * #ak.contents.NumpyArray
+    * #ak.contents.ByteMaskedArray or #ak.contents.UnmaskedArray if the
+      `array` is an np.ma.MaskedArray.
+    * #ak.contents.RegularArray if `regulararray=True`.
+    * #ak.contents.RecordArray if `recordarray=True`.
+
+    See also #ak.to_numpy and #ak.from_cupy.
+    """
+    layout = from_arraylib(array.magnitude, regulararray, recordarray)
+    units = str(array.units)
+
+    def apply(layout, **kwargs):
+        if layout.is_numpy:
+            return with_parameter(layout, "__units__", units, highlevel=False)
+
+    out = recursively_apply(layout, apply, behavior=behavior)
+    return wrap_layout(
+        out,
+        highlevel=highlevel,
+        behavior=behavior,
+    )

--- a/src/awkward/operations/ak_to_pint.py
+++ b/src/awkward/operations/ak_to_pint.py
@@ -1,0 +1,57 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+__all__ = ("to_pint",)
+import awkward as ak
+from awkward._dispatch import high_level_function
+from awkward.units import get_unit_registry
+
+
+@high_level_function
+def to_pint(array, *, allow_missing=True):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        allow_missing (bool): allow missing (None) values.
+
+    Converts `array` (many types supported, including all Awkward Arrays and
+    Records) into a rectilinear Pint.Quantity, if possible.
+
+    If the data are numerical and regular (nested lists have equal lengths
+    in each dimension, as described by the #ak.Array.type), they can be losslessly
+    converted to a Pint.Quantity array and this function returns without an error.
+
+    Otherwise, the function raises an error. It does not create a NumPy
+    array with dtype `"O"` for `np.object_` (see the
+    [note on object_ type](https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html#arrays-scalars-built-in))
+    since silent conversions to dtype `"O"` arrays would not only be a
+    significant performance hit, but would also break functionality, since
+    nested lists in a NumPy `"O"` array are severed from the array and
+    cannot be sliced as dimensions.
+
+    If `array` is not an Awkward Array, then this function is equivalent
+    to calling `pint.Quantity` on it.
+
+    If `allow_missing` is True; NumPy
+    [masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.html)
+    are a possible result; otherwise, missing values (None) cause this
+    function to raise an error.
+
+    See also #ak.from_numpy and #ak.to_cupy.
+    """
+    # Dispatch
+    yield (array,)
+
+    # Implementation
+    return _impl(array, allow_missing)
+
+
+def _impl(array, allow_missing):
+    import numpy  # noqa: TID251
+
+    with numpy.errstate(invalid="ignore"):
+        layout: ak.contents.Content = ak.to_layout(array, allow_record=False)
+
+        content = layout.to_backend_array(allow_missing)
+        unit = layout.purelist_parameter("__units__")
+
+        registry = get_unit_registry()
+        return registry.Quantity(content, unit)

--- a/src/awkward/units.py
+++ b/src/awkward/units.py
@@ -1,0 +1,59 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import annotations
+
+from threading import RLock
+
+_lock = RLock()
+_unit_registry = None
+_checked_for_pint = False
+
+
+def set_unit_registry(registry):
+    global _unit_registry
+    with _lock:
+        _unit_registry = registry
+
+
+def get_unit_registry():
+    with _lock:
+        _register_if_available()
+        return _unit_registry
+
+
+def _register_if_available():
+    global _checked_for_pint, _unit_registry
+    with _lock:
+        if _checked_for_pint:
+            return
+
+        try:
+            import pint
+        except ModuleNotFoundError:
+            return
+        else:
+            _unit_registry = pint.UnitRegistry()
+        finally:
+            _checked_for_pint = True
+
+
+def register_and_check():
+    """
+    Build `pint` unit registry
+    """
+    try:
+        import pint  # noqa: F401
+
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            """install the 'pint' package with:
+
+        python3 -m pip install pint
+
+    or
+
+        conda install -c conda-forge pint
+    """
+        ) from None
+
+    _register_if_available()

--- a/tests/test_1559_fix_ufuncs_records_1439.py
+++ b/tests/test_1559_fix_ufuncs_records_1439.py
@@ -10,7 +10,7 @@ to_list = ak.operations.to_list
 
 def test_ufuncs_on_records_1439_raise_a_warning():
     array = ak.Array([{"x": 1.0, "y": 1.1}, {"x": 2.0, "y": 2.2}])
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         np.absolute(array)
 
 
@@ -36,7 +36,7 @@ def test_ufuncs_on_records_1439_without_warning():
 def test_this_should_raise_a_warning():
     one = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}])
     two = ak.Array([{"x": 1.1}, {"x": 2.2}, {"x": 3.3}])
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         one + two
 
 

--- a/tests/test_1607_no_reducers_on_records.py
+++ b/tests/test_1607_no_reducers_on_records.py
@@ -78,7 +78,7 @@ def test_overloaded_reducers():
     assert ak.to_list(ak.sum(array, axis=1)) == [{"rho": 0, "phi": 0}]
 
     with pytest.raises(
-        TypeError, match=r"overloads for custom types: VectorArray2D, int"
+        TypeError, match=r"overloads for signature: VectorArray2D, <class 'int'>"
     ):
         ak.to_list(array + 1)
 
@@ -116,8 +116,16 @@ def test_overloaded_reducers():
         )
     )
 
-    with pytest.raises(TypeError, match=r"overloads for custom types: a, b"):
-        ak.to_list(ak.sum(array, axis=0))
+    # Check error message for unnamed record
+    with pytest.raises(
+        TypeError, match=r"overloads for unnamed record type: \{a: int64, b: \?int64\}"
+    ):
+        ak.sum(array, axis=0)
+
+    # Check error message for named record
+    named_array = ak.with_name(array, "custom-record")
+    with pytest.raises(TypeError, match=r"overloads for record named 'custom-record'"):
+        ak.sum(named_array, axis=0)
 
     def overload_argmax(array, mask):
         return ak.argmax(array["rho"], axis=-1, mask_identity=False, highlevel=False)


### PR DESCRIPTION
`pint` already partially supports Awkward Arrays:
```python
import awkward as ak
import pint

reg = pint.UnitRegistry()

x = reg.Quantity(ak.Array([[1, 2, 3], [5]]), "m")

print(x + (2 * reg.m))
```

But this doesn't really scale to the nested, complex layout structures that Awkward supports.
This PR adds support for `__units__` parameters in arrays, which allows structures to contain mixed units. Closes #2468.

```python
>>> import awkward as ak
>>> array = ak.zip(
...     {
...         "x": ak.with_parameter([60, 70, 80, 90], "__units__", "mm"),
...         "y": ak.with_parameter([1, 2, 3, 4], "__units__", "cm"),
...     }
... )
>>> result = array.x + array.y
>>> result.show(type=True)
type: 4 * float64[parameters={"__units__": "millimeter"}]
[70,
 90,
 110,
 130]
```

- [x] Add `ak.to_pint` and `ak.from_pint`
- [x] Support ufuncs
- [ ] Support reducers
- [ ] Support concatenation
