### PR TITLE
fix: using `numba.core.errors.Numba<Error>` instead of `Error` in a Numba typing context.

### DIFF
--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -5,6 +5,7 @@ import numba
 import numba.core.typing
 import numba.core.typing.ctypes_utils
 import numpy
+from numba.core.errors import NumbaTypeError
 
 import awkward as ak
 from awkward._behavior import behavior_of, overlay_behavior
@@ -420,7 +421,7 @@ class type_getitem(numba.core.typing.templates.AbstractTemplate):
                     viewtype, wheretype
                 )
             else:
-                raise numba.TypingError(
+                raise NumbaTypeError(
                     "only an integer, start:stop range, or a *constant* "
                     "field name string may be used as ak.Array "
                     "slices in compiled code"
@@ -708,7 +709,7 @@ class type_getitem_record(numba.core.typing.templates.AbstractTemplate):
                 )(recordviewtype, wheretype)
 
             else:
-                raise numba.TypingError(
+                raise NumbaTypeError(
                     "only a *constant* field name string may be used as a "
                     "record slice in compiled code"
                 )

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -420,7 +420,7 @@ class type_getitem(numba.core.typing.templates.AbstractTemplate):
                     viewtype, wheretype
                 )
             else:
-                raise TypeError(
+                raise numba.TypingError(
                     "only an integer, start:stop range, or a *constant* "
                     "field name string may be used as ak.Array "
                     "slices in compiled code"
@@ -708,7 +708,7 @@ class type_getitem_record(numba.core.typing.templates.AbstractTemplate):
                 )(recordviewtype, wheretype)
 
             else:
-                raise TypeError(
+                raise numba.TypingError(
                     "only a *constant* field name string may be used as a "
                     "record slice in compiled code"
                 )

--- a/src/awkward/_connect/numba/arrayview_cuda.py
+++ b/src/awkward/_connect/numba/arrayview_cuda.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numba
+from numba.core.errors import NumbaTypeError
 
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
@@ -23,7 +24,7 @@ class ArrayViewArgHandler:
 
                 return tys, (pos, start, stop, arrayptrs, pylookup)
             else:
-                raise numba.TypingError(
+                raise NumbaTypeError(
                     '`ak.to_backend` should be called with `backend="cuda"` to put '
                     "the array on the GPU before using it: "
                     'ak.to_backend(array, backend="cuda")'

--- a/src/awkward/_connect/numba/arrayview_cuda.py
+++ b/src/awkward/_connect/numba/arrayview_cuda.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-
-from numba import types
+import numba
 
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
@@ -14,7 +13,7 @@ class ArrayViewArgHandler:
         if isinstance(val, ak.Array):
             if isinstance(val.layout.backend, CupyBackend):
                 # Use uint64 for pos, start, stop, the array pointers values, and the pylookup value
-                tys = types.UniTuple(types.uint64, 5)
+                tys = numba.types.UniTuple(numba.types.uint64, 5)
 
                 start = val._numbaview.start
                 stop = val._numbaview.stop
@@ -24,7 +23,7 @@ class ArrayViewArgHandler:
 
                 return tys, (pos, start, stop, arrayptrs, pylookup)
             else:
-                raise TypeError(
+                raise numba.TypingError(
                     '`ak.to_backend` should be called with `backend="cuda"` to put '
                     "the array on the GPU before using it: "
                     'ak.to_backend(array, backend="cuda")'

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -143,14 +143,14 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.clear")
+            raise numba.TypingError("wrong number of arguments for ArrayBuilder.clear")
 
     @numba.core.typing.templates.bound_function("null")
     def resolve_null(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.null")
+            raise numba.TypingError("wrong number of arguments for ArrayBuilder.null")
 
     @numba.core.typing.templates.bound_function("boolean")
     def resolve_boolean(self, arraybuildertype, args, kwargs):
@@ -161,7 +161,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.boolean"
             )
 
@@ -174,7 +174,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.integer"
             )
 
@@ -187,7 +187,9 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.real")
+            raise numba.TypingError(
+                "wrong number or types of arguments for ArrayBuilder.real"
+            )
 
     @numba.core.typing.templates.bound_function("complex")
     def resolve_complex(self, arraybuildertype, args, kwargs):
@@ -200,7 +202,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.complex"
             )
 
@@ -213,7 +215,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.datetime"
             )
 
@@ -226,7 +228,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.timedelta"
             )
 
@@ -239,7 +241,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.string"
             )
 
@@ -248,14 +250,18 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.begin_list")
+            raise numba.TypingError(
+                "wrong number of arguments for ArrayBuilder.begin_list"
+            )
 
     @numba.core.typing.templates.bound_function("end_list")
     def resolve_end_list(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_list")
+            raise numba.TypingError(
+                "wrong number of arguments for ArrayBuilder.end_list"
+            )
 
     @numba.core.typing.templates.bound_function("begin_tuple")
     def resolve_begin_tuple(self, arraybuildertype, args, kwargs):
@@ -266,7 +272,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.begin_tuple"
             )
 
@@ -279,14 +285,18 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return arraybuildertype(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.index")
+            raise numba.TypingError(
+                "wrong number or types of arguments for ArrayBuilder.index"
+            )
 
     @numba.core.typing.templates.bound_function("end_tuple")
     def resolve_end_tuple(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_tuple")
+            raise numba.TypingError(
+                "wrong number of arguments for ArrayBuilder.end_tuple"
+            )
 
     @numba.core.typing.templates.bound_function("begin_record")
     def resolve_begin_record(self, arraybuildertype, args, kwargs):
@@ -299,7 +309,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.begin_record"
             )
 
@@ -312,14 +322,18 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return arraybuildertype(args[0])
         else:
-            raise TypeError("wrong number or types of arguments for ArrayBuilder.field")
+            raise numba.TypingError(
+                "wrong number or types of arguments for ArrayBuilder.field"
+            )
 
     @numba.core.typing.templates.bound_function("end_record")
     def resolve_end_record(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise TypeError("wrong number of arguments for ArrayBuilder.end_record")
+            raise numba.TypingError(
+                "wrong number of arguments for ArrayBuilder.end_record"
+            )
 
     @numba.core.typing.templates.bound_function("append")
     def resolve_append(self, arraybuildertype, args, kwargs):
@@ -386,7 +400,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
                         )(lower)
                         return numba.types.none(args[0])
 
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.append"
             )
 
@@ -399,7 +413,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise TypeError(
+            raise numba.TypingError(
                 "wrong number or types of arguments for ArrayBuilder.extend"
             )
 

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -5,6 +5,7 @@ import numba.core.typing
 import numba.core.typing.ctypes_utils
 import numpy
 from awkward_cpp import libawkward
+from numba.core.errors import NumbaTypeError
 
 import awkward as ak
 
@@ -143,14 +144,14 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError("wrong number of arguments for ArrayBuilder.clear")
+            raise NumbaTypeError("wrong number of arguments for ArrayBuilder.clear")
 
     @numba.core.typing.templates.bound_function("null")
     def resolve_null(self, arraybuildertype, args, kwargs):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError("wrong number of arguments for ArrayBuilder.null")
+            raise NumbaTypeError("wrong number of arguments for ArrayBuilder.null")
 
     @numba.core.typing.templates.bound_function("boolean")
     def resolve_boolean(self, arraybuildertype, args, kwargs):
@@ -161,7 +162,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.boolean"
             )
 
@@ -174,7 +175,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.integer"
             )
 
@@ -187,7 +188,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.real"
             )
 
@@ -202,7 +203,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.complex"
             )
 
@@ -215,7 +216,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.datetime"
             )
 
@@ -228,7 +229,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.timedelta"
             )
 
@@ -241,7 +242,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.string"
             )
 
@@ -250,7 +251,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number of arguments for ArrayBuilder.begin_list"
             )
 
@@ -259,9 +260,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError(
-                "wrong number of arguments for ArrayBuilder.end_list"
-            )
+            raise NumbaTypeError("wrong number of arguments for ArrayBuilder.end_list")
 
     @numba.core.typing.templates.bound_function("begin_tuple")
     def resolve_begin_tuple(self, arraybuildertype, args, kwargs):
@@ -272,7 +271,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.begin_tuple"
             )
 
@@ -285,7 +284,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return arraybuildertype(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.index"
             )
 
@@ -294,9 +293,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError(
-                "wrong number of arguments for ArrayBuilder.end_tuple"
-            )
+            raise NumbaTypeError("wrong number of arguments for ArrayBuilder.end_tuple")
 
     @numba.core.typing.templates.bound_function("begin_record")
     def resolve_begin_record(self, arraybuildertype, args, kwargs):
@@ -309,7 +306,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.begin_record"
             )
 
@@ -322,7 +319,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return arraybuildertype(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.field"
             )
 
@@ -331,7 +328,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         if len(args) == 0 and len(kwargs) == 0:
             return numba.types.none()
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number of arguments for ArrayBuilder.end_record"
             )
 
@@ -400,7 +397,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
                         )(lower)
                         return numba.types.none(args[0])
 
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.append"
             )
 
@@ -413,7 +410,7 @@ class type_methods(numba.core.typing.templates.AttributeTemplate):
         ):
             return numba.types.none(args[0])
         else:
-            raise numba.TypingError(
+            raise NumbaTypeError(
                 "wrong number or types of arguments for ArrayBuilder.extend"
             )
 

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -144,7 +144,7 @@ def find_numba_record_lower(layouttype, behavior):
 @numba.extending.typeof_impl.register(ak.index.Index)
 @numba.extending.typeof_impl.register(ak.record.Record)
 def fake_typeof(obj, c):
-    raise TypeError(
+    raise numba.TypingError(
         "{} objects cannot be passed directly into Numba-compiled functions; "
         "construct a high-level ak.Array or ak.Record instead".format(
             type(obj).__name__
@@ -206,7 +206,7 @@ class ContentType(numba.types.Type):
                 self, viewtype, (*viewtype.fields, key)
             )
         else:
-            raise TypeError(f"array does not have a field with key {key!r}")
+            raise numba.TypingError(f"array does not have a field with key {key!r}")
 
     def lower_getitem_at_check(
         self,
@@ -1224,13 +1224,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
             index = self.fieldindex(key)
             if index is None:
                 if self.fields is None:
-                    raise ValueError(
+                    raise numba.TypingError(
                         "no field {} in tuples with {} fields".format(
                             repr(key), len(self.contenttypes)
                         )
                     )
                 else:
-                    raise ValueError(
+                    raise numba.TypingError(
                         "no field {} in records with fields: [{}]".format(
                             repr(key), ", ".join(repr(x) for x in self.fields)
                         )
@@ -1245,13 +1245,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
         index = self.fieldindex(key)
         if index is None:
             if self.fields is None:
-                raise ValueError(
+                raise numba.TypingError(
                     "no field {} in tuples with {} fields".format(
                         repr(key), len(self.contenttypes)
                     )
                 )
             else:
-                raise ValueError(
+                raise numba.TypingError(
                     "no field {} in records with fields: [{}]".format(
                         repr(key), ", ".join(repr(x) for x in self.fields)
                     )
@@ -1264,13 +1264,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
         index = self.fieldindex(key)
         if index is None:
             if self.fields is None:
-                raise ValueError(
+                raise numba.TypingError(
                     "no field {} in tuple with {} fields".format(
                         repr(key), len(self.contenttypes)
                     )
                 )
             else:
-                raise ValueError(
+                raise numba.TypingError(
                     "no field {} in record with fields: [{}]".format(
                         repr(key), ", ".join(repr(x) for x in self.fields)
                     )
@@ -1482,15 +1482,15 @@ class UnionArrayType(ContentType, ak._lookup.UnionLookup):
 
     def getitem_at(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise numba.TypingError("union types cannot be accessed in Numba")
 
     def getitem_range(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise numba.TypingError("union types cannot be accessed in Numba")
 
     def getitem_field(self, viewtype, key):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise TypeError("union types cannot be accessed in Numba")
+            raise numba.TypingError("union types cannot be accessed in Numba")
 
     def lower_getitem_at(
         self,

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -4,6 +4,7 @@ import json
 
 import llvmlite.ir
 import numba
+from numba.core.errors import NumbaTypeError, NumbaValueError
 
 import awkward as ak
 from awkward._behavior import overlay_behavior
@@ -144,7 +145,7 @@ def find_numba_record_lower(layouttype, behavior):
 @numba.extending.typeof_impl.register(ak.index.Index)
 @numba.extending.typeof_impl.register(ak.record.Record)
 def fake_typeof(obj, c):
-    raise numba.TypingError(
+    raise NumbaTypeError(
         "{} objects cannot be passed directly into Numba-compiled functions; "
         "construct a high-level ak.Array or ak.Record instead".format(
             type(obj).__name__
@@ -206,7 +207,7 @@ class ContentType(numba.types.Type):
                 self, viewtype, (*viewtype.fields, key)
             )
         else:
-            raise numba.TypingError(f"array does not have a field with key {key!r}")
+            raise NumbaTypeError(f"array does not have a field with key {key!r}")
 
     def lower_getitem_at_check(
         self,
@@ -1224,13 +1225,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
             index = self.fieldindex(key)
             if index is None:
                 if self.fields is None:
-                    raise numba.TypingError(
+                    raise NumbaValueError(
                         "no field {} in tuples with {} fields".format(
                             repr(key), len(self.contenttypes)
                         )
                     )
                 else:
-                    raise numba.TypingError(
+                    raise NumbaValueError(
                         "no field {} in records with fields: [{}]".format(
                             repr(key), ", ".join(repr(x) for x in self.fields)
                         )
@@ -1245,13 +1246,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
         index = self.fieldindex(key)
         if index is None:
             if self.fields is None:
-                raise numba.TypingError(
+                raise NumbaValueError(
                     "no field {} in tuples with {} fields".format(
                         repr(key), len(self.contenttypes)
                     )
                 )
             else:
-                raise numba.TypingError(
+                raise NumbaValueError(
                     "no field {} in records with fields: [{}]".format(
                         repr(key), ", ".join(repr(x) for x in self.fields)
                     )
@@ -1264,13 +1265,13 @@ class RecordArrayType(ContentType, ak._lookup.RecordLookup):
         index = self.fieldindex(key)
         if index is None:
             if self.fields is None:
-                raise numba.TypingError(
+                raise NumbaValueError(
                     "no field {} in tuple with {} fields".format(
                         repr(key), len(self.contenttypes)
                     )
                 )
             else:
-                raise numba.TypingError(
+                raise NumbaValueError(
                     "no field {} in record with fields: [{}]".format(
                         repr(key), ", ".join(repr(x) for x in self.fields)
                     )
@@ -1482,15 +1483,15 @@ class UnionArrayType(ContentType, ak._lookup.UnionLookup):
 
     def getitem_at(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise numba.TypingError("union types cannot be accessed in Numba")
+            raise NumbaTypeError("union types cannot be accessed in Numba")
 
     def getitem_range(self, viewtype):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise numba.TypingError("union types cannot be accessed in Numba")
+            raise NumbaTypeError("union types cannot be accessed in Numba")
 
     def getitem_field(self, viewtype, key):
         if not all(isinstance(x, RecordArrayType) for x in self.contenttypes):
-            raise numba.TypingError("union types cannot be accessed in Numba")
+            raise NumbaTypeError("union types cannot be accessed in Numba")
 
     def lower_getitem_at(
         self,

--- a/src/awkward/_connect/numba/layoutbuilder.py
+++ b/src/awkward/_connect/numba/layoutbuilder.py
@@ -62,7 +62,9 @@ class LayoutBuilderType(numba.types.Type):
         if name in self._parameters:
             return numba.types.StringLiteral(self._parameters[name])
         else:
-            raise TypeError(f"LayoutBuilder.parameters does not have a {name!r}")
+            raise numba.TypingError(
+                f"LayoutBuilder.parameters does not have a {name!r}"
+            )
 
     @property
     def length(self):

--- a/src/awkward/_connect/numba/layoutbuilder.py
+++ b/src/awkward/_connect/numba/layoutbuilder.py
@@ -6,6 +6,7 @@ import math
 import numba
 import numba.core.typing.npydecl
 import numpy as np
+from numba.core.errors import NumbaTypeError
 
 import awkward as ak
 from awkward._connect.numba.growablebuffer import GrowableBufferType
@@ -62,9 +63,7 @@ class LayoutBuilderType(numba.types.Type):
         if name in self._parameters:
             return numba.types.StringLiteral(self._parameters[name])
         else:
-            raise numba.TypingError(
-                f"LayoutBuilder.parameters does not have a {name!r}"
-            )
+            raise NumbaTypeError(f"LayoutBuilder.parameters does not have a {name!r}")
 
     @property
     def length(self):


### PR DESCRIPTION
This is the only update needed to pass tests with [Numba 0.58.0rc1](https://numba.discourse.group/t/ann-numba-0-58-0rc1-and-llvmlite-0-41-0rc1/2078). However, that version of Numba still raises a warning if

```bash
export NUMBA_CAPTURED_ERRORS=new_style
```

is not explicitly set (should probably be changed in Numba itself). Most of the exceptions changed were `TypeErrors`, but a few were `ValueErrors` that really ought to have been type errors. (Not finding a record field by name is a type error in compiled code.)

[Vector](https://github.com/scikit-hep/vector) is already up-to-date with respect to `TypeError` versus `numba.TypingError`.