### PR TITLE
chore: drop Python 3.7

### DIFF
--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.13.1
       env:
         CIBW_ARCHS_MACOS: universal2
-        CIBW_BUILD: cp39-win_amd64 cp37-manylinux_x86_64 cp38-macosx_universal2
+        CIBW_BUILD: cp39-win_amd64 cp310-manylinux_x86_64 cp38-macosx_universal2
       with:
         config-file: cibuildwheel.toml
         package-dir: awkward-cpp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
 
         python-architecture:
           - x64
@@ -116,7 +115,6 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
 
     runs-on: macOS-11
 
@@ -187,11 +185,10 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
         numpy-package:
           - "numpy"
         include:
-          - python-version: '3.7'
+          - python-version: '3.8'
             numpy-package: "numpy==1.17.0"
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,7 @@ jobs:
           - "numpy"
         include:
           - python-version: '3.8'
-            numpy-package: "numpy==1.17.0"
+            numpy-package: "numpy==1.18.0"
 
     runs-on: ubuntu-20.04
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,9 @@ repos:
     entry: python dev/validate-test-names.py
     types: [file, python]
     files: ^tests/
+
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.8.0
+  hooks:
+  - id: pyupgrade

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "18"
 dependencies = [
-    "numpy"
+    "numpy>=1.18.0"
 ]
 readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "18"
 dependencies = [
-    "numpy>=1.17.0"
+    "numpy"
 ]
 readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://github.com/scikit-hep/awkward-1.0"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,7 +16,7 @@ myst-nb
 sphinx-external-toc
 ipyleaflet
 
-numpy>=1.13.1
+numpy
 numba>=0.50.0;python_version<"3.11"
 pandas>=0.24.0
 numexpr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,3 +316,6 @@ mccabe.max-complexity = 100
 "numpy".msg = "Use `numpy = ak._nplikes.Numpy.instance()` instead"
 "jax".msg = "Use `jax = ak._nplikes.Jax.instance()` instead"
 "cupy".msg = "Use `cupy = ak._nplikes.Cupy.instance()` instead"
+
+[tool.nbqa.addopts]
+pyupgrade = ["--py38-plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==18",
     "importlib_resources;python_version < \"3.9\"",
-    "numpy>=1.17.0",
+    "numpy",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\""
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "awkward"
 version = "2.2.4"
 description = "Manipulate JSON-like data with NumPy-like idioms."
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Jim Pivarski", email = "pivarski@princeton.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==18",
     "importlib_resources;python_version < \"3.9\"",
-    "numpy",
+    "numpy>=1.18.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\""
 ]

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 from itertools import chain
 
 import numpy
-from packaging.version import parse as parse_version
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -27,13 +26,6 @@ from awkward._regularize import is_non_string_like_iterable
 from awkward._typing import Any, Iterator, Mapping
 from awkward._util import Sentinel
 from awkward.contents.numpyarray import NumpyArray
-
-# NumPy 1.13.1 introduced NEP13, without which Awkward ufuncs won't work, which
-# would be worse than lacking a feature: it would cause unexpected output.
-# NumPy 1.17.0 introduced NEP18, which is optional (use ak.* instead of np.*).
-if parse_version(numpy.__version__) < parse_version("1.13.1"):
-    raise ImportError("NumPy 1.13.1 or later required")
-
 
 UNSUPPORTED = Sentinel("UNSUPPORTED", __name__)
 

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import numpy
-from packaging.version import parse as parse_version
 
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
@@ -57,24 +56,7 @@ class Numpy(ArrayModuleNumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ):
         assert not isinstance(x, PlaceholderArray)
-        if parse_version(numpy.__version__) >= parse_version("1.17.0"):
-            return numpy.packbits(x, axis=axis, bitorder=bitorder)
-        else:
-            assert axis is None, "unsupported argument value for axis given"
-            if bitorder == "little":
-                if len(x) % 8 == 0:
-                    ready_to_pack = x
-                else:
-                    ready_to_pack = numpy.empty(
-                        int(numpy.ceil(len(x) / 8.0)) * 8,
-                        dtype=x.dtype,
-                    )
-                    ready_to_pack[: len(x)] = x
-                    ready_to_pack[len(x) :] = 0
-                return numpy.packbits(ready_to_pack.reshape(-1, 8)[:, ::-1].reshape(-1))
-            else:
-                assert bitorder == "bit"
-                return numpy.packbits(x)
+        return numpy.packbits(x, axis=axis, bitorder=bitorder)
 
     def unpackbits(
         self,
@@ -85,14 +67,4 @@ class Numpy(ArrayModuleNumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ):
         assert not isinstance(x, PlaceholderArray)
-        if parse_version(numpy.__version__) >= parse_version("1.17.0"):
-            return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
-        else:
-            assert axis is None, "unsupported argument value for axis given"
-            assert count is None, "unsupported argument value for count given"
-            ready_to_bitswap = numpy.unpackbits(x)
-            if bitorder == "little":
-                return ready_to_bitswap.reshape(-1, 8)[:, ::-1].reshape(-1)
-            else:
-                assert bitorder == "bit"
-                return ready_to_bitswap
+        return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -27,17 +27,16 @@ __all__ = list(
 AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)  # noqa: F405
 
 if sys.version_info < (3, 11):
+    from typing import Final, SupportsIndex, runtime_checkable
+
     from typing_extensions import (
-        Final,
         Literal,
         Protocol,
         Self,
-        SupportsIndex,
         TypeAlias,
         TypedDict,
         Unpack,
         final,
-        runtime_checkable,
     )
 else:
     from typing import (

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -147,7 +147,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         ak.concatenate
 
-    exists. If your NumPy is older than 1.17, use `ak.concatenate` directly.
+    exists.
 
     Pandas
     ******
@@ -1359,9 +1359,6 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         [available since NumPy 1.17](https://numpy.org/devdocs/release/1.17.0-notes.html#numpy-functions-now-always-support-overrides-with-array-function)
         (and
         [NumPy 1.16 with an experimental flag set](https://numpy.org/devdocs/release/1.16.0-notes.html#numpy-functions-now-support-overrides-with-array-function)).
-        This is not crucial for Awkward Array to work correctly, as NumPy
-        functions like np.concatenate can be manually replaced with
-        #ak.concatenate for early versions of NumPy.
 
         See also #__array_ufunc__.
         """


### PR DESCRIPTION
[Our deprecation schedule](https://github.com/scikit-hep/awkward/wiki#api-breaking-changes-after-20) earmarked the July 2.3.0 release for dropping Python 3.7 support. This PR updates our CI, and package metadata, to reflect this change.