### PR TITLE
fix: convert unknown-length to index in `ListOffsetArray.to_RegularArray`

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -260,7 +260,12 @@ class ListOffsetArray(Content):
             )
 
     def to_RegularArray(self):
-        start, stop = self._offsets[0], self._offsets[self._offsets.length - 1]
+        start, stop = (
+            self._offsets[0],
+            self._offsets[
+                self._backend.index_nplike.shape_item_as_index(self._offsets.length - 1)
+            ],
+        )
         content = self._content._getitem_range(start, stop)
         _size = Index64.empty(1, self._backend.index_nplike)
         assert (

--- a/tests/test_2560_minimal_listarray.py
+++ b/tests/test_2560_minimal_listarray.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+
+def test():
+    layout = ak.to_layout([[1, 2, 3, 4], [5, 6, 7, 8], [4, 5, 6, 9]]).to_typetracer(
+        forget_length=True
+    )
+    result = layout.to_RegularArray()
+    assert result.size is unknown_length
+    assert result.length is unknown_length


### PR DESCRIPTION
This fixes a bug that is raised during the strict dask-awkward test suite.