### PR TITLE
feat: add CPU kernel for `to_numpy` support for strings/bytestrings

### DIFF
--- a/awkward-cpp/include/awkward/unicode.h
+++ b/awkward-cpp/include/awkward/unicode.h
@@ -1,0 +1,23 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+#include <cstddef>
+#include <cstdint>
+
+#ifndef AWKWARD_UNICODE_H_
+#define AWKWARD_UNICODE_H_
+
+
+#define UTF8_ONE_BYTE_MASK 0x80
+#define UTF8_ONE_BYTE_BITS 0
+#define UTF8_TWO_BYTES_MASK 0xE0
+#define UTF8_TWO_BYTES_BITS 0xC0
+#define UTF8_THREE_BYTES_MASK 0xF0
+#define UTF8_THREE_BYTES_BITS 0xE0
+#define UTF8_FOUR_BYTES_MASK 0xF8
+#define UTF8_FOUR_BYTES_BITS 0xF0
+#define UTF8_CONTINUATION_MASK 0xC0
+#define UTF8_CONTINUATION_BITS 0x80
+
+
+size_t utf8_codepoint_size(const uint8_t byte);
+
+#endif // AWKWARD_UNICODE_H_

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_pad_zero_to_length.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_pad_zero_to_length.cpp
@@ -1,0 +1,41 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_NumpyArray_pad_zero_to_length.cpp", line)
+
+#include "awkward/kernels.h"
+
+
+template <typename T>
+ERROR awkward_NumpyArray_pad_zero_to_length(
+    const T* fromptr,
+    const int64_t* fromoffsets,
+    int64_t offsetslength,
+    int64_t target,
+    T* toptr) {
+    int64_t l = 0;
+    for (auto k = 0; k < offsetslength-1; k++) {
+        for (int64_t j=fromoffsets[k]; j<fromoffsets[k+1]; j++) {
+            toptr[l++] = fromptr[j];
+        }
+        auto n_to_pad = target - (fromoffsets[k+1] - fromoffsets[k]);
+        for (int64_t j=0; j<n_to_pad; j++){
+            toptr[l++] = 0;
+        }
+    }
+
+    return success();
+}
+
+ERROR awkward_NumpyArray_pad_zero_to_length_uint8(
+    const uint8_t* fromptr,
+    const int64_t* fromoffsets,
+    int64_t offsetslength,
+    int64_t target,
+    uint8_t* toptr) {
+  return awkward_NumpyArray_pad_zero_to_length<uint8_t>(
+    fromptr,
+    fromoffsets,
+    offsetslength,
+    target,
+    toptr);
+}

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_pad_zero_to_length.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_pad_zero_to_length.cpp
@@ -12,14 +12,18 @@ ERROR awkward_NumpyArray_pad_zero_to_length(
     int64_t offsetslength,
     int64_t target,
     T* toptr) {
-    int64_t l = 0;
-    for (auto k = 0; k < offsetslength-1; k++) {
-        for (int64_t j=fromoffsets[k]; j<fromoffsets[k+1]; j++) {
-            toptr[l++] = fromptr[j];
+    int64_t l_to_char = 0;
+
+    // For each sublist
+    for (auto k_sublist = 0; k_sublist < offsetslength-1; k_sublist++) {
+        // Copy from src to dst
+        for (int64_t j_from_char=fromoffsets[k_sublist]; j_from_char<fromoffsets[k_sublist+1]; j_from_char++) {
+            toptr[l_to_char++] = fromptr[j_from_char];
         }
-        auto n_to_pad = target - (fromoffsets[k+1] - fromoffsets[k]);
-        for (int64_t j=0; j<n_to_pad; j++){
-            toptr[l++] = 0;
+        // Pad to remaining width
+        auto n_to_pad = target - (fromoffsets[k_sublist+1] - fromoffsets[k_sublist]);
+        for (int64_t j_from_char=0; j_from_char<n_to_pad; j_from_char++){
+            toptr[l_to_char++] = 0;
         }
     }
 

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
@@ -14,7 +14,7 @@ ERROR awkward_NumpyArray_prepare_utf8_to_utf32_padded(
 
   *outmaxcodepoints = 0;
   int64_t i_code_unit = fromoffsets[0];
-  int64_t cp_size;
+  int64_t code_point_width;
 
   // For each sublist of code units
   for (auto k_sublist = 0; k_sublist < offsetslength - 1; k_sublist++) {
@@ -23,10 +23,10 @@ ERROR awkward_NumpyArray_prepare_utf8_to_utf32_padded(
 
     // Repeat until we exhaust the code units within this sublist
     for (auto j_code_unit_last = i_code_unit + n_code_units; i_code_unit < j_code_unit_last;) {
-      cp_size = utf8_codepoint_size(fromptr[i_code_unit]);
+      code_point_width = utf8_codepoint_size(fromptr[i_code_unit]);
 
       // Shift the code-unit start index
-      i_code_unit += cp_size;
+      i_code_unit += code_point_width;
 
       // Increment the code-point counter for this sublist
       n_code_point_sublist += 1;

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
@@ -7,30 +7,34 @@
 
 
 ERROR awkward_NumpyArray_prepare_utf8_to_utf32_padded(
-    const uint8_t* fromptr,
-    const int64_t* fromoffsets,
-    int64_t offsetslength,
-    int64_t* outmaxcodepoints) {
+  const uint8_t *fromptr,
+    const int64_t *fromoffsets,
+      int64_t offsetslength,
+      int64_t *outmaxcodepoints) {
 
-    *outmaxcodepoints = 0;
-	int64_t i = fromoffsets[0];
-    int64_t cp_size;
+  *outmaxcodepoints = 0;
+  int64_t i_code_unit = fromoffsets[0];
+  int64_t cp_size;
 
-    // For each sublist of code units
-    for (auto k = 0; k < offsetslength-1; k++) {
-        auto n_code_units = fromoffsets[k+1] - fromoffsets[k];
-        auto n_sublist_code_points = 0;
+  // For each sublist of code units
+  for (auto k_sublist = 0; k_sublist < offsetslength - 1; k_sublist++) {
+    auto n_code_units = fromoffsets[k_sublist + 1] - fromoffsets[k_sublist];
+    auto n_code_point_sublist = 0;
 
-        // Parse one code point at a time, until we exhaust the code units
-        for (auto i_last=i+n_code_units; i<i_last;) {
-            cp_size = utf8_codepoint_size(fromptr[i]);
-            i += cp_size;
-            n_sublist_code_points += 1;
-        }
+    // Repeat until we exhaust the code units within this sublist
+    for (auto j_code_unit_last = i_code_unit + n_code_units; i_code_unit < j_code_unit_last;) {
+      cp_size = utf8_codepoint_size(fromptr[i_code_unit]);
 
-        // Set largest substring length (in code points)
-        *outmaxcodepoints = (*outmaxcodepoints < n_sublist_code_points) ? n_sublist_code_points : *outmaxcodepoints;
+      // Shift the code-unit start index
+      i_code_unit += cp_size;
+
+      // Increment the code-point counter for this sublist
+      n_code_point_sublist += 1;
     }
 
-    return success();
+    // Set largest substring length (in code points)
+    *outmaxcodepoints = ( *outmaxcodepoints < n_code_point_sublist) ? n_code_point_sublist : *outmaxcodepoints;
+  }
+
+  return success();
 }

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp
@@ -1,0 +1,36 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_NumpyArray_prepare_utf8_to_utf32_padded.cpp", line)
+
+#include "awkward/kernels.h"
+#include "awkward/unicode.h"
+
+
+ERROR awkward_NumpyArray_prepare_utf8_to_utf32_padded(
+    const uint8_t* fromptr,
+    const int64_t* fromoffsets,
+    int64_t offsetslength,
+    int64_t* outmaxcodepoints) {
+
+    *outmaxcodepoints = 0;
+	int64_t i = fromoffsets[0];
+    int64_t cp_size;
+
+    // For each sublist of code units
+    for (auto k = 0; k < offsetslength-1; k++) {
+        auto n_code_units = fromoffsets[k+1] - fromoffsets[k];
+        auto n_sublist_code_points = 0;
+
+        // Parse one code point at a time, until we exhaust the code units
+        for (auto i_last=i+n_code_units; i<i_last;) {
+            cp_size = utf8_codepoint_size(fromptr[i]);
+            i += cp_size;
+            n_sublist_code_points += 1;
+        }
+
+        // Set largest substring length (in code points)
+        *outmaxcodepoints = (*outmaxcodepoints < n_sublist_code_points) ? n_sublist_code_points : *outmaxcodepoints;
+    }
+
+    return success();
+}

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
@@ -7,66 +7,67 @@
 
 
 ERROR awkward_NumpyArray_utf8_to_utf32_padded(
-    const uint8_t* fromptr,
-    const int64_t* fromoffsets,
-    int64_t offsetslength,
-    int64_t maxcodepoints,
-    uint32_t* toptr) {
+  const uint8_t *fromptr,
+    const int64_t *fromoffsets,
+      int64_t offsetslength,
+      int64_t maxcodepoints,
+      uint32_t *toptr) {
 
-	int64_t i = fromoffsets[0];
-	int64_t cp_size;
-    int64_t n = 0;
+  int64_t i_code_unit = fromoffsets[0];
+  int64_t cp_size;
+  int64_t n_code_point = 0;
 
-    // For each sublist of code units
-	for (auto k = 0; k < offsetslength-1; k++) {
-	    auto n_code_units = fromoffsets[k+1] - fromoffsets[k];
-	    int64_t n_sublist_code_points = 0;
+  // For each sublist of code units
+  for (auto k_sublist = 0; k_sublist < offsetslength - 1; k_sublist++) {
+    auto n_code_units = fromoffsets[k_sublist + 1] - fromoffsets[k_sublist];
+    int64_t n_code_point_sublist = 0;
 
-        // Parse one code point at a time, until we exhaust the code units
-        for (auto i_last=i+n_code_units; i<i_last;) {
-            cp_size = utf8_codepoint_size(fromptr[i]);
+    // Repeat until we exhaust the code units within this sublist
+    for (auto j_code_unit_last = i_code_unit + n_code_units; i_code_unit < j_code_unit_last;) {
+      // Parse a single codepoint
+      cp_size = utf8_codepoint_size(fromptr[i_code_unit]);
+      switch (cp_size) {
+      case 1:
+        toptr[n_code_point] = ((uint32_t) fromptr[i_code_unit] & ~UTF8_ONE_BYTE_MASK);
+        break;
+      case 2:
+        toptr[n_code_point] =
+          ((uint32_t) fromptr[i_code_unit] & ~UTF8_TWO_BYTES_MASK) << 6 |
+          ((uint32_t) fromptr[i_code_unit + 1] & ~UTF8_CONTINUATION_MASK);
+        break;
+      case 3:
+        toptr[n_code_point] =
+          ((uint32_t) fromptr[i_code_unit] & ~UTF8_THREE_BYTES_MASK) << 12 |
+          ((uint32_t) fromptr[i_code_unit + 1] & ~UTF8_CONTINUATION_MASK) << 6 |
+          ((uint32_t) fromptr[i_code_unit + 2] & ~UTF8_CONTINUATION_MASK);
 
-            switch (cp_size) {
-            case 1:
-                toptr[n] = ((uint32_t) fromptr[i] & ~UTF8_ONE_BYTE_MASK);
-                break;
-            case 2:
-                toptr[n] =
-                    ((uint32_t) fromptr[i] & ~UTF8_TWO_BYTES_MASK) << 6 |
-                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK)
-                ;
-                break;
-            case 3:
-                toptr[n] =
-                    ((uint32_t) fromptr[i] & ~UTF8_THREE_BYTES_MASK) << 12 |
-                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK) << 6 |
-                    ((uint32_t) fromptr[i + 2] & ~UTF8_CONTINUATION_MASK)
-                ;
+        break;
+      case 4:
+        toptr[n_code_point] =
+          ((uint32_t) fromptr[i_code_unit] & ~UTF8_FOUR_BYTES_MASK) << 18 |
+          ((uint32_t) fromptr[i_code_unit + 1] & ~UTF8_CONTINUATION_MASK) << 12 |
+          ((uint32_t) fromptr[i_code_unit + 2] & ~UTF8_CONTINUATION_MASK) << 6 |
+          ((uint32_t) fromptr[i_code_unit + 3] & ~UTF8_CONTINUATION_MASK);
+        break;
+      default:
+        return failure("utf8_to_utf32: invalid byte in UTF8 string", kSliceNone, fromptr[i_code_unit], FILENAME(__LINE__));
+      }
+      // Increment the code-point counter
+      n_code_point++;
 
-                break;
-            case 4:
-                toptr[n] =
-                    ((uint32_t) fromptr[i] & ~UTF8_FOUR_BYTES_MASK) << 18 |
-                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK) << 12 |
-                    ((uint32_t) fromptr[i + 2] & ~UTF8_CONTINUATION_MASK) << 6 |
-                    ((uint32_t) fromptr[i + 3] & ~UTF8_CONTINUATION_MASK)
-                ;
-                break;
-            default:
-                return failure( "utf8_to_utf32: invalid byte in UTF8 string", kSliceNone, fromptr[i], FILENAME(__LINE__));
-            }
+      // Shift the code-unit start index
+      i_code_unit += cp_size;
 
-            n++;
-            i += cp_size;
-            n_sublist_code_points += 1;
-        }
+      // Increment the code-point counter for this sublist
+      n_code_point_sublist += 1;
+    }
 
-        // Zero pad the remaining characters
-        int64_t n_pad_code_points = maxcodepoints-n_sublist_code_points;
-        for (auto j=0; j<n_pad_code_points; j++){
-            toptr[n++] = 0;
-        }
-	}
+    // Zero pad the remaining characters
+    int64_t n_pad_code_points = maxcodepoints - n_code_point_sublist;
+    for (auto j = 0; j < n_pad_code_points; j++) {
+      toptr[n_code_point++] = 0;
+    }
+  }
 
-    return success();
+  return success();
 }

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
@@ -14,7 +14,7 @@ ERROR awkward_NumpyArray_utf8_to_utf32_padded(
       uint32_t *toptr) {
 
   int64_t i_code_unit = fromoffsets[0];
-  int64_t cp_size;
+  int64_t code_point_width;
   int64_t n_code_point = 0;
 
   // For each sublist of code units
@@ -25,8 +25,8 @@ ERROR awkward_NumpyArray_utf8_to_utf32_padded(
     // Repeat until we exhaust the code units within this sublist
     for (auto j_code_unit_last = i_code_unit + n_code_units; i_code_unit < j_code_unit_last;) {
       // Parse a single codepoint
-      cp_size = utf8_codepoint_size(fromptr[i_code_unit]);
-      switch (cp_size) {
+      code_point_width = utf8_codepoint_size(fromptr[i_code_unit]);
+      switch (code_point_width) {
       case 1:
         toptr[n_code_point] = ((uint32_t) fromptr[i_code_unit] & ~UTF8_ONE_BYTE_MASK);
         break;
@@ -50,13 +50,13 @@ ERROR awkward_NumpyArray_utf8_to_utf32_padded(
           ((uint32_t) fromptr[i_code_unit + 3] & ~UTF8_CONTINUATION_MASK);
         break;
       default:
-        return failure("utf8_to_utf32: invalid byte in UTF8 string", kSliceNone, fromptr[i_code_unit], FILENAME(__LINE__));
+        return failure("could not convert UTF8 code point to UTF32: invalid byte in UTF8 string", kSliceNone, fromptr[i_code_unit], FILENAME(__LINE__));
       }
       // Increment the code-point counter
       n_code_point++;
 
       // Shift the code-unit start index
-      i_code_unit += cp_size;
+      i_code_unit += code_point_width;
 
       // Increment the code-point counter for this sublist
       n_code_point_sublist += 1;

--- a/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp
@@ -1,0 +1,72 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/awkward_NumpyArray_utf8_to_utf32_padded.cpp", line)
+
+#include "awkward/kernels.h"
+#include "awkward/unicode.h"
+
+
+ERROR awkward_NumpyArray_utf8_to_utf32_padded(
+    const uint8_t* fromptr,
+    const int64_t* fromoffsets,
+    int64_t offsetslength,
+    int64_t maxcodepoints,
+    uint32_t* toptr) {
+
+	int64_t i = fromoffsets[0];
+	int64_t cp_size;
+    int64_t n = 0;
+
+    // For each sublist of code units
+	for (auto k = 0; k < offsetslength-1; k++) {
+	    auto n_code_units = fromoffsets[k+1] - fromoffsets[k];
+	    int64_t n_sublist_code_points = 0;
+
+        // Parse one code point at a time, until we exhaust the code units
+        for (auto i_last=i+n_code_units; i<i_last;) {
+            cp_size = utf8_codepoint_size(fromptr[i]);
+
+            switch (cp_size) {
+            case 1:
+                toptr[n] = ((uint32_t) fromptr[i] & ~UTF8_ONE_BYTE_MASK);
+                break;
+            case 2:
+                toptr[n] =
+                    ((uint32_t) fromptr[i] & ~UTF8_TWO_BYTES_MASK) << 6 |
+                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK)
+                ;
+                break;
+            case 3:
+                toptr[n] =
+                    ((uint32_t) fromptr[i] & ~UTF8_THREE_BYTES_MASK) << 12 |
+                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK) << 6 |
+                    ((uint32_t) fromptr[i + 2] & ~UTF8_CONTINUATION_MASK)
+                ;
+
+                break;
+            case 4:
+                toptr[n] =
+                    ((uint32_t) fromptr[i] & ~UTF8_FOUR_BYTES_MASK) << 18 |
+                    ((uint32_t) fromptr[i + 1] & ~UTF8_CONTINUATION_MASK) << 12 |
+                    ((uint32_t) fromptr[i + 2] & ~UTF8_CONTINUATION_MASK) << 6 |
+                    ((uint32_t) fromptr[i + 3] & ~UTF8_CONTINUATION_MASK)
+                ;
+                break;
+            default:
+                return failure( "utf8_to_utf32: invalid byte in UTF8 string", kSliceNone, fromptr[i], FILENAME(__LINE__));
+            }
+
+            n++;
+            i += cp_size;
+            n_sublist_code_points += 1;
+        }
+
+        // Zero pad the remaining characters
+        int64_t n_pad_code_points = maxcodepoints-n_sublist_code_points;
+        for (auto j=0; j<n_pad_code_points; j++){
+            toptr[n++] = 0;
+        }
+	}
+
+    return success();
+}

--- a/awkward-cpp/src/cpu-kernels/unicode.cpp
+++ b/awkward-cpp/src/cpu-kernels/unicode.cpp
@@ -1,0 +1,26 @@
+// BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+#define FILENAME(line) FILENAME_FOR_EXCEPTIONS_C("src/cpu-kernels/unicode.cpp", line)
+
+#include "awkward/unicode.h"
+
+
+size_t utf8_codepoint_size(const uint8_t byte) {
+	if ((byte & UTF8_ONE_BYTE_MASK) == UTF8_ONE_BYTE_BITS) {
+		return 1;
+	}
+
+	if ((byte & UTF8_TWO_BYTES_MASK) == UTF8_TWO_BYTES_BITS) {
+		return 2;
+	}
+
+	if ((byte & UTF8_THREE_BYTES_MASK) == UTF8_THREE_BYTES_BITS) {
+		return 3;
+	}
+
+	if ((byte & UTF8_FOUR_BYTES_MASK) == UTF8_FOUR_BYTES_BITS) {
+		return 4;
+	}
+
+	return 0;
+}

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -3386,6 +3386,21 @@ kernels:
     automatic-tests: false
     manual-tests: []
 
+  - name: awkward_NumpyArray_pad_zero_to_length
+    specializations:
+      - name: awkward_NumpyArray_pad_zero_to_length_uint8
+        args:
+          - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: default}
+          - {name: fromoffsets, type: "Const[List[int64_t]]", dir: in, role: ListOffsetArray-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: default}
+          - {name: target, type: "int64_t", dir: in,  role: default}
+          - {name: toptr, type: "List[uint8_t]", dir: out}
+    description: null
+    definition: |
+      Insert Python definition here
+    automatic-tests: false
+    manual-tests: []
+
   - name: awkward_NumpyArray_subrange_equal
     specializations:
       - name: awkward_NumpyArray_subrange_equal_bool

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -3357,6 +3357,35 @@ kernels:
     automatic-tests: false
     manual-tests: []
 
+  - name: awkward_NumpyArray_prepare_utf8_to_utf32_padded
+    specializations:
+      - name: awkward_NumpyArray_prepare_utf8_to_utf32_padded
+        args:
+          - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: default}
+          - {name: fromoffsets, type: "Const[List[int64_t]]", dir: in, role: ListOffsetArray-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: default}
+          - {name: outmaxcodepoints, type: "List[int64_t]", dir: out}
+    description: null
+    definition: |
+      Insert Python definition here
+    automatic-tests: false
+    manual-tests: []
+
+  - name: awkward_NumpyArray_utf8_to_utf32_padded
+    specializations:
+      - name: awkward_NumpyArray_utf8_to_utf32_padded
+        args:
+          - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: default}
+          - {name: fromoffsets, type: "Const[List[int64_t]]", dir: in, role: ListOffsetArray-offsets}
+          - {name: offsetslength, type: "int64_t", dir: in, role: default}
+          - {name: maxcodepoints, type: "int64_t", dir: in,  role: default}
+          - {name: toptr, type: "List[uint32_t]", dir: out}
+    description: null
+    definition: |
+      Insert Python definition here
+    automatic-tests: false
+    manual-tests: []
+
   - name: awkward_NumpyArray_subrange_equal
     specializations:
       - name: awkward_NumpyArray_subrange_equal_bool

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1484,9 +1484,9 @@ class ListArray(Content):
     def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
         if array_param in {"bytestring", "string"}:
-            # As our array-of-strings _may_ be empty, we should pass the dtype
-            dtype = np.str_ if array_param == "string" else np.bytes_
-            return backend.nplike.asarray(self.to_list(), dtype=dtype)
+            return self.to_ListOffsetArray64(False)._to_backend_array(
+                allow_missing, backend
+            )
         else:
             return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -133,7 +133,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             if (
                 counts is not unknown_length
                 and layout.length is not unknown_length
-                and not 0 <= counts < layout.length
+                and not 0 <= counts <= layout.length
             ):
                 raise ValueError("too large counts for array or negative counts")
             out = ak.contents.RegularArray(layout, counts)

--- a/tests/test_2631_vectorised_to_numpy_strings.py
+++ b/tests/test_2631_vectorised_to_numpy_strings.py
@@ -6,9 +6,9 @@ import awkward as ak
 
 
 def test_string():
-    source = ak.Array(["$", "¢", "€", "💰"])
+    source = ak.Array(["abc$¢€", "d¢#", "€e¢", "💰💰"])
     result = source.to_numpy(False)
-    expected = np.array(["$", "¢", "€", "💰"])
+    expected = np.array(["abc$¢€", "d¢#", "€e¢", "💰💰"])
     assert result.dtype == expected.dtype
     np.testing.assert_equal(result, expected)
 

--- a/tests/test_2631_vectorised_to_numpy_strings.py
+++ b/tests/test_2631_vectorised_to_numpy_strings.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_string():
+    source = ak.Array(["$", "¢", "€", "💰"])
+    result = source.to_numpy(False)
+    expected = np.array(["$", "¢", "€", "💰"])
+    assert result.dtype == expected.dtype
+    np.testing.assert_equal(result, expected)
+
+
+def test_bytestring():
+    source = ak.Array([b"foo", b"bar", b"catastrophic", b"\x03\x07"])
+    result = source.to_numpy(False)
+    expected = np.array([b"foo", b"bar", b"catastrophic", b"\x03\x07"])
+    assert result.dtype == expected.dtype
+    np.testing.assert_equal(result, expected)


### PR DESCRIPTION
Currently, `to_numpy` (or rather, `to_backend_array`) uses `to_list()` for strings. We can do better than that, if we build the string view ourselves.

This PR prototypes those kernels; it could definitely be written to be faster, if needed.

In the interests of expediency, some of this code was taken from https://github.com/s22h/cutils. I'm not sure if it needs to be directly licensed as MIT, because it's mostly all adapted.

Closes #2624