### PR TITLE
fix: support lists of strings in `ak.zip` with `optiontype_outside_record=True`

### DIFF
--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -213,14 +213,7 @@ def _impl(
         parameters["__record__"] = with_name
 
     def action(inputs, depth, **ignore):
-        if depth_limit == depth or all(
-            x.purelist_depth == 1
-            or (
-                x.purelist_depth == 2
-                and x.purelist_parameter("__array__") in ("string", "bytestring")
-            )
-            for x in inputs
-        ):
+        if depth_limit == depth or all(x.purelist_depth == 1 for x in inputs):
             # If we want to zip after option types at this depth
             if optiontype_outside_record and any(x.is_option for x in inputs):
                 return None

--- a/tests/test_2623_optiontype_outside_record_strings.py
+++ b/tests/test_2623_optiontype_outside_record_strings.py
@@ -1,0 +1,33 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import awkward as ak
+
+
+def test():
+    record = ak.zip(
+        {
+            "x": ak.mask(["foo", "bar", "world"], [True, True, False]),
+            "y": ak.mask(["do", "re", "mi"], [False, True, True]),
+        },
+        optiontype_outside_record=True,
+    )
+    assert record.to_list() == [None, {"x": "bar", "y": "re"}, None]
+    assert record.type == ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.RecordType(
+                [
+                    ak.types.ListType(
+                        ak.types.NumpyType("uint8", parameters={"__array__": "char"}),
+                        parameters={"__array__": "string"},
+                    ),
+                    ak.types.ListType(
+                        ak.types.NumpyType("uint8", parameters={"__array__": "char"}),
+                        parameters={"__array__": "string"},
+                    ),
+                ],
+                ["x", "y"],
+            )
+        ),
+        3,
+        None,
+    )

--- a/tests/test_2623_optiontype_outside_record_strings.py
+++ b/tests/test_2623_optiontype_outside_record_strings.py
@@ -3,12 +3,39 @@
 import awkward as ak
 
 
-def test():
+def test_ByteMaskedArray():
     record = ak.zip(
         {
             "x": ak.mask(["foo", "bar", "world"], [True, True, False]),
             "y": ak.mask(["do", "re", "mi"], [False, True, True]),
         },
+        optiontype_outside_record=True,
+    )
+    assert record.to_list() == [None, {"x": "bar", "y": "re"}, None]
+    assert record.type == ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.RecordType(
+                [
+                    ak.types.ListType(
+                        ak.types.NumpyType("uint8", parameters={"__array__": "char"}),
+                        parameters={"__array__": "string"},
+                    ),
+                    ak.types.ListType(
+                        ak.types.NumpyType("uint8", parameters={"__array__": "char"}),
+                        parameters={"__array__": "string"},
+                    ),
+                ],
+                ["x", "y"],
+            )
+        ),
+        3,
+        None,
+    )
+
+
+def test_IndexedOptionArray():
+    record = ak.zip(
+        {"x": ["foo", "bar", None], "y": [None, "re", "mi"]},
         optiontype_outside_record=True,
     )
     assert record.to_list() == [None, {"x": "bar", "y": "re"}, None]


### PR DESCRIPTION
The `optiontype_outside_record` flag in `ak.zip` should permit lifting the option from a single record field to the outside of the record. However, with strings this does not happen; we test the wrong depth.