### PR TITLE
fix: raise error for invalid object in `from_dlpack`

### DIFF
--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -10,7 +10,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._typing import Final, Self
+from awkward._typing import Any, Final, Self
 
 np: Final = NumpyMetadata.instance()
 numpy: Final = Numpy.instance()
@@ -144,6 +144,15 @@ class Index:
     @property
     def __array_interface__(self):
         return self._data.__array_interface__
+
+    def __dlpack__(self) -> tuple[int, int]:
+        return self._data.__dlpack_device__()
+
+    def __dlpack_device__(self, stream: Any = None) -> Any:
+        if stream is None:
+            return self._data.__dlpack__()
+        else:
+            return self._data.__dlpack__(stream)
 
     def __repr__(self):
         return self._repr("", "", "")

--- a/src/awkward/operations/ak_from_dlpack.py
+++ b/src/awkward/operations/ak_from_dlpack.py
@@ -39,8 +39,10 @@ def from_dlpack(
     """
     try:
         dlpack_info_func = array.__dlpack_device__
-    except AttributeError:
-        ...
+    except AttributeError as err:
+        raise TypeError(
+            f"Expected an object that implements the DLPack protocol, received {type(array)}"
+        ) from err
     device_type, device_id = dlpack_info_func()
 
     # Only a subset of known devices are supported.

--- a/tests/test_2649_dlpack_support.py
+++ b/tests/test_2649_dlpack_support.py
@@ -62,3 +62,10 @@ def test_to_layout():
 
     np_from_ak = ak.to_numpy(layout)
     assert np.shares_memory(np_array, np_from_ak)
+
+
+def test_invalid_argument():
+    with pytest.raises(
+        TypeError, match=r"Expected an object that implements the DLPack protocol"
+    ):
+        ak.from_dlpack([1, 2, 3])


### PR DESCRIPTION
When I wrote this branch in `from_dlpack`, I think I was considering support for the PyCapsule legacy interface. Apparently I never restored an error case.

Whilst we're at it, this PR also adds support for conversion of index objects to DLPack.