### PR TITLE
fix: support non `int64` index in `ListArray`'s `pad_none`

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1021,9 +1021,7 @@ class Content:
                 ](index.data, target, self.length)
             )
 
-        return ak.contents.IndexedOptionArray.simplified(
-            index, self, parameters=self._parameters
-        )
+        return ak.contents.IndexedOptionArray.simplified(index, self)
 
     def _pad_none(self, target: int, axis: int, depth: int, clip: bool) -> Content:
         raise NotImplementedError

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1424,11 +1424,15 @@ class ListArray(Content):
                     )
 
                     index = ak.index.Index64.empty(tolength, self._backend.index_nplike)
-                    starts_ = ak.index.Index64.empty(
-                        self._starts.length, self._backend.index_nplike
+                    starts_ = ak.index.Index.empty(
+                        self._starts.length,
+                        self._backend.index_nplike,
+                        dtype=self._starts.dtype,
                     )
-                    stops_ = ak.index.Index64.empty(
-                        self._stops.length, self._backend.index_nplike
+                    stops_ = ak.index.Index.empty(
+                        self._stops.length,
+                        self._backend.index_nplike,
+                        dtype=self._stops.dtype,
                     )
                     assert (
                         index.nplike is self._backend.index_nplike

--- a/tests/test_2634_listarray_pad_none.py
+++ b/tests/test_2634_listarray_pad_none.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    layout = ak.to_layout(["hi", "bye"])
+
+    def as_32(index):
+        return ak.index.Index(index.nplike.astype(index.data, np.int32))
+
+    layout = ak.contents.ListArray(
+        as_32(layout.starts),
+        as_32(layout.stops),
+        layout.content,
+        parameters=layout._parameters,
+    )
+    assert ak.pad_none(layout, 3, axis=0).tolist() == ["hi", "bye", None]


### PR DESCRIPTION
This PR does two things:

1. Changes dtypes of a kernel call (`awkward_ListArray_rpad_axis1`)
   The kernel is written with the following template signature
   ```cpp
   T* toindex,
   const C* fromstarts,
   const C* fromstops,
   C* tostarts,
   C* tostops,
   ```
   i.e. `starts` and `tostarts` are expected to have the same dtypes. We can rewrite the kernel call site to ensure that this is true. This bug was observed after reading data from Arrow with 32-bit indices.
2. When using `pad_none`, we shouldn't copy the parameters of the content to the new mask node; this duplicates parameters, and doesn't consider the rules about e.g. whether the content is allowed to possess such parameters.[^note]
[^note]: this remains a general class of problem IIRC with broadcasting that we'll need to work on. However, this fix is also correct; we don't want duplicate parameters.