### PR TITLE
fix: support placeholders in shape-only routines

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -80,17 +80,23 @@ class ArrayModuleNumpyLike(NumpyLike):
         return self._module.full(shape, fill_value, dtype=dtype)
 
     def zeros_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
+        if isinstance(x, PlaceholderArray):
+            return PlaceholderArray(self, x.shape, dtype or x.dtype)
+
         return self._module.zeros_like(x, dtype=dtype)
 
     def ones_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
+        if isinstance(x, PlaceholderArray):
+            return PlaceholderArray(self, x.shape, dtype or x.dtype)
+
         return self._module.ones_like(x, dtype=dtype)
 
     def full_like(
         self, x: ArrayLike, fill_value, *, dtype: np.dtype | None = None
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
+        if isinstance(x, PlaceholderArray):
+            return PlaceholderArray(self, x.shape, dtype or x.dtype)
+
         return self._module.full_like(x, fill_value, dtype=dtype)
 
     def arange(
@@ -141,10 +147,30 @@ class ArrayModuleNumpyLike(NumpyLike):
         assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         return self._module.broadcast_arrays(*arrays)
 
+    def _compute_compatible_shape(
+        self, shape: tuple[ShapeItem, ...], existing_shape: tuple[ShapeItem, ...]
+    ) -> tuple[ShapeItem, ...]:
+        next_shape = list(shape)
+        j = None
+        length_factor = 1
+        for i, item in enumerate(shape):
+            if item != -1:
+                length_factor *= item
+            elif j is not None:
+                raise ValueError("can only have one unknown dimension")
+            else:
+                j = i
+        if j is not None:
+            next_shape[j] = math.prod(existing_shape) // length_factor
+        return tuple(next_shape)
+
     def reshape(
         self, x: ArrayLike, shape: tuple[ShapeItem, ...], *, copy: bool | None = None
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
+        if isinstance(x, PlaceholderArray):
+            next_shape = self._compute_compatible_shape(shape, x.shape)
+            return PlaceholderArray(self, next_shape, x.dtype)
+
         if copy is None:
             return self._module.reshape(x, shape)
         elif copy:
@@ -305,6 +331,13 @@ class ArrayModuleNumpyLike(NumpyLike):
         return self._module.broadcast_to(x, shape)
 
     def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
+        if isinstance(x, PlaceholderArray):
+            # Assume contiguous
+            strides = (x.itemsize,)
+            for item in x.shape[-1:0:-1]:
+                strides = (item * strides[0], *strides)
+            return strides
+
         return x.strides
 
     ############################ ufuncs

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -84,23 +84,23 @@ class ArrayModuleNumpyLike(NumpyLike):
 
     def zeros_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
-            return PlaceholderArray(self, x.shape, dtype or x.dtype)
-
-        return self._module.zeros_like(x, dtype=dtype)
+            return self.zeros(x.shape, dtype=dtype or x.dtype)
+        else:
+            return self._module.zeros_like(x, dtype=dtype)
 
     def ones_like(self, x: ArrayLike, *, dtype: np.dtype | None = None) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
-            return PlaceholderArray(self, x.shape, dtype or x.dtype)
-
-        return self._module.ones_like(x, dtype=dtype)
+            return self.ones(x.shape, dtype=dtype or x.dtype)
+        else:
+            return self._module.ones_like(x, dtype=dtype)
 
     def full_like(
         self, x: ArrayLike, fill_value, *, dtype: np.dtype | None = None
     ) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
-            return PlaceholderArray(self, x.shape, dtype or x.dtype)
-
-        return self._module.full_like(x, fill_value, dtype=dtype)
+            return self.full(x.shape, fill_value, dtype=dtype or x.dtype)
+        else:
+            return self._module.full_like(x, fill_value, dtype=dtype)
 
     def arange(
         self,

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -79,6 +79,6 @@ class Jax(ArrayModuleNumpyLike):
     def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
         x.touch_shape()
         out = (x._dtype.itemsize,)
-        for item in reversed(x._shape):
+        for item in x._shape[-1:0:-1]:
             out = (item * out[0], *out)
         return out

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -51,6 +51,11 @@ class ArrayLike(Protocol):
 
     @property
     @abstractmethod
+    def nbytes(self) -> ShapeItem:
+        ...
+
+    @property
+    @abstractmethod
     def T(self) -> Self:
         ...
 

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -36,15 +36,15 @@ class PlaceholderArray(ArrayLike):
         return reduce(mul, self._shape)
 
     @property
+    def nbytes(self) -> ShapeItem:
+        return self.size * self._dtype.itemsize
+
+    @property
     def strides(self) -> tuple[ShapeItem, ...]:
         out = (self._dtype.itemsize,)
         for item in reversed(self._shape):
             out = (item * out[0], *out)
         return out
-
-    @property
-    def itemsize(self) -> int:
-        return self._dtype.itemsize
 
     @property
     def T(self):
@@ -53,7 +53,9 @@ class PlaceholderArray(ArrayLike):
     def view(self, dtype: dtype) -> Self:
         dtype = np.dtype(dtype)
         if len(self._shape) >= 1:
-            last, remainder = divmod(self._shape[-1] * self.itemsize, dtype.itemsize)
+            last, remainder = divmod(
+                self._shape[-1] * self._dtype.itemsize, dtype.itemsize
+            )
             if remainder is not unknown_length and remainder != 0:
                 raise ValueError(
                     "new size of array with larger dtype must be a "

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -24,7 +24,7 @@ class PlaceholderArray(ArrayLike):
         return self._dtype
 
     @property
-    def shape(self) -> tuple[ShapeItem, ...]:
+    def shape(self) -> tuple[int, ...]:
         return self._shape
 
     @property
@@ -32,15 +32,15 @@ class PlaceholderArray(ArrayLike):
         return len(self._shape)
 
     @property
-    def size(self) -> ShapeItem:
+    def size(self) -> int:
         return reduce(mul, self._shape)
 
     @property
-    def nbytes(self) -> ShapeItem:
+    def nbytes(self) -> int:
         return self.size * self._dtype.itemsize
 
     @property
-    def strides(self) -> tuple[ShapeItem, ...]:
+    def strides(self) -> tuple[int, ...]:
         out = (self._dtype.itemsize,)
         for item in reversed(self._shape):
             out = (item * out[0], *out)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -251,10 +251,16 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         self.touch_shape()
         return len(self._shape)
 
+    @property
+    def nbytes(self) -> ShapeItem:
+        return self.size * self._dtype.itemsize
+
     def view(self, dtype: np.dtype) -> Self:
         dtype = np.dtype(dtype)
         if len(self._shape) >= 1:
-            last, remainder = divmod(self._shape[-1] * self.itemsize, dtype.itemsize)
+            last, remainder = divmod(
+                self._shape[-1] * self._dtype.itemsize, dtype.itemsize
+            )
             if remainder is not unknown_length and remainder != 0:
                 raise ValueError(
                     "new size of array with larger dtype must be a "
@@ -284,10 +290,6 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         raise AssertionError(
             "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
         )
-
-    @property
-    def itemsize(self) -> int:
-        return self._dtype.itemsize
 
     class _CTypes:
         data = 0


### PR DESCRIPTION
When dask-awkward used its column optimisation to generate placeholder arrays, we were seeing placeholders in some `nplike` functions that were not prepared for them. This is because these nplike functions explicitly don't touch data for typetracers. 

This fix won't solve the re-hydration issues by itself, but it should get us closer and is fairly easy to reason about.