### PR TITLE
fix: add inline to prevent multiple definitions

### DIFF
--- a/.github/workflows/header-only-test.yml
+++ b/.github/workflows/header-only-test.yml
@@ -2,8 +2,8 @@ name: Header-only Tests
 
 on:
   pull_request:
-    # paths:
-      # - 'header-only'
+     paths:
+       - 'header-only'
 
   workflow_dispatch:
 

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -13,13 +13,13 @@
 #include <string>
 #include <functional>
 
+/// @brief Object of {@link BuilderOptions BuilderOptions} which sets the
+/// values of the default options.
+#define AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS awkward::BuilderOptions(1024, 1)
+
 namespace awkward {
 
   namespace LayoutBuilder {
-
-    /// @brief Object of {@link BuilderOptions BuilderOptions} which sets the
-    /// values of the default options.
-    inline awkward::BuilderOptions default_options(1024, 1);
 
     /// @class Field
     ///
@@ -55,10 +55,10 @@ namespace awkward {
     class Numpy {
     public:
       /// @brief Creates a new Numpy layout builder by allocating a new buffer,
-      /// using `default_options` for initializing the buffer.
+      /// using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       Numpy()
           : data_(
-                awkward::GrowableBuffer<PRIMITIVE>(default_options)) {
+                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
       }
@@ -210,10 +210,10 @@ namespace awkward {
     class ListOffset {
     public:
       /// @brief Creates a new ListOffset layout builder by allocating a new `offset`
-      ///  buffer, using `default_options` for initializing the buffer.
+      ///  buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       ListOffset()
           : offsets_(
-                awkward::GrowableBuffer<PRIMITIVE>(default_options)) {
+                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         offsets_.append(0);
         size_t id = 0;
         set_id(id);
@@ -1034,10 +1034,10 @@ namespace awkward {
     class IndexedOption {
     public:
       /// @brief Creates a new IndexedOption layout builder by allocating a new `index`
-      /// buffer, using `default_options` for initializing the buffer.
+      /// buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       IndexedOption()
           : index_(
-                awkward::GrowableBuffer<PRIMITIVE>(default_options)),
+                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
             last_valid_(-1) {
         size_t id = 0;
         set_id(id);
@@ -1358,9 +1358,9 @@ namespace awkward {
     class ByteMasked {
     public:
       /// @brief Creates a new ByteMasked layout builder by allocating a new `mask`
-      ///  buffer, using `default_options` for initializing the buffer.
+      ///  buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       ByteMasked()
-          : mask_(awkward::GrowableBuffer<int8_t>(default_options)) {
+          : mask_(awkward::GrowableBuffer<int8_t>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
       }
@@ -1571,9 +1571,9 @@ namespace awkward {
     class BitMasked {
     public:
       /// @brief Creates a new BitMasked layout builder by allocating a new `mask`
-      /// buffer, using `default_options` for initializing the buffer.
+      /// buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       BitMasked()
-          : mask_(awkward::GrowableBuffer<uint8_t>(default_options)),
+          : mask_(awkward::GrowableBuffer<uint8_t>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
             current_byte_(uint8_t(0)),
             current_byte_ref_(mask_.append_and_get_ref(current_byte_)),
             current_index_(0) {
@@ -1877,10 +1877,10 @@ namespace awkward {
       using ContentType = std::tuple_element_t<I, Contents>;
 
       /// @brief Creates a new Union layout builder by allocating new tags and
-      /// index buffers, using `default_options` for initializing the buffer.
+      /// index buffers, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       Union()
-          : tags_(awkward::GrowableBuffer<TAGS>(default_options)),
-            index_(awkward::GrowableBuffer<INDEX>(default_options)) {
+          : tags_(awkward::GrowableBuffer<TAGS>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
+            index_(awkward::GrowableBuffer<INDEX>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
         for (size_t i = 0; i < contents_count_; i++)

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -19,7 +19,7 @@ namespace awkward {
 
     /// @brief Object of {@link BuilderOptions BuilderOptions} which sets the
     /// values of the default options.
-    awkward::BuilderOptions default_options(1024, 1);
+    inline awkward::BuilderOptions default_options(1024, 1);
 
     /// @class Field
     ///

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -415,7 +415,7 @@ namespace awkward {
       /// contents in the form of a JSON-like string.
       std::string
       form() const noexcept {
-        return "{ \"class\": \"EmptyArray\", \"parameters\": {} }";
+        return "{ \"class\": \"EmptyArray\" }";
       }
 
     private:

--- a/header-only/layout-builder/awkward/utils.h
+++ b/header-only/layout-builder/awkward/utils.h
@@ -30,7 +30,7 @@ namespace awkward {
 
   /// @brief Returns the name of a primitive type as a string.
   template <typename T>
-  const std::string
+  inline const std::string
   type_to_name() {
     if (is_integral_v<T>) {
       if (is_signed_v<T>) {
@@ -81,7 +81,7 @@ namespace awkward {
   }
 
   template <>
-  const std::string
+  inline const std::string
   type_to_name<bool>() {
     // This takes precedence over the unspecialized template, and therefore any
     // 8-bit data that is not named bool will be mapped to "int8" or "uint8".
@@ -89,7 +89,7 @@ namespace awkward {
   }
 
   template <>
-  const std::string
+  inline const std::string
   type_to_name<char>() {
     // This takes precedence over the unspecialized template, and therefore any
     // 8-bit data that is not named char will be mapped to "int8" or "uint8".
@@ -100,7 +100,7 @@ namespace awkward {
   /// @brief Returns `char` string when the primitive type
   /// is a character.
   template <typename T>
-  const std::string
+  inline const std::string
   type_to_numpy_like() {
     return type_to_name<T>();
   }
@@ -108,7 +108,7 @@ namespace awkward {
   /// @brief Returns numpy-like character code of a primitive
   /// type as a string.
   template <>
-  const std::string
+  inline const std::string
   type_to_numpy_like<uint8_t>() {
     return "u8";
   }
@@ -116,7 +116,7 @@ namespace awkward {
   /// @brief Returns numpy-like character code `i8`, when the
   /// primitive type is an 8-bit signed integer.
   template <>
-  const std::string
+  inline const std::string
   type_to_numpy_like<int8_t>() {
     return "i8";
   }
@@ -124,7 +124,7 @@ namespace awkward {
   /// @brief Returns numpy-like character code `u32`, when the
   /// primitive type is a 32-bit unsigned integer.
   template <>
-  const std::string
+  inline const std::string
   type_to_numpy_like<uint32_t>() {
     return "u32";
   }
@@ -132,7 +132,7 @@ namespace awkward {
   /// @brief Returns numpy-like character code `i32`, when the
   /// primitive type is a 32-bit signed integer.
   template <>
-  const std::string
+  inline const std::string
   type_to_numpy_like<int32_t>() {
     return "i32";
   }
@@ -140,7 +140,7 @@ namespace awkward {
   /// @brief Returns numpy-like character code `i64`, when the
   /// primitive type is a 64-bit signed integer.
   template <>
-  const std::string
+  inline const std::string
   type_to_numpy_like<int64_t>() {
     return "i64";
   }

--- a/header-only/tests/test_1494-layout-builder.cpp
+++ b/header-only/tests/test_1494-layout-builder.cpp
@@ -460,7 +460,8 @@ test_Empty() {
 
   assert(builder.form() ==
   "{ "
-      "\"class\": \"EmptyArray\" "
+      "\"class\": \"EmptyArray\", "
+      "\"parameters\": {} "
   "}");
 
   clear_buffers(buffers);
@@ -531,7 +532,8 @@ test_ListOffset_Empty() {
           "\"class\": \"ListOffsetArray\", "
           "\"offsets\": \"i64\", "
           "\"content\": { "
-              "\"class\": \"EmptyArray\" "
+              "\"class\": \"EmptyArray\", "
+              "\"parameters\": {} "
           "}, "
           "\"form_key\": \"node1\" "
       "}, "

--- a/header-only/tests/test_1494-layout-builder.cpp
+++ b/header-only/tests/test_1494-layout-builder.cpp
@@ -460,8 +460,7 @@ test_Empty() {
 
   assert(builder.form() ==
   "{ "
-      "\"class\": \"EmptyArray\", "
-      "\"parameters\": {} "
+      "\"class\": \"EmptyArray\" "
   "}");
 
   clear_buffers(buffers);
@@ -532,8 +531,7 @@ test_ListOffset_Empty() {
           "\"class\": \"ListOffsetArray\", "
           "\"offsets\": \"i64\", "
           "\"content\": { "
-              "\"class\": \"EmptyArray\", "
-              "\"parameters\": {} "
+              "\"class\": \"EmptyArray\" "
           "}, "
           "\"form_key\": \"node1\" "
       "}, "


### PR DESCRIPTION
The following changes are made -
- Some methods were causing multiple definitions when including LayoutBuilder in another C++ header file so inline is added to `default_options`, `type_to_name`, and `type_to_numpy_like`.
- preprocessor `#define` is used as a temporary workaround in place of `default_options` as inline variables are supported starting from C++17. Once the requirements are updated to C++17, `default_options` can be inlined.
- Also, two of the tests in `test_1494-layout-builder.cpp` which included the EmptyArray case were failing due to missing parameter string in the form, so that has been fixed too by removing parameters from the `LayoutBuilder` code.