### PR TITLE
fix: allow JAX tracers in `from_arraylib`

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -7,7 +7,6 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._errors import AxisError
 from awkward._nplikes.dispatch import nplike_of
-from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 
@@ -51,10 +50,6 @@ def from_arraylib(array, regulararray, recordarray):
     nplike = nplike_of(array)
 
     def recurse(array, mask=None):
-        cls = type(array)
-        if Jax.is_tracer_type(cls):
-            raise TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
-
         if regulararray and len(array.shape) > 1:
             new_shape = (-1,) + array.shape[2:]
             return RegularArray(


### PR DESCRIPTION
This should fix #2556, though I'm not sure why we had that check there. It looks intentional. Let's see what the test suite picks up.