### PR TITLE
fix: prefer known to unknown lengths in broadcasting

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -66,8 +66,7 @@ def length_of_broadcast(inputs: Sequence) -> int | type[unknown_length]:
             if x.length is unknown_length:
                 has_seen_unknown_length = True
                 continue
-            else:
-                maxlen = max(maxlen, x.length)
+            maxlen = max(maxlen, x.length)
 
     if has_seen_unknown_length:
         return unknown_length
@@ -438,22 +437,22 @@ def apply_step(
 
                 if x.is_tuple:
                     continue
-                else:
-                    # Check fields match
-                    if fields is UNSET:
-                        fields = x._fields
-                        frozen_fields = frozenset(x._fields)
-                    elif frozen_fields != frozenset(x.fields):
-                        raise ValueError(
-                            "cannot broadcast records because fields don't "
-                            "match{}:\n    {}\n    {}".format(
-                                in_function(options),
-                                ", ".join(sorted(fields)),
-                                ", ".join(sorted(x.fields)),
-                            )
+
+                # Check fields match
+                if fields is UNSET:
+                    fields = x._fields
+                    frozen_fields = frozenset(x._fields)
+                elif frozen_fields != frozenset(x.fields):
+                    raise ValueError(
+                        "cannot broadcast records because fields don't "
+                        "match{}:\n    {}\n    {}".format(
+                            in_function(options),
+                            ", ".join(sorted(fields)),
+                            ", ".join(sorted(x.fields)),
                         )
-                    # Records win over tuples
-                    is_tuple = False
+                    )
+                # Records win over tuples
+                is_tuple = False
             else:
                 nextparameters.append(NO_PARAMETERS)
 
@@ -512,7 +511,7 @@ def apply_step(
                     if content.size is unknown_length:
                         continue
                     # Any zero-length column triggers zero broadcasting
-                    elif content.size == 0:
+                    if content.size == 0:
                         dim_size = 0
                         break
                     else:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -18,7 +18,7 @@ from awkward._parameters import (
     parameters_are_equal,
     parameters_intersect,
 )
-from awkward._typing import Any, JSONMapping, List
+from awkward._typing import Any, JSONMapping, List, TypedDict
 from awkward._util import UNSET, Sentinel
 from awkward.contents.bitmaskedarray import BitMaskedArray
 from awkward.contents.bytemaskedarray import ByteMaskedArray
@@ -344,6 +344,16 @@ def left_broadcast_to(content: Content, depth: int) -> Content:
     return content
 
 
+class BroadcastOptions(TypedDict):
+    allow_records: bool
+    left_broadcast: bool
+    right_broadcast: bool
+    numpy_to_regular: bool
+    regular_to_jagged: bool
+    function_name: str | None
+    broadcast_parameters_rule: BroadcastParameterRule
+
+
 def apply_step(
     backend: Backend,
     inputs: Sequence,
@@ -352,7 +362,7 @@ def apply_step(
     depth_context,
     lateral_context,
     behavior,
-    options,
+    options: BroadcastOptions,
 ):
     # This happens when descending anyway, but setting the option does it before action.
     if options["numpy_to_regular"] and any(
@@ -1064,12 +1074,12 @@ def broadcast_and_apply(
     behavior,
     depth_context=None,
     lateral_context=None,
-    allow_records=True,
-    left_broadcast=True,
-    right_broadcast=True,
-    numpy_to_regular=False,
-    regular_to_jagged=False,
-    function_name=None,
+    allow_records: bool = True,
+    left_broadcast: bool = True,
+    right_broadcast: bool = True,
+    numpy_to_regular: bool = False,
+    regular_to_jagged: bool = False,
+    function_name: str | None = None,
     broadcast_parameters_rule=BroadcastParameterRule.INTERSECT,
 ):
     backend = backend_of(*inputs)

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -47,6 +47,16 @@ optiontypes = (IndexedOptionArray, ByteMaskedArray, BitMaskedArray, UnmaskedArra
 listtypes = (ListOffsetArray, ListArray, RegularArray)
 
 
+class BroadcastOptions(TypedDict):
+    allow_records: bool
+    left_broadcast: bool
+    right_broadcast: bool
+    numpy_to_regular: bool
+    regular_to_jagged: bool
+    function_name: str | None
+    broadcast_parameters_rule: BroadcastParameterRule
+
+
 def length_of_broadcast(inputs: Sequence) -> int | type[unknown_length]:
     maxlen = -1
 
@@ -109,7 +119,7 @@ def in_function(options):
         return " in " + options["function_name"]
 
 
-def ensure_common_length(inputs, options) -> ShapeItem:
+def ensure_common_length(inputs, options: BroadcastOptions) -> ShapeItem:
     it = iter(inputs)
     length: int
     for content in it:
@@ -343,16 +353,6 @@ def left_broadcast_to(content: Content, depth: int) -> Content:
     for _ in range(content.purelist_depth, depth):
         content = RegularArray(content, 1, content.length)
     return content
-
-
-class BroadcastOptions(TypedDict):
-    allow_records: bool
-    left_broadcast: bool
-    right_broadcast: bool
-    numpy_to_regular: bool
-    regular_to_jagged: bool
-    function_name: str | None
-    broadcast_parameters_rule: BroadcastParameterRule
 
 
 def apply_step(

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -58,19 +58,21 @@ class BroadcastOptions(TypedDict):
 
 
 def length_of_broadcast(inputs: Sequence) -> int | type[unknown_length]:
-    maxlen = -1
+    maxlen = 1
 
+    has_seen_unknown_length: bool = False
     for x in inputs:
         if isinstance(x, Content):
             if x.length is unknown_length:
-                return x.length
+                has_seen_unknown_length = True
+                continue
+            else:
+                maxlen = max(maxlen, x.length)
 
-            maxlen = max(maxlen, x.length)
-
-    if maxlen < 0:
-        maxlen = 1
-
-    return maxlen
+    if has_seen_unknown_length:
+        return unknown_length
+    else:
+        return maxlen
 
 
 def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -109,7 +109,7 @@ def in_function(options):
         return " in " + options["function_name"]
 
 
-def checklength(inputs, options) -> ShapeItem:
+def ensure_common_length(inputs, options) -> ShapeItem:
     it = iter(inputs)
     length: int
     for content in it:
@@ -406,8 +406,8 @@ def apply_step(
                     options,
                 )
 
-    # Now all lengths must agree.
-    checklength(contents, options)
+    # Now all lengths must agree
+    length = ensure_common_length(contents, options)
 
     # Load the parameter broadcasting rule implementation
     rule = options["broadcast_parameters_rule"]
@@ -429,9 +429,6 @@ def apply_step(
 
         is_tuple: bool = True
         nextparameters = []
-
-        # Ensure all layouts have same length
-        length = checklength(contents, options)
 
         for x in contents:
             if x.is_record:
@@ -495,9 +492,6 @@ def apply_step(
         index_nplike = backend.index_nplike
         # All regular?
         if all(x.is_regular or not x.is_list for x in contents):
-            # Ensure all layouts have same length
-            length = checklength(contents, options)
-
             # Determine the size of the broadcast result
             dim_size = None
             for x in contents:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -121,7 +121,7 @@ def in_function(options):
 
 def ensure_common_length(inputs, options: BroadcastOptions) -> ShapeItem:
     it = iter(inputs)
-    length: int
+    length: ShapeItem = unknown_length
     for content in it:
         if content.length is not unknown_length:
             length = content.length
@@ -492,46 +492,46 @@ def apply_step(
         index_nplike = backend.index_nplike
         # All regular?
         if all(x.is_regular or not x.is_list for x in contents):
-            # Determine the size of the broadcast result
-            dim_size = None
-            for x in contents:
-                if not x.is_regular:
-                    continue
+            it_regular_contents = iter(c for c in contents if c.is_regular)
 
-                # Any unknown length sets max_size to unknown
-                if x.size is unknown_length:
-                    dim_size = unknown_length
-                # Any zero-length column triggers zero broadcasting
-                elif x.size == 0:
-                    dim_size = 0
+            # Find known size out of our contents
+            dim_size: ShapeItem
+            for content in it_regular_contents:
+                if content.size is not unknown_length:
+                    dim_size = content.size
                     break
-                # Take first size as dim_size
-                elif dim_size is None:
-                    dim_size = x.size
-                # If the dim_size is unknown, we can't compare
-                elif dim_size is unknown_length:
-                    continue
-                else:
-                    dim_size = max(dim_size, x.size)
+            else:
+                dim_size = unknown_length
+            # Now we know that we have at least one layout with concrete size, let's check the remainder
+            if not (dim_size is unknown_length or dim_size == 0):
+                # Determine the size of the broadcast result
+                for content in it_regular_contents:
+                    # Any unknown lengths can't be compared
+                    if content.size is unknown_length:
+                        continue
+                    # Any zero-length column triggers zero broadcasting
+                    elif content.size == 0:
+                        dim_size = 0
+                        break
+                    else:
+                        dim_size = max(dim_size, content.size)
 
-            dimsize_greater_than_one_if_known = (
-                dim_size is unknown_length or dim_size > 1
-            )
-            dimsize_known_to_be_zero = dim_size is not unknown_length and dim_size == 0
+            dimsize_maybe_broadcastable = dim_size is unknown_length or dim_size > 1
+            dimsize_is_zero = dim_size is not unknown_length and dim_size == 0
 
             # Build a broadcast index for size=1 contents
             size_one_carry_index = None
-            for x in contents:
-                if x.is_regular:
-                    x_size_known_to_be_one = (
-                        x.size is not unknown_length and x.size == 1
+            for content in contents:
+                if content.is_regular:
+                    content_size_maybe_one = (
+                        content.size is not unknown_length and content.size == 1
                     )
-                    if dimsize_greater_than_one_if_known and x_size_known_to_be_one:
+                    if dimsize_maybe_broadcastable and content_size_maybe_one:
                         # For any (N, 1) array, we know we'll broadcast to (N, M) where M is maxsize
                         size_one_carry_index = Index64(
                             index_nplike.repeat(
                                 index_nplike.arange(
-                                    index_nplike.shape_item_as_index(x.length),
+                                    index_nplike.shape_item_as_index(content.length),
                                     dtype=np.int64,
                                 ),
                                 index_nplike.shape_item_as_index(dim_size),
@@ -546,40 +546,42 @@ def apply_step(
             # 3. otherwise, recurse into the content as-is
             nextinputs = []
             nextparameters = []
-            for x in inputs:
-                if isinstance(x, RegularArray):
-                    x_size_known_to_be_one = (
-                        x.size is not unknown_length and x.size == 1
+            for content in inputs:
+                if isinstance(content, RegularArray):
+                    content_size_maybe_one = (
+                        content.size is not unknown_length and content.size == 1
                     )
                     # If dimsize is known to be exactly zero, all contents are zero length
-                    if dimsize_known_to_be_zero:
-                        nextinputs.append(x.content[:0])
-                        nextparameters.append(x._parameters)
+                    if dimsize_is_zero:
+                        nextinputs.append(content.content[:0])
+                        nextparameters.append(content._parameters)
                     # If we have a known size=1 content, then broadcast it to the dimension size
-                    elif dimsize_greater_than_one_if_known and x_size_known_to_be_one:
+                    elif dimsize_maybe_broadcastable and content_size_maybe_one:
                         nextinputs.append(
-                            x.content[: x.length * x.size]._carry(
+                            content.content[: content.length * content.size]._carry(
                                 size_one_carry_index, allow_lazy=False
                             )
                         )
-                        nextparameters.append(x._parameters)
+                        nextparameters.append(content._parameters)
                     # Any unknown values or sizes are assumed to be correct as-is
                     elif (
                         dim_size is unknown_length
-                        or x.size is unknown_length
-                        or x.size == dim_size
+                        or content.size is unknown_length
+                        or content.size == dim_size
                     ):
-                        nextinputs.append(x.content[: x.length * x.size])
-                        nextparameters.append(x._parameters)
+                        nextinputs.append(
+                            content.content[: content.length * content.size]
+                        )
+                        nextparameters.append(content._parameters)
                     else:
                         raise ValueError(
                             "cannot broadcast RegularArray of size "
                             "{} with RegularArray of size {} {}".format(
-                                x.size, dim_size, in_function(options)
+                                content.size, dim_size, in_function(options)
                             )
                         )
                 else:
-                    nextinputs.append(x)
+                    nextinputs.append(content)
                     nextparameters.append(NO_PARAMETERS)
 
             outcontent = apply_step(
@@ -607,30 +609,30 @@ def apply_step(
             nextinputs = []
             nextparameters = []
 
-            for x in inputs:
-                if isinstance(x, ListOffsetArray):
-                    offsets = x.offsets
+            for content in inputs:
+                if isinstance(content, ListOffsetArray):
+                    offsets = content.offsets
                     lencontent = index_nplike.index_as_shape_item(offsets[-1])
-                    nextinputs.append(x.content[:lencontent])
-                    nextparameters.append(x._parameters)
+                    nextinputs.append(content.content[:lencontent])
+                    nextparameters.append(content._parameters)
 
-                elif isinstance(x, ListArray):
-                    starts, stops = x.starts, x.stops
+                elif isinstance(content, ListArray):
+                    starts, stops = content.starts, content.stops
                     if (starts.length is not unknown_length and starts.length == 0) or (
                         stops.length is not unknown_length and stops.length == 0
                     ):
-                        nextinputs.append(x.content[:0])
+                        nextinputs.append(content.content[:0])
                     else:
                         lencontent = index_nplike.index_as_shape_item(
                             index_nplike.max(stops)
                         )
-                        nextinputs.append(x.content[:lencontent])
-                        nextparameters.append(x._parameters)
-                elif isinstance(x, RegularArray):
-                    nextinputs.append(x.content[: x.size * x.length])
-                    nextparameters.append(x._parameters)
+                        nextinputs.append(content.content[:lencontent])
+                        nextparameters.append(content._parameters)
+                elif isinstance(content, RegularArray):
+                    nextinputs.append(content.content[: content.size * content.length])
+                    nextparameters.append(content._parameters)
                 else:
-                    nextinputs.append(x)
+                    nextinputs.append(content)
                     nextparameters.append(NO_PARAMETERS)
 
             outcontent = apply_step(
@@ -676,9 +678,9 @@ def apply_step(
             offsets_content = None
             all_content_strings = True
             input_is_string = []
-            for x in inputs:
-                if isinstance(x, Content):
-                    content_is_string = x.parameter("__array__") in {
+            for content in inputs:
+                if isinstance(content, Content):
+                    content_is_string = content.parameter("__array__") in {
                         "string",
                         "bytestring",
                     }
@@ -686,8 +688,12 @@ def apply_step(
                     if not content_is_string:
                         all_content_strings = False
                         # Take the offsets from the first irregular list
-                        if x.is_list and not x.is_regular and offsets_content is None:
-                            offsets_content = x
+                        if (
+                            content.is_list
+                            and not content.is_regular
+                            and offsets_content is None
+                        ):
+                            offsets_content = content
                     input_is_string.append(content_is_string)
                 else:
                     input_is_string.append(False)
@@ -713,7 +719,7 @@ def apply_step(
 
             nextinputs = []
             nextparameters = []
-            for x, x_is_string in zip(inputs, input_is_string):
+            for content, x_is_string in zip(inputs, input_is_string):
                 if x_is_string:
                     offsets_data = backend.index_nplike.asarray(offsets)
                     counts = offsets_data[1:] - offsets_data[:-1]
@@ -724,23 +730,23 @@ def apply_step(
                     )
                     nextinputs.append(
                         ak.contents.IndexedArray(
-                            ak.index.Index64(parents, nplike=index_nplike), x
+                            ak.index.Index64(parents, nplike=index_nplike), content
                         ).project()
                     )
                     nextparameters.append(NO_PARAMETERS)
-                elif isinstance(x, listtypes):
-                    nextinputs.append(x._broadcast_tooffsets64(offsets).content)
-                    nextparameters.append(x._parameters)
+                elif isinstance(content, listtypes):
+                    nextinputs.append(content._broadcast_tooffsets64(offsets).content)
+                    nextparameters.append(content._parameters)
                 # Handle implicit left-broadcasting (non-NumPy-like broadcasting).
-                elif options["left_broadcast"] and isinstance(x, Content):
+                elif options["left_broadcast"] and isinstance(content, Content):
                     nextinputs.append(
-                        RegularArray(x, 1, x.length)
+                        RegularArray(content, 1, content.length)
                         ._broadcast_tooffsets64(offsets)
                         .content
                     )
                     nextparameters.append(NO_PARAMETERS)
                 else:
-                    nextinputs.append(x)
+                    nextinputs.append(content)
                     nextparameters.append(NO_PARAMETERS)
 
             outcontent = apply_step(

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -496,13 +496,7 @@ def apply_step(
         # All regular?
         if all(x.is_regular or not x.is_list for x in contents):
             # Ensure all layouts have same length
-            length = None
-            for x in contents:
-                if length is None:
-                    length = x.length
-                elif length is not unknown_length and x.length is not unknown_length:
-                    assert length == x.length
-            assert length is not None
+            length = checklength(contents, options)
 
             # Determine the size of the broadcast result
             dim_size = None


### PR DESCRIPTION
This PR is a first pass over the broadcasting logic to change direction from "unknown lengths are infectious" to "known lengths are infectious". 

As we've discussed here previously, typetracer should only fail for ahead-of-time known errors. We defer validation of the unknown data to runtime, via a second pass using a known-data backend. As such, we can rewrite assertions of the form `assert unknown_value == x` with `unknown_value = x`, rather than propagating unknown values everywhere.

i.e. operations like
```python
require_equal_lengths(contents)
next_length = unknown_length
```
become
```python
require_equal_lengths(contents)
next_length = contents[0].length
```

I think we might have assumed this before; I'm just getting around to changing the code after  re-orienting my thinking a while back. 

Relatedly, slicing typetracer arrays should assume that the length succeeds, and use the concrete length, for obvious reason.