### PR TITLE
fix: restore NEP-18 overloads for concatenate and where

### DIFF
--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -17,6 +17,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@ak._connect.numpy.implements("concatenate")
 @high_level_function
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -12,6 +12,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
+@ak._connect.numpy.implements("where")
 @high_level_function
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """


### PR DESCRIPTION
These were accidentally removed by `semgrep` when I was refactoring the high-level API in #2531. I've grepped the guilty merge commit to ensure that these are the only two functions.