### PR TITLE
feat: add `__dlpack__`, `from_dlpack` support

### DIFF
--- a/src/awkward/_connect/dlpack.py
+++ b/src/awkward/_connect/dlpack.py
@@ -1,0 +1,51 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("DLPackDevice", "get_layout_device", "to_dlpack")
+from enum import IntEnum
+
+from awkward._do import recursively_apply
+from awkward._typing import Any
+from awkward.contents import Content
+
+
+class DLPackDevice(IntEnum):
+    CPU = 1  # CPU
+    CUDA = 2  # GPU
+    CUDA_PINNED = 3  # GPU & CPU
+    OPENCL = 4  # UNSUPPORTED
+    VULKAN = 7  # UNSUPPORTED
+    METAL = 8  # UNSUPPORTED
+    VPI = 9  # UNSUPPORTED
+    ROCM = 10  # GPU
+    ROCM_PINNED = 11  # GPU & CPU
+    CUDA_MANAGED = 13  # GPU & CPU
+
+
+def get_layout_device(layout: Content) -> tuple[int, int]:
+    device: tuple[int, int] | None = None
+
+    def apply(layout, **kwargs):
+        nonlocal device
+        if layout.is_numpy:
+            device = layout.data.__dlpack_device__()
+
+    recursively_apply(
+        layout,
+        apply,
+        return_simplified=False,
+        numpy_to_regular=False,
+        return_array=False,
+    )
+
+    if device is None:
+        raise TypeError(
+            "Cannot determine the DLPack device for an array "
+            "without any NumpyArray layout nodes"
+        )
+    return device
+
+
+def to_dlpack(layout: Content, stream: Any) -> Any:
+    array = layout.to_backend_array(allow_missing=False)
+    return array.__dlpack__(stream)

--- a/src/awkward/_connect/dlpack.py
+++ b/src/awkward/_connect/dlpack.py
@@ -46,6 +46,9 @@ def get_layout_device(layout: Content) -> tuple[int, int]:
     return device
 
 
-def to_dlpack(layout: Content, stream: Any) -> Any:
+def to_dlpack(layout: Content, stream: Any = None) -> Any:
     array = layout.to_backend_array(allow_missing=False)
-    return array.__dlpack__(stream)
+    if stream is None:
+        return array.__dlpack__()
+    else:
+        return array.__dlpack__(stream)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -30,14 +30,6 @@ from awkward.contents.numpyarray import NumpyArray
 UNSUPPORTED = Sentinel("UNSUPPORTED", __name__)
 
 
-def convert_to_array(layout, args, kwargs):
-    out = ak.operations.to_numpy(layout, allow_missing=False)
-    if args == () and kwargs == {}:
-        return out
-    else:
-        return numpy.array(out, *args, **kwargs)
-
-
 implemented = {}
 
 

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -30,7 +30,9 @@ def to_nplike(
         )
 
     # Copy to host memory
-    if isinstance(from_nplike, awkward._nplikes.cupy.Cupy):
+    if isinstance(from_nplike, awkward._nplikes.cupy.Cupy) and not isinstance(
+        nplike, awkward._nplikes.cupy.Cupy
+    ):
         array = array.get()
 
     return nplike.asarray(array)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -14,7 +14,7 @@ from awkward._nplikes.numpylike import (
 )
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._typing import Final, Literal
+from awkward._typing import Any, Final, Literal
 
 np = NumpyMetadata.instance()
 
@@ -58,6 +58,9 @@ class ArrayModuleNumpyLike(NumpyLike):
         assert not isinstance(buffer, PlaceholderArray)
         assert not isinstance(count, PlaceholderArray)
         return self._module.frombuffer(buffer, dtype=dtype, count=count)
+
+    def from_dlpack(self, x: Any) -> ArrayLike:
+        return self._module.from_dlpack(x)
 
     def zeros(
         self, shape: int | tuple[int, ...], *, dtype: np.dtype | None = None

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -183,8 +183,23 @@ class ArrayModuleNumpyLike(NumpyLike):
         `_getitem_range` (if step == 1). Normalize lengths to fit length of array,
         and for arrays with unknown lengths, these offsets become none.
         """
-        start, stop, step = slice_.indices(length)
+        # We have known_data (therefore known shape), so we can safely convert to int
+        slice_as_shape = slice(
+            slice_.start
+            if slice_.start is None
+            else self.index_as_shape_item(slice_.start),
+            slice_.stop
+            if slice_.stop is None
+            else self.index_as_shape_item(slice_.stop),
+            slice_.step
+            if slice_.step is None
+            else self.index_as_shape_item(slice_.step),
+        )
+        start, stop, step = slice_as_shape.indices(length)
         slice_length = math.ceil((stop - start) / step)
+
+        # Shape items are already valid indices, so we don't need to invoke
+        # `shape_item_as_index`
         return start, stop, step, slice_length
 
     def regularize_index_for_length(

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -14,6 +14,7 @@ from awkward._typing import Final
 @register_nplike
 class Cupy(ArrayModuleNumpyLike):
     is_eager: Final = False
+    supports_structured_dtypes: Final = False
 
     def __init__(self):
         import awkward._connect.cuda  # noqa: F401

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -12,6 +12,7 @@ from awkward._typing import Final
 @register_nplike
 class Jax(ArrayModuleNumpyLike):
     is_eager: Final = True
+    supports_structured_dtypes: Final = False
 
     def __init__(self):
         jax = ak.jax.import_jax()

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -15,6 +15,7 @@ np = NumpyMetadata.instance()
 @register_nplike
 class Numpy(ArrayModuleNumpyLike):
     is_eager: Final = True
+    supports_structured_dtypes: Final = True
 
     def __init__(self):
         self._module = numpy

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -165,6 +165,12 @@ class ArrayLike(Protocol):
     def __invert__(self) -> Self:
         ...
 
+    def __dlpack_device__(self) -> tuple[int, int]:
+        ...
+
+    def __dlpack__(self, stream: Any = None) -> Any:
+        ...
+
 
 class NumpyMetadata(Singleton):
     bool_ = numpy.bool_
@@ -233,6 +239,11 @@ if hasattr(numpy, "timedelta64"):
 
 class NumpyLike(Singleton, Protocol):
     ############################ Awkward features
+
+    @property
+    @abstractmethod
+    def supports_structured_dtypes(self) -> bool:
+        ...
 
     @property
     @abstractmethod

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -8,6 +8,7 @@ import numpy
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._singleton import Singleton
 from awkward._typing import (
+    Any,
     Literal,
     NamedTuple,
     Protocol,
@@ -263,6 +264,10 @@ class NumpyLike(Singleton, Protocol):
     def frombuffer(
         self, buffer, *, dtype: numpy.dtype | None = None, count: int = -1
     ) -> ArrayLike:
+        ...
+
+    @abstractmethod
+    def from_dlpack(self, x: Any) -> ArrayLike:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -652,6 +652,11 @@ class TypeTracer(NumpyLike):
             try_touch_data(x)
         raise NotImplementedError
 
+    def from_dlpack(self, x: Any) -> TypeTracerArray:
+        assert not isinstance(x, PlaceholderArray)
+        try_touch_data(x)
+        raise NotImplementedError
+
     def zeros(
         self, shape: ShapeItem | tuple[ShapeItem, ...], *, dtype: np.dtype | None = None
     ) -> TypeTracerArray:

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -500,6 +500,7 @@ def try_touch_shape(array):
 class TypeTracer(NumpyLike):
     known_data: Final = False
     is_eager: Final = True
+    supports_structured_dtypes: Final = True
 
     def _apply_ufunc(self, ufunc, *inputs):
         for x in inputs:
@@ -1382,6 +1383,12 @@ class TypeTracer(NumpyLike):
     def is_c_contiguous(self, x: ArrayLike) -> bool:
         assert not isinstance(x, PlaceholderArray)
         return True
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        raise NotImplementedError
+
+    def __dlpack__(self, stream=None):
+        raise NotImplementedError
 
 
 def _attach_report(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1115,6 +1115,13 @@ class RecordArray(Content):
         contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
+
+        if not backend.nplike.supports_structured_dtypes:
+            raise TypeError(
+                f"backend {backend.name!r} does not support structured "
+                f"dtypes required for converting {type(self).__name__} "
+                f"into a backend array"
+            )
         out = backend.nplike.empty(
             self.length,
             dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1297,33 +1297,21 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             "text/plain": repr(self),
         }
 
-    def __array__(self, *args, **kwargs):
-        """
-        Intercepts attempts to convert this Array into a NumPy array and
-        either performs a zero-copy conversion or raises an error.
+    @property
+    def __cuda_array_interface__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__cuda_array_interface__", (self,), {}
+        ):
+            array = ak.operations.to_cupy(self)
+            return array.__cuda_array_interface__
 
-        This function is also called by the
-        [np.asarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html)
-        family of functions, which have `copy=False` by default.
-
-            >>> np.asarray(ak.Array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
-            array([[1.1, 2.2, 3.3],
-                   [4.4, 5.5, 6.6]])
-
-        If the data are numerical and regular (nested lists have equal lengths
-        in each dimension, as described by the #type), they can be losslessly
-        converted to a NumPy array and this function returns without an error.
-
-        Otherwise, the function raises an error. It does not create a NumPy
-        array with dtype `"O"` for `np.object_` (see the
-        [note on object_ type](https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html#arrays-scalars-built-in))
-        since silent conversions to dtype `"O"` arrays would not only be a
-        significant performance hit, but would also break functionality, since
-        nested lists in a NumPy `"O"` array are severed from the array and
-        cannot be sliced as dimensions.
-        """
-        with ak._errors.OperationErrorContext("numpy.asarray", (self, *args), kwargs):
-            return ak._connect.numpy.convert_to_array(self._layout, args, kwargs)
+    @property
+    def __array_interface__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__array_interface__", (self,), {}
+        ):
+            array = ak.operations.to_numpy(self)
+            return array.__array_interface__
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """
@@ -2406,16 +2394,21 @@ class ArrayBuilder(Sized):
             limit_rows=limit_rows, limit_cols=limit_cols, type=type, stream=stream
         )
 
-    def __array__(self, *args, **kwargs):
-        """
-        Intercepts attempts to convert a #snapshot of this array into a
-        NumPy array and either performs a zero-copy conversion or raises
-        an error.
+    @property
+    def __cuda_array_interface__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__cuda_array_interface__", (self,), {}
+        ):
+            array = ak.operations.to_cupy(self)
+            return array.__cuda_array_interface__
 
-        See #ak.Array.__array__ for a more complete description.
-        """
-        with ak._errors.OperationErrorContext("numpy.asarray", (self, *args), kwargs):
-            return ak._connect.numpy.convert_to_array(self.snapshot(), args, kwargs)
+    @property
+    def __array_interface__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__array_interface__", (self,), {}
+        ):
+            array = ak.operations.to_numpy(self)
+            return array.__array_interface__
 
     @property
     def numba_type(self):

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -19,6 +19,7 @@ import awkward._connect.hist
 from awkward._backends.dispatch import register_backend_lookup_factory
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of, get_array_class, get_record_class
+from awkward._connect.dlpack import get_layout_device, to_dlpack
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -1313,6 +1314,15 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             array = ak.operations.to_numpy(self)
             return array.__array_interface__
 
+    def __dlpack_device__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__dlpack_device__", (self,), {}
+        ):
+            return get_layout_device(self._layout)
+
+    def __dlpack__(self, stream=None):
+        return to_dlpack(self._layout, stream)
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """
         Intercepts attempts to pass this Array to a NumPy
@@ -2409,6 +2419,12 @@ class ArrayBuilder(Sized):
         ):
             array = ak.operations.to_numpy(self)
             return array.__array_interface__
+
+    def __dlpack_device__(self):
+        with ak._errors.OperationErrorContext(
+            f"{type(self).__name__}.__dlpack_device__", (self,), {}
+        ):
+            return get_layout_device(self.snapshot())
 
     @property
     def numba_type(self):

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -33,6 +33,7 @@ from awkward.operations.ak_from_avro_file import *
 from awkward.operations.ak_from_buffers import *
 from awkward.operations.ak_from_categorical import *
 from awkward.operations.ak_from_cupy import *
+from awkward.operations.ak_from_dlpack import *
 from awkward.operations.ak_from_iter import *
 from awkward.operations.ak_from_jax import *
 from awkward.operations.ak_from_json import *

--- a/src/awkward/operations/ak_from_dlpack.py
+++ b/src/awkward/operations/ak_from_dlpack.py
@@ -1,25 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 __all__ = ("from_dlpack",)
-from enum import IntEnum
 
+from awkward._connect.dlpack import DLPackDevice
 from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike
-
-
-class DLPackDevice(IntEnum):
-    CPU = 1  # CPU
-    CUDA = 2  # GPU
-    CUDA_PINNED = 3  # GPU & CPU
-    OPENCL = 4  # UNSUPPORTED
-    VULKAN = 7  # UNSUPPORTED
-    METAL = 8  # UNSUPPORTED
-    VPI = 9  # UNSUPPORTED
-    ROCM = 10  # GPU
-    ROCM_PINNED = 11  # GPU & CPU
-    CUDA_MANAGED = 13  # GPU & CPU
 
 
 @high_level_function()

--- a/src/awkward/operations/ak_from_dlpack.py
+++ b/src/awkward/operations/ak_from_dlpack.py
@@ -1,0 +1,83 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+__all__ = ("from_dlpack",)
+from enum import IntEnum
+
+from awkward._dispatch import high_level_function
+from awkward._layout import from_arraylib, wrap_layout
+from awkward._nplikes.cupy import Cupy
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.numpylike import NumpyLike
+
+
+class DLPackDevice(IntEnum):
+    CPU = 1  # CPU
+    CUDA = 2  # GPU
+    CUDA_PINNED = 3  # GPU & CPU
+    OPENCL = 4  # UNSUPPORTED
+    VULKAN = 7  # UNSUPPORTED
+    METAL = 8  # UNSUPPORTED
+    VPI = 9  # UNSUPPORTED
+    ROCM = 10  # GPU
+    ROCM_PINNED = 11  # GPU & CPU
+    CUDA_MANAGED = 13  # GPU & CPU
+
+
+@high_level_function()
+def from_dlpack(
+    array, *, prefer_cpu=True, regulararray=False, highlevel=True, behavior=None
+):
+    """
+    Args:
+        array (cp.ndarray): The DLPack-supporting array to convert into an
+            Awkward Array.
+        prefer_cpu (bool): If True, and the array device supports both CPU and
+            GPU backends, prefer the CPU; otherwise, prefer the GPU.
+        regulararray (bool): If True and the array is multidimensional,
+            the dimensions are represented by nested #ak.contents.RegularArray
+            nodes; if False and the array is multidimensional, the dimensions
+            are represented by a multivalued #ak.contents.NumpyArray.shape.
+            If the array is one-dimensional, this has no effect.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Converts a DLPack-aware array into an Awkward Array.
+
+    The resulting layout may involve the following #ak.contents.Content types
+    (only):
+
+    * #ak.contents.NumpyArray
+    * #ak.contents.RegularArray if `regulararray=True`.
+    """
+    try:
+        dlpack_info_func = array.__dlpack_device__
+    except AttributeError:
+        ...
+    device_type, device_id = dlpack_info_func()
+
+    # Only a subset of known devices are supported.
+    nplike: NumpyLike
+    if device_type == DLPackDevice.CPU:
+        nplike = Numpy.instance()
+    elif device_type == DLPackDevice.CUDA:
+        nplike = Cupy.instance()
+    elif device_type == DLPackDevice.CUDA_PINNED:
+        # TODO: this should support GPU
+        # nplike = (Numpy if prefer_cpu else Cupy).instance()
+        nplike = Numpy.instance()
+    elif device_type == DLPackDevice.ROCM:
+        nplike = Cupy.instance()
+    elif device_type == DLPackDevice.ROCM_PINNED:
+        nplike = (Numpy if prefer_cpu else Cupy).instance()
+    elif device_type == DLPackDevice.CUDA_MANAGED:
+        nplike = (Numpy if prefer_cpu else Cupy).instance()
+    else:
+        raise AssertionError
+
+    array = nplike.from_dlpack(array)
+    return wrap_layout(
+        from_arraylib(array, regulararray, False),
+        highlevel=highlevel,
+        behavior=behavior,
+    )

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -102,6 +102,9 @@ def _impl(array, allow_record, allow_other, regulararray):
     elif ak._util.in_module(array, "pyarrow"):
         return ak.operations.from_arrow(array, highlevel=False)
 
+    elif hasattr(array, "__dlpack__") and hasattr(array, "__dlpack_device__"):
+        return ak.operations.from_dlpack(array, highlevel=False)
+
     elif isinstance(array, (str, bytes)):
         return ak.operations.from_iter([array], highlevel=False)[0]
 

--- a/tests/test_2649_dlpack_support.py
+++ b/tests/test_2649_dlpack_support.py
@@ -38,3 +38,27 @@ def test_to_dlpack_cupy():
     array = ak.from_cupy(cp_array, regulararray=True)
     cp_from_ak = cp.from_dlpack(array)
     assert cp.shares_memory(cp_array, cp_from_ak)
+
+
+class DLPackOf:
+    def __init__(self, array):
+        self._array = array
+
+    def __dlpack__(self, stream=None):
+        if stream is None:
+            return self._array.__dlpack__()
+        else:
+            return self._array.__dlpack__(stream)
+
+    def __dlpack_device__(self):
+        return self._array.__dlpack_device__()
+
+
+def test_to_layout():
+    np_array = np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    dlpack_array = DLPackOf(np_array)
+    layout = ak.to_layout(dlpack_array)
+    assert layout.is_numpy
+
+    np_from_ak = ak.to_numpy(layout)
+    assert np.shares_memory(np_array, np_from_ak)

--- a/tests/test_2649_dlpack_support.py
+++ b/tests/test_2649_dlpack_support.py
@@ -1,0 +1,40 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward._connect.dlpack import DLPackDevice
+
+
+def test_from_dlpack_numpy():
+    np_array = np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    array = ak.from_dlpack(np_array)
+    np_from_ak = ak.to_numpy(array)
+    assert np.shares_memory(np_array, np_from_ak)
+
+
+def test_to_dlpack_numpy():
+    np_array = np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    array = ak.from_numpy(np_array, regulararray=True)
+    np_from_ak = np.from_dlpack(array)
+    assert np.shares_memory(np_array, np_from_ak)
+    assert array.__dlpack_device__()[0] == DLPackDevice.CPU
+
+
+def test_from_dlpack_cupy():
+    # This test only checks cupy usage, it doesn't explicitly test GPU & CPU
+    cp = pytest.importorskip("cupy")
+    cp_array = cp.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    array = ak.from_dlpack(cp_array)
+    cp_from_ak = ak.to_cupy(array)
+    assert cp.shares_memory(cp_array, cp_from_ak)
+
+
+def test_to_dlpack_cupy():
+    # This test only checks cupy usage, it doesn't explicitly test GPU & CPU
+    cp = pytest.importorskip("cupy")
+    cp_array = cp.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    array = ak.from_cupy(cp_array, regulararray=True)
+    cp_from_ak = cp.from_dlpack(array)
+    assert cp.shares_memory(cp_array, cp_from_ak)


### PR DESCRIPTION
This PR fixes #2648. 

- Adds `Array.__dlpack__(stream=None)` and `Array.__dlpack_device__()`
- Adds `ak.from_dlpack`
- Fixes copying from CUDA in `to_nplike`
- Replaces `Array.__array__` with `Array.__array_interface__` and `Array.__cuda_array_interface__` (as these are higher precedence, and symmetric to one-another. It's arbitrary, we could keep `__array__`, but I think `__array_interface__` should be fairly well supported).