### PR TITLE
feat!: deprecate `forget_length`, add parameters to `typetracer_with_report`

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -32,7 +32,7 @@ def from_buffers(
     """
     Args:
         form (#ak.forms.Form or str/dict equivalent): The form of the Awkward
-            Array to _reconstitute from named buffers.
+            Array to reconstitute from named buffers.
         length (int): Length of the array. (The output of this function is always
             single-partition.)
         container (Mapping, such as dict): The str \u2192 Python buffers that

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -147,3 +147,32 @@ def typetracer_with_report(
         )
     layout, report = _typetracer_with_report(form, forget_length=forget_length)
     return wrap_layout(layout, behavior=behavior, highlevel=highlevel), report
+
+
+def typetracer_from_form(form, *, highlevel: bool = False, behavior=None):
+    """
+    Args:
+        form (#ak.forms.Form or str/dict equivalent): The form of the Awkward
+            Array to build a typetracer-backed array from.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Returns a typetracer array built from a form.
+    """
+    if isinstance(form, str):
+        if is_primitive(form):
+            form = awkward.forms.NumpyForm(form)
+        else:
+            form = awkward.forms.from_json(form)
+    elif isinstance(form, dict):
+        form = awkward.forms.from_dict(form)
+    elif not isinstance(form, awkward.forms.Form):
+        raise TypeError(
+            "'form' argument must be a Form or its Python dict/JSON string representation"
+        )
+
+    layout = form.length_zero_array(highlevel=False).to_typetracer(forget_length=True)
+
+    return wrap_layout(layout, behavior=behavior, highlevel=highlevel)

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -22,9 +22,13 @@ from awkward._nplikes.typetracer import (
     TypeTracerReport,
     is_unknown_array,
     is_unknown_scalar,
-    typetracer_with_report,
+)
+from awkward._nplikes.typetracer import (
+    typetracer_with_report as _typetracer_with_report,
 )
 from awkward._typing import TypeVar
+from awkward._util import UNSET
+from awkward.contents import Content
 from awkward.forms import Form
 from awkward.highlevel import Array, Record
 from awkward.operations.ak_to_layout import to_layout
@@ -101,3 +105,18 @@ def touch_data(array, *, highlevel: bool = True, behavior=None) -> T:
     layout = to_layout(array, allow_other=False)
     _touch_data(layout)
     return wrap_layout(layout, behavior=behavior, highlevel=highlevel)
+
+
+def typetracer_with_report(
+    form: Form, forget_length: bool = UNSET
+) -> tuple[Content, TypeTracerReport]:
+    if forget_length is UNSET:
+        forget_length = True
+    else:
+        deprecate(
+            "passing `forget_length` to typetracer_with_report is deprecated. "
+            "In future, this argument will be removed, and the function will "
+            "always forget lengths",
+            "2.5.0",
+        )
+    return _typetracer_with_report(form, forget_length=forget_length)

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -149,7 +149,7 @@ def typetracer_with_report(
     return wrap_layout(layout, behavior=behavior, highlevel=highlevel), report
 
 
-def typetracer_from_form(form, *, highlevel: bool = False, behavior=None):
+def typetracer_from_form(form, *, highlevel: bool = True, behavior=None):
     """
     Args:
         form (#ak.forms.Form or str/dict equivalent): The form of the Awkward

--- a/tests/test_2671_typetracer_with_report_deprecated_length.py
+++ b/tests/test_2671_typetracer_with_report_deprecated_length.py
@@ -6,6 +6,7 @@ import numpy as np  # noqa: F401
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._nplikes.shape import unknown_length
 
 form_dict = {
     "class": "RecordArray",
@@ -112,3 +113,17 @@ def test_form_str():
     ak.sum(y)
     assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
     assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}
+
+
+def test_typetracer_from_form_highlevel_false():
+    layout = ak.typetracer.typetracer_from_form(form_dict, highlevel=False)
+    assert isinstance(layout, ak.contents.Content)
+    assert layout.backend.name == "typetracer"
+    assert layout.length is unknown_length
+
+
+def test_typetracer_from_form_highlevel_true():
+    array = ak.typetracer.typetracer_from_form(form_dict, highlevel=True)
+    assert isinstance(array, ak.Array)
+    assert ak.backend(array) == "typetracer"
+    assert array.layout.length is unknown_length

--- a/tests/test_2671_typetracer_with_report_deprecated_length.py
+++ b/tests/test_2671_typetracer_with_report_deprecated_length.py
@@ -1,0 +1,114 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import json
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak
+
+form_dict = {
+    "class": "RecordArray",
+    "fields": ["x", "y"],
+    "contents": [
+        {
+            "class": "ListOffsetArray",
+            "offsets": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "inner_shape": [],
+                "parameters": {},
+                "form_key": "x.list.content",
+            },
+            "parameters": {},
+            "form_key": "x.list.offsets",
+        },
+        {
+            "class": "ListOffsetArray",
+            "offsets": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "inner_shape": [],
+                "parameters": {},
+                "form_key": "y.list.content",
+            },
+            "parameters": {},
+            "form_key": "y.list.offsets",
+        },
+    ],
+    "parameters": {},
+}
+
+
+def test_layout():
+    form = ak.forms.from_dict(form_dict)
+    layout, report = ak.typetracer.typetracer_with_report(form)
+    assert isinstance(layout, ak.contents.Content)
+    array = ak.Array(layout)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.sum(y)
+    assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
+    assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}
+
+
+def test_layout_highlevel_false():
+    form = ak.forms.from_dict(form_dict)
+    layout, report = ak.typetracer.typetracer_with_report(form, highlevel=False)
+    assert isinstance(layout, ak.contents.Content)
+    array = ak.Array(layout)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.sum(y)
+    assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
+    assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}
+
+
+def test_array_highlevel_true():
+    form = ak.forms.from_dict(form_dict)
+    array, report = ak.typetracer.typetracer_with_report(form, highlevel=True)
+    assert isinstance(array, ak.Array)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.sum(y)
+    assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
+    assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}
+
+
+def test_form_dict():
+    layout, report = ak.typetracer.typetracer_with_report(form_dict)
+    assert isinstance(layout, ak.contents.Content)
+    array = ak.Array(layout)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.sum(y)
+    assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
+    assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}
+
+
+def test_form_str():
+    layout, report = ak.typetracer.typetracer_with_report(json.dumps(form_dict))
+    assert isinstance(layout, ak.contents.Content)
+    array = ak.Array(layout)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.sum(y)
+    assert set(report.data_touched) == {"y.list.offsets", "y.list.content"}
+    assert set(report.shape_touched) == {"y.list.offsets", "y.list.content"}


### PR DESCRIPTION
1. Deprecation of `forget_length`:
   This argument represents a leak of the implementation details; the function only accepts a form, which has no known length.
  
   - [ ] Add deprecation notice to wiki
  
   In future, we could add a `*, length=unknown_length` keyword-only argument that would be _more_ powerful, but I can't see any examples of people needing that right now.
2. Extend `typetracer_with_report` parameters
   Most uses of our `typetracer_with_report` function immediately wrap the result with an `ak.Array`. We should just support that, given that the `highlevel` argument is so widely used in our L1 API. Although typetracer isn't exactly L1, in my view L1-L2 is more about who uses these functions, rather than how painful they can be to use. @jpivarski this might reflect a changing view of mine, I am not sure. Please weigh in you think we should keep these functions "simple".