### PR TITLE
feat: support out-of-band buffers in pickling

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1458,8 +1458,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         return numba.typeof(self._numbaview)
 
     def __reduce_ex__(self, protocol: int) -> tuple:
+        packed_layout = ak.operations.to_packed(self._layout, highlevel=False)
         form, length, container = ak.operations.to_buffers(
-            self._layout,
+            packed_layout,
             buffer_key="{form_key}-{attribute}",
             form_key="node{id}",
             byteorder="<",
@@ -2124,8 +2125,9 @@ class Record(NDArrayOperatorsMixin):
         return numba.typeof(self._numbaview)
 
     def __reduce_ex__(self, protocol: int) -> tuple:
+        packed_layout = ak.operations.to_packed(self._layout, highlevel=False)
         form, length, container = ak.operations.to_buffers(
-            self._layout.array,
+            packed_layout.array,
             buffer_key="{form_key}-{attribute}",
             form_key="node{id}",
             byteorder="<",
@@ -2141,7 +2143,7 @@ class Record(NDArrayOperatorsMixin):
         return (
             object.__new__,
             (Record,),
-            (form.to_dict(), length, container, behavior, self._layout.at),
+            (form.to_dict(), length, container, behavior, packed_layout.at),
         )
 
     def __setstate__(self, state):

--- a/tests/test_2665_out_of_band_pickle.py
+++ b/tests/test_2665_out_of_band_pickle.py
@@ -1,0 +1,60 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pickle
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_protocol_5():
+    # Check arrays
+    array = ak.Array([[1, 2, 4, 5, 6], [7, 8, 9], [10]])
+    buffers = []
+
+    array_round_trip = pickle.loads(
+        pickle.dumps(array, buffer_callback=buffers.append, protocol=5), buffers=buffers
+    )
+    assert np.shares_memory(
+        array_round_trip.layout.content.data, array.layout.content.data
+    )
+
+    # Now check records
+    record = ak.Record({"x": 1, "y": [2, 3]})
+    buffers = []
+
+    record_round_trip = pickle.loads(
+        pickle.dumps(record, buffer_callback=buffers.append, protocol=5),
+        buffers=buffers,
+    )
+    assert np.shares_memory(
+        record.layout.array.contents[0].data,
+        record_round_trip.layout.array.contents[0].data,
+    )
+    assert np.shares_memory(
+        record.layout.array.contents[1].content.data,
+        record_round_trip.layout.array.contents[1].content.data,
+    )
+
+
+def test_protocol_4():
+    array = ak.Array([[1, 2, 4, 5, 6], [7, 8, 9], [10]])
+
+    array_round_trip = pickle.loads(pickle.dumps(array, protocol=4))
+    assert not np.shares_memory(
+        array_round_trip.layout.content.data, array.layout.content.data
+    )
+
+    # Now check records
+    record = ak.Record({"x": 1, "y": [2, 3]})
+
+    record_round_trip = pickle.loads(pickle.dumps(record, protocol=4))
+    assert not np.shares_memory(
+        record.layout.array.contents[0].data,
+        record_round_trip.layout.array.contents[0].data,
+    )
+    assert not np.shares_memory(
+        record.layout.array.contents[1].content.data,
+        record_round_trip.layout.array.contents[1].content.data,
+    )


### PR DESCRIPTION
Pickle 5 supports out-of-band data, which supports zero-copy round-trips with pickle.