### PR TITLE
feat: export error classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,8 @@ mccabe.max-complexity = 100
 [tool.ruff.per-file-ignores]
 "dev/*" = ["T20", "TID251"]
 "src/awkward/numba/*" = ["TID251"]
+"src/awkward/_errors.py" = ["TID251"]
+"src/awkward/errors.py" = ["TID251"]
 "src/awkward/_connect/*" = ["TID251"]
 "src/awkward/__init__.py" = ["E402", "F401", "F403", "I001"]
 "src/awkward/operations/__init__.py" = ["F403"]

--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -13,12 +13,12 @@ import awkward.contents
 import awkward.record
 import awkward.types
 import awkward.forms
+
+# internal
 import awkward._do
 import awkward._slicing
 import awkward._broadcasting
 import awkward._reducers
-
-# internal
 import awkward._util
 import awkward._errors
 import awkward._lookup
@@ -43,6 +43,9 @@ from awkward.behaviors.mixins import *
 # exports
 import awkward.builder
 import awkward.forth
+
+# errors
+import awkward.errors
 
 behavior: dict = {}
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -7,10 +7,10 @@ from numbers import Integral
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import Any, AxisMaybeNone, Literal
 from awkward.contents.content import ActionType, Content
+from awkward.errors import AxisError
 from awkward.forms import form
 from awkward.record import Record
 

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -8,7 +8,7 @@ import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping
 from functools import wraps
 
-import numpy  # noqa: TID251
+import numpy
 
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._typing import Any, TypeVar
@@ -418,13 +418,6 @@ Issue: {}.""".format(
         version, date, will_be, message
     )
     warnings.warn(warning, category, stacklevel=stacklevel + 1)
-
-
-class FieldNotFoundError(IndexError):
-    ...
-
-
-AxisError = numpy.AxisError
 
 
 T = TypeVar("T", bound=Callable)

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -5,11 +5,11 @@ from collections.abc import Mapping
 
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._errors import AxisError
 from awkward._nplikes.dispatch import nplike_of
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -8,7 +8,6 @@ from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -23,6 +22,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.forms.form import Form
 from awkward.index import Index

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -7,7 +7,6 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -17,6 +16,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.emptyform import EmptyForm
 from awkward.forms.form import Form
 from awkward.index import Index

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -6,7 +6,6 @@ from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -22,6 +21,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -6,7 +6,6 @@ from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -22,6 +21,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -6,7 +6,6 @@ from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -20,6 +19,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index, Index64

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -9,7 +9,6 @@ from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes import to_nplike
 from awkward._nplikes.jax import Jax
@@ -26,6 +25,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.numpyform import NumpyForm
 from awkward.index import Index

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -10,7 +10,6 @@ from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import find_record_reducer
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -24,6 +23,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.recordform import RecordForm
 from awkward.index import Index

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError, deprecate
+from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -20,6 +20,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -7,7 +7,6 @@ from collections.abc import MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
@@ -23,6 +22,7 @@ from awkward._slicing import NO_HEAD
 from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
 from awkward._util import UNSET
 from awkward.contents.content import Content
+from awkward.errors import AxisError
 from awkward.forms.form import Form
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.index import Index

--- a/src/awkward/errors.py
+++ b/src/awkward/errors.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("FieldNotFoundError", "AxisError")
+
+import numpy
+
+
+class FieldNotFoundError(IndexError):
+    ...
+
+
+AxisError = numpy.AxisError

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -6,6 +6,7 @@ from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
+from awkward.errors import FieldNotFoundError
 from awkward.forms.form import Form
 
 
@@ -119,7 +120,7 @@ class RecordForm(Form):
                 pass
             else:
                 return i
-        raise ak._errors.FieldNotFoundError(
+        raise FieldNotFoundError(
             "no field {} in record with {} fields".format(
                 repr(field), len(self._contents)
             )

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -7,10 +7,10 @@ from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -2,10 +2,10 @@
 __all__ = ("drop_none",)
 import awkward as ak
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -7,10 +7,10 @@ from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_sized_iterable, regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -3,10 +3,10 @@ __all__ = ("firsts",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -3,10 +3,10 @@ __all__ = ("from_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -3,10 +3,10 @@ __all__ = ("is_none",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -4,10 +4,10 @@ import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -4,10 +4,10 @@ import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -3,10 +3,10 @@ __all__ = ("num",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -3,10 +3,10 @@ __all__ = ("singletons",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -3,10 +3,10 @@ __all__ = ("to_regular",)
 import awkward as ak
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
-from awkward._errors import AxisError
 from awkward._layout import maybe_posaxis, wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
+from awkward.errors import AxisError
 
 np = NumpyMetadata.instance()
 

--- a/tests/test_2120_missing_field_error.py
+++ b/tests/test_2120_missing_field_error.py
@@ -12,9 +12,9 @@ def test():
             {"x": 300, "y": 400},
         ]
     )
-    with pytest.raises(ak._errors.FieldNotFoundError):
+    with pytest.raises(ak.errors.FieldNotFoundError):
         array["z"]
-    with pytest.raises(ak._errors.FieldNotFoundError):
+    with pytest.raises(ak.errors.FieldNotFoundError):
         array[["z", "k"]]
-    with pytest.raises(ak._errors.FieldNotFoundError):
+    with pytest.raises(ak.errors.FieldNotFoundError):
         array[0, "z"]


### PR DESCRIPTION
Fixes #2611

Now we have `ak._errors` and `ak._errors`. This is unfortunate. The constraints I'm operating under are:
- public symbols should live in public modules
- private symbols should preferably live in private modules

There are enough internal symbols (deprecation, error handling) that we don't want to put these inside `ak.errors` in my opinion, hence the two modules.

I'm open to suggestions on how to structure this differently @jpivarski.