### PR TITLE
refactor: add new `module` and `name` arguments to `high_level_function` decorator

### DIFF
--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def all(
     array,
     axis=None,

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -12,7 +12,7 @@ from awkward.operations.ak_to_layout import to_layout
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def almost_equal(
     left,
     right,

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def any(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -15,7 +15,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def argcartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def argcombinations(
     array,
     n,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def argmax(
     array,
     axis=None,
@@ -67,7 +67,7 @@ def argmax(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@high_level_function
+@high_level_function()
 def nanargmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def argmin(
     array,
     axis=None,
@@ -67,7 +67,7 @@ def argmin(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@high_level_function
+@high_level_function()
 def nanargmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def argsort(
     array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -4,7 +4,7 @@ from awkward._backends.dispatch import backend_of
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def backend(*arrays):
     """
     Args:

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def broadcast_arrays(
     *arrays,
     depth_limit=None,

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -10,7 +10,7 @@ from awkward._layout import wrap_layout
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def broadcast_fields(*arrays, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -16,7 +16,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def cartesian(
     arrays,
     axis=1,

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -6,7 +6,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@high_level_function
+@high_level_function()
 def categories(array, highlevel=True):
     """
     Args:

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def combinations(
     array,
     n,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -18,7 +18,7 @@ cpu = NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("concatenate")
-@high_level_function
+@high_level_function()
 def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def copy(array):
     """
     Args:

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def corr(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def count(
     array,
     axis=None,

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def count_nonzero(
     array,
     axis=None,

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def covar(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -10,7 +10,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def drop_none(array, axis=None, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -17,7 +17,7 @@ from awkward.types.numpytype import primitive_to_dtype
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def enforce_type(array, type, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_fields.py
+++ b/src/awkward/operations/ak_fields.py
@@ -7,7 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def fields(array):
     """
     Args:

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -16,7 +16,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def fill_none(array, value, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def firsts(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def flatten(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_arrow(array, *, generate_bitmasks=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -6,7 +6,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_avro_file(
     file, limit_entries=None, *, debug_forth=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -16,7 +16,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_buffers(
     form,
     length,

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -6,7 +6,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 
-@high_level_function
+@high_level_function()
 def from_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -4,7 +4,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function
+@high_level_function()
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_iter(
     iterable,
     *,

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -5,7 +5,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function
+@high_level_function()
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_json(
     source,
     *,

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -4,7 +4,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 
 
-@high_level_function
+@high_level_function()
 def from_numpy(
     array, *, regulararray=False, recordarray=True, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -6,7 +6,7 @@ from awkward._layout import wrap_layout
 from awkward._regularize import is_integer
 
 
-@high_level_function
+@high_level_function()
 def from_parquet(
     path,
     *,
@@ -76,7 +76,7 @@ def from_parquet(
     )
 
 
-@high_level_function
+@high_level_function()
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -7,7 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def from_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -12,7 +12,7 @@ from awkward.operations.ak_zeros_like import _ZEROS
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def full_like(
     array,
     fill_value,

--- a/src/awkward/operations/ak_is_categorical.py
+++ b/src/awkward/operations/ak_is_categorical.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def is_categorical(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def is_none(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_is_tuple.py
+++ b/src/awkward/operations/ak_is_tuple.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def is_tuple(array):
     """
     Args:

--- a/src/awkward/operations/ak_is_valid.py
+++ b/src/awkward/operations/ak_is_valid.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def is_valid(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def isclose(
     a, b, rtol=1e-05, atol=1e-08, equal_nan=False, *, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -12,7 +12,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def local_index(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def max(
     array,
     axis=None,
@@ -76,7 +76,7 @@ def max(
     )
 
 
-@high_level_function
+@high_level_function()
 def nanmax(
     array,
     axis=None,

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -82,7 +82,7 @@ def mean(x, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     return _impl(x, weight, axis, keepdims, mask_identity)
 
 
-@high_level_function
+@high_level_function()
 def nanmean(x, weight=None, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def merge_option_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def merge_union_of_records(array, axis=-1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -15,7 +15,7 @@ ParquetMetadata = collections.namedtuple(
 )
 
 
-@high_level_function
+@high_level_function()
 def metadata_from_parquet(
     path,
     *,

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def min(
     array,
     axis=None,
@@ -76,7 +76,7 @@ def min(
     )
 
 
-@high_level_function
+@high_level_function()
 def nanmin(
     array,
     axis=None,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def moment(x, n, weight=None, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def nan_to_none(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def nan_to_num(
     array,
     copy=True,

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def num(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_ones_like.py
+++ b/src/awkward/operations/ak_ones_like.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def ones_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -9,7 +9,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def pad_none(array, target, axis=1, *, clip=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_parameters.py
+++ b/src/awkward/operations/ak_parameters.py
@@ -12,7 +12,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def parameters(array):
     """
     Args:

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def prod(
     array,
     axis=None,
@@ -60,7 +60,7 @@ def prod(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@high_level_function
+@high_level_function()
 def nanprod(
     array,
     axis=None,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def ptp(array, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def ravel(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def run_lengths(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def singletons(array, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def softmax(x, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -10,7 +10,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def sort(array, axis=-1, *, ascending=True, stable=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -12,7 +12,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -64,7 +64,7 @@ def std(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@high_level_function
+@high_level_function()
 def nanstd(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -11,7 +11,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def strings_astype(array, to, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def sum(
     array,
     axis=None,
@@ -204,7 +204,7 @@ def sum(
     return _impl(array, axis, keepdims, mask_identity, highlevel, behavior)
 
 
-@high_level_function
+@high_level_function()
 def nansum(
     array,
     axis=None,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -7,7 +7,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_arrow(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_arrow_table(
     array,
     *,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_backend(array, backend, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_buffers(
     array,
     container=None,

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -12,7 +12,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_categorical(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -5,7 +5,7 @@ from awkward._backends.cupy import CupyBackend
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def to_cupy(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -13,7 +13,7 @@ def _default_levelname(index: int) -> str:
     return "sub" * index + "entry"
 
 
-@high_level_function
+@high_level_function()
 def to_dataframe(
     array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -5,7 +5,7 @@ from awkward._backends.jax import JaxBackend
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def to_jax(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -17,7 +17,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_json(
     array,
     file=None,

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -17,7 +17,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_layout(array, *, allow_record=True, allow_other=False, regulararray=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -12,7 +12,7 @@ from awkward._regularize import is_non_string_like_iterable
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_numpy.py
+++ b/src/awkward/operations/ak_to_numpy.py
@@ -5,7 +5,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def to_numpy(array, *, allow_missing=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_packed.py
+++ b/src/awkward/operations/ak_to_packed.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_packed(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -10,7 +10,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 metadata = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_parquet(
     array,
     destination,

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -9,7 +9,7 @@ from awkward._dispatch import high_level_function
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -11,7 +11,7 @@ from awkward.errors import AxisError
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def to_regular(array, axis=1, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -12,7 +12,7 @@ from awkward._layout import wrap_layout
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def transform(
     transformation,
     array,

--- a/src/awkward/operations/ak_type.py
+++ b/src/awkward/operations/ak_type.py
@@ -13,7 +13,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def type(array, *, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -12,7 +12,7 @@ from awkward._regularize import is_integer_like, regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def unzip(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -4,7 +4,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 
 
-@high_level_function
+@high_level_function()
 def validity_error(array, *, exception=False):
     """
     Args:

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -8,7 +8,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def values_astype(array, to, *, including_unknown=False, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -11,7 +11,7 @@ from awkward._regularize import regularize_axis
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=False):
     """
     Args:
@@ -69,7 +69,7 @@ def var(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=Fals
     return _impl(x, weight, ddof, axis, keepdims, mask_identity)
 
 
-@high_level_function
+@high_level_function()
 def nanvar(x, weight=None, ddof=0, axis=None, *, keepdims=False, mask_identity=True):
     """
     Args:

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -13,7 +13,7 @@ cpu = NumpyBackend.instance()
 
 
 @ak._connect.numpy.implements("where")
-@high_level_function
+@high_level_function()
 def where(condition, *args, mergebool=True, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -17,7 +17,7 @@ np = NumpyMetadata.instance()
 cpu = NumpyBackend.instance()
 
 
-@high_level_function
+@high_level_function()
 def with_field(array, what, where=None, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def with_name(array, name, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_with_parameter.py
+++ b/src/awkward/operations/ak_with_parameter.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def with_parameter(array, parameter, value, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def without_field(array, where, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -9,7 +9,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def without_parameters(array, *, highlevel=True, behavior=None):
     """
     Args:

--- a/src/awkward/operations/ak_zeros_like.py
+++ b/src/awkward/operations/ak_zeros_like.py
@@ -11,7 +11,7 @@ np = NumpyMetadata.instance()
 _ZEROS = object()
 
 
-@high_level_function
+@high_level_function()
 def zeros_like(
     array, *, dtype=None, including_unknown=False, highlevel=True, behavior=None
 ):

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -11,7 +11,7 @@ from awkward._nplikes.numpylike import NumpyMetadata
 np = NumpyMetadata.instance()
 
 
-@high_level_function
+@high_level_function()
 def zip(
     arrays,
     depth_limit=None,


### PR DESCRIPTION
This paves the way for #2616 to override the module for `ak.str` operations