### PR TITLE
fix: adjust for numexpr 2.8.5, which hid getContext's frame_depth argument

### DIFF
--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -71,7 +71,7 @@ def evaluate(
 ):
     numexpr = _import_numexpr()
 
-    context = numexpr.necompiler.getContext(kwargs, frame_depth=1)
+    context = numexpr.necompiler.getContext(kwargs)
     expr_key = (expression, tuple(sorted(context.items())))
     if expr_key not in numexpr.necompiler._names_cache:
         numexpr.necompiler._names_cache[expr_key] = numexpr.necompiler.getExprNames(


### PR DESCRIPTION
In https://github.com/pydata/numexpr/commit/21ff376a0853aff6aea63343c6010d6434917319, `frame_depth` was changed to `_frame_depth`. We didn't need to set it, anyway, since we were selecting its default value. It came from code copied directly from NumExpr itself.