### PR TITLE
feat: move string features into core

### DIFF
--- a/docs/user-guide/how-to-convert-python.md
+++ b/docs/user-guide/how-to-convert-python.md
@@ -340,12 +340,6 @@ ak.Array(["one", "two", "three", "four"]) == ak.Array(
 
 (Without this overloaded behavior, the string comparison would yield `[True, True, True]` for `"one" == "one"` and would fail to broadcast `"three"` and `"thirty three"`.)
 
-Special behaviors for strings are implemented using the same {data}`ak.behavior` mechanism that you might use to give special behaviors to Arrays and Records.
-
-
-```{code-cell} ipython3
-ak.behavior[np.equal, "string", "string"]
-```
 
 The fact that strings are really just variable-length lists is worth keeping in mind, since they might behave in unexpectedly list-like ways. If you notice any behavior that ought to be overloded for strings, recommend it as a [feature request](https://github.com/scikit-hep/awkward-1.0/issues/new?assignees=&labels=feature&template=feature-request.md&title=).
 

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -45,8 +45,6 @@ import awkward.builder
 import awkward.forth
 
 behavior: dict = {}
-awkward.behaviors.string.register(behavior)
-awkward.behaviors.categorical.register(behavior)
 
 # operations
 from awkward.operations import *

--- a/src/awkward/_categorical.py
+++ b/src/awkward/_categorical.py
@@ -1,0 +1,46 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.numpylike import NumpyMetadata
+
+np = NumpyMetadata.instance()
+numpy = Numpy.instance()
+
+
+class HashableDict:
+    def __init__(self, obj):
+        self.keys = tuple(sorted(obj))
+        self.values = tuple(as_hashable(obj[k]) for k in self.keys)
+        self.hash = hash((HashableDict, *self.keys), self.values)
+
+    def __hash__(self):
+        return self.hash
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, HashableDict)
+            and self.keys == other.keys
+            and self.values == other.values
+        )
+
+
+class HashableList:
+    def __init__(self, obj):
+        self.values = tuple(obj)
+        self.hash = hash((HashableList, *self.values))
+
+    def __hash__(self):
+        return self.hash
+
+    def __eq__(self, other):
+        return isinstance(other, HashableList) and self.values == other.values
+
+
+def as_hashable(obj):
+    if isinstance(obj, dict):
+        return HashableDict(obj)
+    elif isinstance(obj, tuple):
+        return tuple(as_hashable(x) for x in obj)
+    elif isinstance(obj, list):
+        return HashableList(obj)
+    else:
+        return obj

--- a/src/awkward/_connect/avro.py
+++ b/src/awkward/_connect/avro.py
@@ -292,6 +292,7 @@ class ReadAvroFT:
                     parameters={"__array__": "char"},
                     form_key=f"node{form_next_id+1}",
                 ),
+                parameters={"__array__": "string"},
                 form_key=f"node{form_next_id}",
             )
             declarations.append(f"output node{form_next_id+1}-data uint8 \n")
@@ -793,6 +794,7 @@ class ReadAvroFT:
                         parameters={"__array__": "char"},
                         form_key=f"node{form_next_id+2}",
                     ),
+                    parameters={"__array__": "string"},
                     form_key=f"node{form_next_id+1}",
                 ),
                 parameters={"__array__": "categorical"},

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -2,6 +2,7 @@
 
 import json
 
+import llvmlite.ir
 import numba
 
 import awkward as ak
@@ -9,8 +10,6 @@ from awkward._behavior import overlay_behavior
 
 
 def string_numba_typer(viewtype):
-    import numba
-
     if viewtype.type.parameters["__array__"] == "string":
         return numba.types.string
     else:
@@ -20,9 +19,6 @@ def string_numba_typer(viewtype):
 def string_numba_lower(
     context, builder, rettype, viewtype, viewval, viewproxy, attype, atval
 ):
-    import llvmlite.ir
-    import numba
-
     whichpos = ak._connect.numba.layout.posat(
         context, builder, viewproxy.pos, viewtype.type.CONTENT
     )

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -234,7 +234,7 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 
         # Support known string ufuncs
         if (
-            ufunc in (numpy.equal, numpy.not_equal, numpy.add)
+            ufunc in (numpy.equal, numpy.not_equal)
             and len(inputs) == 2
             and isinstance(inputs[0], ak.contents.Content)
             and isinstance(inputs[1], ak.contents.Content)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -268,17 +268,12 @@ def array_ufunc(ufunc, method, inputs, kwargs):
 
     def action(inputs, **ignore):
         signature = _array_ufunc_signature(ufunc, inputs)
-        custom = find_ufunc(behavior, signature)
         # Do we have a custom ufunc (an override of the given ufunc)?
+        custom = find_ufunc(behavior, signature)
         if custom is not None:
             return _array_ufunc_adjust(custom, inputs, kwargs, behavior)
 
-        if ufunc is numpy.matmul:
-            raise NotImplementedError(
-                "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"
-            )
-
-        # Intercept string ufuncs
+        # Do we have only strings?
         if all(
             isinstance(x, ak.contents.Content)
             and x.parameter("__array__") in ("string", "bytestring")
@@ -287,6 +282,11 @@ def array_ufunc(ufunc, method, inputs, kwargs):
             out = _array_ufunc_string_likes(ufunc, inputs, kwargs, behavior)
             if out is not None:
                 return out
+
+        if ufunc is numpy.matmul:
+            raise NotImplementedError(
+                "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"
+            )
 
         if all(
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -4,6 +4,7 @@ import numbers
 import re
 
 import awkward as ak
+from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 
 numpy = Numpy.instance()
@@ -32,6 +33,38 @@ def alternate(length):
 
 
 is_identifier = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
+
+
+# avoid recursion in which ak.Array.__getitem__ calls prettyprint
+# to form an error string: private reimplementation of ak.Array.__getitem__
+
+
+def get_at(data, index):
+    out = data._layout._getitem_at(index)
+    if isinstance(out, ak.contents.NumpyArray):
+        array_param = out.parameter("__array__")
+        if array_param == "byte":
+            return ak._util.tobytes(out._raw(numpy))
+        elif array_param == "char":
+            return ak._util.tobytes(out._raw(numpy)).decode(errors="surrogateescape")
+    if isinstance(out, (ak.contents.Content, ak.record.Record)):
+        return wrap_layout(out, data._behavior)
+    else:
+        return out
+
+
+def get_field(data, field):
+    out = data._layout._getitem_field(field)
+    if isinstance(out, ak.contents.NumpyArray):
+        array_param = out.parameter("__array__")
+        if array_param == "byte":
+            return ak._util.tobytes(out._raw(numpy))
+        elif array_param == "char":
+            return ak._util.tobytes(out._raw(numpy)).decode(errors="surrogateescape")
+    if isinstance(out, (ak.contents.Content, ak.record.Record)):
+        return wrap_layout(out, data._behavior)
+    else:
+        return out
 
 
 def custom_str(current):
@@ -74,14 +107,14 @@ def valuestr_horiz(data, limit_cols):
             return 2, front + back
 
         elif len(data) == 1:
-            cols_taken, strs = valuestr_horiz(data._getitem(0), limit_cols)
+            cols_taken, strs = valuestr_horiz(get_at(data, 0), limit_cols)
             return 2 + cols_taken, front + strs + back
 
         else:
             limit_cols -= 5  # anticipate the ", ..."
             which = 0
             for forward, index in alternate(len(data)):
-                current = data._getitem(index)
+                current = get_at(data, index)
                 if forward:
                     for_comma = 0 if which == 0 else 2
                     cols_taken, strs = valuestr_horiz(current, limit_cols - for_comma)
@@ -154,7 +187,7 @@ def valuestr_horiz(data, limit_cols):
                 which += 1
 
                 target = limit_cols if len(fields) == 1 else half(limit_cols)
-                cols_taken, strs = valuestr_horiz(data._getitem(key), target)
+                cols_taken, strs = valuestr_horiz(get_field(data, key), target)
                 if limit_cols - cols_taken >= 0:
                     front.extend(strs)
                     limit_cols -= cols_taken
@@ -211,7 +244,7 @@ def valuestr(data, limit_rows, limit_cols):
         front, back = [], []
         which = 0
         for forward, index in alternate(len(data)):
-            _, strs = valuestr_horiz(data._getitem(index), limit_cols - 2)
+            _, strs = valuestr_horiz(get_at(data, index), limit_cols - 2)
             if forward:
                 front.append("".join(strs))
             else:
@@ -254,7 +287,9 @@ def valuestr(data, limit_rows, limit_cols):
                         key_str = key_str[1:]
                 else:
                     key_str = key + ": "
-            _, strs = valuestr_horiz(data._getitem(key), limit_cols - 2 - len(key_str))
+            _, strs = valuestr_horiz(
+                get_field(data, key), limit_cols - 2 - len(key_str)
+            )
             front.append(key_str + "".join(strs))
 
             which += 1

--- a/src/awkward/behaviors/categorical.py
+++ b/src/awkward/behaviors/categorical.py
@@ -1,113 +1,16 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-import awkward as ak
-from awkward._behavior import behavior_of
-from awkward._layout import wrap_layout
-from awkward._nplikes import ufuncs
-from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._errors import deprecate
 from awkward.highlevel import Array
-
-np = NumpyMetadata.instance()
-numpy = Numpy.instance()
 
 
 class CategoricalBehavior(Array):
     __name__ = "Array"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-class _HashableDict:
-    def __init__(self, obj):
-        self.keys = tuple(sorted(obj))
-        self.values = tuple(_as_hashable(obj[k]) for k in self.keys)
-        self.hash = hash((_HashableDict, *self.keys), self.values)
-
-    def __hash__(self):
-        return self.hash
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, _HashableDict)
-            and self.keys == other.keys
-            and self.values == other.values
+        deprecate(
+            f"{type(self).__name__} is deprecated: categorical types are now considered a built-in feature "
+            f"provided by Awkward Array, rather than an extension.",
+            version="2.4.0",
         )
-
-
-class _HashableList:
-    def __init__(self, obj):
-        self.values = tuple(obj)
-        self.hash = hash((_HashableList, *self.values))
-
-    def __hash__(self):
-        return self.hash
-
-    def __eq__(self, other):
-        return isinstance(other, _HashableList) and self.values == other.values
-
-
-def _as_hashable(obj):
-    if isinstance(obj, dict):
-        return _HashableDict(obj)
-    elif isinstance(obj, tuple):
-        return tuple(_as_hashable(x) for x in obj)
-    elif isinstance(obj, list):
-        return _HashableList(obj)
-    else:
-        return obj
-
-
-def _categorical_equal(one, two):
-    behavior = behavior_of(one, two)
-
-    one, two = one.layout, two.layout
-
-    assert one.is_indexed or (one.is_option and one.is_indexed)
-    assert two.is_indexed or (two.is_option and two.is_indexed)
-    assert one.parameter("__array__") == "categorical"
-    assert two.parameter("__array__") == "categorical"
-
-    one_index = numpy.asarray(one.index)
-    two_index = numpy.asarray(two.index)
-    one_content = wrap_layout(one.content, behavior)
-    two_content = wrap_layout(two.content, behavior)
-
-    if len(one_content) == len(two_content) and ak.operations.all(
-        one_content == two_content, axis=None
-    ):
-        one_mapped = one_index
-
-    else:
-        one_list = ak.operations.to_list(one_content)
-        two_list = ak.operations.to_list(two_content)
-        one_hashable = [_as_hashable(x) for x in one_list]
-        two_hashable = [_as_hashable(x) for x in two_list]
-        two_lookup = {x: i for i, x in enumerate(two_hashable)}
-
-        one_to_two = numpy.empty(len(one_hashable) + 1, dtype=np.int64)
-        for i, x in enumerate(one_hashable):
-            one_to_two[i] = two_lookup.get(x, len(two_hashable))
-        one_to_two[-1] = -1
-
-        one_mapped = one_to_two[one_index]
-
-    out = one_mapped == two_index
-    out = wrap_layout(ak.contents.NumpyArray(out), behavior_of(one, two))
-    return out
-
-
-def _apply_ufunc(ufunc, method, inputs, kwargs):
-    nextinputs = []
-    for x in inputs:
-        if isinstance(x, ak.highlevel.Array) and x.layout.is_indexed:
-            nextinputs.append(
-                ak.highlevel.Array(x.layout.project(), behavior=behavior_of(x))
-            )
-        else:
-            nextinputs.append(x)
-
-    return getattr(ufunc, method)(*nextinputs, **kwargs)
-
-
-def register(behavior):
-    behavior["categorical"] = CategoricalBehavior
-    behavior[ufuncs.equal, "categorical", "categorical"] = _categorical_equal
-    behavior[ufuncs.ufunc, "categorical"] = _apply_ufunc

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -1,10 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-import awkward as ak
 from awkward._errors import deprecate
-from awkward._nplikes.numpylike import NumpyMetadata
 from awkward.highlevel import Array
-
-np = NumpyMetadata.instance()
 
 
 class ByteBehavior(Array):
@@ -14,7 +10,7 @@ class ByteBehavior(Array):
         super().__init__(*args, **kwargs)
 
         deprecate(
-            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"{type(self).__name__} is deprecated: string types are now considered a built-in feature "
             f"provided by Awkward Array, rather than an extension.",
             version="2.4.0",
         )
@@ -27,7 +23,7 @@ class CharBehavior(Array):
         super().__init__(*args, **kwargs)
 
         deprecate(
-            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"{type(self).__name__} is deprecated: string types are now considered a built-in feature "
             f"provided by Awkward Array, rather than an extension.",
             version="2.4.0",
         )
@@ -40,7 +36,7 @@ class ByteStringBehavior(Array):
         super().__init__(*args, **kwargs)
 
         deprecate(
-            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"{type(self).__name__} is deprecated: string types are now considered a built-in feature "
             f"provided by Awkward Array, rather than an extension.",
             version="2.4.0",
         )
@@ -53,107 +49,7 @@ class StringBehavior(Array):
         super().__init__(*args, **kwargs)
 
         deprecate(
-            f"{type(self).__name__} is deprecated: string-types are now considered a built-in feature "
+            f"{type(self).__name__} is deprecated: string types are now considered a built-in feature "
             f"provided by Awkward Array, rather than an extension.",
             version="2.4.0",
         )
-
-
-def _string_numba_typer(viewtype):
-    import numba
-
-    if viewtype.type.parameters["__array__"] == "string":
-        return numba.types.string
-    else:
-        return numba.cpython.charseq.bytes_type
-
-
-def _string_numba_lower(
-    context, builder, rettype, viewtype, viewval, viewproxy, attype, atval
-):
-    import llvmlite.ir
-    import numba
-
-    whichpos = ak._connect.numba.layout.posat(
-        context, builder, viewproxy.pos, viewtype.type.CONTENT
-    )
-    nextpos = ak._connect.numba.layout.getat(
-        context, builder, viewproxy.arrayptrs, whichpos
-    )
-
-    whichnextpos = ak._connect.numba.layout.posat(
-        context, builder, nextpos, viewtype.type.contenttype.ARRAY
-    )
-
-    startspos = ak._connect.numba.layout.posat(
-        context, builder, viewproxy.pos, viewtype.type.STARTS
-    )
-    startsptr = ak._connect.numba.layout.getat(
-        context, builder, viewproxy.arrayptrs, startspos
-    )
-    startsarraypos = builder.add(viewproxy.start, atval)
-    start = ak._connect.numba.layout.getat(
-        context, builder, startsptr, startsarraypos, viewtype.type.indextype.dtype
-    )
-
-    stopspos = ak._connect.numba.layout.posat(
-        context, builder, viewproxy.pos, viewtype.type.STOPS
-    )
-    stopsptr = ak._connect.numba.layout.getat(
-        context, builder, viewproxy.arrayptrs, stopspos
-    )
-    stopsarraypos = builder.add(viewproxy.start, atval)
-    stop = ak._connect.numba.layout.getat(
-        context, builder, stopsptr, stopsarraypos, viewtype.type.indextype.dtype
-    )
-
-    baseptr = ak._connect.numba.layout.getat(
-        context, builder, viewproxy.arrayptrs, whichnextpos
-    )
-    rawptr = builder.add(
-        baseptr,
-        ak._connect.numba.layout.castint(
-            context, builder, viewtype.type.indextype.dtype, numba.intp, start
-        ),
-    )
-    rawptr_cast = builder.inttoptr(
-        rawptr,
-        llvmlite.ir.PointerType(llvmlite.ir.IntType(numba.intp.bitwidth // 8)),
-    )
-    strsize = builder.sub(stop, start)
-    strsize_cast = ak._connect.numba.layout.castint(
-        context, builder, viewtype.type.indextype.dtype, numba.intp, strsize
-    )
-
-    pyapi = context.get_python_api(builder)
-    gil = pyapi.gil_ensure()
-
-    strptr = builder.bitcast(rawptr_cast, pyapi.cstring)
-
-    if viewtype.type.parameters["__array__"] == "string":
-        kind = context.get_constant(numba.types.int32, pyapi.py_unicode_1byte_kind)
-        pystr = pyapi.string_from_kind_and_data(kind, strptr, strsize_cast)
-    else:
-        pystr = pyapi.bytes_from_string_and_size(strptr, strsize_cast)
-
-    out = pyapi.to_native_value(rettype, pystr).value
-
-    pyapi.decref(pystr)
-
-    pyapi.gil_release(gil)
-
-    return out
-
-
-def _cast_bytes_or_str_to_string(string):
-    return ak.to_layout([string])
-
-
-def register(behavior):
-    behavior["__numba_typer__", "bytestring"] = _string_numba_typer
-    behavior["__numba_lower__", "bytestring"] = _string_numba_lower
-    behavior["__numba_typer__", "string"] = _string_numba_typer
-    behavior["__numba_lower__", "string"] = _string_numba_lower
-
-    behavior["__cast__", str] = _cast_bytes_or_str_to_string
-    behavior["__cast__", bytes] = _cast_bytes_or_str_to_string

--- a/src/awkward/behaviors/string.py
+++ b/src/awkward/behaviors/string.py
@@ -22,21 +22,11 @@ class ByteBehavior(Array):
             version="2.4.0",
         )
 
-    def __bytes__(self):
-        tmp = self.layout.backend.nplike.asarray(self.layout)
-        if hasattr(tmp, "tobytes"):
-            return tmp.tobytes()
-        else:
-            return tmp.tostring()
-
     def __str__(self):
         return str(self.__bytes__())
 
     def __repr__(self):
         return repr(self.__bytes__())
-
-    def __iter__(self):
-        yield from self.__bytes__()
 
     def __eq__(self, other):
         if isinstance(other, (bytes, ByteBehavior)):
@@ -72,21 +62,11 @@ class CharBehavior(Array):
             version="2.4.0",
         )
 
-    def __bytes__(self):
-        tmp = self.layout.backend.nplike.asarray(self.layout)
-        if hasattr(tmp, "tobytes"):
-            return tmp.tobytes()
-        else:
-            return tmp.tostring()
-
     def __str__(self):
         return self.__bytes__().decode("utf-8", "surrogateescape")
 
     def __repr__(self):
         return repr(self.__bytes__().decode("utf-8", "surrogateescape"))
-
-    def __iter__(self):
-        yield from self.__str__()
 
     def __eq__(self, other):
         if isinstance(other, (str, CharBehavior)):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -300,7 +300,14 @@ class ListOffsetArray(Content):
         ):
             raise ak._errors.index_error(self, where)
         start, stop = self._offsets[where], self._offsets[where + 1]
-        return self._content._getitem_range(start, stop)
+        out = self._content._getitem_range(start, stop)
+        array_param = out.parameter("__array__")
+        if array_param == "byte":
+            return ak._util.tobytes(out.data)
+        elif array_param == "char":
+            return ak._util.tobytes(out.data).decode(errors="surrogateescape")
+        else:
+            return out
 
     def _getitem_range(self, start: SupportsIndex, stop: IndexType) -> Content:
         if not self._backend.nplike.known_data:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -297,7 +297,13 @@ class NumpyArray(Content):
         except IndexError as err:
             raise ak._errors.index_error(self, where, str(err)) from err
 
-        if hasattr(out, "shape") and len(out.shape) != 0:
+        # Character / byte arrays should be converted to Python types
+        name = self.parameter("__array__")
+        if name == "char":
+            return chr(out)
+        elif name == "byte":
+            return bytes(out)
+        elif hasattr(out, "shape") and len(out.shape) != 0:
             return NumpyArray(out, parameters=None, backend=self._backend)
         else:
             return out

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1278,6 +1278,18 @@ class NumpyArray(Content):
         if not self._backend.nplike.known_data:
             raise TypeError("cannot convert typetracer arrays to Python lists")
 
+        if self.parameter("__array__") == "byte":
+            convert_bytes = (
+                None if json_conversions is None else json_conversions["convert_bytes"]
+            )
+            if convert_bytes is None:
+                return ak._util.tobytes(self._data)
+            else:
+                return convert_bytes(ak._util.tobytes(self._data))
+
+        elif self.parameter("__array__") == "char":
+            return ak._util.tobytes(self._data).decode(errors="surrogateescape")
+
         out = self._to_list_custom(behavior, json_conversions)
         if out is not None:
             return out

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -297,13 +297,7 @@ class NumpyArray(Content):
         except IndexError as err:
             raise ak._errors.index_error(self, where, str(err)) from err
 
-        # Character / byte arrays should be converted to Python types
-        name = self.parameter("__array__")
-        if name == "char":
-            return chr(out)
-        elif name == "byte":
-            return bytes(out)
-        elif hasattr(out, "shape") and len(out.shape) != 0:
+        if hasattr(out, "shape") and len(out.shape) != 0:
             return NumpyArray(out, parameters=None, backend=self._backend)
         else:
             return out
@@ -1284,64 +1278,51 @@ class NumpyArray(Content):
         if not self._backend.nplike.known_data:
             raise TypeError("cannot convert typetracer arrays to Python lists")
 
-        if self.parameter("__array__") == "byte":
-            convert_bytes = (
-                None if json_conversions is None else json_conversions["convert_bytes"]
-            )
-            if convert_bytes is None:
-                return ak._util.tobytes(self._data)
-            else:
-                return convert_bytes(ak._util.tobytes(self._data))
-
-        elif self.parameter("__array__") == "char":
-            return ak._util.tobytes(self._data).decode(errors="surrogateescape")
-
-        else:
-            out = self._to_list_custom(behavior, json_conversions)
-            if out is not None:
-                return out
-
-            if json_conversions is not None:
-                complex_real_string = json_conversions["complex_real_string"]
-                complex_imag_string = json_conversions["complex_imag_string"]
-                if complex_real_string is not None:
-                    if issubclass(self.dtype.type, np.complexfloating):
-                        return ak.contents.RecordArray(
-                            [
-                                ak.contents.NumpyArray(
-                                    self._data.real, backend=self._backend
-                                ),
-                                ak.contents.NumpyArray(
-                                    self._data.imag, backend=self._backend
-                                ),
-                            ],
-                            [complex_real_string, complex_imag_string],
-                            self.length,
-                            parameters=self._parameters,
-                            backend=self._backend,
-                        )._to_list(behavior, json_conversions)
-
-            out = self._data.tolist()
-
-            if json_conversions is not None:
-                nan_string = json_conversions["nan_string"]
-                if nan_string is not None:
-                    for i in self._backend.nplike.nonzero(
-                        self._backend.nplike.isnan(self._data)
-                    )[0]:
-                        out[i] = nan_string
-
-                posinf_string = json_conversions["posinf_string"]
-                if posinf_string is not None:
-                    for i in self._backend.nplike.nonzero(self._data == np.inf)[0]:
-                        out[i] = posinf_string
-
-                neginf_string = json_conversions["neginf_string"]
-                if neginf_string is not None:
-                    for i in self._backend.nplike.nonzero(self._data == -np.inf)[0]:
-                        out[i] = neginf_string
-
+        out = self._to_list_custom(behavior, json_conversions)
+        if out is not None:
             return out
+
+        if json_conversions is not None:
+            complex_real_string = json_conversions["complex_real_string"]
+            complex_imag_string = json_conversions["complex_imag_string"]
+            if complex_real_string is not None:
+                if issubclass(self.dtype.type, np.complexfloating):
+                    return ak.contents.RecordArray(
+                        [
+                            ak.contents.NumpyArray(
+                                self._data.real, backend=self._backend
+                            ),
+                            ak.contents.NumpyArray(
+                                self._data.imag, backend=self._backend
+                            ),
+                        ],
+                        [complex_real_string, complex_imag_string],
+                        self.length,
+                        parameters=self._parameters,
+                        backend=self._backend,
+                    )._to_list(behavior, json_conversions)
+
+        out = self._data.tolist()
+
+        if json_conversions is not None:
+            nan_string = json_conversions["nan_string"]
+            if nan_string is not None:
+                for i in self._backend.nplike.nonzero(
+                    self._backend.nplike.isnan(self._data)
+                )[0]:
+                    out[i] = nan_string
+
+            posinf_string = json_conversions["posinf_string"]
+            if posinf_string is not None:
+                for i in self._backend.nplike.nonzero(self._data == np.inf)[0]:
+                    out[i] = posinf_string
+
+            neginf_string = json_conversions["neginf_string"]
+            if neginf_string is not None:
+                for i in self._backend.nplike.nonzero(self._data == -np.inf)[0]:
+                    out[i] = neginf_string
+
+        return out
 
     def _to_backend(self, backend: Backend) -> Self:
         return NumpyArray(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -504,7 +504,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         See also #ak.to_list.
         """
         for item in self._layout:
-            yield prepare_layout(item)
+            yield wrap_layout(prepare_layout(item), self._behavior, allow_other=True)
 
     def _getitem(self, where):
         return wrap_layout(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -31,12 +31,11 @@ _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
 def post_process_layout(layout: ak.contents.Content):
     if isinstance(layout, ak.contents.NumpyArray):
-        array = layout._raw(numpy)
         array_param = layout.parameter("__array__")
         if array_param == "byte":
-            return ak._util.tobytes(array)
+            return ak._util.tobytes(layout)
         elif array_param == "char":
-            return ak._util.tobytes(array).decode(errors="surrogateescape")
+            return ak._util.tobytes(layout).decode(errors="surrogateescape")
         else:
             return layout
     else:

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -33,9 +33,9 @@ def post_process_layout(layout: ak.contents.Content):
     if isinstance(layout, ak.contents.NumpyArray):
         array_param = layout.parameter("__array__")
         if array_param == "byte":
-            return ak._util.tobytes(layout)
+            return ak._util.tobytes(layout.data)
         elif array_param == "char":
-            return ak._util.tobytes(layout).decode(errors="surrogateescape")
+            return ak._util.tobytes(layout.data).decode(errors="surrogateescape")
         else:
             return layout
     else:

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1,4 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
 __all__ = ("Array", "ArrayBuilder", "Record")
 
 import copy
@@ -22,6 +24,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._operators import NDArrayOperatorsMixin
 from awkward._regularize import is_non_string_like_iterable
+from awkward._typing import TypeVar
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -29,7 +32,10 @@ numpy = Numpy.instance()
 _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
 
-def prepare_layout(layout: ak.contents.Content):
+T = TypeVar("T", bound=ak.contents.Content)
+
+
+def prepare_layout(layout: T) -> T | str | bytes:
     if isinstance(layout, ak.contents.NumpyArray):
         array_param = layout.parameter("__array__")
         if array_param == "byte":

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -29,19 +29,6 @@ numpy = Numpy.instance()
 _dir_pattern = re.compile(r"^[a-zA-Z_]\w*$")
 
 
-def post_process_layout(layout: ak.contents.Content):
-    if isinstance(layout, ak.contents.NumpyArray):
-        array_param = layout.parameter("__array__")
-        if array_param == "byte":
-            return ak._util.tobytes(layout.data)
-        elif array_param == "char":
-            return ak._util.tobytes(layout.data).decode(errors="surrogateescape")
-        else:
-            return layout
-    else:
-        return layout
-
-
 class Array(NDArrayOperatorsMixin, Iterable, Sized):
     """
     Args:
@@ -503,15 +490,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         See also #ak.to_list.
         """
-        if isinstance(self._layout, ak.contents.NumpyArray):
-            yield from post_process_layout(self._layout)
-        else:
-            for x in self._layout:
-                yield post_process_layout(x)
+        yield from self._layout
 
     def _getitem(self, where):
-        out = post_process_layout(self._layout[where])
-        return wrap_layout(out, self._behavior, allow_other=True)
+        return wrap_layout(self._layout[where], self._behavior, allow_other=True)
 
     def __getitem__(self, where):
         """
@@ -1711,8 +1693,7 @@ class Record(NDArrayOperatorsMixin):
         return str(self.type)
 
     def _getitem(self, where):
-        out = post_process_layout(self._layout[where])
-        return wrap_layout(out, self._behavior, allow_other=True)
+        return wrap_layout(self._layout[where], self._behavior, allow_other=True)
 
     def __getitem__(self, where):
         """

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -512,11 +512,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         for item in self._layout:
             yield wrap_layout(prepare_layout(item), self._behavior, allow_other=True)
 
-    def _getitem(self, where):
-        return wrap_layout(
-            prepare_layout(self._layout[where]), self._behavior, allow_other=True
-        )
-
     def __getitem__(self, where):
         """
         Args:
@@ -947,7 +942,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         have the same dimension as the array being indexed.
         """
         with ak._errors.SlicingErrorContext(self, where):
-            return self._getitem(where)
+            return wrap_layout(
+                prepare_layout(self._layout[where]), self._behavior, allow_other=True
+            )
 
     def __bytes__(self) -> bytes:
         if isinstance(self._layout, ak.contents.NumpyArray) and self._layout.parameter(
@@ -1714,11 +1711,6 @@ class Record(NDArrayOperatorsMixin):
         """
         return str(self.type)
 
-    def _getitem(self, where):
-        return wrap_layout(
-            prepare_layout(self._layout[where]), self._behavior, allow_other=True
-        )
-
     def __getitem__(self, where):
         """
         Args:
@@ -1746,7 +1738,9 @@ class Record(NDArrayOperatorsMixin):
             2
         """
         with ak._errors.SlicingErrorContext(self, where):
-            return self._getitem(where)
+            return wrap_layout(
+                prepare_layout(self._layout[where]), self._behavior, allow_other=True
+            )
 
     def __setitem__(self, where, what):
         """

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -2,6 +2,7 @@
 __all__ = ("to_categorical",)
 import awkward as ak
 from awkward._behavior import behavior_of
+from awkward._categorical import as_hashable
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
@@ -107,7 +108,7 @@ def _impl(array, highlevel, behavior):
                 cls = ak.contents.IndexedArray
 
             content_list = ak.operations.to_list(content)
-            hashable = [ak.behaviors.categorical._as_hashable(x) for x in content_list]
+            hashable = [as_hashable(x) for x in content_list]
 
             lookup = {}
             is_first = numpy.empty(len(hashable), dtype=np.bool_)

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -1,12 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("to_list",)
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 
 from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._regularize import is_non_string_like_iterable
 
 np = NumpyMetadata.instance()
 
@@ -77,7 +78,7 @@ def _impl(array):
     elif isinstance(array, Mapping):
         return {k: _impl(v) for k, v in array.items()}
 
-    elif isinstance(array, Iterable):
+    elif is_non_string_like_iterable(array):
         return [_impl(x) for x in array]
 
     else:

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -134,8 +134,7 @@ class Record:
         self._array._touch_shape(recursive)
 
     def __getitem__(self, where):
-        with ak._errors.SlicingErrorContext(self, where):
-            return self._getitem(where)
+        return self._getitem(where)
 
     def _getitem(self, where):
         if is_integer(where):

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -54,10 +54,12 @@ class ListType(Type):
             return None
 
         name = self._parameters.get("__array__")
-        if name in {"string", "bytestring"}:
-            return name
-
-        return None
+        if name == "string":
+            return "string"
+        elif name == "bytestring":
+            return "bytes"
+        else:
+            return None
 
     def _str(self, indent, compact, behavior):
         if self._typestr is not None:

--- a/src/awkward/types/listtype.py
+++ b/src/awkward/types/listtype.py
@@ -53,15 +53,19 @@ class ListType(Type):
         if typestr is not None:
             out = [typestr]
         else:
-            params = self._str_parameters()
-            if params is None:
-                out = ["var * ", *self._content._str(indent, compact, behavior)]
+            name = self._parameters.get("__array__")
+            if name in {"string", "bytestring"}:
+                out = [name]
             else:
-                out = [
-                    "[var * ",
-                    *self._content._str(indent, compact, behavior),
-                    f", {params}]",
-                ]
+                params = self._str_parameters()
+                if params is None:
+                    out = ["var * ", *self._content._str(indent, compact, behavior)]
+                else:
+                    out = [
+                        "[var * ",
+                        *self._content._str(indent, compact, behavior),
+                        f", {params}]",
+                    ]
 
         return [self._str_categorical_begin(), *out, self._str_categorical_end()]
 

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -135,25 +135,31 @@ class NumpyType(Type):
             out = [typestr]
 
         else:
-            if self.parameter("__unit__") is not None:
-                numpy_unit = str(np.dtype("M8[" + self._parameters["__unit__"] + "]"))
-                bracket_index = numpy_unit.index("[")
-                units = "unit=" + json.dumps(numpy_unit[bracket_index + 1 : -1])
+            name = self._parameters.get("__array__")
+            if name in {"byte", "char"}:
+                out = [name]
             else:
-                units = None
+                if self.parameter("__unit__") is not None:
+                    numpy_unit = str(
+                        np.dtype("M8[" + self._parameters["__unit__"] + "]")
+                    )
+                    bracket_index = numpy_unit.index("[")
+                    units = "unit=" + json.dumps(numpy_unit[bracket_index + 1 : -1])
+                else:
+                    units = None
 
-            params = self._str_parameters()
+                params = self._str_parameters()
 
-            if units is None and params is None:
-                out = [self._primitive]
-            else:
-                if units is not None and params is not None:
-                    units = units + ", "
-                elif units is None:
-                    units = ""
-                elif params is None:
-                    params = ""
-                out = [self._primitive, "[", units, params, "]"]
+                if units is None and params is None:
+                    out = [self._primitive]
+                else:
+                    if units is not None and params is not None:
+                        units = units + ", "
+                    elif units is None:
+                        units = ""
+                    elif params is None:
+                        params = ""
+                    out = [self._primitive, "[", units, params, "]"]
 
         return [self._str_categorical_begin(), *out, self._str_categorical_end()]
 

--- a/src/awkward/types/regulartype.py
+++ b/src/awkward/types/regulartype.py
@@ -66,11 +66,27 @@ class RegularType(Type):
     def size(self):
         return self._size
 
+    def _get_typestr(self, behavior) -> str | None:
+        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
+        if typestr is not None:
+            return typestr
+
+        if self._parameters is None:
+            return None
+
+        name = self._parameters.get("__array__")
+        if name == "string":
+            return "string"
+        elif name == "bytestring":
+            return "bytes"
+        else:
+            return None
+
     def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
+        typestr = self._get_typestr(behavior)
         if typestr is not None:
             out = [f"{typestr}[{self._size}]"]
 

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -61,8 +61,11 @@ class Type:
         out = []
         if self._parameters is not None:
             for k, v in self._parameters.items():
-                if k not in self._str_parameters_exclude:
-                    out.append(json.dumps(k) + ": " + json.dumps(v))
+                if v is None:
+                    continue
+                if k in self._str_parameters_exclude:
+                    continue
+                out.append(json.dumps(k) + ": " + json.dumps(v))
 
         if len(out) == 0:
             return None

--- a/src/awkward/types/type.py
+++ b/src/awkward/types/type.py
@@ -45,19 +45,19 @@ class Type:
 
     _str_parameters_exclude = ("__categorical__",)
 
-    def _str_categorical_begin(self):
+    def _str_categorical_begin(self) -> str:
         if self.parameter("__categorical__") is not None:
             return "categorical[type="
         else:
             return ""
 
-    def _str_categorical_end(self):
+    def _str_categorical_end(self) -> str:
         if self.parameter("__categorical__") is not None:
             return "]"
         else:
             return ""
 
-    def _str_parameters(self):
+    def _str_parameters(self) -> str:
         out = []
         if self._parameters is not None:
             for k, v in self._parameters.items():
@@ -72,7 +72,7 @@ class Type:
         else:
             return "parameters={" + ", ".join(out) + "}"
 
-    def _repr_args(self):
+    def _repr_args(self) -> list[str]:
         out = []
 
         if self._parameters is not None and len(self._parameters) > 0:

--- a/tests/test_0019_use_json_library.py
+++ b/tests/test_0019_use_json_library.py
@@ -81,17 +81,14 @@ def test_bytearray():
     array = ak.contents.NumpyArray(
         np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "byte"}
     )
-    assert (
-        ak.operations.to_json(array, convert_bytes=bytes.decode)
-        == "[104,101,108,108,111,116,104,101,114,101]"
-    )
+    assert ak.operations.to_json(array, convert_bytes=bytes.decode) == '"hellothere"'
 
 
 def test_chararray():
     array = ak.contents.NumpyArray(
         np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "char"}
     )
-    assert ak.operations.to_json(array) == "[104,101,108,108,111,116,104,101,114,101]"
+    assert ak.operations.to_json(array) == '"hellothere"'
 
 
 def test_string_array():

--- a/tests/test_0019_use_json_library.py
+++ b/tests/test_0019_use_json_library.py
@@ -81,7 +81,41 @@ def test_bytearray():
     array = ak.contents.NumpyArray(
         np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "byte"}
     )
-    assert ak.operations.to_json(array, convert_bytes=bytes.decode) == '"hellothere"'
+    assert (
+        ak.operations.to_json(array, convert_bytes=bytes.decode)
+        == "[104,101,108,108,111,116,104,101,114,101]"
+    )
+
+
+def test_chararray():
+    array = ak.contents.NumpyArray(
+        np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "char"}
+    )
+    assert ak.operations.to_json(array) == "[104,101,108,108,111,116,104,101,114,101]"
+
+
+def test_string_array():
+    array = ak.contents.ListOffsetArray(
+        ak.index.Index64([0, 5, 10]),
+        ak.contents.NumpyArray(
+            np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "char"}
+        ),
+        parameters={"__array__": "string"},
+    )
+    assert ak.operations.to_json(array) == '["hello","there"]'
+
+
+def test_bytestring_array():
+    array = ak.contents.ListOffsetArray(
+        ak.index.Index64([0, 5, 10]),
+        ak.contents.NumpyArray(
+            np.frombuffer(b"hellothere", "u1"), parameters={"__array__": "byte"}
+        ),
+        parameters={"__array__": "bytestring"},
+    )
+    assert (
+        ak.operations.to_json(array, convert_bytes=bytes.decode) == '["hello","there"]'
+    )
 
 
 def test_complex():

--- a/tests/test_0028_add_dressed_types.py
+++ b/tests/test_0028_add_dressed_types.py
@@ -49,13 +49,24 @@ class Dummy(ak.highlevel.Array):
     pass
 
 
-def test_string1():
+def test_byte():
     a = ak.highlevel.Array(
-        np.array([ord(x) for x in "hey there"], dtype=np.uint8), check_valid=True
+        np.array([ord(x) for x in "hey there"], dtype=np.uint8),
+        check_valid=True,
     )
-    a.__class__ = ak.behaviors.string.ByteBehavior
-    assert str(a) == str(b"hey there")
-    assert str(a) == str(b"hey there")
+    a = ak.with_parameter(a, "__array__", "byte")
+    assert bytes(a) == b"hey there"
+    assert ak.to_list(a) == [*b"hey there"]
+
+
+def test_char():
+    a = ak.highlevel.Array(
+        np.array([ord(x) for x in "hey there"], dtype=np.uint8),
+        check_valid=True,
+    )
+    a = ak.with_parameter(a, "__array__", "char")
+    assert str(a) == str([ord(c) for c in "hey there"])
+    assert ak.to_list(a) == [ord(c) for c in "hey there"]
 
 
 def test_string2():

--- a/tests/test_0028_add_dressed_types.py
+++ b/tests/test_0028_add_dressed_types.py
@@ -56,7 +56,8 @@ def test_byte():
     )
     a = ak.with_parameter(a, "__array__", "byte")
     assert bytes(a) == b"hey there"
-    assert ak.to_list(a) == [*b"hey there"]
+    assert str(a) == str([ord(c) for c in "hey there"])
+    assert ak.to_list(a) == b"hey there"
 
 
 def test_char():
@@ -66,7 +67,7 @@ def test_char():
     )
     a = ak.with_parameter(a, "__array__", "char")
     assert str(a) == str([ord(c) for c in "hey there"])
-    assert ak.to_list(a) == [ord(c) for c in "hey there"]
+    assert ak.to_list(a) == "hey there"
 
 
 def test_string2():


### PR DESCRIPTION
This PR tackes #1682 by moving existing behavior-based string logic into the core Awkward routines.

- [x] Adds `__bytes__` to `ak.Array`, to replace the `ByteBehavior.__bytes__`
- [x] Reworks `__getitem__` bypass logic
- [x] Removes `__add__` and `__radd__` support for `chat`/`byte` arrays.
- [x] Hardcodes ufunc handling for strings
- [x] Hardcodes typestr handling for strings / chars
