### PR TITLE
fix: support non-hashable values in `parameters_union`

### DIFF
--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -95,7 +95,7 @@ def parameters_intersect(
         return None
 
     common_keys = iter(left.keys() & right.keys())
-    has_exclusions = bool(exclude)
+    has_exclusions = exclude is not None and len(exclude) > 0
 
     # Avoid creating `result` unless we have to
     result = None
@@ -132,7 +132,7 @@ def parameters_union(
     Returns the merged key-value pairs of `left` and `right` as a dictionary.
 
     """
-    has_exclusions = bool(exclude)
+    has_exclusions = exclude is not None and len(exclude) > 0
     items = []
     if left is not None:
         items.append(left.items())

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Collection
 from itertools import chain
 
-from awkward._typing import Any, JSONMapping, JSONSerializable, Set
+from awkward._typing import JSONMapping, Set
 
 TYPE_PARAMETERS = ("__array__", "__list__", "__record__", "__categorical__")
 
@@ -81,13 +80,13 @@ def parameters_intersect(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
-    exclude: Collection[tuple[str, JSONSerializable]] = (),
+    exclude: Set[str] = frozenset(),
 ) -> JSONMapping | None:
     """
     Args:
         left: first parameters mapping
         right: second parameters mapping
-        exclude: collection of (key, value) items to exclude
+        exclude: collection of keys to exclude
 
     Returns the intersected key-value pairs of `left` and `right` as a dictionary.
     """
@@ -95,18 +94,13 @@ def parameters_intersect(
         return None
 
     common_keys = iter(left.keys() & right.keys())
-    has_no_exclusions = len(exclude) == 0
 
     # Avoid creating `result` unless we have to
     result = None
     for key in common_keys:
         left_value = left[key]
         # Do our keys match?
-        if (
-            left_value is not None
-            and left_value == right[key]
-            and (has_no_exclusions or (key, left_value) not in exclude)
-        ):
+        if left_value is not None and left_value == right[key] and key not in exclude:
             # Exit, indicating that we want to create `result`
             if result is None:
                 result = {key: left_value}
@@ -119,7 +113,7 @@ def parameters_union(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
-    exclude: Set[tuple[str, Any]] = frozenset(),
+    exclude: Set[str] = frozenset(),
 ) -> JSONMapping | None:
     """
     Args:
@@ -142,7 +136,7 @@ def parameters_union(
         key, value = item
         if value is None:
             continue
-        if has_exclusions and item in exclude:
+        if has_exclusions and key in exclude:
             continue
         if parameters is None:
             parameters = {key: value}

--- a/src/awkward/_parameters.py
+++ b/src/awkward/_parameters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Collection
 from itertools import chain
 
-from awkward._typing import Any, JSONMapping
+from awkward._typing import JSONMapping, JSONSerializable
 
 TYPE_PARAMETERS = ("__array__", "__list__", "__record__", "__categorical__")
 
@@ -81,7 +81,7 @@ def parameters_intersect(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
-    exclude: Collection[tuple[str, Any]] | None = None,
+    exclude: Collection[tuple[str, JSONSerializable]] | None = None,
 ) -> JSONMapping | None:
     """
     Args:
@@ -121,7 +121,7 @@ def parameters_union(
     left: JSONMapping | None,
     right: JSONMapping | None,
     *,
-    exclude: Collection[tuple[str, Any]] | None = None,
+    exclude: Collection[tuple[str, JSONSerializable]] | None = None,
 ) -> JSONMapping | None:
     """
     Args:

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -473,7 +473,7 @@ class IndexedArray(Content):
                 parameters=parameters_union(
                     next._parameters,
                     self._parameters,
-                    exclude={("__array__", "categorical")},
+                    exclude={"__array__"},
                 )
             )
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -473,7 +473,7 @@ class IndexedArray(Content):
                 parameters=parameters_union(
                     next._parameters,
                     self._parameters,
-                    exclude={"__array__"},
+                    exclude=(("__array__", "categorical"),),
                 )
             )
 

--- a/tests/test_2651_parameter_union.py
+++ b/tests/test_2651_parameter_union.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    layout = ak.contents.IndexedArray(
+        ak.index.Index64([0, 1, 2]),
+        ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.uint32)),
+        parameters={"foo": {"bar": "baz"}},
+    )
+    result = layout.project()
+    assert result.is_equal_to(
+        ak.contents.NumpyArray(
+            np.array([1, 2, 3], dtype=np.uint32), parameters={"foo": {"bar": "baz"}}
+        )
+    )


### PR DESCRIPTION
Fixes dask-contrib/dask-awkward#340