### PR TITLE
feat: allow `form_key` to round-trip through `length_zero_array`

### DIFF
--- a/src/awkward/_connect/avro.py
+++ b/src/awkward/_connect/avro.py
@@ -222,7 +222,7 @@ class ReadAvroFT:
         if file["type"] == "null":
             aform = ak.forms.IndexedOptionForm(
                 "i64",
-                ak.forms.EmptyForm(form_key=f"node{form_next_id+1}"),
+                ak.forms.EmptyForm(),
                 form_key=f"node{form_next_id}",
             )
             declarations.append(f"output node{form_next_id+1}-data uint8 \n")

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -192,6 +192,31 @@ class Content:
     def form(self) -> Form:
         return self.form_with_key(None)
 
+    @property
+    def form_with_key_from_parameter(self) -> Form:
+        def getkey(layout):
+            return layout.parameter("__form_key__")
+
+        def remove_parameter(form):
+            if form._parameters is not None and "__form_key__" in form._parameters:
+                if len(form._parameters) == 1:
+                    form._parameters = None
+                else:
+                    form._parameters = {
+                        k: v for k, v in form._parameters.items() if k != "__form_key__"
+                    }
+
+            if hasattr(form, "_content"):
+                remove_parameter(form._content)
+
+            elif hasattr(form, "_contents"):
+                for x in form._contents:
+                    remove_parameter(x)
+
+        out = self._form_with_key(getkey)
+        remove_parameter(out)
+        return out
+
     def form_with_key(
         self, form_key: str | None | Callable = "node{id}", id_start: int = 0
     ) -> Form:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -101,7 +101,8 @@ class EmptyArray(Content):
         return cls(backend=backend)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
-        return self.form_cls(form_key=getkey(self))
+        getkey(self)  # skip a number but don't add a form_key to EmptyForm
+        return self.form_cls()
 
     def _to_buffers(
         self,

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -50,7 +50,7 @@ def from_dict(input: Mapping) -> Form:
         )
 
     elif input["class"] == "EmptyArray":
-        return ak.forms.EmptyForm(parameters=parameters, form_key=form_key)
+        return ak.forms.EmptyForm(parameters=parameters)  # ignore form_key
 
     elif input["class"] == "RegularArray":
         return ak.forms.RegularForm(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -510,7 +510,12 @@ class Form:
         raise NotImplementedError
 
     def length_zero_array(
-        self, *, backend=numpy_backend, highlevel=True, behavior=None
+        self,
+        *,
+        backend=numpy_backend,
+        form_keys_to_parameters=False,
+        highlevel=True,
+        behavior=None,
     ):
         if highlevel:
             deprecate(
@@ -528,9 +533,17 @@ class Form:
             highlevel=highlevel,
             behavior=behavior,
             simplify=False,
+            form_keys_to_parameters=form_keys_to_parameters,
         )
 
-    def length_one_array(self, *, backend=numpy_backend, highlevel=True, behavior=None):
+    def length_one_array(
+        self,
+        *,
+        backend=numpy_backend,
+        form_keys_to_parameters=False,
+        highlevel=True,
+        behavior=None,
+    ):
         # The naive implementation of a length-1 array requires that we have a sufficiently
         # large buffer to be able to build _any_ subtree.
         def max_prefer_unknown(this: ShapeItem, that: ShapeItem) -> ShapeItem:
@@ -629,4 +642,5 @@ class Form:
             highlevel=highlevel,
             behavior=behavior,
             simplify=False,
+            form_keys_to_parameters=form_keys_to_parameters,
         )

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -89,8 +89,8 @@ class UnionForm(Form):
         form_key=None,
     ):
         return ak.contents.UnionArray.simplified(
-            ak.index._form_to_zero_length(tags),
-            ak.index._form_to_zero_length(index),
+            ak.index._form_to_length_zero(tags),
+            ak.index._form_to_length_zero(index),
             [x.length_zero_array(highlevel=False) for x in contents],
             parameters=parameters,
         ).form
@@ -98,7 +98,7 @@ class UnionForm(Form):
     def _union_of_optionarrays(self, index, parameters):
         return (
             self.length_zero_array(highlevel=False)
-            ._union_of_optionarrays(ak.index._form_to_zero_length(index), parameters)
+            ._union_of_optionarrays(ak.index._form_to_length_zero(index), parameters)
             .form
         )
 

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -96,13 +96,13 @@ class UnionForm(Form):
                 for x in contents
             ],
             parameters=parameters,
-        ).form
+        ).form_with_key_from_parameter
 
     def _union_of_optionarrays(self, index, parameters):
         return (
             self.length_zero_array(form_keys_to_parameters=True, highlevel=False)
             ._union_of_optionarrays(ak.index._form_to_length_zero(index), parameters)
-            .form
+            .form_with_key_from_parameter
         )
 
     def content(self, index):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -91,13 +91,16 @@ class UnionForm(Form):
         return ak.contents.UnionArray.simplified(
             ak.index._form_to_length_zero(tags),
             ak.index._form_to_length_zero(index),
-            [x.length_zero_array(highlevel=False) for x in contents],
+            [
+                x.length_zero_array(form_keys_to_parameters=True, highlevel=False)
+                for x in contents
+            ],
             parameters=parameters,
         ).form
 
     def _union_of_optionarrays(self, index, parameters):
         return (
-            self.length_zero_array(highlevel=False)
+            self.length_zero_array(form_keys_to_parameters=True, highlevel=False)
             ._union_of_optionarrays(ak.index._form_to_length_zero(index), parameters)
             .form
         )

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2505,6 +2505,7 @@ class ArrayBuilder(Sized):
                 highlevel=True,
                 behavior=self._behavior,
                 simplify=True,
+                form_keys_to_parameters=False,
             )
 
     def null(self):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -27,7 +27,7 @@ _dtype_to_form: Final = {
 _form_to_dtype: Final = {v: k for k, v in _dtype_to_form.items()}
 
 
-def _form_to_zero_length(form: str) -> Index:
+def _form_to_length_zero(form: str) -> Index:
     try:
         dtype = _form_to_dtype[form]
     except KeyError:

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -62,4 +62,5 @@ def _impl(form, length, container, highlevel, behavior):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
+        form_keys_to_parameters=False,
     )

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -104,4 +104,5 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
+        form_keys_to_parameters=False,
     )[0]

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -10,6 +10,8 @@ __all__ = [
     "unknown_length",
 ]
 
+from typing import Callable
+
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._errors import deprecate
@@ -30,7 +32,9 @@ from awkward.operations.ak_to_layout import to_layout
 T = TypeVar("T", Array, Record)
 
 
-def _length_0_1_if_typetracer(array: T, function):
+def _length_0_1_if_typetracer(
+    array: T, function: Callable, form_keys_to_parameters: bool
+):
     typetracer_backend = TypeTracerBackend.instance()
 
     layout = to_layout(array, allow_other=False)
@@ -38,7 +42,11 @@ def _length_0_1_if_typetracer(array: T, function):
 
     if layout.backend is typetracer_backend:
         layout._touch_data(True)
-        layout = function(layout.form, highlevel=False)
+        layout = function(
+            layout.form,
+            form_keys_to_parameters=form_keys_to_parameters,
+            highlevel=False,
+        )
 
     return wrap_layout(layout, behavior=behavior)
 
@@ -52,9 +60,13 @@ def empty_if_typetracer(array: T) -> T:
     return length_zero_if_typetracer(array)
 
 
-def length_zero_if_typetracer(array: T) -> T:
-    return _length_0_1_if_typetracer(array, Form.length_zero_array)
+def length_zero_if_typetracer(array: T, form_keys_to_parameters: bool = False) -> T:
+    return _length_0_1_if_typetracer(
+        array, Form.length_zero_array, form_keys_to_parameters
+    )
 
 
-def length_one_if_typetracer(array: T) -> T:
-    return _length_0_1_if_typetracer(array, Form.length_one_array)
+def length_one_if_typetracer(array: T, form_keys_to_parameters: bool = False) -> T:
+    return _length_0_1_if_typetracer(
+        array, Form.length_one_array, form_keys_to_parameters
+    )

--- a/tests/test_0057_introducing_forms.py
+++ b/tests/test_0057_introducing_forms.py
@@ -101,21 +101,16 @@ def test_forms():
             parameters={"hey": ["you"]},
             form_key="yowzers",
         )
-    form = ak.forms.EmptyForm(
-        form_key="yowzers",
-    )
+    form = ak.forms.EmptyForm()
     assert form == form
     assert pickle.loads(pickle.dumps(form, -1)) == form
     assert ak.forms.from_json(form.to_json()) == form
     assert json.loads(form.to_json()) == {
         "class": "EmptyArray",
         "parameters": {},
-        "form_key": "yowzers",
+        "form_key": None,
     }
-    assert json.loads(str(form)) == {
-        "class": "EmptyArray",
-        "form_key": "yowzers",
-    }
+    assert json.loads(str(form)) == {"class": "EmptyArray"}
 
     form = ak.forms.IndexedForm(
         "i64",

--- a/tests/test_0914_types_and_forms.py
+++ b/tests/test_0914_types_and_forms.py
@@ -1186,13 +1186,6 @@ def test_EmptyForm():
     "class": "EmptyArray"
 }"""
     )
-    assert (
-        str(ak.forms.emptyform.EmptyForm(form_key="hello"))
-        == """{
-    "class": "EmptyArray",
-    "form_key": "hello"
-}"""
-    )
     assert repr(ak.forms.emptyform.EmptyForm()) == "EmptyForm()"
     with pytest.raises(TypeError):
         ak.forms.emptyform.EmptyForm(parameters={"x": 123}, form_key="hello")
@@ -1205,9 +1198,8 @@ def test_EmptyForm():
         "parameters": {},
         "form_key": None,
     }
-    assert ak.forms.emptyform.EmptyForm(form_key="hello").to_dict(verbose=False) == {
-        "class": "EmptyArray",
-        "form_key": "hello",
+    assert ak.forms.emptyform.EmptyForm().to_dict(verbose=False) == {
+        "class": "EmptyArray"
     }
     assert ak.forms.from_dict({"class": "EmptyArray"}).to_dict() == {
         "class": "EmptyArray",

--- a/tests/test_2661_round_trip_form_keys_through_length_0_1_arrays.py
+++ b/tests/test_2661_round_trip_form_keys_through_length_0_1_arrays.py
@@ -1,0 +1,930 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_EmptyArray():
+    a = ak.contents.emptyarray.EmptyArray()
+    form, length, container = ak.to_buffers(a)
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_NumpyArray_to_RegularArray():
+    a = ak.operations.from_numpy(np.arange(2 * 3 * 5).reshape(2, 3, 5)).layout
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    b = a.to_RegularArray()
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    a = ak.operations.from_numpy(np.arange(2 * 0 * 5).reshape(2, 0, 5)).layout
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    b = a.to_RegularArray()
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_NumpyArray():
+    a = ak.contents.numpyarray.NumpyArray(
+        np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    b = ak.contents.numpyarray.NumpyArray(
+        np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_RegularArray_NumpyArray():
+    a = ak.contents.regulararray.RegularArray(
+        ak.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+        ),
+        3,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    b = ak.contents.regulararray.RegularArray(
+        ak.contents.emptyarray.EmptyArray(), 0, zeros_length=10
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ListArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak.contents.listarray.ListArray(
+        ak.index.Index(np.array([4, 100, 1], dtype=np.int64)),
+        ak.index.Index(np.array([7, 100, 3, 200], dtype=np.int64)),
+        ak.contents.numpyarray.NumpyArray(
+            np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ListOffsetArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak.contents.listoffsetarray.ListOffsetArray(
+        ak.index.Index(np.array([1, 4, 4, 6])),
+        ak.contents.numpyarray.NumpyArray(
+            np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_RecordArray_NumpyArray():
+    # 5.5 is inaccessible
+    a = ak.contents.recordarray.RecordArray(
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+        ["x", "y"],
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 5.5 is inaccessible
+    b = ak.contents.recordarray.RecordArray(
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([0, 1, 2, 3, 4])),
+            ak.contents.numpyarray.NumpyArray(np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+        None,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    c = ak.contents.recordarray.RecordArray([], [], 10)
+    form, length, container = ak.to_buffers(c)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    d = ak.contents.recordarray.RecordArray([], None, 10)
+    form, length, container = ak.to_buffers(d)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_IndexedArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak.contents.indexedarray.IndexedArray(
+        ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_IndexedOptionArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak.contents.indexedoptionarray.IndexedOptionArray(
+        ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ByteMaskedArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=True,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
+        valid_when=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_BitMaskedArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(c)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.numpyarray.NumpyArray(
+            np.array(
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6]
+            )
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(d)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_UnmaskedArray_NumpyArray():
+    a = ak.contents.unmaskedarray.UnmaskedArray(
+        ak.contents.numpyarray.NumpyArray(
+            np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+        )
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_UnionArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak.contents.unionarray.UnionArray.simplified(
+        ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak.contents.numpyarray.NumpyArray(np.array([1, 2, 3])),
+            ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
+        ],
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_RegularArray_RecordArray_NumpyArray():
+    # 6.6 is inaccessible
+    a = ak.contents.regulararray.RegularArray(
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        3,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    b = ak.contents.regulararray.RegularArray(
+        ak.contents.recordarray.RecordArray(
+            [ak.contents.emptyarray.EmptyArray()], ["nest"]
+        ),
+        0,
+        zeros_length=10,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ListArray_RecordArray_NumpyArray():
+    # 200 is inaccessible in stops
+    # 6.6, 7.7, and 8.8 are inaccessible in content
+    a = ak.contents.listarray.ListArray(
+        ak.index.Index(np.array([4, 100, 1])),
+        ak.index.Index(np.array([7, 100, 3, 200])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ListOffsetArray_RecordArray_NumpyArray():
+    # 6.6 and 7.7 are inaccessible
+    a = ak.contents.listoffsetarray.ListOffsetArray(
+        ak.index.Index(np.array([1, 4, 4, 6])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_IndexedArray_RecordArray_NumpyArray():
+    # 4.4 is inaccessible; 3.3 and 5.5 appear twice
+    a = ak.contents.indexedarray.IndexedArray(
+        ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_IndexedOptionArray_RecordArray_NumpyArray():
+    # 1.1 and 4.4 are inaccessible; 3.3 appears twice
+    a = ak.contents.indexedoptionarray.IndexedOptionArray(
+        ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_ByteMaskedArray_RecordArray_NumpyArray():
+    # 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bytemaskedarray.ByteMaskedArray(
+        ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_BitMaskedArray_RecordArray_NumpyArray():
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    a = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        True,
+                        True,
+                        True,
+                        True,
+                        False,
+                        False,
+                        False,
+                        False,
+                        True,
+                        False,
+                        True,
+                        False,
+                        True,
+                    ]
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    b = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=False,
+    )
+    form, length, container = ak.to_buffers(b)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    c = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                        1,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=True,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(c)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+    # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
+    d = ak.contents.bitmaskedarray.BitMaskedArray(
+        ak.index.Index(
+            np.packbits(
+                np.array(
+                    [
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        1,
+                        0,
+                    ],
+                    dtype=np.uint8,
+                )
+            )
+        ),
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array(
+                        [
+                            0.0,
+                            1.0,
+                            2.0,
+                            3.0,
+                            4.0,
+                            5.0,
+                            6.0,
+                            7.0,
+                            1.1,
+                            2.2,
+                            3.3,
+                            4.4,
+                            5.5,
+                            6.6,
+                        ]
+                    )
+                )
+            ],
+            ["nest"],
+        ),
+        valid_when=False,
+        length=13,
+        lsb_order=True,
+    )
+    form, length, container = ak.to_buffers(d)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_UnmaskedArray_RecordArray_NumpyArray():
+    a = ak.contents.unmaskedarray.UnmaskedArray(
+        ak.contents.recordarray.RecordArray(
+            [
+                ak.contents.numpyarray.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
+                )
+            ],
+            ["nest"],
+        )
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters
+
+
+def test_UnionArray_RecordArray_NumpyArray():
+    # 100 is inaccessible in index
+    # 1.1 is inaccessible in contents[1]
+    a = ak.contents.unionarray.UnionArray.simplified(
+        ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak.contents.recordarray.RecordArray(
+                [ak.contents.numpyarray.NumpyArray(np.array([1, 2, 3]))], ["nest"]
+            ),
+            ak.contents.recordarray.RecordArray(
+                [
+                    ak.contents.numpyarray.NumpyArray(
+                        np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+                    )
+                ],
+                ["nest"],
+            ),
+        ],
+    )
+    form, length, container = ak.to_buffers(a)
+    assert form != form.length_zero_array(highlevel=False).form
+    round_trip = form.length_zero_array(
+        form_keys_to_parameters=True, highlevel=False
+    ).form_with_key_from_parameter
+    assert form == round_trip
+    assert form.to_dict() == round_trip.to_dict()  # checks non-type parameters


### PR DESCRIPTION
**Note:** see below; this _deprecates_ `form_key != None` on `EmptyForm` and immediately changes some of the ways that `EmptyForm` works with `form_keys`. @agoose77, @douglasdavis, and @lgray probably want to know about this and weigh in on whether it will be a problem.

--------------------

This started as an observation that `UnionForm.simplified` is wrong because it strips the `form_keys` from all of its `contents` (in https://github.com/bluesky/tiled/pull/549#discussion_r1298819704). That's because it's implemented by a round-trip through length-zero `UnionArray.simplified`. (The `UnionArray.simplified` logic is too complex to replicate in `UnionForm`. It would be a maintenance burden to try to do so.)

I know that we've struggled with this aspect of `Form.length_zero_array` in the past: we occasionally need it to simulate what should happen to a Form, but the Form is carrying important `form_keys` that we don't want to just drop. Repopulating the round-tripped Form with the original `form_keys` is a hassle and error-prone.

Therefore, this PR introduces a new parameter, `"__form_key__"`, to carry `form_keys` through temporary arrays made by `Form.length_zero_array` and `Form.length_one_array`. It's opt-in.

```python
>>> from awkward.forms import *
>>> form = ListOffsetForm(
...     "i64",
...     RecordForm(
...         [
...             NumpyForm("float64", form_key="node2"),
...             ListOffsetForm(
...                 "i64", NumpyForm("int64", form_key="node4"), form_key="node3"
...             ),
...         ],
...         ["x", "y"],
...         form_key="node1",
...     ),
...     form_key="node0",
... )
>>> layout = form.length_zero_array(form_keys_to_parameters=True, highlevel=False)
>>> layout
<ListOffsetArray len='0'>
    <parameter name='__form_key__'>'node0'</parameter>
    <offsets><Index dtype='int64' len='1'>[0]</Index></offsets>
    <content><RecordArray is_tuple='false' len='0'>
        <parameter name='__form_key__'>'node1'</parameter>
        <content index='0' field='x'>
            <NumpyArray dtype='float64' len='0'>
                <parameter name='__form_key__'>'node2'</parameter>
                []
            </NumpyArray>
        </content>
        <content index='1' field='y'>
            <ListOffsetArray len='0'>
                <parameter name='__form_key__'>'node3'</parameter>
                <offsets><Index dtype='int64' len='1'>[0]</Index></offsets>
                <content><NumpyArray dtype='int64' len='0'>
                    <parameter name='__form_key__'>'node4'</parameter>
                    []
                </NumpyArray></content>
            </ListOffsetArray>
        </content>
    </RecordArray></content>
</ListOffsetArray>
```

Converting all of the `"__form_key__"` parameters back into `form_keys` (as opposed to `parameters` on the Form) is also opt-in, but a library developer would know about both by following examples:

```python
>>> print(layout.form)
{
    "class": "ListOffsetArray",
    "offsets": "i64",
    "content": {
        "class": "RecordArray",
        "fields": [
            "x",
            "y"
        ],
        "contents": [
            {
                "class": "NumpyArray",
                "primitive": "float64",
                "parameters": {
                    "__form_key__": "node2"
                }
            },
            {
                "class": "ListOffsetArray",
                "offsets": "i64",
                "content": {
                    "class": "NumpyArray",
                    "primitive": "int64",
                    "parameters": {
                        "__form_key__": "node4"
                    }
                },
                "parameters": {
                    "__form_key__": "node3"
                }
            }
        ],
        "parameters": {
            "__form_key__": "node1"
        }
    },
    "parameters": {
        "__form_key__": "node0"
    }
}
>>> print(layout.form_with_key_from_parameter)
{
    "class": "ListOffsetArray",
    "offsets": "i64",
    "content": {
        "class": "RecordArray",
        "fields": [
            "x",
            "y"
        ],
        "contents": [
            {
                "class": "NumpyArray",
                "primitive": "float64",
                "form_key": "node2"
            },
            {
                "class": "ListOffsetArray",
                "offsets": "i64",
                "content": {
                    "class": "NumpyArray",
                    "primitive": "int64",
                    "form_key": "node4"
                },
                "form_key": "node3"
            }
        ],
        "form_key": "node1"
    },
    "form_key": "node0"
}
```

And then there's the issue that `EmptyArrays` don't have `parameters`. For this mechanism to work on all node types, `EmptyArrays` can't have `form_keys`, either. That's okay: they can't have buffers, so they don't really need `form_keys`.

So this PR makes the following immediate changes, which I think are safe:

* `EmptyForm.__eq__` ignores the `form_key` when determining if two Forms are equal.
* `ak.forms.from_dict` (and `from_json`) ignores `form_key` when constructing `EmptyForm` from dicts (or JSON). It's important to allow the dict (or JSON) format continue to have `"parameters"` and `"form_key"` keys, for format version independence/schema evolution, but we no longer read these fields.
* `EmptyForm.to_dict` (and `to_json`) outputs `"form_key": None` if `verbose=True`, rather than outputting its actual `form_key`.
* All of the functions in Awkward Array that create `EmptyForms` create them without `form_keys`. In particular, `Content.form_with_key` _skips a number_ when constructing `form_key` names from `f"node{number}"`. This is so that old Forms that might be saved somewhere in JSON format don't have to be modified in a major way (changing all the numbers after the first `EmptyForm`) to get the same `form_keys` as the new `Content.form_with_key` outputs.

It also deprecates intentional, explicit passing of `form_key != None` in

* the `EmptyArray` constructor
* the `EmptyArray.copy` method
* the `EmptyArray.simplified` constructor

The deprecation warning turns into an error in Awkward Array **2.5.0** (much as non-empty `parameters` were removed in Awkward Array 2.2.0).