### PR TITLE
fix: support unflattening a typetracer-backed array at `axis != 0`

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1284,7 +1284,11 @@ class Content:
     ) -> bool:
         return (
             self.__class__ is other.__class__
-            and len(self) == len(other)
+            and (
+                self.length is unknown_length
+                or other.length is unknown_length
+                or self.length == other.length
+            )
             and type_parameters_equal(self._parameters, other._parameters)
             and self._is_equal_to(other, index_dtype, numpyarray)
         )

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1346,7 +1346,10 @@ class NumpyArray(Content):
     def _is_equal_to(self, other, index_dtype, numpyarray):
         if numpyarray:
             return (
-                self._backend.nplike.array_equal(self.data, other.data)
+                (
+                    not self._backend.nplike.known_data
+                    or self._backend.nplike.array_equal(self.data, other.data)
+                )
                 and self.dtype == other.dtype
                 and self.shape == other.shape
             )

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -220,18 +220,19 @@ class Index:
     def is_equal_to(self, other, index_dtype=True, numpyarray=True):
         if index_dtype:
             return (
-                self.nplike.array_equal(self.data, other.data)
-                and self._data.dtype == other.data.dtype
-            )
+                not self._nplike.known_data
+                or self._nplike.array_equal(self.data, other.data)
+            ) and self._data.dtype == other.data.dtype
+
         else:
-            return self.nplike.array_equal(self.data, other.data)
+            return self._nplike.array_equal(self.data, other.data)
 
     def _touch_data(self):
-        if not self.nplike.known_data:
+        if not self._nplike.known_data:
             self._data.touch_data()
 
     def _touch_shape(self):
-        if not self.nplike.known_data:
+        if not self._nplike.known_data:
             self._data.touch_shape()
 
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -208,8 +208,11 @@ def _impl(array, counts, axis, highlevel, behavior):
                     )
                     - 1
                 )
-                if not backend.index_nplike.array_equal(
-                    inneroffsets[positions], outeroffsets
+                if (
+                    backend.index_nplike.known_data
+                    and not backend.index_nplike.array_equal(
+                        inneroffsets[positions], outeroffsets
+                    )
                 ):
                     raise ValueError(
                         "structure imposed by 'counts' does not fit in the array or partition "

--- a/tests/test_2656_unflatten_axis_typetracer.py
+++ b/tests/test_2656_unflatten_axis_typetracer.py
@@ -1,0 +1,104 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+
+def test():
+    fromjson = {
+        "class": "RecordArray",
+        "fields": ["muon", "anindex"],
+        "contents": [
+            {
+                "class": "ListOffsetArray",
+                "offsets": "i64",
+                "content": {
+                    "class": "RecordArray",
+                    "fields": ["pt", "eta", "phi", "crossref", "thing1"],
+                    "contents": [
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "inner_shape": [],
+                            "parameters": {},
+                            "form_key": "muon_pt!",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "inner_shape": [],
+                            "parameters": {},
+                            "form_key": "muon_eta!",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "inner_shape": [],
+                            "parameters": {},
+                            "form_key": "muon_phi!",
+                        },
+                        {
+                            "class": "ListOffsetArray",
+                            "offsets": "i64",
+                            "content": {
+                                "class": "NumpyArray",
+                                "primitive": "int64",
+                                "inner_shape": [],
+                                "parameters": {},
+                                "form_key": "muon_crossref_content!",
+                            },
+                            "parameters": {},
+                            "form_key": "muon_crossref_index!",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "inner_shape": [],
+                            "parameters": {},
+                            "form_key": "muon_thing1!",
+                        },
+                    ],
+                    "parameters": {},
+                    "form_key": "muon_record!",
+                },
+                "parameters": {},
+                "form_key": "muon_list_outer!",
+            },
+            {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "inner_shape": [],
+                "parameters": {},
+                "form_key": "anindex!",
+            },
+        ],
+        "parameters": {},
+        "form_key": "outer!",
+    }
+
+    form = ak.forms.from_dict(fromjson)
+
+    ttlayout = form.length_zero_array(highlevel=False).to_typetracer(forget_length=True)
+
+    ttarray = ak.Array(ttlayout, behavior=ak.behavior)
+    backend = ttlayout.backend
+
+    result = ak.unflatten(ttarray.muon.pt, ttarray.anindex, axis=1)
+    assert result.layout.is_equal_to(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64(
+                backend.index_nplike.empty(unknown_length, dtype=np.int64)
+            ),
+            ak.contents.ListOffsetArray(
+                ak.index.Index64(
+                    backend.index_nplike.empty(unknown_length, dtype=np.int64)
+                ),
+                ak.contents.NumpyArray(
+                    backend.nplike.empty(unknown_length, dtype=np.int64)
+                ),
+            ),
+        )
+    )


### PR DESCRIPTION
Fixes #2656