### PR TITLE
fix: support `highlevel=False` in all branches for `from_parquet`

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -218,13 +218,8 @@ def _load(
             )
         )
 
-    if len(arrays) == 0:
-        return wrap_layout(
-            subform.length_zero_array(highlevel=False),
-            highlevel=highlevel,
-            behavior=behavior,
-        )
-    elif len(arrays) == 1:
+    assert len(arrays) != 0
+    if len(arrays) == 1:
         # make high-level
         if isinstance(arrays[0], ak.record.Record):
             return ak.Record(arrays[0])

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -220,13 +220,15 @@ def _load(
 
     if len(arrays) == 0:
         return wrap_layout(
-            subform.length_zero_array(highlevel=False), behavior=behavior
+            subform.length_zero_array(highlevel=False),
+            highlevel=highlevel,
+            behavior=behavior,
         )
     elif len(arrays) == 1:
         # make high-level
         if isinstance(arrays[0], ak.record.Record):
             return ak.Record(arrays[0])
-        return ak.Array(arrays[0])
+        return wrap_layout(arrays[0], highlevel=highlevel, behavior=behavior)
     else:
         # TODO: if each array is a record?
         return ak.operations.ak_concatenate._impl(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -174,9 +174,9 @@ def _impl(
             )
         )
         arrow_fields.append(
-            pyarrow.field("", arrow_arrays[-1].type).with_nullable(
-                layout.is_option or layout.is_identity_like
-            )
+            # Arrow tables must contain at-least one field. To store a
+            # non-record layout, we create an un-named field.
+            pyarrow.field("", arrow_arrays[-1].type).with_nullable(layout.is_option)
         )
 
     batch = pyarrow.RecordBatch.from_arrays(

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -1,10 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
 __all__ = ("to_arrow_table",)
 import json
 
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._typing import Any
 
 np = NumpyMetadata.instance()
 
@@ -101,18 +104,20 @@ def _impl(
     else:
         record_is_scalar = False
 
+    # If we're building a table from an array of records, we need to keep track
+    # of the "wrapper" layouts above the record
     wrapper_layouts = [layout]
     while wrapper_layouts[-1].is_option or wrapper_layouts[-1].is_indexed:
         wrapper_layouts.append(wrapper_layouts[-1].content)
 
-    parameters = None
-    paarrays, pafields = [], []
+    schema_parameters: list[dict[str, Any]] | None = None
+    arrow_arrays, arrow_fields = [], []
     if wrapper_layouts[-1].is_record and not wrapper_layouts[-1].is_tuple:
         record_content = wrapper_layouts[-1]
-        optiontype_fields = []
+        optiontype_fields: list[str] = []
         for name in record_content.fields:
             outer_field_content = layout[name]
-            paarrays.append(
+            arrow_arrays.append(
                 outer_field_content.to_arrow(
                     list_to32=list_to32,
                     string_to32=string_to32,
@@ -124,26 +129,39 @@ def _impl(
                     record_is_scalar=record_is_scalar,
                 )
             )
-            pafields.append(
-                pyarrow.field(name, paarrays[-1].type).with_nullable(
+            # The nullability of this arrow field is determined by whether
+            # the field is considered an option w.r.t to the root, i.e.
+            # accounting for options above the record layout.
+            arrow_fields.append(
+                pyarrow.field(name, arrow_arrays[-1].type).with_nullable(
                     outer_field_content.is_option
                 )
             )
-            if record_content.contents[record_content.field_to_index(name)].is_option:
+
+            # Is this field layout directly an option-type?
+            record_field_content = record_content.contents[
+                record_content.field_to_index(name)
+            ]
+            if record_field_content.is_option:
                 optiontype_fields.append(name)
 
-        parameters = [
+        schema_parameters = [
             {"optiontype_fields": optiontype_fields},
             {"record_is_scalar": record_is_scalar},
         ]
 
-        # We build a table from the _contents_ of the record layout. Therefore,
-        # we must explicitly include the parameters of each layout above and including the record
-        for x in wrapper_layouts:
-            parameters.append({direct_Content_subclass(x).__name__: x._parameters})
+        # The parameters that _may_ be serialised in the Arrow schema
+        # (depending upon the value of `extensionarray`) will not include those
+        # that are defined on nodes above the record; slicing a RecordArray
+        # drops parameters above the record. As such, we need to explicitly
+        # track these in order to rebuild the layouts above the record.
+        for content in wrapper_layouts:
+            schema_parameters.append(
+                {direct_Content_subclass(content).__name__: content._parameters}
+            )
 
     else:
-        paarrays.append(
+        arrow_arrays.append(
             layout.to_arrow(
                 list_to32=list_to32,
                 string_to32=string_to32,
@@ -155,16 +173,20 @@ def _impl(
                 record_is_scalar=record_is_scalar,
             )
         )
-        pafields.append(
-            pyarrow.field("", paarrays[-1].type).with_nullable(
+        arrow_fields.append(
+            pyarrow.field("", arrow_arrays[-1].type).with_nullable(
                 layout.is_option or layout.is_identity_like
             )
         )
 
-    batch = pyarrow.RecordBatch.from_arrays(paarrays, schema=pyarrow.schema(pafields))
+    batch = pyarrow.RecordBatch.from_arrays(
+        arrow_arrays, schema=pyarrow.schema(arrow_fields)
+    )
     out = pyarrow.Table.from_batches([batch])
 
-    if parameters is None:
+    if schema_parameters is None:
         return out
     else:
-        return out.replace_schema_metadata({"ak:parameters": json.dumps(parameters)})
+        return out.replace_schema_metadata(
+            {"ak:parameters": json.dumps(schema_parameters)}
+        )

--- a/tests/test_2646_from_parquet_highlevel.py
+++ b/tests/test_2646_from_parquet_highlevel.py
@@ -1,8 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import pytest  # noqa: F401
+import pytest
 
 import awkward as ak
+
+pytest.importorskip("pyarrow")
 
 
 def test(tmp_path):

--- a/tests/test_2646_from_parquet_highlevel.py
+++ b/tests/test_2646_from_parquet_highlevel.py
@@ -1,0 +1,18 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test(tmp_path):
+    ak.to_parquet([1, 2, 3], tmp_path / "test.parquet", extensionarray=True)
+    ak.to_parquet([1, 2, 3], tmp_path / "test2.parquet", extensionarray=True)
+
+    # Single paths
+    layout = ak.from_parquet(tmp_path / "test.parquet", highlevel=False)
+    assert isinstance(layout, ak.contents.Content)
+
+    # Multiple paths
+    layout = ak.from_parquet(tmp_path / "test*.parquet", highlevel=False)
+    assert isinstance(layout, ak.contents.Content)


### PR DESCRIPTION
This PR ensures that `ak.from_parquet` can handle `highlevel=False` in all branches. It also adds some useful comments to the Arrow table-reading code.