### PR TITLE
fix: fix/harden broadcasting through tuples

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -473,44 +473,46 @@ def apply_step(
         if not options["allow_records"]:
             raise ValueError(f"cannot broadcast records{in_function(options)}")
 
-        fields: list[str] | None = UNSET
-        frozen_fields: frozenset[str] | None = UNSET
-
-        is_tuple: bool = True
+        frozen_record_fields: frozenset[str] | None = UNSET
+        first_record = next(c for c in contents if c.is_record)
         nextparameters = []
 
         for x in contents:
             if x.is_record:
                 nextparameters.append(x._parameters)
 
-                if x.is_tuple:
-                    continue
-
-                # Check fields match
-                if fields is UNSET:
-                    fields = x._fields
-                    frozen_fields = frozenset(x._fields)
-                elif frozen_fields != frozenset(x.fields):
-                    raise ValueError(
-                        "cannot broadcast records because fields don't "
-                        "match{}:\n    {}\n    {}".format(
-                            in_function(options),
-                            ", ".join(sorted(fields)),
-                            ", ".join(sorted(x.fields)),
-                        )
+                # Ensure all records are tuples, or all records are records
+                if x.is_tuple != first_record.is_tuple:
+                    raise TypeError(
+                        f"cannot broadcast a tuple against a record{in_function(options)}"
                     )
-                # Records win over tuples
-                is_tuple = False
+
+                # Check fields match for records
+                if not x.is_tuple:
+                    if frozen_record_fields is UNSET:
+                        frozen_record_fields = frozenset(x.fields)
+                    elif frozen_record_fields != frozenset(x.fields):
+                        raise ValueError(
+                            "cannot broadcast records because fields don't "
+                            "match{}:\n    {}\n    {}".format(
+                                in_function(options),
+                                ", ".join(sorted(first_record.fields)),
+                                ", ".join(sorted(x.fields)),
+                            )
+                        )
             else:
                 nextparameters.append(NO_PARAMETERS)
 
         numoutputs = None
         outcontents = []
-        for field in fields:
+        for field in first_record.fields:
             outcontents.append(
                 apply_step(
                     backend,
-                    [x[field] if isinstance(x, RecordArray) else x for x in inputs],
+                    [
+                        x.content(field) if isinstance(x, RecordArray) else x
+                        for x in inputs
+                    ],
                     action,
                     depth,
                     copy.copy(depth_context),
@@ -530,7 +532,8 @@ def apply_step(
         return tuple(
             RecordArray(
                 [x[i] for x in outcontents],
-                None if is_tuple else fields,
+                # Explicitly set fields to None if this is a tuple
+                None if first_record.is_tuple else first_record.fields,
                 length,
                 parameters=p,
             )

--- a/tests/test_2663_broadcast_tuples.py
+++ b/tests/test_2663_broadcast_tuples.py
@@ -1,0 +1,88 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest
+
+import awkward as ak
+
+
+def test_tuple_tuple():
+    tuple_1 = ak.Array(
+        [
+            [
+                ([1, 5, 1], [2, 5, 1]),
+                ([3, 5, 1], [4, 5, 1]),
+            ]
+        ]
+    )
+    tuple_2 = ak.Array(
+        [
+            [
+                ([1, 5, 1], [9, 10, 11]),
+                ([6, 7, 8], [4, 5, 1]),
+            ]
+        ]
+    )
+
+    result = ak.concatenate([tuple_1, tuple_2], axis=-1)
+    assert ak.almost_equal(
+        result,
+        [
+            [
+                ([1, 5, 1, 1, 5, 1], [2, 5, 1, 9, 10, 11]),
+                ([3, 5, 1, 6, 7, 8], [4, 5, 1, 4, 5, 1]),
+            ]
+        ],
+    )
+
+
+def test_record_tuple():
+    record_1 = ak.Array(
+        [
+            [
+                {"0": [1, 5, 1], "1": [2, 5, 1]},
+                {"0": [3, 5, 1], "1": [4, 5, 1]},
+            ]
+        ]
+    )
+    tuple_2 = ak.Array(
+        [
+            [
+                ([1, 5, 1], [9, 10, 11]),
+                ([6, 7, 8], [4, 5, 1]),
+            ]
+        ]
+    )
+
+    with pytest.raises(TypeError):
+        ak.concatenate([record_1, tuple_2], axis=-1)
+
+
+def test_record_record():
+    record_1 = ak.Array(
+        [
+            [
+                {"0": [1, 5, 1], "1": [2, 5, 1]},
+                {"0": [3, 5, 1], "1": [4, 5, 1]},
+            ]
+        ]
+    )
+    record_2 = ak.Array(
+        [
+            [
+                {"0": [1, 5, 1], "1": [9, 10, 11]},
+                {"0": [6, 7, 8], "1": [4, 5, 1]},
+            ]
+        ]
+    )
+
+    result = ak.concatenate([record_1, record_2], axis=-1)
+    assert ak.almost_equal(
+        result,
+        [
+            [
+                {"0": [1, 5, 1, 1, 5, 1], "1": [2, 5, 1, 9, 10, 11]},
+                {"0": [3, 5, 1, 6, 7, 8], "1": [4, 5, 1, 4, 5, 1]},
+            ]
+        ],
+    )


### PR DESCRIPTION
At some point, refactoring work broke broadcasting of tuples whereby the broadcast proceeds through the fields. 

This PR fixes that, and also prohibits broadcasting of tuples against records, even if the field names are considered compatible (`"0"` in a record has a mapping onto tuple slot 0). I think we want to meaningfully distinguish between records and tuples, so I made this change.