### PR TITLE
feat!: apply retroactive deprecations

### DIFF
--- a/docs/user-guide/how-to-create-constructors.md
+++ b/docs/user-guide/how-to-create-constructors.md
@@ -100,7 +100,9 @@ Sections in this document about a subclass of Content are named "`Content >: XYZ
 Parameters
 ----------
 
-Each layout node can have arbitrary metadata, called "parameters." Some parameters have built-in meanings, which are described below, and others can be given meanings by defining functions in {data}`ak.behavior`.
+Each layout node can have arbitrary metadata[^foot], called "parameters." Some parameters have built-in meanings, which are described below, and others can be given meanings by defining functions in {data}`ak.behavior`.
+
+[^foot]: Except for `ak.contents.EmptyArray`, which is an identity type.
 
 +++
 
@@ -124,7 +126,7 @@ Content >: EmptyArray
 
 {class}`ak.contents.EmptyArray` is one of the two possible leaf types of a layout tree; the other is {class}`ak.contents.NumpyArray` (A third, corner-case "leaf type" is a {class}`ak.contents.RecordArray` with zero fields).
 
-EmptyArray is a trivial node type: it can only represent empty arrays with unknown type.
+EmptyArray is a trivial node type: it can only represent empty arrays with unknown type. It is an identity — when merging an array against an empty array, the empty array has no effect upon the result type. As such, this node cannot have user-defined parameters; {attr}`ak.contents.EmptyArray.parameters` is always empty.
 
 ```{code-cell} ipython3
 ak.contents.EmptyArray()
@@ -132,14 +134,6 @@ ak.contents.EmptyArray()
 
 ```{code-cell} ipython3
 ak.Array(ak.contents.EmptyArray())
-```
-
-Since this is such a simple node type, let's use it to show examples of adding parameters.
-
-```{code-cell} ipython3
-ak.contents.EmptyArray(
-    parameters={"name1": "value1", "name2": {"more": ["complex", "value"]}}
-)
 ```
 
 Content >: NumpyArray
@@ -194,6 +188,17 @@ ak.Array(
 ```
 
 If you are _producing_ arrays, you can pick any representation that is convenient. If you are _consuming_ arrays, you need to be aware of the different representations.
+
+Since this is such a simple node type, let's use it to show examples of adding parameters.
+
+```{code-cell} ipython3
+ak.Array(
+    ak.contents.NumpyArray(
+        np.array([[1, 2, 3], [4, 5, 6]]),
+        parameters={"name1": "value1", "name2": {"more": ["complex", "value"]}}
+    )
+)
+```
 
 +++
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -68,7 +68,7 @@ class EmptyArray(Content):
     is_leaf = True
 
     def __init__(self, *, parameters=None, backend=None):
-        if parameters is not None:
+        if not (parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if backend is None:
             backend = NumpyBackend.instance()
@@ -82,7 +82,7 @@ class EmptyArray(Content):
         parameters=UNSET,
         backend=UNSET,
     ):
-        if not (parameters is UNSET or parameters is None):
+        if not (parameters is UNSET or parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyArray(
             backend=self._backend if backend is UNSET else backend,
@@ -96,7 +96,7 @@ class EmptyArray(Content):
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
-        if not (parameters is UNSET or parameters is None):
+        if not (parameters is UNSET or parameters is None or parameters == {}):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(backend=backend)
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -68,7 +68,7 @@ class EmptyArray(Content):
     is_leaf = True
 
     def __init__(self, *, parameters=None, backend=None):
-        if not (parameters is None or parameters == {}):
+        if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if backend is None:
             backend = NumpyBackend.instance()
@@ -82,7 +82,7 @@ class EmptyArray(Content):
         parameters=UNSET,
         backend=UNSET,
     ):
-        if not (parameters is UNSET or parameters is None or parameters == {}):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyArray(
             backend=self._backend if backend is UNSET else backend,
@@ -96,7 +96,7 @@ class EmptyArray(Content):
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
-        if not (parameters is UNSET or parameters is None or parameters == {}):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(backend=backend)
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -96,7 +96,7 @@ class EmptyArray(Content):
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
-        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
+        if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(backend=backend)
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -8,7 +8,7 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import AxisError, deprecate
+from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -70,9 +70,7 @@ class EmptyArray(Content):
 
     def __init__(self, *, parameters=None, backend=None):
         if not (parameters is None or len(parameters) == 0):
-            deprecate(
-                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
-            )
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         if backend is None:
             backend = NumpyBackend.instance()
         self._init(parameters, backend)
@@ -86,9 +84,7 @@ class EmptyArray(Content):
         backend=UNSET,
     ):
         if not (parameters is UNSET or parameters is None or len(parameters) == 0):
-            deprecate(
-                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
-            )
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         return EmptyArray(
             parameters=self._parameters if parameters is UNSET else parameters,
             backend=self._backend if backend is UNSET else backend,
@@ -102,8 +98,7 @@ class EmptyArray(Content):
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
-        if not (parameters is None or len(parameters) == 0):
-            deprecate(f"{cls.__name__} cannot contain parameters", version="2.2.0")
+        raise ValueError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, backend=backend)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -68,8 +68,8 @@ class EmptyArray(Content):
     is_leaf = True
 
     def __init__(self, *, parameters=None, backend=None):
-        if not (parameters is None or len(parameters) == 0):
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+        if parameters is not None:
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if backend is None:
             backend = NumpyBackend.instance()
         self._init(parameters, backend)
@@ -83,7 +83,7 @@ class EmptyArray(Content):
         backend=UNSET,
     ):
         if not (parameters is UNSET or parameters is None):
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyArray(
             backend=self._backend if backend is UNSET else backend,
         )
@@ -97,7 +97,7 @@ class EmptyArray(Content):
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
         if not (parameters is UNSET or parameters is None):
-            raise ValueError(f"{cls.__name__} cannot contain parameters")
+            raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(backend=backend)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-import copy
 from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
@@ -83,10 +82,9 @@ class EmptyArray(Content):
         parameters=UNSET,
         backend=UNSET,
     ):
-        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
+        if not (parameters is UNSET or parameters is None):
             raise ValueError(f"{type(self).__name__} cannot contain parameters")
         return EmptyArray(
-            parameters=self._parameters if parameters is UNSET else parameters,
             backend=self._backend if backend is UNSET else backend,
         )
 
@@ -94,15 +92,16 @@ class EmptyArray(Content):
         return self.copy()
 
     def __deepcopy__(self, memo):
-        return self.copy(parameters=copy.deepcopy(self._parameters, memo))
+        return self.copy()
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):
-        raise ValueError(f"{cls.__name__} cannot contain parameters")
-        return cls(parameters=parameters, backend=backend)
+        if not (parameters is UNSET or parameters is None):
+            raise ValueError(f"{cls.__name__} cannot contain parameters")
+        return cls(backend=backend)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
-        return self.form_cls(parameters=self._parameters, form_key=getkey(self))
+        return self.form_cls(form_key=getkey(self))
 
     def _to_buffers(
         self,
@@ -116,7 +115,6 @@ class EmptyArray(Content):
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         return EmptyArray(
-            parameters=self._parameters,
             backend=TypeTracerBackend.instance(),
         )
 
@@ -248,7 +246,7 @@ class EmptyArray(Content):
             offsets = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
             return (
                 offsets,
-                EmptyArray(parameters=self._parameters, backend=self._backend),
+                EmptyArray(backend=self._backend),
             )
 
     def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
@@ -263,7 +261,7 @@ class EmptyArray(Content):
             return others[0]._mergemany(others[1:])
 
     def _fill_none(self, value: Content) -> Content:
-        return EmptyArray(parameters=self._parameters, backend=self._backend)
+        return EmptyArray(backend=self._backend)
 
     def _local_index(self, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
@@ -300,9 +298,7 @@ class EmptyArray(Content):
         return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        return ak.contents.EmptyArray(
-            parameters=self._parameters, backend=self._backend
-        )
+        return ak.contents.EmptyArray(backend=self._backend)
 
     def _reduce_next(
         self,
@@ -383,7 +379,7 @@ class EmptyArray(Content):
                 if options["keep_parameters"]:
                     return self
                 else:
-                    return EmptyArray(parameters=None, backend=self._backend)
+                    return EmptyArray(backend=self._backend)
 
         else:
 
@@ -417,7 +413,7 @@ class EmptyArray(Content):
         return []
 
     def _to_backend(self, backend: Backend) -> Self:
-        return EmptyArray(parameters=self._parameters, backend=backend)
+        return EmptyArray(backend=backend)
 
     def _is_equal_to(self, other, index_dtype, numpyarray):
         return True

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -17,24 +17,23 @@ class EmptyForm(Form):
     is_unknown = True
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
-        if not (parameters is None or len(parameters) == 0):
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+        if parameters is not None:
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
-        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+        if not (parameters is UNSET or parameters is None):
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
-            parameters=self._parameters if parameters is UNSET else parameters,
             form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
-        if not (parameters is None or len(parameters) == 0):
-            raise ValueError(f"{cls.__name__} cannot contain parameters")
+        if parameters is not None:
+            raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
 
     def __repr__(self):
@@ -46,7 +45,7 @@ class EmptyForm(Form):
 
     @property
     def type(self):
-        return ak.types.UnknownType(parameters=self._parameters)
+        return ak.types.UnknownType()
 
     def __eq__(self, other) -> bool:
         return isinstance(other, EmptyForm) and self._form_key == other._form_key
@@ -58,10 +57,10 @@ class EmptyForm(Form):
                 f"in favour of a new `primitive` argument. Pass `primitive` by keyword to opt-in to the new behavior.",
                 version="2.4.0",
             )
-            return ak.forms.numpyform.from_dtype(dtype, parameters=self._parameters)
+            return ak.forms.numpyform.from_dtype(dtype)
 
         def new_impl(*, primitive):
-            return ak.forms.numpyform.NumpyForm(primitive, parameters=self._parameters)
+            return ak.forms.numpyform.NumpyForm(primitive)
 
         dispatch_table = [
             new_impl,
@@ -81,10 +80,7 @@ class EmptyForm(Form):
         )
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
+        return None
 
     @property
     def purelist_isregular(self) -> bool:

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -18,18 +18,14 @@ class EmptyForm(Form):
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
         if not (parameters is None or len(parameters) == 0):
-            deprecate(
-                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
-            )
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
         if not (parameters is UNSET or parameters is None or len(parameters) == 0):
-            deprecate(
-                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
-            )
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
             parameters=self._parameters if parameters is UNSET else parameters,
             form_key=self._form_key if form_key is UNSET else form_key,
@@ -38,7 +34,7 @@ class EmptyForm(Form):
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
         if not (parameters is None or len(parameters) == 0):
-            deprecate(f"{cls.__name__} cannot contain parameters", version="2.2.0")
+            raise ValueError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
 
     def __repr__(self):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -17,14 +17,14 @@ class EmptyForm(Form):
     is_unknown = True
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
-        if not (parameters is None or parameters == {}):
+        if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
-        if not (parameters is UNSET or parameters is None or parameters == {}):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
             form_key=self._form_key if form_key is UNSET else form_key,
@@ -32,7 +32,7 @@ class EmptyForm(Form):
 
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
-        if not (parameters is None or parameters == {}):
+        if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
 

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -17,14 +17,14 @@ class EmptyForm(Form):
     is_unknown = True
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
-        if parameters is not None:
+        if not (parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
-        if not (parameters is UNSET or parameters is None):
+        if not (parameters is UNSET or parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
             form_key=self._form_key if form_key is UNSET else form_key,
@@ -32,7 +32,7 @@ class EmptyForm(Form):
 
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
-        if parameters is not None:
+        if not (parameters is None or parameters == {}):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
 

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -11,14 +11,14 @@ from awkward.types.type import Type
 class UnknownType(Type):
     def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
         if not (parameters is UNSET or parameters is None):
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return UnknownType(
             typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, *, parameters=None, typestr=None):
         if parameters is not None:
-            raise ValueError(f"{type(self).__name__} cannot contain parameters")
+            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if typestr is not None and not isinstance(typestr, str):
             raise TypeError(
                 "{} 'typestr' must be of type string or None, not {}".format(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -1,9 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from awkward._behavior import find_array_typestr
 from awkward._errors import deprecate
-from awkward._parameters import parameters_are_equal, type_parameters_equal
 from awkward._typing import Self, final
 from awkward._util import UNSET
 from awkward.types.type import Type
@@ -12,34 +10,29 @@ from awkward.types.type import Type
 @final
 class UnknownType(Type):
     def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
+        if not (parameters is UNSET or parameters is None):
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         return UnknownType(
-            parameters=self._parameters if parameters is UNSET else parameters,
             typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, *, parameters=None, typestr=None):
         if parameters is not None:
             raise ValueError(f"{type(self).__name__} cannot contain parameters")
-        if parameters is not None and not isinstance(parameters, dict):
-            raise TypeError(
-                "{} 'parameters' must be of type dict or None, not {}".format(
-                    type(self).__name__, repr(parameters)
-                )
-            )
         if typestr is not None and not isinstance(typestr, str):
             raise TypeError(
                 "{} 'typestr' must be of type string or None, not {}".format(
                     type(self).__name__, repr(typestr)
                 )
             )
-        self._parameters = parameters
+        self._parameters = None
         self._typestr = typestr
 
     def _str(self, indent, compact, behavior):
         if self._typestr is not None:
             deprecate("typestr argument is deprecated", "2.4.0")
 
-        typestr = find_array_typestr(behavior, self._parameters, self._typestr)
+        typestr = self._typestr
         if typestr is not None:
             out = [typestr]
 
@@ -57,9 +50,4 @@ class UnknownType(Type):
         return "{}({})".format(type(self).__name__, ", ".join(args))
 
     def _is_equal_to(self, other, all_parameters: bool):
-        compare_parameters = (
-            parameters_are_equal if all_parameters else type_parameters_equal
-        )
-        return isinstance(other, type(self)) and compare_parameters(
-            self._parameters, other._parameters
-        )
+        return isinstance(other, type(self))

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -19,9 +19,7 @@ class UnknownType(Type):
 
     def __init__(self, *, parameters=None, typestr=None):
         if parameters is not None:
-            deprecate(
-                f"{type(self).__name__} cannot contain parameters", version="2.2.0"
-            )
+            raise ValueError(f"{type(self).__name__} cannot contain parameters")
         if parameters is not None and not isinstance(parameters, dict):
             raise TypeError(
                 "{} 'parameters' must be of type dict or None, not {}".format(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -10,14 +10,14 @@ from awkward.types.type import Type
 @final
 class UnknownType(Type):
     def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
-        if not (parameters is UNSET or parameters is None):
+        if not (parameters is UNSET or parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return UnknownType(
             typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, *, parameters=None, typestr=None):
-        if parameters is not None:
+        if not (parameters is None or parameters == {}):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if typestr is not None and not isinstance(typestr, str):
             raise TypeError(

--- a/src/awkward/types/unknowntype.py
+++ b/src/awkward/types/unknowntype.py
@@ -10,14 +10,14 @@ from awkward.types.type import Type
 @final
 class UnknownType(Type):
     def copy(self, *, parameters=UNSET, typestr=UNSET) -> Self:
-        if not (parameters is UNSET or parameters is None or parameters == {}):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return UnknownType(
             typestr=self._typestr if typestr is UNSET else typestr,
         )
 
     def __init__(self, *, parameters=None, typestr=None):
-        if not (parameters is None or parameters == {}):
+        if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         if typestr is not None and not isinstance(typestr, str):
             raise TypeError(

--- a/tests/test_0032_replace_dressedtype.py
+++ b/tests/test_0032_replace_dressedtype.py
@@ -12,9 +12,10 @@ def test_types_with_parameters():
     t = ak.types.UnknownType()
     assert t.parameters == {}
 
-    with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(parameters={"latitude": ["val", "ue"]})
-        assert t.parameters == {"latitude": ["val", "ue"]}
+    with pytest.raises(TypeError):
+        ak.types.UnknownType(parameters={"latitude": ["val", "ue"]})
+    t = ak.types.UnknownType()
+    assert t.parameters == {}
 
     t = ak.types.NumpyType("int32", parameters={"latitude": ["val", "ue"]})
     assert t.parameters == {"latitude": ["val", "ue"]}
@@ -50,17 +51,6 @@ def test_types_with_parameters():
         parameters={"latitude": ["val", "ue"]},
     )
     assert t.parameters == {"latitude": ["val", "ue"]}
-
-    with pytest.warns(DeprecationWarning):
-        t = ak.types.UnknownType(
-            parameters={"key1": ["val", "ue"], "__record__": "one \u2192 two"}
-        )
-        assert t.parameters == {"__record__": "one \u2192 two", "key1": ["val", "ue"]}
-
-        assert t == ak.types.UnknownType(
-            parameters={"__record__": "one \u2192 two", "key1": ["val", "ue"]}
-        )
-        assert t != ak.types.UnknownType(parameters={"latitude": ["val", "ue"]})
 
 
 def test_dress():

--- a/tests/test_0057_introducing_forms.py
+++ b/tests/test_0057_introducing_forms.py
@@ -96,22 +96,24 @@ def test_forms():
         "form_key": "yowzers",
     }
 
-    with pytest.warns(DeprecationWarning):
-        form = ak.forms.EmptyForm(
+    with pytest.raises(TypeError):
+        ak.forms.EmptyForm(
             parameters={"hey": ["you"]},
             form_key="yowzers",
         )
-        assert form == form
-        assert pickle.loads(pickle.dumps(form, -1)) == form
-        assert ak.forms.from_json(form.to_json()) == form
+    form = ak.forms.EmptyForm(
+        form_key="yowzers",
+    )
+    assert form == form
+    assert pickle.loads(pickle.dumps(form, -1)) == form
+    assert ak.forms.from_json(form.to_json()) == form
     assert json.loads(form.to_json()) == {
         "class": "EmptyArray",
-        "parameters": {"hey": ["you"]},
+        "parameters": {},
         "form_key": "yowzers",
     }
     assert json.loads(str(form)) == {
         "class": "EmptyArray",
-        "parameters": {"hey": ["you"]},
         "form_key": "yowzers",
     }
 

--- a/tests/test_0089_numpy_functions.py
+++ b/tests/test_0089_numpy_functions.py
@@ -192,17 +192,8 @@ def test_tonumpy():
     array = ak.highlevel.Array(
         ak.contents.UnionArray(tags, index, [content0, content1]), check_valid=True
     )
-    with pytest.warns(DeprecationWarning):
-        assert ak.operations.to_numpy(array).tolist() == [
-            "1.1",
-            "1",
-            "2",
-            "2.2",
-            "3.3",
-            "4.4",
-            "3",
-            "5.5",
-        ]
+    with pytest.raises(TypeError):
+        assert ak.operations.to_numpy(array)
 
     assert ak.operations.to_numpy(
         ak.highlevel.Array([1.1, 2.2, None, None, 3.3], check_valid=True)
@@ -281,17 +272,8 @@ def test_numpy_array():
     array = ak.highlevel.Array(
         ak.contents.UnionArray(tags, index, [content0, content1]), check_valid=True
     )
-    with pytest.warns(DeprecationWarning):
-        assert np.asarray(array).tolist() == [
-            "1.1",
-            "1",
-            "2",
-            "2.2",
-            "3.3",
-            "4.4",
-            "3",
-            "5.5",
-        ]
+    with pytest.raises(TypeError):
+        np.asarray(array)
 
     assert ak.operations.to_numpy(
         ak.highlevel.Array([1.1, 2.2, None, None, 3.3], check_valid=True)

--- a/tests/test_0773_typeparser.py
+++ b/tests/test_0773_typeparser.py
@@ -35,10 +35,8 @@ def test_unknown_1():
 
 def test_unknown_2():
     text = 'unknown[parameters={"wonky": ["parameter", 3.14]}]'
-    with pytest.warns(DeprecationWarning):
-        parsedtype = ak.types.from_datashape(text, highlevel=False)
-    assert isinstance(parsedtype, ak.types.UnknownType)
-    assert str(parsedtype) == text
+    with pytest.raises(ValueError):
+        ak.types.from_datashape(text, highlevel=False)
 
 
 def test_record_tuple_1():
@@ -148,10 +146,8 @@ def test_option_unknown_1():
 
 def test_option_unknown_2():
     text = '?unknown[parameters={"foo": "bar"}]'
-    with pytest.warns(DeprecationWarning):
-        parsedtype = ak.types.from_datashape(text, highlevel=False)
-    assert isinstance(parsedtype, ak.types.OptionType)
-    assert str(parsedtype) == text
+    with pytest.raises(ValueError):
+        ak.types.from_datashape(text, highlevel=False)
 
 
 def test_option_unknown_1_parm():
@@ -489,21 +485,18 @@ def test_unknowntype():
 
 
 def test_unknowntype_parameter():
-    with pytest.warns(DeprecationWarning):
-        t = UnknownType(parameters={"__array__": "Something"})
-        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.raises(ValueError):
+        UnknownType(parameters={"__array__": "Something"})
 
 
 def test_unknowntype_categorical():
-    with pytest.warns(DeprecationWarning):
-        t = UnknownType(parameters={"__categorical__": True})
-        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.raises(ValueError):
+        UnknownType(parameters={"__categorical__": True})
 
 
 def test_unknowntype_categorical_parameter():
-    with pytest.warns(DeprecationWarning):
-        t = UnknownType(parameters={"__array__": "Something", "__categorical__": True})
-        assert str(ak.types.from_datashape(str(t), highlevel=False)) == str(t)
+    with pytest.raises(ValueError):
+        UnknownType(parameters={"__array__": "Something", "__categorical__": True})
 
 
 def test_regulartype_numpytype():

--- a/tests/test_0773_typeparser.py
+++ b/tests/test_0773_typeparser.py
@@ -35,7 +35,7 @@ def test_unknown_1():
 
 def test_unknown_2():
     text = 'unknown[parameters={"wonky": ["parameter", 3.14]}]'
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ak.types.from_datashape(text, highlevel=False)
 
 
@@ -146,7 +146,7 @@ def test_option_unknown_1():
 
 def test_option_unknown_2():
     text = '?unknown[parameters={"foo": "bar"}]'
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ak.types.from_datashape(text, highlevel=False)
 
 
@@ -485,17 +485,17 @@ def test_unknowntype():
 
 
 def test_unknowntype_parameter():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         UnknownType(parameters={"__array__": "Something"})
 
 
 def test_unknowntype_categorical():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         UnknownType(parameters={"__categorical__": True})
 
 
 def test_unknowntype_categorical_parameter():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         UnknownType(parameters={"__array__": "Something", "__categorical__": True})
 
 

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -29,31 +29,11 @@ def assert_overrides_typestr(
 
 def test_UnknownType():
     assert str(ak.types.unknowntype.UnknownType()) == "unknown"
-    with pytest.warns(DeprecationWarning):
-        assert (
-            str(ak.types.unknowntype.UnknownType(parameters={"x": 123}))
-            == 'unknown[parameters={"x": 123}]'
-        )
-    with pytest.warns(DeprecationWarning):
-        assert (
-            str(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
-            == "categorical[type=unknown]"
-        )
-        assert (
-            str(
-                ak.types.unknowntype.UnknownType(
-                    parameters={"__categorical__": True, "x": 123}
-                )
-            )
-            == 'categorical[type=unknown[parameters={"x": 123}]]'
-        )
-
+    with pytest.raises(TypeError):
+        ak.types.unknowntype.UnknownType(parameters={"x": 123})
+    with pytest.raises(TypeError):
+        ak.types.unknowntype.UnknownType(parameters={"__categorical__": True})
     assert repr(ak.types.unknowntype.UnknownType()) == "UnknownType()"
-    with pytest.warns(DeprecationWarning):
-        assert (
-            repr(ak.types.unknowntype.UnknownType(parameters={"__categorical__": True}))
-            == "UnknownType(parameters={'__categorical__': True})"
-        )
 
 
 @pytest.mark.skipif(
@@ -1206,23 +1186,16 @@ def test_EmptyForm():
     "class": "EmptyArray"
 }"""
     )
-    with pytest.warns(DeprecationWarning):
-        assert (
-            str(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
-            == """{
+    assert (
+        str(ak.forms.emptyform.EmptyForm(form_key="hello"))
+        == """{
     "class": "EmptyArray",
-    "parameters": {
-        "x": 123
-    },
     "form_key": "hello"
 }"""
-        )
+    )
     assert repr(ak.forms.emptyform.EmptyForm()) == "EmptyForm()"
-    with pytest.warns(DeprecationWarning):
-        assert (
-            repr(ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello"))
-            == "EmptyForm(parameters={'x': 123}, form_key='hello')"
-        )
+    with pytest.raises(TypeError):
+        ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello")
 
     assert ak.forms.emptyform.EmptyForm().to_dict(verbose=False) == {
         "class": "EmptyArray"
@@ -1232,31 +1205,15 @@ def test_EmptyForm():
         "parameters": {},
         "form_key": None,
     }
-    with pytest.warns(DeprecationWarning):
-        assert ak.forms.emptyform.EmptyForm(
-            parameters={"x": 123}, form_key="hello"
-        ).to_dict(verbose=False) == {
-            "class": "EmptyArray",
-            "parameters": {"x": 123},
-            "form_key": "hello",
-        }
+    assert ak.forms.emptyform.EmptyForm(form_key="hello").to_dict(verbose=False) == {
+        "class": "EmptyArray",
+        "form_key": "hello",
+    }
     assert ak.forms.from_dict({"class": "EmptyArray"}).to_dict() == {
         "class": "EmptyArray",
         "parameters": {},
         "form_key": None,
     }
-    with pytest.warns(DeprecationWarning):
-        assert ak.forms.from_dict(
-            {
-                "class": "EmptyArray",
-                "parameters": {"x": 123},
-                "form_key": "hello",
-            }
-        ).to_dict() == {
-            "class": "EmptyArray",
-            "parameters": {"x": 123},
-            "form_key": "hello",
-        }
 
 
 @pytest.mark.skipif(

--- a/tests/test_1125_to_arrow_from_arrow.py
+++ b/tests/test_1125_to_arrow_from_arrow.py
@@ -241,15 +241,14 @@ def test_indexedoptionarray_numpyarray(tmp_path, extensionarray):
 
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, extensionarray):
-    with pytest.warns(DeprecationWarning):
-        akarray = ak.contents.IndexedOptionArray(
-            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-            ak.contents.EmptyArray(parameters={"which": "inner"}),
-            parameters={"which": "outer"},
-        )
-        paarray = akarray.to_arrow(extensionarray=extensionarray)
-        arrow_round_trip(akarray, paarray, extensionarray)
-        parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
+    akarray = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+        ak.contents.EmptyArray(),
+        parameters={"which": "outer"},
+    )
+    paarray = akarray.to_arrow(extensionarray=extensionarray)
+    arrow_round_trip(akarray, paarray, extensionarray)
+    parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
 
 @pytest.mark.parametrize("categorical_as_dictionary", [False, True])

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -290,18 +290,16 @@ def test_indexedoptionarray_numpyarray(tmp_path, through, extensionarray):
 @pytest.mark.parametrize("through", [through_arrow, through_parquet])
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, through, extensionarray):
-    with pytest.warns(DeprecationWarning):
-        akarray = ak.contents.IndexedOptionArray(
-            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-            ak.contents.EmptyArray(parameters={"which": "inner"}),
-            parameters={"which": "outer"},
-        )
+    akarray = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+        ak.contents.EmptyArray(),
+    )
 
-        schema_arrow, array_form = through(akarray, extensionarray, tmp_path)
-        predicted_form = ak._connect.pyarrow.form_handle_arrow(
-            schema_arrow, pass_empty_field=True
-        )
-        assert predicted_form == array_form
+    schema_arrow, array_form = through(akarray, extensionarray, tmp_path)
+    predicted_form = ak._connect.pyarrow.form_handle_arrow(
+        schema_arrow, pass_empty_field=True
+    )
+    assert predicted_form == array_form
 
 
 @pytest.mark.parametrize("categorical_as_dictionary", [False, True])

--- a/tests/test_1440_start_v2_to_parquet.py
+++ b/tests/test_1440_start_v2_to_parquet.py
@@ -212,13 +212,12 @@ def test_indexedoptionarray_numpyarray(tmp_path, extensionarray):
 
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_indexedoptionarray_emptyarray(tmp_path, extensionarray):
-    with pytest.warns(DeprecationWarning):
-        akarray = ak.contents.IndexedOptionArray(
-            ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
-            ak.contents.EmptyArray(parameters={"which": "inner"}),
-            parameters={"which": "outer"},
-        )
-        parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
+    akarray = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.array([-1, -1, -1, -1, -1], dtype=np.int64)),
+        ak.contents.EmptyArray(),
+        parameters={"which": "outer"},
+    )
+    parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
- Raise error for `parameters` that are neither `None` or `{}` in `EmptyForm` et al.
  - We still allow `parameters=None` and `parameters={}` in the constructor arguments, to ensure that content-naive workflows still work.
- Raise error for conversions of unions to backend arrays
 
