### PR TITLE
feat: add `touch_data` to `ak.typetracer`

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -423,3 +423,11 @@ def sort(
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
     parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.index_nplike)
     return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
+
+
+def touch_data(layout: Content, recursive: bool = True):
+    layout._touch_data(recursive)
+
+
+def touch_shape(layout: Content, recursive: bool = True):
+    layout._touch_shape(recursive)

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -12,6 +12,7 @@ __all__ = [
 
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
+from awkward._do import touch_data as _touch_data
 from awkward._errors import deprecate
 from awkward._layout import wrap_layout
 from awkward._nplikes.placeholder import PlaceholderArray
@@ -30,20 +31,20 @@ from awkward.operations.ak_to_layout import to_layout
 T = TypeVar("T", Array, Record)
 
 
-def _length_0_1_if_typetracer(array: T, function):
+def _length_0_1_if_typetracer(array, function, highlevel: bool, behavior) -> T:
     typetracer_backend = TypeTracerBackend.instance()
 
     layout = to_layout(array, allow_other=False)
-    behavior = behavior_of(array)
+    behavior = behavior_of(array, behavior=behavior)
 
     if layout.backend is typetracer_backend:
-        layout._touch_data(True)
+        _touch_data(layout)
         layout = function(layout.form, highlevel=False)
 
-    return wrap_layout(layout, behavior=behavior)
+    return wrap_layout(layout, behavior=behavior, highlevel=highlevel)
 
 
-def empty_if_typetracer(array: T) -> T:
+def empty_if_typetracer(array) -> T:
     deprecate(
         "'empty_if_typetracer' is being replaced by 'length_zero_if_typetracer' (change name)",
         "2.4.0",
@@ -52,9 +53,50 @@ def empty_if_typetracer(array: T) -> T:
     return length_zero_if_typetracer(array)
 
 
-def length_zero_if_typetracer(array: T) -> T:
-    return _length_0_1_if_typetracer(array, Form.length_zero_array)
+def length_zero_if_typetracer(array, *, highlevel: bool = True, behavior=None) -> T:
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Recursively touches the data of an array, before returning a length-zero
+    NumPy-backed iff. the given array has a typetracer backend; otherwise, a
+    shallow copy of the original array is returned.
+    """
+    return _length_0_1_if_typetracer(array, Form.length_zero_array, highlevel, behavior)
 
 
-def length_one_if_typetracer(array: T) -> T:
-    return _length_0_1_if_typetracer(array, Form.length_one_array)
+def length_one_if_typetracer(array, *, highlevel: bool = True, behavior=None) -> T:
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Recursively touches the data of an array, before returning a length-one
+    NumPy-backed iff. the given array has a typetracer backend; otherwise, a
+    shallow copy of the original array is returned.
+    """
+    return _length_0_1_if_typetracer(array, Form.length_one_array, highlevel, behavior)
+
+
+def touch_data(array, *, highlevel: bool = True, behavior=None) -> T:
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Recursively touches the data and returns a shall copy of the given array.
+    """
+    behavior = behavior_of(array, behavior=behavior)
+    layout = to_layout(array, allow_other=False)
+    _touch_data(layout)
+    return wrap_layout(layout, behavior=behavior, highlevel=highlevel)

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -8,6 +8,7 @@ __all__ = [
     "typetracer_with_report",
     "PlaceholderArray",
     "unknown_length",
+    "touch_data",
 ]
 
 from awkward._backends.typetracer import TypeTracerBackend

--- a/tests/test_2672_touch_data.py
+++ b/tests/test_2672_touch_data.py
@@ -1,0 +1,54 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    form = ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": ["x", "y"],
+            "contents": [
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "x.list.content",
+                    },
+                    "parameters": {},
+                    "form_key": "x.list.offsets",
+                },
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "y.list.content",
+                    },
+                    "parameters": {},
+                    "form_key": "y.list.offsets",
+                },
+            ],
+            "parameters": {},
+        }
+    )
+    layout, report = ak.typetracer.typetracer_with_report(form)
+    array = ak.Array(layout)
+
+    y = array.y
+    assert len(report.data_touched) == 0
+    assert len(report.shape_touched) == 0
+
+    ak.typetracer.touch_data(y)
+    assert len(report.data_touched) == 2
+    assert len(report.shape_touched) == 2


### PR DESCRIPTION
This was requested in #2668, and I've identified that Coffea and dask-awkward currently use our private APIs. We should just make this public. 

At this stage, I'd prefer to expose this via `ak.typetracer`, rather than `Content.touch_data`, as we can better control the public API (e.g. always recursive, return `self`), and most people are already working with `ak.Array` objects.

Closes #2668 