### PR TITLE
fix: update string to search for in determing parquet column list separator

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -115,7 +115,7 @@ def metadata(
     for column_metadata in parquetfile_for_metadata.schema:
         if (
             column_metadata.max_repetition_level > 0
-            and ".list.element." in column_metadata.path
+            and ".list.element" in column_metadata.path
         ):
             list_indicator = "list.element"
             break


### PR DESCRIPTION
With pyarrow 13 it appears that `list.element` is used over `list.item` in some datasets. Looks like our original check to look for `list.element` was too strict (the final `.`). We also need to make this change in dask-awkward!

more info at https://github.com/dask-contrib/dask-awkward/issues/346