### PR TITLE
ci: cap `pydantic<2` to fix WASM build

### DIFF
--- a/docs/requirements-wasm.txt
+++ b/docs/requirements-wasm.txt
@@ -1,1 +1,2 @@
 pyodide-build==0.23.3
+pydantic<2


### PR DESCRIPTION
See https://github.com/pyodide/pyodide/pull/3971