### PR TITLE
feat: add new `__list__` parameter for list-based array types

### DIFF
--- a/docs/reference/ak.behavior.md
+++ b/docs/reference/ak.behavior.md
@@ -520,9 +520,7 @@ First, one must define the behavior class
 ```python
 class ReversibleArray(ak.Array):
     def reversed(self):
-        index = ak.local_index(self)
-        reversed_index = index[..., ::-1]
-        return self[reversed_index]
+        return self[..., ::-1]
 ```
 To make this behavior class available to new arrays, it must be associated with its name
 ```python

--- a/docs/reference/ak.behavior.md
+++ b/docs/reference/ak.behavior.md
@@ -510,41 +510,46 @@ One may wish to disable this by type-checking, since the functionalities are rat
 ## Adding behavior to arrays
 
 Occasionally, you may want to add behavior to an array that does not contain
-records. A good example of this is to implement strings: strings are not a
-special data type in Awkward Array as they are in many other libraries, they
-are a behavior overlaid on arrays.
+records. Historically, this mechanism was used to help implement strings (although)
+strings have since been made a part of Awkward's internals, alongside categorical types.
 
-There are four predefined string behaviors:
+Awkward Array supports adding behaviors to the list-types in an array. Let's suppose that 
+one wishes to define a special list that defines a `reversed()` method, equivalent to `array[..., ::-1]`.
 
-- {class}`ak.CharBehavior`: an array of UTF-8 encoded characters;
-- {class}`ak.ByteBehavior`: an array of unencoded characters;
-- {class}`ak.StringBehavior`: an array of variable-length UTF-8 encoded strings;
-- {class}`ak.ByteStringBehavior`: an array of variable-length unencoded bytestrings.
-
-All four override the string representations (`__str__` and `__repr__`),
-but the string behaviors additionally override equality:
-
+First, one must define the behavior class
 ```python
->>> ak.Array(["one", "two", "three"]) == ak.Array(["1", "TWO", "three"])
-<Array [False, False, True] type='3 * bool'>
+class ReversibleArray(ak.Array):
+    def reversed(self):
+        index = ak.local_index(self)
+        reversed_index = index[..., ::-1]
+        return self[reversed_index]
+```
+To make this behavior class available to new arrays, it must be associated with its name
+```python
+ak.behavior["reversible"] = ReversibleArray
+```
+One can then add the `__list__` parameter to a list-type array to request this behavior class
+```pycon
+>>> reversible_list = ak.with_parameter([[1, 2, 3], [4], [5, 6, 7]], "__list__", "reversible")
+>>> reversible_list.reversed()
+[[3, 2, 1], [4], [7, 6, 5]]
+```
+If this list is nested within another list, the array class will not be found:
+```pycon
+>>> nested_list = ak.unflatten(reversible_list, [2, 1])
+>>> nested_list.reversed()
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+...
+AttributeError: no field named 'reversed'
 ```
 
-The only difference here is the parameter: instead of setting `"__record__"`,
-we set `"__array__"`.
-
+Just like with records, we can register a "deep" array class that will be found for all levels of list-depth, using `"*"`:
 ```python
->>> ak.Array(["one", "two", "three"]).layout
-<ListOffsetArray64>
-    <parameters>
-        <param key="__array__">"string"</param>
-    </parameters>
-    <offsets><Index64 i="[0 3 6 11]" offset="0" length="4""/></offsets>
-    <content><NumpyArray format="B" shape="11" data="0x 6f6e6574 776f7468 726565">
-        <parameters>
-            <param key="__array__">"char"</param>
-        </parameters>
-    </NumpyArray></content>
-</ListOffsetArray64>
+>>> ak.behavior["*", "reversible"] = ReversibleArray
+>>> nested_list = ak.unflatten(reversible_list, [2, 1])
+>>> nested_list.reversed()
+[[[3, 2, 1], [4]], [[7, 6, 5]]]
 ```
 
 In `ak.behaviors.string`, string behaviors are assigned with lines like
@@ -556,18 +561,17 @@ ak.behavior[np.equal, "string", "string"] = _string_equal
 
 ## Custom type names
 
-To make the string type appear as `string` in type representations, a
-`"__typestr__"` behavior is overriden (in `ak.behaviors.string`):
-
+To change the type-string representation of our custom list, a
+`"__typestr__"` behavior can be registered:
 ```python
-ak.behavior["__typestr__", "string"] = "string"
+ak.behavior["__typestr__", "reversible"] = "a-reversible-list"
 ```
 
 so that
 
 ```python
->>> ak.type(ak.Array(["one", "two", "three"]))
-3 * string
+>>> ak.type(ak.with_parameter([[1, 2, 3], [4], [5, 6, 7]], "__list__", "reversible"))
+3 * a-reversible-list
 ```
 
 ## Overriding behavior in Numba
@@ -656,9 +660,9 @@ ak.behavior["__numba_lower__", ".", record_name] = lower
 ak.behavior["__numba_typer__", "*", record_name] = typer
 ak.behavior["__numba_lower__", "*", record_name] = lower
 
-# parameters["__array__"] = array_name
-ak.behavior["__numba_typer__", array_name] = typer
-ak.behavior["__numba_lower__", array_name] = lower
+# parameters["__list__"] = list_name
+ak.behavior["__numba_typer__", list_name] = typer
+ak.behavior["__numba_lower__", list_name] = lower
 ```
 
 The `typer` function takes an

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -26,9 +26,9 @@ def get_array_class(layout, behavior):
     from awkward.highlevel import Array
 
     behavior = overlay_behavior(behavior)
-    arr = layout.parameter("__array__")
-    if isinstance(arr, str):
-        cls = behavior.get(arr)
+    list_name = layout.parameter("__list__")
+    if isinstance(list_name, str):
+        cls = behavior.get(list_name)
         if isinstance(cls, type) and issubclass(cls, Array):
             return cls
     deeprec = layout.purelist_parameter("__record__")
@@ -69,7 +69,7 @@ def find_custom_cast(obj, behavior):
 
 def find_ufunc_generic(ufunc, layout, behavior):
     behavior = overlay_behavior(behavior)
-    custom = layout.parameter("__array__")
+    custom = layout.parameter("__list__")
     if custom is None:
         custom = layout.parameter("__record__")
     if isinstance(custom, str):
@@ -122,7 +122,7 @@ def find_array_typestr(
     if parameters is None:
         return default
     behavior = overlay_behavior(behavior)
-    return behavior.get(("__typestr__", parameters.get("__array__")), default)
+    return behavior.get(("__typestr__", parameters.get("__list__")), default)
 
 
 def behavior_of(*arrays, **kwargs):

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -31,9 +31,9 @@ def get_array_class(layout, behavior):
         cls = behavior.get(list_name)
         if isinstance(cls, type) and issubclass(cls, Array):
             return cls
-    deeprec = layout.purelist_parameter("__record__")
-    if isinstance(deeprec, str):
-        cls = behavior.get(("*", deeprec))
+    deep_list_record_name = layout.purelist_parameters("__record__", "__list__")
+    if isinstance(deep_list_record_name, str):
+        cls = behavior.get(("*", deep_list_record_name))
         if isinstance(cls, type) and issubclass(cls, Array):
             return cls
     return Array

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -92,7 +92,7 @@ def string_numba_lower(
 
 def find_numba_array_typer(layouttype, behavior):
     behavior = overlay_behavior(behavior)
-    arr = layouttype.parameters.get("__array__")
+    arr = layouttype.parameters.get("__list__")
     if isinstance(arr, str):
         typer = behavior.get(("__numba_typer__", arr))
         if callable(typer):
@@ -107,7 +107,7 @@ def find_numba_array_typer(layouttype, behavior):
 
 def find_numba_array_lower(layouttype, behavior):
     behavior = overlay_behavior(behavior)
-    arr = layouttype.parameters.get("__array__")
+    arr = layouttype.parameters.get("__list__")
     if isinstance(arr, str):
         lower = behavior.get(("__numba_lower__", arr))
         if callable(lower):

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -401,15 +401,14 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
                     return out
 
         if all(
-            x.parameter("__array__") is not None
-            or x.parameter("__record__") is not None
+            x.parameter("__list__") is not None or x.parameter("__record__") is not None
             for x in contents
         ):
             error_message = []
             for x in inputs:
                 if isinstance(x, ak.contents.Content):
-                    if x.parameter("__array__") is not None:
-                        error_message.append(x.parameter("__array__"))
+                    if x.parameter("__list__") is not None:
+                        error_message.append(x.parameter("__list__"))
                     elif x.parameter("__record__") is not None:
                         error_message.append(x.parameter("__record__"))
                     else:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -202,11 +202,11 @@ def _array_ufunc_signature(ufunc, inputs):
     signature = [ufunc]
     for x in inputs:
         if isinstance(x, ak.contents.Content):
-            record, array = x.parameter("__record__"), x.parameter("__array__")
-            if record is not None:
-                signature.append(record)
-            elif array is not None:
-                signature.append(array)
+            record_name, list_name = x.parameter("__record__"), x.parameter("__list__")
+            if record_name is not None:
+                signature.append(record_name)
+            elif list_name is not None:
+                signature.append(list_name)
             elif isinstance(x, NumpyArray):
                 signature.append(x.dtype.type)
             else:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -363,6 +363,38 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
                 "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"
             )
 
+        # Do we have a custom generic ufunc override (a function that accepts _all_ ufuncs)?
+        for x in contents:
+            apply_ufunc = find_ufunc_generic(ufunc, x, behavior)
+            if apply_ufunc is not None:
+                out = _array_ufunc_adjust_apply(
+                    apply_ufunc, ufunc, method, inputs, kwargs, behavior
+                )
+                if out is not None:
+                    return out
+
+        # Do we have any nominal types without custom overloads?
+        if any(
+            x.parameter("__list__") is not None or x.parameter("__record__") is not None
+            for x in contents
+        ):
+            error_message = []
+            for x in inputs:
+                if isinstance(x, ak.contents.Content):
+                    if x.parameter("__list__") is not None:
+                        error_message.append(x.parameter("__list__"))
+                    elif x.parameter("__record__") is not None:
+                        error_message.append(x.parameter("__record__"))
+                    else:
+                        error_message.append(type(x).__name__)
+                else:
+                    error_message.append(type(x).__name__)
+            raise TypeError(
+                "no {}.{} overloads for custom types: {}".format(
+                    type(ufunc).__module__, ufunc.__name__, ", ".join(error_message)
+                )
+            )
+
         if all(
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
@@ -389,37 +421,6 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
             result = impl(*args, **kwargs)
 
             return (NumpyArray(result, backend=backend, parameters=parameters),)
-
-        # Do we have a custom generic ufunc override (a function that accepts _all_ ufuncs)?
-        for x in contents:
-            apply_ufunc = find_ufunc_generic(ufunc, x, behavior)
-            if apply_ufunc is not None:
-                out = _array_ufunc_adjust_apply(
-                    apply_ufunc, ufunc, method, inputs, kwargs, behavior
-                )
-                if out is not None:
-                    return out
-
-        if all(
-            x.parameter("__list__") is not None or x.parameter("__record__") is not None
-            for x in contents
-        ):
-            error_message = []
-            for x in inputs:
-                if isinstance(x, ak.contents.Content):
-                    if x.parameter("__list__") is not None:
-                        error_message.append(x.parameter("__list__"))
-                    elif x.parameter("__record__") is not None:
-                        error_message.append(x.parameter("__record__"))
-                    else:
-                        error_message.append(type(x).__name__)
-                else:
-                    error_message.append(type(x).__name__)
-            raise TypeError(
-                "no {}.{} overloads for custom types: {}".format(
-                    type(ufunc).__module__, ufunc.__name__, ", ".join(error_message)
-                )
-            )
 
         return None
 

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -358,6 +358,18 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
             if out is not None:
                 return out
 
+            # Do we have all-strings? If so, we can't proceed
+            if all(
+                x.is_list and x.parameter("__array__") in ("string", "bytestring")
+                for x in contents
+            ):
+                raise TypeError(
+                    "{}.{} is not implemented for string types. "
+                    "To register an implementation, add a name to these string(s) and register a behavior overload".format(
+                        type(ufunc).__module__, ufunc.__name__
+                    )
+                )
+
         if ufunc is numpy.matmul:
             raise NotImplementedError(
                 "matrix multiplication (`@` or `np.matmul`) is not yet implemented for Awkward Arrays"

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -4,6 +4,8 @@ from collections.abc import Collection
 
 from awkward._typing import JSONMapping, JSONSerializable
 
+NOMINAL_PARAMETERS = ("__list__", "__record__", "__categorical__")
+
 
 def type_parameters_equal(
     one: JSONMapping | None, two: JSONMapping | None, *, allow_missing: bool = False
@@ -14,19 +16,19 @@ def type_parameters_equal(
     elif one is None:
         # NB: __categorical__ is currently a type-only parameter, but
         # we check it here as types check this too.
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if two.get(key) is not None:
                 return allow_missing
         return True
 
     elif two is None:
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if one.get(key) is not None:
                 return allow_missing
         return True
 
     else:
-        for key in ("__array__", "__record__", "__categorical__"):
+        for key in NOMINAL_PARAMETERS:
             if one.get(key) != two.get(key):
                 return False
         return True
@@ -41,7 +43,7 @@ def parameters_are_equal(
         if only_array_record:
             # NB: __categorical__ is currently a type-only parameter, but
             # we check it here as types check this too.
-            for key in ("__array__", "__record__", "__categorical__"):
+            for key in NOMINAL_PARAMETERS:
                 if two.get(key) is not None:
                     return False
             return True
@@ -53,7 +55,7 @@ def parameters_are_equal(
 
     elif two is None:
         if only_array_record:
-            for key in ("__array__", "__record__", "__categorical__"):
+            for key in NOMINAL_PARAMETERS:
                 if one.get(key) is not None:
                     return False
             return True

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 
 from awkward._typing import JSONMapping, JSONSerializable
 
-NOMINAL_PARAMETERS = ("__list__", "__record__", "__categorical__")
+TYPE_PARAMETERS = ("__array__", "__list__", "__record__", "__categorical__")
 
 
 def type_parameters_equal(
@@ -16,19 +16,19 @@ def type_parameters_equal(
     elif one is None:
         # NB: __categorical__ is currently a type-only parameter, but
         # we check it here as types check this too.
-        for key in NOMINAL_PARAMETERS:
+        for key in TYPE_PARAMETERS:
             if two.get(key) is not None:
                 return allow_missing
         return True
 
     elif two is None:
-        for key in NOMINAL_PARAMETERS:
+        for key in TYPE_PARAMETERS:
             if one.get(key) is not None:
                 return allow_missing
         return True
 
     else:
-        for key in NOMINAL_PARAMETERS:
+        for key in TYPE_PARAMETERS:
             if one.get(key) != two.get(key):
                 return False
         return True
@@ -43,7 +43,7 @@ def parameters_are_equal(
         if only_array_record:
             # NB: __categorical__ is currently a type-only parameter, but
             # we check it here as types check this too.
-            for key in NOMINAL_PARAMETERS:
+            for key in TYPE_PARAMETERS:
                 if two.get(key) is not None:
                     return False
             return True
@@ -55,7 +55,7 @@ def parameters_are_equal(
 
     elif two is None:
         if only_array_record:
-            for key in NOMINAL_PARAMETERS:
+            for key in TYPE_PARAMETERS:
                 if one.get(key) is not None:
                     return False
             return True
@@ -67,7 +67,7 @@ def parameters_are_equal(
 
     else:
         if only_array_record:
-            keys = ("__array__", "__record__", "__categorical__")
+            keys = TYPE_PARAMETERS
         else:
             keys = set(one.keys()).union(two.keys())
         for key in keys:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -101,8 +101,10 @@ class Content:
                     type(self).__name__, repr(parameters)
                 )
             )
-        else:
-            if not self.is_list and parameters.get("__array__") in (
+        # Validate built-in `__array__`
+        elif parameters.get("__array__") is not None:
+            array_name = parameters["__array__"]
+            if not self.is_list and array_name in (
                 "string",
                 "bytestring",
             ):
@@ -119,13 +121,13 @@ class Content:
                         type(self).__name__, parameters["__array__"]
                     )
                 )
-            if not self.is_indexed and parameters.get("__array__") == "categorical":
+            if not self.is_indexed and array_name == "categorical":
                 raise TypeError(
                     '{} is not allowed to have parameters["__array__"] = "{}"'.format(
                         type(self).__name__, parameters["__array__"]
                     )
                 )
-            if not self.is_record and parameters.get("__array__") == "sorted_map":
+            if not self.is_record and array_name == "sorted_map":
                 raise TypeError(
                     '{} is not allowed to have parameters["__array__"] = "{}"'.format(
                         type(self).__name__, parameters["__array__"]

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -139,6 +139,12 @@ class Content:
                     type(self).__name__, parameters["__list__"]
                 )
             )
+        elif not (self.is_record or parameters.get("__record__") is None):
+            raise TypeError(
+                '{} is not allowed to have parameters["__record__"] = "{}"'.format(
+                    type(self).__name__, parameters["__record__"]
+                )
+            )
 
         if not isinstance(backend, Backend):
             raise TypeError(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -932,10 +932,20 @@ class Content:
         Return the value of the outermost parameter matching `key` in a sequence
         of nested lists, stopping at the first record or tuple layer.
 
-         If a layer has #ak.types.UnionType, the value is only returned if all
+        If a layer has #ak.types.UnionType, the value is only returned if all
         possibilities have the same value.
         """
         return self.form_cls.purelist_parameter(self, key)
+
+    def purelist_parameters(self, *keys: str):
+        """
+        Return the value of the outermost parameter matching one of `keys` in a sequence
+        of nested lists, stopping at the first record or tuple layer.
+
+        If a layer has #ak.types.UnionType, the value is only returned if all
+        possibilities have the same value.
+        """
+        return self.form_cls.purelist_parameters(self, *keys)
 
     def _is_unique(
         self,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -133,6 +133,12 @@ class Content:
                         type(self).__name__, parameters["__array__"]
                     )
                 )
+        elif not (self.is_list or parameters.get("__list__") is None):
+            raise TypeError(
+                '{} is not allowed to have parameters["__list__"] = "{}"'.format(
+                    type(self).__name__, parameters["__list__"]
+                )
+            )
 
         if not isinstance(backend, Backend):
             raise TypeError(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -133,18 +133,19 @@ class Content:
                         type(self).__name__, parameters["__array__"]
                     )
                 )
-        elif not (self.is_list or parameters.get("__list__") is None):
-            raise TypeError(
-                '{} is not allowed to have parameters["__list__"] = "{}"'.format(
-                    type(self).__name__, parameters["__list__"]
-                )
-            )
-        elif not (self.is_record or parameters.get("__record__") is None):
-            raise TypeError(
-                '{} is not allowed to have parameters["__record__"] = "{}"'.format(
-                    type(self).__name__, parameters["__record__"]
-                )
-            )
+        # TODO: enable this once we can guarantee this doesn't happen during broadcasting
+        # elif not (self.is_list or parameters.get("__list__") is None):
+        #     raise TypeError(
+        #         '{} is not allowed to have parameters["__list__"] = "{}"'.format(
+        #             type(self).__name__, parameters["__list__"]
+        #         )
+        #     )
+        # elif not (self.is_record or parameters.get("__record__") is None):
+        #     raise TypeError(
+        #         '{} is not allowed to have parameters["__record__"] = "{}"'.format(
+        #             type(self).__name__, parameters["__record__"]
+        #         )
+        #     )
 
         if not isinstance(backend, Backend):
             raise TypeError(

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -160,11 +160,13 @@ class BitMaskedForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -137,11 +137,13 @@ class ByteMaskedForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -6,7 +6,7 @@ from inspect import signature
 import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import Iterator, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, JSONMapping
 
@@ -84,11 +84,11 @@ class EmptyForm(Form):
             f"argument, or the legacy `dtype` argument as positional or keyword"
         )
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return None
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
 
     @property
     def purelist_isregular(self) -> bool:

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -377,6 +377,9 @@ class Form:
             return self._parameters.get(key)
 
     def purelist_parameter(self, key: str) -> JSONSerializable:
+        return self.purelist_parameters(key)
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
         raise NotImplementedError
 
     @property

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -2,7 +2,7 @@
 
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -141,11 +141,13 @@ class IndexedForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -122,11 +122,13 @@ class IndexedOptionForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import final
+from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -123,11 +123,13 @@ class ListForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONMapping, final
+from awkward._typing import JSONMapping, JSONSerializable, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -90,11 +90,13 @@ class ListOffsetForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -5,7 +5,7 @@ import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -170,11 +170,11 @@ class NumpyForm(Form):
         out._parameters = self._parameters
         return out
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return None
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 import awkward as ak
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
-from awkward._typing import final
+from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -190,8 +190,11 @@ class RecordForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        return self.parameter(key)
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -3,7 +3,7 @@ import awkward as ak
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
-from awkward._typing import final
+from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -84,11 +84,13 @@ class RegularForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 import awkward as ak
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -152,16 +152,19 @@ class UnionForm(Form):
 
         return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        for key in keys:
             out = self._contents[0].purelist_parameter(key)
             for content in self._contents[1:]:
                 tmp = content.purelist_parameter(key)
                 if out != tmp:
                     return None
             return out
-        else:
-            return self._parameters[key]
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 import awkward as ak
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import Self, final
+from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
 
@@ -94,11 +94,13 @@ class UnmaskedForm(Form):
         else:
             return False
 
-    def purelist_parameter(self, key):
-        if self._parameters is None or key not in self._parameters:
-            return self._content.purelist_parameter(key)
-        else:
-            return self._parameters[key]
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -15,7 +15,7 @@ from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer
-from awkward._typing import Self
+from awkward._typing import JSONSerializable, Self
 from awkward._util import UNSET
 from awkward.contents.content import Content
 
@@ -106,8 +106,11 @@ class Record:
     def parameter(self, key):
         return self._array.parameter(key)
 
-    def purelist_parameter(self, key):
-        return self._array.purelist_parameter(key)
+    def purelist_parameter(self, key) -> JSONSerializable:
+        return self._array.purelist_parameters(key)
+
+    def purelist_parameters(self, *keys):
+        return self._array.purelist_parameters(*keys)
 
     @property
     def purelist_isregular(self):

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -13,43 +13,43 @@ def test_types_with_parameters():
     assert t.parameters == {}
 
     with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
-        assert t.parameters == {"__array__": ["val", "ue"]}
+        t = ak.types.UnknownType(parameters={"latitude": ["val", "ue"]})
+        assert t.parameters == {"latitude": ["val", "ue"]}
 
-    t = ak.types.NumpyType("int32", parameters={"__array__": ["val", "ue"]})
-    assert t.parameters == {"__array__": ["val", "ue"]}
-    t = ak.types.NumpyType("float64", parameters={"__array__": ["val", "ue"]})
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    t = ak.types.NumpyType("int32", parameters={"latitude": ["val", "ue"]})
+    assert t.parameters == {"latitude": ["val", "ue"]}
+    t = ak.types.NumpyType("float64", parameters={"latitude": ["val", "ue"]})
+    assert t.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.ArrayType(
-        ak.types.NumpyType("int32", parameters={"__array__": ["val", "ue"]}), 100
+        ak.types.NumpyType("int32", parameters={"latitude": ["val", "ue"]}), 100
     )
-    assert t.content.parameters == {"__array__": ["val", "ue"]}
+    assert t.content.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.ListType(
-        ak.types.NumpyType("int32"), parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"latitude": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.RegularType(
-        ak.types.NumpyType("int32"), 5, parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), 5, parameters={"latitude": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.OptionType(
-        ak.types.NumpyType("int32"), parameters={"__array__": ["val", "ue"]}
+        ak.types.NumpyType("int32"), parameters={"latitude": ["val", "ue"]}
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.UnionType(
         (ak.types.NumpyType("int32"), ak.types.NumpyType("float64")),
-        parameters={"__array__": ["val", "ue"]},
+        parameters={"latitude": ["val", "ue"]},
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"latitude": ["val", "ue"]}
     t = ak.types.RecordType(
         [
             ak.types.NumpyType("int32"),
             ak.types.NumpyType("float64"),
         ],
         fields=["one", "two"],
-        parameters={"__array__": ["val", "ue"]},
+        parameters={"latitude": ["val", "ue"]},
     )
-    assert t.parameters == {"__array__": ["val", "ue"]}
+    assert t.parameters == {"latitude": ["val", "ue"]}
 
     with pytest.warns(DeprecationWarning):
         t = ak.types.UnknownType(
@@ -60,7 +60,7 @@ def test_types_with_parameters():
         assert t == ak.types.UnknownType(
             parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
         )
-        assert t != ak.types.UnknownType(parameters={"__array__": ["val", "ue"]})
+        assert t != ak.types.UnknownType(parameters={"latitude": ["val", "ue"]})
 
 
 def test_dress():
@@ -70,26 +70,27 @@ def test_dress():
 
     ns = {"Dummy": Dummy}
 
-    x = ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    x.parameters["__array__"] = "Dummy"
+    x = ak.contents.RegularArray(
+        ak.contents.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6, 6])),
+        size=3,
+        parameters={"__list__": "Dummy"},
+    )
     a = ak.highlevel.Array(x, behavior=ns, check_valid=True)
-    assert str(a) == "<Dummy [1.1, 2.2, 3.3, 4.4, 5.5]>"
+    assert str(a) == "<Dummy [[1.1, 2.2, 3.3], [4.4, 5.5, 6]]>"
 
     x2 = ak.contents.ListOffsetArray(
-        ak.index.Index64(np.array([0, 3, 3, 5], dtype=np.int64)),
-        ak.contents.NumpyArray(
-            np.array([1.1, 2.2, 3.3, 4.4, 5.5]), parameters={"__array__": "Dummy"}
-        ),
+        ak.index.Index64(np.array([0, 2, 2, 2], dtype=np.int64)),
+        x,
     )
     a2 = ak.highlevel.Array(x2, behavior=ns, check_valid=True)
     # columns limit changed from 40 to 80 in v2
     assert (
         repr(a2)
-        == "<Array [<Dummy [1.1, 2.2, 3.3]>, <Dummy []>, <Dummy [4.4, 5.5]>] type='3 * ...'>"
+        == "<Array [<Dummy [[1.1, 2.2, 3.3], [4.4, 5.5, 6]]>, <Dummy []>, <Dummy []>] type='...'>"
     )
-    assert str(a2[0]) == "<Dummy [1.1, 2.2, 3.3]>"
+    assert str(a2[0]) == "<Dummy [[1.1, 2.2, 3.3], [4.4, 5.5, 6]]>"
     assert str(a2[1]) == "<Dummy []>"
-    assert str(a2[2]) == "<Dummy [4.4, 5.5]>"
+    assert str(a2[2]) == "<Dummy []>"
 
 
 def test_record_name():

--- a/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
+++ b/tests/test_0527_fix_unionarray_ufuncs_and_parameters_in_merging.py
@@ -15,8 +15,8 @@ import awkward as ak
 
 
 def test_0459_types():
-    plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__array__", "zoinks")
+    plain_plain = ak.highlevel.Array([[0.0, 1.1, 2.2, 3.3, 4.4]])
+    array_plain = ak.operations.with_parameter(plain_plain, "__list__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -25,10 +25,10 @@ def test_0459_types():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__array__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__list__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__array__": "zoinks",
+        "__list__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -49,20 +49,20 @@ def test_0459_types():
     assert ak.operations.type(plain_isdoc) != ak.operations.type(array_isdoc)
     assert ak.operations.type(array_isdoc) != ak.operations.type(plain_isdoc)
 
-    assert array_plain.layout.parameters == {"__array__": "zoinks"}
+    assert array_plain.layout.parameters == {"__list__": "zoinks"}
     assert ak.operations.without_parameters(array_plain).layout.parameters == {}
     assert plain_isdoc.layout.parameters == {"__doc__": "This is a zoink."}
     assert ak.operations.without_parameters(plain_isdoc).layout.parameters == {}
     assert array_isdoc.layout.parameters == {
-        "__array__": "zoinks",
+        "__list__": "zoinks",
         "__doc__": "This is a zoink.",
     }
     assert ak.operations.without_parameters(array_isdoc).layout.parameters == {}
 
 
 def test_0459():
-    plain_plain = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3, 4.4])
-    array_plain = ak.operations.with_parameter(plain_plain, "__array__", "zoinks")
+    plain_plain = ak.highlevel.Array([[0.0, 1.1, 2.2, 3.3, 4.4]])
+    array_plain = ak.operations.with_parameter(plain_plain, "__list__", "zoinks")
     plain_isdoc = ak.operations.with_parameter(
         plain_plain, "__doc__", "This is a zoink."
     )
@@ -71,10 +71,10 @@ def test_0459():
     )
 
     assert ak.operations.parameters(plain_plain) == {}
-    assert ak.operations.parameters(array_plain) == {"__array__": "zoinks"}
+    assert ak.operations.parameters(array_plain) == {"__list__": "zoinks"}
     assert ak.operations.parameters(plain_isdoc) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(array_isdoc) == {
-        "__array__": "zoinks",
+        "__list__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
@@ -84,32 +84,32 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_plain])
-    ) == {"__array__": "zoinks"}
+    ) == {"__list__": "zoinks"}
     assert ak.operations.parameters(
         ak.operations.concatenate([plain_isdoc, plain_isdoc])
     ) == {"__doc__": "This is a zoink."}
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_isdoc])
     ) == {
-        "__array__": "zoinks",
+        "__list__": "zoinks",
         "__doc__": "This is a zoink.",
     }
 
     assert isinstance(
         ak.operations.concatenate([plain_plain, plain_plain]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([array_plain, array_plain]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([plain_isdoc, plain_isdoc]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([array_isdoc, array_isdoc]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
 
     assert (
@@ -152,30 +152,30 @@ def test_0459():
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_plain, array_isdoc])
-    ) == {"__array__": "zoinks"}
+    ) == {"__list__": "zoinks"}
     assert (
         ak.operations.parameters(ak.operations.concatenate([plain_isdoc, plain_plain]))
         == {}
     )
     assert ak.operations.parameters(
         ak.operations.concatenate([array_isdoc, array_plain])
-    ) == {"__array__": "zoinks"}
+    ) == {"__list__": "zoinks"}
 
     assert isinstance(
         ak.operations.concatenate([plain_plain, plain_isdoc]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([array_plain, array_isdoc]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([plain_isdoc, plain_plain]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
     assert isinstance(
         ak.operations.concatenate([array_isdoc, array_plain]).layout,
-        ak.contents.NumpyArray,
+        ak.contents.ListOffsetArray,
     )
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -14,7 +14,8 @@ def assert_overrides_typestr(type_, typestr: str = "override", expected: str = N
     if isinstance(type_, ak.types.RecordType):
         parameters = {**type_.parameters, "__record__": "custom"}
     else:
-        parameters = {**type_.parameters, "__array__": "custom"}
+        assert isinstance(type_, (ak.types.ListType, ak.types.RegularType))
+        parameters = {**type_.parameters, "__list__": "custom"}
     behavior = {("__typestr__", "custom"): typestr}
     # Build highlevel type with custom behavior
     with_parameter = type_.copy(parameters=parameters)
@@ -30,11 +31,6 @@ def test_UnknownType():
             == 'unknown[parameters={"x": 123}]'
         )
     with pytest.warns(DeprecationWarning):
-        assert_overrides_typestr(ak.types.unknowntype.UnknownType())
-
-        assert_overrides_typestr(
-            ak.types.unknowntype.UnknownType(parameters={"x": 123})
-        )
         assert (
             str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
             == "categorical[type=unknown]"
@@ -46,12 +42,6 @@ def test_UnknownType():
                 )
             )
             == 'categorical[type=unknown[parameters={"x": 123}]]'
-        )
-        assert_overrides_typestr(
-            ak.types.unknowntype.UnknownType(
-                parameters={"__categorical__": True, "x": 123}
-            ),
-            expected="categorical[type=override]",
         )
 
     assert repr(ak.types.unknowntype.UnknownType()) == "UnknownType()"
@@ -90,11 +80,6 @@ def test_NumpyType():
         str(ak.types.numpytype.NumpyType("bool", parameters={"x": 123}))
         == 'bool[parameters={"x": 123}]'
     )
-    assert_overrides_typestr(ak.types.numpytype.NumpyType("bool"))
-
-    assert_overrides_typestr(
-        ak.types.numpytype.NumpyType("bool", parameters={"x": 123})
-    )
     assert (
         str(ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}))
         == "categorical[type=bool]"
@@ -108,10 +93,6 @@ def test_NumpyType():
         == 'categorical[type=bool[parameters={"x": 123}]]'
     )
 
-    assert_overrides_typestr(
-        ak.types.numpytype.NumpyType("bool", parameters={"__categorical__": True}),
-        expected="categorical[type=override]",
-    )
     assert str(ak.types.numpytype.NumpyType("datetime64")) == "datetime64"
     assert (
         str(ak.types.numpytype.NumpyType("datetime64", parameters={"__unit__": "Y"}))
@@ -1017,40 +998,6 @@ def test_OptionType():
         )
         == 'option[10 * unknown, parameters={"x": 123}]'
     )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.unknowntype.UnknownType(), parameters=None
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-            parameters=None,
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10)
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.unknowntype.UnknownType(),
-            parameters={"x": 123},
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-            parameters={"x": 123},
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
-            parameters={"x": 123},
-        )
-    )
     assert (
         str(
             ak.types.optiontype.OptionType(
@@ -1108,48 +1055,6 @@ def test_OptionType():
         )
         == 'option[categorical[type=10 * unknown], parameters={"x": 123}]'
     )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.unknowntype.UnknownType(),
-            parameters={"__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-            parameters={"__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
-            parameters={"__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.unknowntype.UnknownType(),
-            parameters={"x": 123, "__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.listtype.ListType(ak.types.unknowntype.UnknownType()),
-            parameters={"x": 123, "__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.optiontype.OptionType(
-            ak.types.regulartype.RegularType(ak.types.unknowntype.UnknownType(), 10),
-            parameters={"x": 123, "__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
 
     assert (
         repr(ak.types.optiontype.OptionType(content=ak.types.unknowntype.UnknownType()))
@@ -1200,24 +1105,6 @@ def test_UnionType():
         )
         == 'union[unknown, bool, parameters={"x": 123}]'
     )
-    assert_overrides_typestr(
-        ak.types.uniontype.UnionType(
-            [
-                ak.types.unknowntype.UnknownType(),
-                ak.types.numpytype.NumpyType("bool"),
-            ],
-            parameters=None,
-        )
-    )
-    assert_overrides_typestr(
-        ak.types.uniontype.UnionType(
-            [
-                ak.types.unknowntype.UnknownType(),
-                ak.types.numpytype.NumpyType("bool"),
-            ],
-            parameters={"x": 123},
-        )
-    )
     assert (
         str(
             ak.types.uniontype.UnionType(
@@ -1241,26 +1128,6 @@ def test_UnionType():
             )
         )
         == 'categorical[type=union[unknown, bool, parameters={"x": 123}]]'
-    )
-    assert_overrides_typestr(
-        ak.types.uniontype.UnionType(
-            [
-                ak.types.unknowntype.UnknownType(),
-                ak.types.numpytype.NumpyType("bool"),
-            ],
-            parameters={"__categorical__": True},
-        ),
-        expected="categorical[type=override]",
-    )
-    assert_overrides_typestr(
-        ak.types.uniontype.UnionType(
-            [
-                ak.types.unknowntype.UnknownType(),
-                ak.types.numpytype.NumpyType("bool"),
-            ],
-            parameters={"x": 123, "__categorical__": True},
-        ),
-        expected="categorical[type=override]",
     )
 
     assert (
@@ -1319,25 +1186,12 @@ def test_ArrayType():
         str(
             ak.types.arraytype.ArrayType(
                 content=ak.types.numpytype.NumpyType(
-                    "int64", parameters={"__array__": "custom"}
-                ),
-                length=10,
-                behavior={("__typestr__", "custom"): "override"},
-            )
-        )
-        == "10 * override"
-    )
-
-    assert (
-        str(
-            ak.types.arraytype.ArrayType(
-                content=ak.types.numpytype.NumpyType(
-                    "int64", parameters={"__array__": "custom"}
+                    "int64", parameters={"catastrophe": "apocalypse"}
                 ),
                 length=10,
             )
         )
-        == '10 * int64[parameters={"__array__": "custom"}]'
+        == '10 * int64[parameters={"catastrophe": "apocalypse"}]'
     )
 
 

--- a/tests/test_1709_ak_array_constructor_behavior.py
+++ b/tests/test_1709_ak_array_constructor_behavior.py
@@ -14,7 +14,7 @@ class MyBehavior(ak.Array):
 
 def test():
     behavior = {"MyBehavior": MyBehavior}
-    array = ak.with_parameter([1, 2, 3], "__array__", "MyBehavior", behavior=behavior)
+    array = ak.with_parameter([[1, 2, 3]], "__list__", "MyBehavior", behavior=behavior)
     assert isinstance(array, MyBehavior)
 
     shallow_copy = ak.Array(array)

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -122,12 +122,12 @@ def test_behavior():
 
     behavior = {"custom_list": CustomList}
 
-    array = ak.with_parameter([1, 2, 3], "__array__", "custom_list", behavior=behavior)
-    other_array = ak.with_parameter([1, 2, 3], "__array__", "custom_list")
+    array = ak.with_parameter([[1, 2, 3]], "__list__", "custom_list", behavior=behavior)
+    other_array = ak.with_parameter([[1, 2, 3]], "__list__", "custom_list")
     assert not ak.almost_equal(array, other_array)
     assert ak.almost_equal(array, other_array, check_parameters=False)
 
-    another_array = ak.Array([1, 2, 3], behavior=behavior)
+    another_array = ak.Array([[1, 2, 3]], behavior=behavior)
     assert not ak.almost_equal(array, another_array)
     assert not ak.almost_equal(other_array, another_array)
 

--- a/tests/test_2549_list_nominal_type.py
+++ b/tests/test_2549_list_nominal_type.py
@@ -1,0 +1,109 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+class ReversibleArray(ak.Array):
+    def reversed(self):
+        index = ak.local_index(self)
+        reversed_index = index[..., ::-1]
+        return self[reversed_index]
+
+
+class ReversibleStringArray(ak.Array):
+    def reversed(self):
+        without_parameters = ak.with_parameter(self, "__list__", None)
+        index = ak.local_index(without_parameters)
+        reversed_index = index[..., ::-1]
+        return ak.with_parameter(
+            without_parameters[reversed_index], "__list__", "string"
+        )
+
+
+def test_class():
+    behavior = {"reversible": ReversibleArray}
+    reversible_array = ak.with_parameter(
+        [[1, 2, 3], [4, 5, 6, 7], [8, 9]], "__list__", "reversible", behavior=behavior
+    )
+    assert isinstance(reversible_array, ReversibleArray)
+    assert reversible_array.to_list() == [[1, 2, 3], [4, 5, 6, 7], [8, 9]]
+    assert reversible_array.reversed().to_list() == [[3, 2, 1], [7, 6, 5, 4], [9, 8]]
+
+
+def test_deep_class():
+    behavior = {"reversible": ReversibleArray, ("*", "reversible"): ReversibleArray}
+    reversible_array = ak.with_parameter(
+        [[1, 2, 3], [4, 5, 6, 7], [8, 9]], "__list__", "reversible", behavior=behavior
+    )
+    outer_array = ak.Array(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 2, 3, 3]), reversible_array.layout
+        ),
+        behavior=behavior,
+    )
+    assert isinstance(outer_array, ReversibleArray)
+    assert outer_array.to_list() == [[[1, 2, 3], [4, 5, 6, 7]], [[8, 9]], []]
+    assert outer_array.reversed().to_list() == [
+        [[3, 2, 1], [7, 6, 5, 4]],
+        [[9, 8]],
+        [],
+    ]
+
+
+def test_ufunc():
+    behavior = {"reversible": ReversibleArray}
+    reversible_array = ak.with_parameter(
+        [[1, 2, 3], [4, 5, 6, 7], [8, 9]], "__list__", "reversible", behavior=behavior
+    )
+    assert isinstance(reversible_array, ReversibleArray)
+
+    def reversible_add(x, y):
+        return x.reversed() + y.reversed()
+
+    ak.behavior[np.add, "reversible", "reversible"] = reversible_add
+
+    assert (reversible_array + reversible_array).to_list() == [
+        [6, 4, 2],
+        [14, 12, 10, 8],
+        [18, 16],
+    ]
+
+    # We can't apply ufunc to types without overloads
+    with pytest.raises(TypeError, match=r"overloads for custom types"):
+        reversible_array + ak.without_parameters(reversible_array)
+
+
+def test_string_ufuncs():
+    # Strings can't gt by default
+    with pytest.raises(TypeError, match=r"is not implemented for string types"):
+        np.greater(
+            ak.Array(["do", "not", "go", "gentle"]),
+            ak.Array(["gentle", "into", "that", "good"]),
+        )
+
+    # Implement gt for a custom string type
+    def string_greater(left, right):
+        return ak.num(left) > ak.num(right)
+
+    behavior = {(np.greater, "stringy", "stringy"): string_greater}
+    result = np.greater(
+        ak.with_parameter(
+            ["do", "not", "go", "gentle"], "__list__", "stringy", behavior=behavior
+        ),
+        ak.with_parameter(
+            ["gentle", "into", "that", "good"], "__list__", "stringy", behavior=behavior
+        ),
+    )
+    assert result.to_list() == [False, False, False, True]
+
+
+def test_string_class():
+    ak.behavior["reversible-string"] = ReversibleStringArray
+
+    strings = ak.with_parameter(["hi", "book", "cats"], "__list__", "reversible-string")
+    assert isinstance(strings, ReversibleStringArray)
+    assert strings.to_list() == ["hi", "book", "cats"]
+    assert strings.reversed().to_list() == ["cats", "book", "hi"]

--- a/tests/test_2549_list_nominal_type.py
+++ b/tests/test_2549_list_nominal_type.py
@@ -13,16 +13,6 @@ class ReversibleArray(ak.Array):
         return self[reversed_index]
 
 
-class ReversibleStringArray(ak.Array):
-    def reversed(self):
-        without_parameters = ak.with_parameter(self, "__list__", None)
-        index = ak.local_index(without_parameters)
-        reversed_index = index[..., ::-1]
-        return ak.with_parameter(
-            without_parameters[reversed_index], "__list__", "string"
-        )
-
-
 def test_class():
     behavior = {"reversible": ReversibleArray}
     reversible_array = ak.with_parameter(
@@ -107,9 +97,9 @@ def test_string_ufuncs():
 
 
 def test_string_class():
-    ak.behavior["reversible-string"] = ReversibleStringArray
+    ak.behavior["reversible-string"] = ReversibleArray
 
     strings = ak.with_parameter(["hi", "book", "cats"], "__list__", "reversible-string")
-    assert isinstance(strings, ReversibleStringArray)
+    assert isinstance(strings, ReversibleArray)
     assert strings.to_list() == ["hi", "book", "cats"]
     assert strings.reversed().to_list() == ["cats", "book", "hi"]

--- a/tests/test_2549_list_nominal_type.py
+++ b/tests/test_2549_list_nominal_type.py
@@ -70,10 +70,16 @@ def test_ufunc():
         [14, 12, 10, 8],
         [18, 16],
     ]
-
-    # We can't apply ufunc to types without overloads
     with pytest.raises(TypeError, match=r"overloads for custom types"):
-        reversible_array + ak.without_parameters(reversible_array)
+        reversible_array + ak.with_parameter(
+            reversible_array, "__list__", "non-reversible"
+        )
+
+    # TODO: this should become true once string broadcasting is addressed
+    #       so that we can generalise the solution
+    # # We can't apply ufunc to types without overloads
+    # with pytest.raises(TypeError, match=r"overloads for custom types"):
+    #     reversible_array + ak.without_parameters(reversible_array)
 
 
 def test_string_ufuncs():

--- a/tests/test_2549_list_nominal_type.py
+++ b/tests/test_2549_list_nominal_type.py
@@ -8,9 +8,7 @@ import awkward as ak
 
 class ReversibleArray(ak.Array):
     def reversed(self):
-        index = ak.local_index(self)
-        reversed_index = index[..., ::-1]
-        return self[reversed_index]
+        return self[..., ::-1]
 
 
 def test_class():
@@ -51,7 +49,9 @@ def test_ufunc():
     assert isinstance(reversible_array, ReversibleArray)
 
     def reversible_add(x, y):
-        return x.reversed() + y.reversed()
+        return ak.with_parameter(x.reversed(), "__list__", None) + ak.with_parameter(
+            y.reversed(), "__list__", None
+        )
 
     ak.behavior[np.add, "reversible", "reversible"] = reversible_add
 


### PR DESCRIPTION
This PR adds a new `__list__` nominal type parameter to associate with behaviors. It should only be added to lists. In addition to setting an array-class for `ListOffsetArray` (et al.) via `layout.parameter("__list__")`, we can also lookup the list in a purelist sense, allowing list-of-type to have an array class too.

Setting `__list__` and `__record__` an error for non-intended types, but that should be another PR (there are fixes that need to be made to both `validity_error` and broadcasting).