### PR TITLE
fix: support `counts=len(array)` in `ak.unflatten`

### DIFF
--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -133,7 +133,7 @@ def _impl(array, counts, axis, highlevel, behavior):
             if (
                 counts is not unknown_length
                 and layout.length is not unknown_length
-                and not 0 <= counts < layout.length
+                and not 0 <= counts <= layout.length
             ):
                 raise ValueError("too large counts for array or negative counts")
             out = ak.contents.RegularArray(layout, counts)

--- a/tests/test_2632_unflatten_length.py
+++ b/tests/test_2632_unflatten_length.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    x = ak.from_numpy(np.arange(3, dtype=np.int64))
+    y = ak.unflatten(x, len(x))
+    assert y.to_list() == [[0, 1, 2]]
+    assert y.type == ak.types.ArrayType(
+        ak.types.RegularType(ak.types.NumpyType("int64"), 3), 1
+    )


### PR DESCRIPTION
It should be possible to invoke `ak.unflatten` with the length of the layout, such that it is wrapped in a length-1 `RegularArray`. However, this currently raises an error because the upper bound of permissible integers is taken to be `len(layout)-1`.