### PR TITLE
fix: remove unneeded cast

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -417,7 +417,6 @@ class ListOffsetArray(Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        advanced = advanced.to_nplike(self._backend.nplike)
         if head is NO_HEAD:
             return self
 

--- a/tests/test_2653_slice_listoffsetarray.py
+++ b/tests/test_2653_slice_listoffsetarray.py
@@ -1,0 +1,30 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.zip({"x": [[1, 2, 3]], "y": [[4, 5]]}, depth_limit=1)
+    sliced = array[..., np.newaxis]
+    assert sliced.layout.is_equal_to(
+        ak.contents.RecordArray(
+            [
+                ak.contents.RegularArray(
+                    ak.contents.ListOffsetArray(
+                        ak.index.Index64([0, 3]), ak.contents.NumpyArray([1, 2, 3])
+                    ),
+                    1,
+                ),
+                ak.contents.RegularArray(
+                    ak.contents.ListOffsetArray(
+                        ak.index.Index64([0, 2]), ak.contents.NumpyArray([4, 5])
+                    ),
+                    1,
+                ),
+            ],
+            ["x", "y"],
+        )
+    )

--- a/tests/test_2653_slice_listoffsetarray.py
+++ b/tests/test_2653_slice_listoffsetarray.py
@@ -7,20 +7,34 @@ import awkward as ak
 
 
 def test():
-    array = ak.zip({"x": [[1, 2, 3]], "y": [[4, 5]]}, depth_limit=1)
-    sliced = array[..., np.newaxis]
-    assert sliced.layout.is_equal_to(
+    layout = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index64([0, 3]),
+                ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.uint16)),
+            ),
+            ak.contents.ListOffsetArray(
+                ak.index.Index64([0, 2]),
+                ak.contents.NumpyArray(np.array([4, 5], dtype=np.uint16)),
+            ),
+        ],
+        ["x", "y"],
+    )
+    sliced = layout[..., np.newaxis]
+    assert sliced.is_equal_to(
         ak.contents.RecordArray(
             [
                 ak.contents.RegularArray(
                     ak.contents.ListOffsetArray(
-                        ak.index.Index64([0, 3]), ak.contents.NumpyArray([1, 2, 3])
+                        ak.index.Index64([0, 3]),
+                        ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.uint16)),
                     ),
                     1,
                 ),
                 ak.contents.RegularArray(
                     ak.contents.ListOffsetArray(
-                        ak.index.Index64([0, 2]), ak.contents.NumpyArray([4, 5])
+                        ak.index.Index64([0, 2]),
+                        ak.contents.NumpyArray(np.array([4, 5], dtype=np.uint16)),
                     ),
                     1,
                 ),


### PR DESCRIPTION
I noticed a bug during slicing for a record of ragged lists. This PR fixes the bug, which was introduced during the backend addition.