### PR TITLE
feat: `Form.expected_from_buffers` for names/dtypes `ak.from_buffers` needs.

### DIFF
--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -24,8 +24,9 @@ from awkward.index import Index
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem
 
-np = NumpyMetadata.instance()
 numpy = Numpy.instance()
+
+np = NumpyMetadata.instance()
 
 
 @final

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -251,3 +251,9 @@ class BitMaskedForm(Form):
                 parameters=parameters,
                 form_key=form_key,
             )
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "mask"), _index_to_dtype[self._mask])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -1,9 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("BitMaskedForm",)
+
+from collections.abc import Callable
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -252,8 +261,8 @@ class BitMaskedForm(Form):
                 form_key=form_key,
             )
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "mask"), _index_to_dtype[self._mask])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "mask"), index_to_dtype[self._mask])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -215,3 +215,9 @@ class ByteMaskedForm(Form):
             self.__init__(
                 mask, content, valid_when, parameters=parameters, form_key=form_key
             )
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "mask"), _index_to_dtype[self._mask])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -1,9 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("ByteMaskedForm",)
+from collections.abc import Callable
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -216,8 +224,8 @@ class ByteMaskedForm(Form):
                 mask, content, valid_when, parameters=parameters, form_key=form_key
             )
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "mask"), _index_to_dtype[self._mask])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "mask"), index_to_dtype[self._mask])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -1,14 +1,20 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+__all__ = ("EmptyForm",)
+
+from collections.abc import Callable
 from inspect import signature
 
 import awkward as ak
 from awkward._errors import deprecate
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
 from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, JSONMapping
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -144,5 +150,7 @@ class EmptyForm(Form):
 
             self.__init__(form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
         yield from ()

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -143,3 +143,6 @@ class EmptyForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        yield from ()

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -630,3 +630,17 @@ class Form:
             behavior=behavior,
             simplify=False,
         )
+
+    def expected_from_buffers(self, buffer_key="{form_key}-{attribute}"):
+        """
+        Args:
+            buffer_key (str or callable): Python format string containing
+                `"{form_key}"` and/or `"{attribute}"` or a function that takes these
+                as keyword arguments and returns a string to use as a key for a buffer
+                in the `container`.
+        """
+        from awkward.operations.ak_from_buffers import _regularize_buffer_key
+
+        getkey = _regularize_buffer_key(buffer_key)
+
+        return dict(self._expected_from_buffers(getkey))

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -219,3 +219,9 @@ class IndexedForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(index, content, parameters=parameters, form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "index"), _index_to_dtype[self._index])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -1,10 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("IndexedForm",)
+
+from collections.abc import Callable
 
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -220,8 +228,8 @@ class IndexedForm(Form):
 
             self.__init__(index, content, parameters=parameters, form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "index"), _index_to_dtype[self._index])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "index"), index_to_dtype[self._index])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -1,9 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("IndexedOptionForm",)
+from collections.abc import Callable
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -201,8 +209,8 @@ class IndexedOptionForm(Form):
 
             self.__init__(index, content, parameters=parameters, form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "index"), _index_to_dtype[self._index])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "index"), index_to_dtype[self._index])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -200,3 +200,9 @@ class IndexedOptionForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(index, content, parameters=parameters, form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "index"), _index_to_dtype[self._index])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -226,3 +226,10 @@ class ListForm(Form):
             self.__init__(
                 starts, stops, content, parameters=parameters, form_key=form_key
             )
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "starts"), _index_to_dtype[self._starts])
+        yield (getkey(self, "stops"), _index_to_dtype[self._stops])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -1,9 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("ListForm",)
+from collections.abc import Callable
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONSerializable, final
+from awkward._typing import Iterator, JSONSerializable, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -227,9 +235,9 @@ class ListForm(Form):
                 starts, stops, content, parameters=parameters, form_key=form_key
             )
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "starts"), _index_to_dtype[self._starts])
-        yield (getkey(self, "stops"), _index_to_dtype[self._stops])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "starts"), index_to_dtype[self._starts])
+        yield (getkey(self, "stops"), index_to_dtype[self._stops])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -1,11 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+__all__ = ("ListOffsetForm",)
+
+from collections.abc import Callable
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONMapping, JSONSerializable, final
+from awkward._typing import Iterator, JSONMapping, JSONSerializable, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -190,8 +197,8 @@ class ListOffsetForm(Form):
 
             self.__init__(offsets, content, parameters=parameters, form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "offsets"), _index_to_dtype[self._offsets])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "offsets"), index_to_dtype[self._offsets])
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -189,3 +189,9 @@ class ListOffsetForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(offsets, content, parameters=parameters, form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "offsets"), _index_to_dtype[self._offsets])
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -284,3 +284,8 @@ class NumpyForm(Form):
             self.__init__(
                 primitive, inner_shape, parameters=parameters, form_key=form_key
             )
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.types.numpytype import primitive_to_dtype
+
+        yield (getkey(self, "data"), primitive_to_dtype(self.primitive))

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -1,5 +1,8 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-from collections.abc import Iterable
+from __future__ import annotations
+
+__all__ = ("NumpyForm",)
+from collections.abc import Callable, Iterable, Iterator
 
 import awkward as ak
 from awkward._errors import deprecate
@@ -285,7 +288,9 @@ class NumpyForm(Form):
                 primitive, inner_shape, parameters=parameters, form_key=form_key
             )
 
-    def _expected_from_buffers(self, getkey):
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
         from awkward.types.numpytype import primitive_to_dtype
 
         yield (getkey(self, "data"), primitive_to_dtype(self.primitive))

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -301,3 +301,7 @@ class RecordForm(Form):
             self.__init__(
                 contents, recordlookup, parameters=parameters, form_key=form_key
             )
+
+    def _expected_from_buffers(self, getkey):
+        for content in self._contents:
+            yield from content._expected_from_buffers(getkey)

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -1,13 +1,19 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-from collections.abc import Iterable
+from __future__ import annotations
+
+__all__ = ("RecordForm",)
+from collections.abc import Callable, Iterable, Iterator
 
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
 from awkward.errors import FieldNotFoundError
 from awkward.forms.form import Form
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -302,6 +308,8 @@ class RecordForm(Form):
                 contents, recordlookup, parameters=parameters, form_key=form_key
             )
 
-    def _expected_from_buffers(self, getkey):
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
         for content in self._contents:
             yield from content._expected_from_buffers(getkey)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -1,11 +1,19 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("RegularForm",)
+from collections.abc import Callable, Iterator
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import JSONSerializable, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -184,5 +192,7 @@ class RegularForm(Form):
 
             self.__init__(content, size, parameters=parameters, form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -183,3 +183,6 @@ class RegularForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(content, size, parameters=parameters, form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -287,3 +287,11 @@ class UnionForm(Form):
             self.__init__(
                 tags, index, contents, parameters=parameters, form_key=form_key
             )
+
+    def _expected_from_buffers(self, getkey):
+        from awkward.operations.ak_from_buffers import _index_to_dtype
+
+        yield (getkey(self, "tags"), _index_to_dtype[self._tags])
+        yield (getkey(self, "index"), _index_to_dtype[self._index])
+        for content in self._contents:
+            yield from content._expected_from_buffers(getkey)

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -1,12 +1,18 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("UnionForm",)
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, index_to_dtype
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -288,10 +294,10 @@ class UnionForm(Form):
                 tags, index, contents, parameters=parameters, form_key=form_key
             )
 
-    def _expected_from_buffers(self, getkey):
-        from awkward.operations.ak_from_buffers import _index_to_dtype
-
-        yield (getkey(self, "tags"), _index_to_dtype[self._tags])
-        yield (getkey(self, "index"), _index_to_dtype[self._index])
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
+        yield (getkey(self, "tags"), index_to_dtype[self._tags])
+        yield (getkey(self, "index"), index_to_dtype[self._index])
         for content in self._contents:
             yield from content._expected_from_buffers(getkey)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -1,9 +1,17 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("UnmaskedForm",)
+from collections.abc import Callable, Iterator
+
 import awkward as ak
+from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form
+
+np = NumpyMetadata.instance()
 
 
 @final
@@ -173,5 +181,7 @@ class UnmaskedForm(Form):
 
             self.__init__(content, parameters=parameters, form_key=form_key)
 
-    def _expected_from_buffers(self, getkey):
+    def _expected_from_buffers(
+        self, getkey: Callable[[Form, str], str]
+    ) -> Iterator[tuple[str, np.dtype]]:
         yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -172,3 +172,6 @@ class UnmaskedForm(Form):
                 form_key = "part0-" + form_key  # only the first partition
 
             self.__init__(content, parameters=parameters, form_key=form_key)
+
+    def _expected_from_buffers(self, getkey):
+        yield from self._content._expected_from_buffers(getkey)

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -116,23 +116,31 @@ def _impl(
             "'form' argument must be a Form or its Python dict/JSON string representation"
         )
 
+    getkey = _regularize_buffer_key(buffer_key)
+
+    out = _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
+    return wrap_layout(out, behavior, highlevel)
+
+
+def _regularize_buffer_key(buffer_key):
     if isinstance(buffer_key, str):
 
         def getkey(form, attribute):
             return buffer_key.format(form_key=form.form_key, attribute=attribute)
+
+        return getkey
 
     elif callable(buffer_key):
 
         def getkey(form, attribute):
             return buffer_key(form_key=form.form_key, attribute=attribute, form=form)
 
+        return getkey
+
     else:
         raise TypeError(
             f"buffer_key must be a string or a callable, not {type(buffer_key)}"
         )
-
-    out = _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
-    return wrap_layout(out, behavior, highlevel)
 
 
 _index_to_dtype = {

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -11,6 +11,7 @@ from awkward._layout import wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import is_integer
+from awkward.forms.form import index_to_dtype, regularize_buffer_key
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -116,40 +117,10 @@ def _impl(
             "'form' argument must be a Form or its Python dict/JSON string representation"
         )
 
-    getkey = _regularize_buffer_key(buffer_key)
+    getkey = regularize_buffer_key(buffer_key)
 
     out = _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
     return wrap_layout(out, behavior, highlevel)
-
-
-def _regularize_buffer_key(buffer_key):
-    if isinstance(buffer_key, str):
-
-        def getkey(form, attribute):
-            return buffer_key.format(form_key=form.form_key, attribute=attribute)
-
-        return getkey
-
-    elif callable(buffer_key):
-
-        def getkey(form, attribute):
-            return buffer_key(form_key=form.form_key, attribute=attribute, form=form)
-
-        return getkey
-
-    else:
-        raise TypeError(
-            f"buffer_key must be a string or a callable, not {type(buffer_key)}"
-        )
-
-
-_index_to_dtype = {
-    "i8": np.dtype("<i1"),
-    "u8": np.dtype("<u1"),
-    "i32": np.dtype("<i4"),
-    "u32": np.dtype("<u4"),
-    "i64": np.dtype("<i8"),
-}
 
 
 def _from_buffer(nplike, buffer, dtype, count, byteorder):
@@ -215,7 +186,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         mask = _from_buffer(
             backend.index_nplike,
             raw_array,
-            dtype=_index_to_dtype[form.mask],
+            dtype=index_to_dtype[form.mask],
             count=excess_length,
             byteorder=byteorder,
         )
@@ -240,7 +211,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         mask = _from_buffer(
             backend.index_nplike,
             raw_array,
-            dtype=_index_to_dtype[form.mask],
+            dtype=index_to_dtype[form.mask],
             count=length,
             byteorder=byteorder,
         )
@@ -263,7 +234,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         index = _from_buffer(
             backend.index_nplike,
             raw_array,
-            dtype=_index_to_dtype[form.index],
+            dtype=index_to_dtype[form.index],
             count=length,
             byteorder=byteorder,
         )
@@ -288,7 +259,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         index = _from_buffer(
             backend.index_nplike,
             raw_array,
-            dtype=_index_to_dtype[form.index],
+            dtype=index_to_dtype[form.index],
             count=length,
             byteorder=byteorder,
         )
@@ -318,14 +289,14 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         starts = _from_buffer(
             backend.index_nplike,
             raw_array1,
-            dtype=_index_to_dtype[form.starts],
+            dtype=index_to_dtype[form.starts],
             count=length,
             byteorder=byteorder,
         )
         stops = _from_buffer(
             backend.index_nplike,
             raw_array2,
-            dtype=_index_to_dtype[form.stops],
+            dtype=index_to_dtype[form.stops],
             count=length,
             byteorder=byteorder,
         )
@@ -346,7 +317,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         offsets = _from_buffer(
             backend.index_nplike,
             raw_array,
-            dtype=_index_to_dtype[form.offsets],
+            dtype=index_to_dtype[form.offsets],
             count=length + 1,
             byteorder=byteorder,
         )
@@ -392,14 +363,14 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
         tags = _from_buffer(
             backend.index_nplike,
             raw_array1,
-            dtype=_index_to_dtype[form.tags],
+            dtype=index_to_dtype[form.tags],
             count=length,
             byteorder=byteorder,
         )
         index = _from_buffer(
             backend.index_nplike,
             raw_array2,
-            dtype=_index_to_dtype[form.index],
+            dtype=index_to_dtype[form.index],
             count=length,
             byteorder=byteorder,
         )

--- a/tests/test_2660_expected_container_keys_from_form.py
+++ b/tests/test_2660_expected_container_keys_from_form.py
@@ -1,0 +1,775 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_EmptyArray():
+    a = ak.contents.emptyarray.EmptyArray()
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_NumpyArray_to_RegularArray():
+    a = ak.operations.from_numpy(np.arange(2 * 3 * 5).reshape(2, 3, 5)).layout
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    b = a.to_RegularArray()
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    a = ak.operations.from_numpy(np.arange(2 * 0 * 5).reshape(2, 0, 5)).layout
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    b = a.to_RegularArray()
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_NumpyArray():
+    a = ak.contents.numpyarray.NumpyArray(
+        np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    b = ak.contents.numpyarray.NumpyArray(
+        np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_RegularArray_NumpyArray():
+    a = ak.contents.regulararray.RegularArray(
+        ak.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+        ),
+        3,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    b = ak.contents.regulararray.RegularArray(
+        ak.contents.emptyarray.EmptyArray(), 0, zeros_length=10
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ListArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak.contents.listarray.ListArray(
+        ak.index.Index(np.array([4, 100, 1], dtype=np.int64)),
+        ak.index.Index(np.array([7, 100, 3, 200], dtype=np.int64)),
+        ak.contents.numpyarray.NumpyArray(
+            np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ListOffsetArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak.contents.listoffsetarray.ListOffsetArray(
+        ak.index.Index(np.array([1, 4, 4, 6])),
+        ak.contents.numpyarray.NumpyArray(
+            np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_RecordArray_NumpyArray():
+    # 5.5 is inaccessible
+    a = ak.contents.recordarray.RecordArray(
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+        ["x", "y"],
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 5.5 is inaccessible
+    b = ak.contents.recordarray.RecordArray(
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+        None,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    c = ak.contents.recordarray.RecordArray([], [], 10)
+    form, length, container = ak.to_buffers(c)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    d = ak.contents.recordarray.RecordArray([], None, 10)
+    form, length, container = ak.to_buffers(d)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_IndexedArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak.contents.indexedarray.IndexedArray(
+        ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_IndexedOptionArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak.contents.indexedoptionarray.IndexedOptionArray(
+        ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ByteMaskedArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_BitMaskedArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(c)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(d)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_UnmaskedArray_NumpyArray():
+    a = ak.contents.unmaskedarray.UnmaskedArray(
+        ak.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+        )
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_UnionArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak.contents.unionarray.UnionArray.simplified(
+        ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([1, 2, 3])),
+            ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_RegularArray_RecordArray_NumpyArray():
+    # 6.6 is inaccessible
+    a = ak.contents.regulararray.RegularArray(
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        3,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    b = ak.contents.regulararray.RegularArray(
+        ak.contents.recordarray.RecordArray(
+            [ak.contents.emptyarray.EmptyArray()], ["nest"]
+        ),
+        0,
+        zeros_length=10,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ListArray_RecordArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak.contents.listarray.ListArray(
+        ak.index.Index(np.array([4, 100, 1])),
+        ak.index.Index(np.array([7, 100, 3, 200])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ListOffsetArray_RecordArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak.contents.listoffsetarray.ListOffsetArray(
+        ak.index.Index(np.array([1, 4, 4, 6])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_IndexedArray_RecordArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak.contents.indexedarray.IndexedArray(
+        ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_IndexedOptionArray_RecordArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak.contents.indexedoptionarray.IndexedOptionArray(
+        ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_ByteMaskedArray_RecordArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_BitMaskedArray_RecordArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        True,
+                        True,
+                        True,
+                        True,
+                        False,
+                        False,
+                        False,
+                        False,
+                        True,
+                        False,
+                        True,
+                        False,
+                        True,
+                    ]
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(c)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(d)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_UnmaskedArray_RecordArray_NumpyArray():
+    a = ak.contents.unmaskedarray.UnmaskedArray(
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+                )
+            ],
+            ["nest"],
+        )
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype
+
+
+def test_UnionArray_RecordArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak.contents.unionarray.UnionArray.simplified(
+        ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak.contents.recordarray.RecordArray(
+                [ak.contents.numpyarray.NumpyArray(np.array([1, 2, 3]))], ["nest"]
+            ),
+            ak.contents.recordarray.RecordArray(
+                [
+                    ak.contents.numpyarray.NumpyArray(
+                        np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+                    )
+                ],
+                ["nest"],
+            ),
+        ],
+    )
+    form, length, container = ak.to_buffers(a)
+    for name, dtype in form.expected_from_buffers().items():
+        assert container[name].dtype == dtype


### PR DESCRIPTION
Requested by @danielballan in https://github.com/bluesky/tiled/pull/549#issuecomment-1682987096.