### PR TITLE
fix: multiple-output ufuncs e.g. `divmod`

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -57,20 +57,27 @@ class BroadcastOptions(TypedDict):
 
 
 def length_of_broadcast(inputs: Sequence) -> int | type[unknown_length]:
-    maxlen = 1
-
+    max_length: int | None = None
     has_seen_unknown_length: bool = False
     for x in inputs:
-        if isinstance(x, Content):
-            if x.length is unknown_length:
-                has_seen_unknown_length = True
-                continue
-            maxlen = max(maxlen, x.length)
+        if not isinstance(x, Content):
+            continue
+        if x.length is unknown_length:
+            has_seen_unknown_length = True
+        elif max_length is None:
+            max_length = x.length
+        else:
+            max_length = max(max_length, x.length)
 
     if has_seen_unknown_length:
-        return unknown_length
+        if max_length is None:
+            return unknown_length
+        else:
+            return max_length
+    elif max_length is None:
+        return 1
     else:
-        return maxlen
+        return max_length
 
 
 def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -106,14 +106,14 @@ def broadcast_pack(inputs: Sequence, isscalar: list[bool]) -> list:
     return nextinputs
 
 
-def broadcast_unpack(x, isscalar: list[bool], backend: Backend):
+def broadcast_unpack(x, isscalar: list[bool]):
     if all(isscalar):
-        if not backend.nplike.known_data or x.length == 0:
+        if x.length is not unknown_length and x.length == 0:
             return x._getitem_nothing()._getitem_nothing()
         else:
             return x[0][0]
     else:
-        if not backend.nplike.known_data or x.length == 0:
+        if x.length is not unknown_length and x.length == 0:
             return x._getitem_nothing()
         else:
             return x[0]
@@ -1045,4 +1045,4 @@ def broadcast_and_apply(
         },
     )
     assert isinstance(out, tuple)
-    return tuple(broadcast_unpack(x, isscalar, backend) for x in out)
+    return tuple(broadcast_unpack(x, isscalar) for x in out)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -319,6 +319,7 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
 
     def action(inputs, **ignore):
         contents = [x for x in inputs if isinstance(x, ak.contents.Content)]
+        assert len(contents) >= 1
 
         signature = _array_ufunc_signature(ufunc, inputs)
         # Do we have a custom ufunc (an override of the given ufunc)?
@@ -374,12 +375,9 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
-            # Broadcast parameters against one another, with the default
-            # parameters taken from the first content
-            it_parameters = (c._parameters for c in contents)
-            first_parameters = next(it_parameters, None)
+            # Broadcast parameters against one another
             parameters = functools.reduce(
-                parameters_intersect, it_parameters, first_parameters
+                parameters_intersect, (c._parameters for c in contents)
             )
 
             args = [x.data if isinstance(x, NumpyArray) else x for x in inputs]

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -376,9 +376,12 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
         ):
             nplike = backend.nplike
 
-            # Broadcast parameters against one another
+            # Broadcast parameters against one another, with the default
+            # parameters taken from the first content
+            it_parameters = (c._parameters for c in contents)
+            first_parameters = next(it_parameters, None)
             parameters = functools.reduce(
-                parameters_intersect, [x._parameters for x in contents]
+                parameters_intersect, it_parameters, first_parameters
             )
 
             args = []

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -374,8 +374,6 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
             isinstance(x, NumpyArray) or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
-            nplike = backend.nplike
-
             # Broadcast parameters against one another, with the default
             # parameters taken from the first content
             it_parameters = (c._parameters for c in contents)
@@ -384,12 +382,7 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
                 parameters_intersect, it_parameters, first_parameters
             )
 
-            args = []
-            for x in inputs:
-                if isinstance(x, NumpyArray):
-                    args.append(x._raw(nplike))
-                else:
-                    args.append(x)
+            args = [x.data if isinstance(x, NumpyArray) else x for x in inputs]
 
             # Give backend a chance to change the ufunc implementation
             impl = backend.prepare_ufunc(ufunc)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -6,6 +6,13 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
+from awkward._broadcasting import (
+    apply_step as apply_broadcasting_step,
+)
+from awkward._broadcasting import (
+    broadcast_pack,
+    broadcast_unpack,
+)
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
@@ -554,9 +561,9 @@ def _impl(
 
         inputs = [layout, *more_layouts]
         isscalar = []
-        out = ak._broadcasting.apply_step(
+        out = apply_broadcasting_step(
             backend,
-            ak._broadcasting.broadcast_pack(inputs, isscalar),
+            broadcast_pack(inputs, isscalar),
             action,
             0,
             copy.copy(depth_context),
@@ -565,7 +572,7 @@ def _impl(
             options,
         )
         assert isinstance(out, tuple)
-        out = [ak._broadcasting.broadcast_unpack(x, isscalar, backend) for x in out]
+        out = [broadcast_unpack(x, isscalar) for x in out]
 
         if return_value == "none":
             return

--- a/tests/test_2654_divmod.py
+++ b/tests/test_2654_divmod.py
@@ -1,0 +1,13 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array([[1, 2, 3, 5, 7, 8, 10], [100000, 20000, 301]])
+    quotient, remainder = np.divmod(array, 2)
+    assert ak.almost_equal(quotient, [[0, 1, 1, 2, 3, 4, 5], [50000, 10000, 150]])
+    assert ak.almost_equal(remainder, [[1, 0, 1, 1, 1, 0, 0], [0, 0, 1]])


### PR DESCRIPTION
It turns out that we didn't yet test the `nout != 1` ufuncs, such as `divmod`. 
```python
>>> import awkward as ak
>>> import numpy as np
>>> array = ak.Array([
...     [1, 2, 3],
...     [4]
... ])
>>> np.divmod(array, 2)
[[[0, 1, 1, 2], [1, 0, 1, 0]], []]
```
This PR adds support for this ufunc, with some refactoring work along the way.
```python
>>> import awkward as ak
>>> import numpy as np
>>> array = ak.Array([
...     [1, 2, 3],
...     [4]
... ])
>>> np.divmod(array, 2)
(<Array [[0, 1, 1], [2]] type='2 * var * int64'>, <Array [[1, 0, 1], [0]] type='2 * var * int64'>)
```