### PR TITLE
feat: add support for expected termination of transform functions

### DIFF
--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -511,7 +511,13 @@ def _impl(
             options,
         )
 
-        if return_value != "none":
+        if return_value == "none":
+            return None
+        elif expect_termination and not transformer_did_terminate:
+            raise RuntimeError(
+                "the transformation function was expected to terminate by returning a Content, but instead only returned None."
+            )
+        else:
             return wrap_layout(out, behavior, highlevel)
 
     else:
@@ -563,8 +569,8 @@ def _impl(
             return
         elif expect_termination and not transformer_did_terminate:
             raise RuntimeError(
-                "the transformation function was expected to terminate by returning a layout, "
-                "or tuple of layouts, but instead only returned None."
+                "the transformation function was expected to terminate by returning a Content, "
+                "or tuple of Contents, but instead only returned None."
             )
         else:
             if len(out) == 1:

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -26,6 +26,7 @@ def transform(
     numpy_to_regular=False,
     regular_to_jagged=False,
     return_value="simplified",
+    expect_termination=False,
     highlevel=True,
     behavior=None,
 ):
@@ -73,6 +74,8 @@ def transform(
             nodes are not nested inappropriately. Note that if `return_value` is `"none"`,
             the only way to get information out of this function is through the
             `lateral_context`.
+        expect_termination (bool): If True, raise a `RuntimeError` if the transformer
+            does not terminate the recursion.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -428,6 +431,7 @@ def transform(
         numpy_to_regular,
         regular_to_jagged,
         return_value,
+        expect_termination,
         behavior,
         highlevel,
     )
@@ -446,6 +450,7 @@ def _impl(
     numpy_to_regular,
     regular_to_jagged,
     return_value,
+    expect_termination,
     behavior,
     highlevel,
 ):
@@ -472,17 +477,22 @@ def _impl(
         "return_array": return_value != "none",
         "function_name": "ak.transform",
         "broadcast_parameters_rule": broadcast_parameters_rule,
+        "expect_termination": expect_termination,
     }
+
+    transformer_did_terminate = False
 
     if len(more_layouts) == 0:
 
         def action(layout, **kwargs):
+            nonlocal transformer_did_terminate
             out = transformation(layout, **kwargs)
 
             if out is None:
                 return out
 
             elif isinstance(out, ak.contents.Content):
+                transformer_did_terminate = True
                 return out
 
             else:
@@ -507,6 +517,7 @@ def _impl(
     else:
 
         def action(inputs, **kwargs):
+            nonlocal transformer_did_terminate
             out = transformation(tuple(inputs), **kwargs)
 
             if out is None:
@@ -516,6 +527,7 @@ def _impl(
                     return None
 
             elif isinstance(out, tuple):
+                transformer_did_terminate = True
                 for x in out:
                     if not isinstance(x, ak.contents.Content):
                         raise TypeError(
@@ -524,6 +536,7 @@ def _impl(
                 return out
 
             elif isinstance(out, ak.contents.Content):
+                transformer_did_terminate = True
                 return (out,)
 
             else:
@@ -546,7 +559,14 @@ def _impl(
         assert isinstance(out, tuple)
         out = [ak._broadcasting.broadcast_unpack(x, isscalar, backend) for x in out]
 
-        if return_value != "none":
+        if return_value == "none":
+            return
+        elif expect_termination and not transformer_did_terminate:
+            raise RuntimeError(
+                "the transformation function was expected to terminate by returning a layout, "
+                "or tuple of layouts, but instead only returned None."
+            )
+        else:
             if len(out) == 1:
                 return wrap_layout(out[0], behavior, highlevel)
             else:

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -26,7 +26,7 @@ def transform(
     numpy_to_regular=False,
     regular_to_jagged=False,
     return_value="simplified",
-    expect_termination=False,
+    expect_return_value=False,
     highlevel=True,
     behavior=None,
 ):
@@ -74,7 +74,7 @@ def transform(
             nodes are not nested inappropriately. Note that if `return_value` is `"none"`,
             the only way to get information out of this function is through the
             `lateral_context`.
-        expect_termination (bool): If True, raise a `RuntimeError` if the transformer
+        expect_return_value (bool): If True, raise a `RuntimeError` if the transformer
             does not terminate the recursion.
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
@@ -431,7 +431,7 @@ def transform(
         numpy_to_regular,
         regular_to_jagged,
         return_value,
-        expect_termination,
+        expect_return_value,
         behavior,
         highlevel,
     )
@@ -450,7 +450,7 @@ def _impl(
     numpy_to_regular,
     regular_to_jagged,
     return_value,
-    expect_termination,
+    expect_return_value,
     behavior,
     highlevel,
 ):
@@ -477,7 +477,7 @@ def _impl(
         "return_array": return_value != "none",
         "function_name": "ak.transform",
         "broadcast_parameters_rule": broadcast_parameters_rule,
-        "expect_termination": expect_termination,
+        "expect_return_value": expect_return_value,
     }
 
     transformer_did_terminate = False
@@ -513,7 +513,7 @@ def _impl(
 
         if return_value == "none":
             return None
-        elif expect_termination and not transformer_did_terminate:
+        elif expect_return_value and not transformer_did_terminate:
             raise RuntimeError(
                 "the transformation function was expected to terminate by returning a Content, but instead only returned None."
             )
@@ -567,7 +567,7 @@ def _impl(
 
         if return_value == "none":
             return
-        elif expect_termination and not transformer_did_terminate:
+        elif expect_return_value and not transformer_did_terminate:
             raise RuntimeError(
                 "the transformation function was expected to terminate by returning a Content, "
                 "or tuple of Contents, but instead only returned None."

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -515,7 +515,8 @@ def _impl(
             return None
         elif expect_return_value and not transformer_did_terminate:
             raise RuntimeError(
-                "the transformation function was expected to terminate by returning a Content, but instead only returned None."
+                "the transformation function was expected to terminate by returning a Content, "
+                "but instead only returned None."
             )
         else:
             return wrap_layout(out, behavior, highlevel)
@@ -537,7 +538,8 @@ def _impl(
                 for x in out:
                     if not isinstance(x, ak.contents.Content):
                         raise TypeError(
-                            f"transformation must return a Content, tuple of Contents, or None, not a tuple containing {type(x)}\n\n{x!r}"
+                            f"transformation must return a Content, tuple of Contents, or None, "
+                            f"not a tuple containing {type(x)}\n\n{x!r}"
                         )
                 return out
 
@@ -572,8 +574,7 @@ def _impl(
                 "the transformation function was expected to terminate by returning a Content, "
                 "or tuple of Contents, but instead only returned None."
             )
+        elif len(out) == 1:
+            return wrap_layout(out[0], behavior, highlevel)
         else:
-            if len(out) == 1:
-                return wrap_layout(out[0], behavior, highlevel)
-            else:
-                return tuple(wrap_layout(x, behavior, highlevel) for x in out)
+            return tuple(wrap_layout(x, behavior, highlevel) for x in out)

--- a/tests/test_2595_transform_termination.py
+++ b/tests/test_2595_transform_termination.py
@@ -1,0 +1,73 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+def test_single_no_termination():
+    def transform(layout, **kwargs):
+        pass
+
+    with pytest.raises(RuntimeError, match=r"expected to terminate"):
+        ak.transform(transform, [{"x": 1}], expect_termination=True)
+
+    result = ak.transform(transform, [{"x": 1}], expect_termination=False)
+    assert result.to_list() == [{"x": 1}]
+
+    result = ak.transform(
+        transform, [{"x": 1}], expect_termination=True, return_value="none"
+    )
+    assert result is None
+
+
+def test_single_termination():
+    def transform(layout, **kwargs):
+        if layout.is_numpy:
+            return ak.contents.NumpyArray(layout.data * 2)
+
+    result = ak.transform(transform, [{"x": 1}], expect_termination=True)
+    assert result.to_list() == [{"x": 2}]
+
+    result = ak.transform(transform, [{"x": 1}], expect_termination=False)
+    assert result.to_list() == [{"x": 2}]
+
+    ak.transform(transform, [{"x": 1}], expect_termination=True, return_value="none")
+    assert result.to_list() == [{"x": 2}]
+
+
+def test_many_no_termination():
+    def transform(layout, **kwargs):
+        pass
+
+    with pytest.raises(RuntimeError, match=r"expected to terminate"):
+        ak.transform(transform, [{"x": 1}], [2], expect_termination=True)
+
+    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=False)
+    assert result[0].to_list() == [{"x": 1}]
+    assert result[1].to_list() == [{"x": 2}]
+
+    result = ak.transform(
+        transform, [{"x": 1}], [2], expect_termination=True, return_value="none"
+    )
+    assert result is None
+
+
+def test_many_termination():
+    def transform(inputs, **kwargs):
+        if all(layout.is_numpy for layout in inputs):
+            return tuple([ak.contents.NumpyArray(layout.data * 2) for layout in inputs])
+
+    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=True)
+    assert result[0].to_list() == [{"x": 2}]
+    assert result[1].to_list() == [{"x": 4}]
+
+    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=False)
+    assert result[0].to_list() == [{"x": 2}]
+    assert result[1].to_list() == [{"x": 4}]
+
+    ak.transform(
+        transform, [{"x": 1}], [2], expect_termination=True, return_value="none"
+    )
+    assert result[0].to_list() == [{"x": 2}]
+    assert result[1].to_list() == [{"x": 4}]

--- a/tests/test_2595_transform_termination.py
+++ b/tests/test_2595_transform_termination.py
@@ -10,13 +10,13 @@ def test_single_no_termination():
         pass
 
     with pytest.raises(RuntimeError, match=r"expected to terminate"):
-        ak.transform(transform, [{"x": 1}], expect_termination=True)
+        ak.transform(transform, [{"x": 1}], expect_return_value=True)
 
-    result = ak.transform(transform, [{"x": 1}], expect_termination=False)
+    result = ak.transform(transform, [{"x": 1}], expect_return_value=False)
     assert result.to_list() == [{"x": 1}]
 
     result = ak.transform(
-        transform, [{"x": 1}], expect_termination=True, return_value="none"
+        transform, [{"x": 1}], expect_return_value=True, return_value="none"
     )
     assert result is None
 
@@ -26,13 +26,13 @@ def test_single_termination():
         if layout.is_numpy:
             return ak.contents.NumpyArray(layout.data * 2)
 
-    result = ak.transform(transform, [{"x": 1}], expect_termination=True)
+    result = ak.transform(transform, [{"x": 1}], expect_return_value=True)
     assert result.to_list() == [{"x": 2}]
 
-    result = ak.transform(transform, [{"x": 1}], expect_termination=False)
+    result = ak.transform(transform, [{"x": 1}], expect_return_value=False)
     assert result.to_list() == [{"x": 2}]
 
-    ak.transform(transform, [{"x": 1}], expect_termination=True, return_value="none")
+    ak.transform(transform, [{"x": 1}], expect_return_value=True, return_value="none")
     assert result.to_list() == [{"x": 2}]
 
 
@@ -41,14 +41,14 @@ def test_many_no_termination():
         pass
 
     with pytest.raises(RuntimeError, match=r"expected to terminate"):
-        ak.transform(transform, [{"x": 1}], [2], expect_termination=True)
+        ak.transform(transform, [{"x": 1}], [2], expect_return_value=True)
 
-    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=False)
+    result = ak.transform(transform, [{"x": 1}], [2], expect_return_value=False)
     assert result[0].to_list() == [{"x": 1}]
     assert result[1].to_list() == [{"x": 2}]
 
     result = ak.transform(
-        transform, [{"x": 1}], [2], expect_termination=True, return_value="none"
+        transform, [{"x": 1}], [2], expect_return_value=True, return_value="none"
     )
     assert result is None
 
@@ -58,16 +58,16 @@ def test_many_termination():
         if all(layout.is_numpy for layout in inputs):
             return tuple([ak.contents.NumpyArray(layout.data * 2) for layout in inputs])
 
-    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=True)
+    result = ak.transform(transform, [{"x": 1}], [2], expect_return_value=True)
     assert result[0].to_list() == [{"x": 2}]
     assert result[1].to_list() == [{"x": 4}]
 
-    result = ak.transform(transform, [{"x": 1}], [2], expect_termination=False)
+    result = ak.transform(transform, [{"x": 1}], [2], expect_return_value=False)
     assert result[0].to_list() == [{"x": 2}]
     assert result[1].to_list() == [{"x": 4}]
 
     ak.transform(
-        transform, [{"x": 1}], [2], expect_termination=True, return_value="none"
+        transform, [{"x": 1}], [2], expect_return_value=True, return_value="none"
     )
     assert result[0].to_list() == [{"x": 2}]
     assert result[1].to_list() == [{"x": 4}]


### PR DESCRIPTION
#2593 demonstrates a case where it would be nice for `ak.transform` to be able to error if the user function never terminates.

This PR adds an `expect_return_value` argument, which causes `ak.transform` to throw a `RuntimeError` if the user transform is supposed to return a non-None value, but never terminates.