### PR TITLE
fix: guard `broadcast_and_apply` from mixed backends

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Set
 
 from awkward._backends.backend import Backend
 from awkward._nplikes.numpy import Numpy
@@ -46,18 +46,17 @@ def register_backend(primary_nplike_cls: type[NumpyLike]):
     return wrapper
 
 
-def common_backend(backends: Iterable[Backend]) -> Backend:
-    unique_backends = frozenset(backends)
+def common_backend(backends: Set[Backend]) -> Backend:
     # Either we have one nplike, or one + typetracer
-    if len(unique_backends) == 1:
-        return next(iter(unique_backends))
+    if len(backends) == 1:
+        return next(iter(backends))
     else:
         # We allow typetracers to mix with other nplikes, and take precedence
-        for backend in unique_backends:
+        for backend in backends:
             if not backend.nplike.known_data:
                 return backend
 
-        if len(unique_backends) > 1:
+        if len(backends) > 1:
             raise ValueError(
                 "cannot operate on arrays with incompatible backends. Use #ak.to_backend to coerce the arrays "
                 "to the same backend"
@@ -101,19 +100,19 @@ def backend_of(
     suitable backend is found, return the `default` value, or raise a `ValueError` if
     no default is given.
     """
-    backends = [
+    unique_backends = frozenset(
         b for b in (_backend_of(o, default=None) for o in objects) if b is not None
-    ]
+    )
 
-    if len(backends) == 0:
+    if len(unique_backends) == 0:
         if default is UNSET:
             raise ValueError("could not find backend for", objects)
         else:
             return default
-    elif len(backends) == 1:
-        return backends[0]
+    elif len(unique_backends) == 1:
+        return next(iter(unique_backends))
     elif coerce_to_common:
-        return common_backend(backends)
+        return common_backend(unique_backends)
     else:
         raise ValueError(
             "could not find singular backend for",

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -1006,6 +1006,11 @@ def apply_step(
     )
 
     if isinstance(result, tuple) and all(isinstance(x, Content) for x in result):
+        if any(content.backend is not backend for content in result):
+            raise ValueError(
+                "broadcasting action returned layouts with different backends: ",
+                ", ".join([content.backend.name for content in result]),
+            )
         return result
     elif result is None:
         return continuation()
@@ -1017,8 +1022,8 @@ def broadcast_and_apply(
     inputs,
     action,
     behavior,
-    depth_context=None,
-    lateral_context=None,
+    depth_context: dict[str, Any] | None = None,
+    lateral_context: dict[str, Any] | None = None,
     allow_records: bool = True,
     left_broadcast: bool = True,
     right_broadcast: bool = True,

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -313,7 +313,7 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
         return NotImplemented
 
     behavior = behavior_of(*inputs)
-    backend = backend_of(*inputs)
+    backend = backend_of(*inputs, coerce_to_common=True)
 
     inputs = _array_ufunc_custom_cast(inputs, behavior, backend)
 

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -87,7 +87,9 @@ def array_function(func, types, args, kwargs: dict[str, Any], behavior: Mapping 
         return function(*args, **kwargs)
     # Use NumPy's implementation
     else:
-        backend = common_backend(_find_backends(chain(args, kwargs.values())))
+        all_arguments = chain(args, kwargs.values())
+        unique_backends = frozenset(_find_backends(all_arguments))
+        backend = common_backend(unique_backends)
 
         rectilinear_args = tuple(_to_rectilinear(x, backend) for x in args)
         rectilinear_kwargs = {k: _to_rectilinear(v, backend) for k, v in kwargs.items()}

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -546,7 +546,7 @@ class Content:
                 return self
 
             # Backend may change if index contains typetracers
-            backend = backend_of(self, *where)
+            backend = backend_of(self, *where, coerce_to_common=True)
             this = self.to_backend(backend)
 
             # Normalise valid indices onto well-defined basis
@@ -576,7 +576,7 @@ class Content:
             isinstance(where, ak.contents.Content)
             and where.backend is not self._backend
         ):
-            backend = backend_of(self, where)
+            backend = backend_of(self, where, coerce_to_common=True)
             return self.to_backend(backend)._getitem(where.to_backend(backend))
 
         elif isinstance(where, ak.contents.NumpyArray):

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 __all__ = ("almost_equal",)
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of, get_array_class, get_record_class
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -10,6 +11,7 @@ from awkward._parameters import parameters_are_equal
 from awkward.operations.ak_to_layout import to_layout
 
 np = NumpyMetadata.instance()
+cpu = NumpyBackend.instance()
 
 
 @high_level_function()
@@ -52,10 +54,15 @@ def almost_equal(
     left_behavior = behavior_of(left)
     right_behavior = behavior_of(right)
 
-    left = to_layout(left, allow_record=False).to_packed()
-    right = to_layout(right, allow_record=False).to_packed()
+    left_backend = backend_of(left, default=cpu)
+    right_backend = backend_of(right, default=cpu)
+    if left_backend is not right_backend:
+        return False
+    backend = left_backend
 
-    backend = backend_of(left, right)
+    left_layout = to_layout(left, allow_record=False).to_packed()
+    right_layout = to_layout(right, allow_record=False).to_packed()
+
     if not backend.nplike.known_data:
         raise NotImplementedError(
             "Awkward Arrays with typetracer backends cannot yet be compared with `ak.almost_equal`."
@@ -210,4 +217,4 @@ def almost_equal(
         else:
             return False
 
-    return visitor(left, right)
+    return visitor(left_layout, right_layout)

--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -106,8 +106,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = regularize_axis(axis)
 
     if isinstance(arrays, dict):
-        backend = backend_of(*arrays.values(), default=cpu)
         behavior = behavior_of(*arrays.values(), behavior=behavior)
+        backend = backend_of(*arrays.values(), default=cpu, coerce_to_common=True)
         layouts = {
             n: ak._do.local_index(
                 ak.operations.to_layout(x, allow_record=False, allow_other=False),
@@ -117,8 +117,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
         }
     else:
         arrays = list(arrays)
-        backend = backend_of(*arrays, default=cpu)
         behavior = behavior_of(*arrays, behavior=behavior)
+        backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
         layouts = [
             ak._do.local_index(
                 ak.operations.to_layout(x, allow_record=False, allow_other=False),

--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -19,6 +19,9 @@ def backend(*arrays):
     * None if the objects are not Awkward, NumPy, JAX, CuPy, or typetracer arrays (e.g.
       Python numbers, booleans, strings).
 
+    If there are multiple, compatible backends (e.g. NumPy & typetracer) amongst the given arrays, the
+    coercible backend is returned.
+
     See #ak.to_backend.
     """
     # Dispatch
@@ -29,5 +32,5 @@ def backend(*arrays):
 
 
 def _impl(arrays) -> str:
-    backend_impl = backend_of(*arrays, default=None)
+    backend_impl = backend_of(*arrays, default=None, coerce_to_common=True)
     return backend_impl.name

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -206,7 +206,7 @@ def _impl(
     if len(arrays) == 0:
         return []
 
-    backend = backend_of(*arrays, default=cpu)
+    backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
 
     inputs = []
     for x in arrays:

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -56,7 +56,7 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None):
 
 
 def _impl(arrays, highlevel, behavior):
-    backend = backend_of(*arrays, default=cpu)
+    backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
     layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
     behavior = behavior_of(*arrays, behavior=behavior)
 

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -209,7 +209,7 @@ def cartesian(
 def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
     axis = regularize_axis(axis)
     if isinstance(arrays, dict):
-        backend = backend_of(*arrays.values(), default=cpu)
+        backend = backend_of(*arrays.values(), default=cpu, coerce_to_common=True)
         behavior = behavior_of(*arrays.values(), behavior=behavior)
         array_layouts = {
             name: ak.operations.to_layout(
@@ -222,7 +222,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
 
     else:
         arrays = list(arrays)
-        backend = backend_of(*arrays, default=cpu)
+        backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
         behavior = behavior_of(*arrays, behavior=behavior)
         array_layouts = [
             ak.operations.to_layout(

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -57,9 +57,8 @@ def concatenate(arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None
 
 def _impl(arrays, axis, mergebool, highlevel, behavior):
     axis = regularize_axis(axis)
-    # Simple single-array, axis=0 fast-path
-    backend = backend_of(*arrays, default=cpu)
     behavior = behavior_of(*arrays, behavior=behavior)
+    # Simple single-array, axis=0 fast-path
     if (
         # Is an array with a known backend
         backend_of(arrays, default=None)
@@ -72,6 +71,8 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
         if maybe_posaxis(content, axis, 1) == 0:
             return ak.operations.ak_flatten._impl(content, 1, highlevel, behavior)
 
+    # Now that we're sure `arrays` is not a singular array
+    backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
     content_or_others = [
         x.to_backend(backend) if isinstance(x, ak.contents.Content) else x
         for x in (

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -2,6 +2,7 @@
 __all__ = ("linear_fit",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -9,6 +10,7 @@ from awkward._nplikes import ufuncs
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._regularize import regularize_axis
 
+cpu = NumpyBackend.instance()
 np = NumpyMetadata.instance()
 
 
@@ -76,7 +78,7 @@ def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=Fa
 def _impl(x, y, weight, axis, keepdims, mask_identity):
     axis = regularize_axis(axis)
     behavior = behavior_of(x, y, weight)
-    backend = backend_of(x, y, weight, coerce_to_common=True)
+    backend = backend_of(x, y, weight, coerce_to_common=True, default=cpu)
     x = ak.highlevel.Array(
         ak.operations.to_layout(x, allow_record=False, allow_other=False).to_backend(
             backend

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -76,22 +76,28 @@ def linear_fit(x, y, weight=None, axis=None, *, keepdims=False, mask_identity=Fa
 def _impl(x, y, weight, axis, keepdims, mask_identity):
     axis = regularize_axis(axis)
     behavior = behavior_of(x, y, weight)
+    backend = backend_of(x, y, weight, coerce_to_common=True)
     x = ak.highlevel.Array(
-        ak.operations.to_layout(x, allow_record=False, allow_other=False),
+        ak.operations.to_layout(x, allow_record=False, allow_other=False).to_backend(
+            backend
+        ),
         behavior=behavior,
     )
     y = ak.highlevel.Array(
-        ak.operations.to_layout(y, allow_record=False, allow_other=False),
+        ak.operations.to_layout(y, allow_record=False, allow_other=False).to_backend(
+            backend
+        ),
         behavior=behavior,
     )
     if weight is not None:
         weight = ak.highlevel.Array(
-            ak.operations.to_layout(weight, allow_record=False, allow_other=False),
+            ak.operations.to_layout(
+                weight, allow_record=False, allow_other=False
+            ).to_backend(backend),
             behavior=behavior,
         )
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        backend = backend_of(x, y, weight)
         if weight is None:
             sumw = ak.operations.ak_count._impl(
                 x,

--- a/src/awkward/operations/ak_to_backend.py
+++ b/src/awkward/operations/ak_to_backend.py
@@ -61,7 +61,7 @@ def _impl(array, backend, highlevel, behavior):
     layout = ak.operations.to_layout(
         array,
         allow_record=True,
-        allow_other=True,
+        allow_other=False,
     )
     behavior = behavior_of(array, behavior=behavior)
     backend_layout = layout.to_backend(regularize_backend(backend))

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -462,7 +462,7 @@ def _impl(
     highlevel,
 ):
     behavior = behavior_of(array, *more_arrays, behavior=behavior)
-    backend = backend_of(array, *more_arrays, default=cpu)
+    backend = backend_of(array, *more_arrays, default=cpu, coerce_to_common=True)
     layout = ak.operations.ak_to_layout._impl(
         array, allow_record=False, allow_other=False, regulararray=True
     ).to_backend(backend)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -87,19 +87,14 @@ def _impl1(condition, mergebool, highlevel, behavior):
 
 
 def _impl3(condition, x, y, mergebool, highlevel, behavior):
+    behavior = behavior_of(condition, x, y, behavior=behavior)
+    backend = backend_of(condition, x, y, default=cpu, coerce_to_common=True)
     akcondition = ak.operations.to_layout(
         condition, allow_record=False, allow_other=False
-    )
+    ).to_backend(backend)
 
     left = ak.operations.to_layout(x, allow_record=False, allow_other=True)
     right = ak.operations.to_layout(y, allow_record=False, allow_other=True)
-
-    good_arrays = [akcondition]
-    if isinstance(left, ak.contents.Content):
-        good_arrays.append(left)
-    if isinstance(right, ak.contents.Content):
-        good_arrays.append(right)
-    backend = backend_of(*good_arrays, default=cpu)
 
     def action(inputs, **kwargs):
         akcondition, left, right = inputs
@@ -135,7 +130,6 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
         else:
             return None
 
-    behavior = behavior_of(condition, x, y, behavior=behavior)
     out = ak._broadcasting.broadcast_and_apply(
         [akcondition, left, right],
         action,

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -82,7 +82,7 @@ def _impl(base, what, where, highlevel, behavior):
             where = where[0]
 
         behavior = behavior_of(base, what, behavior=behavior)
-        backend = backend_of(base, what, default=cpu)
+        backend = backend_of(base, what, default=cpu, coerce_to_common=True)
 
         base = ak.operations.to_layout(
             base, allow_record=True, allow_other=False

--- a/src/awkward/operations/str/akstr_count_substring.py
+++ b/src/awkward/operations/str/akstr_count_substring.py
@@ -48,7 +48,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.count_substring")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.count_substring,

--- a/src/awkward/operations/str/akstr_count_substring_regex.py
+++ b/src/awkward/operations/str/akstr_count_substring_regex.py
@@ -48,7 +48,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.count_substring_regex")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.count_substring_regex,

--- a/src/awkward/operations/str/akstr_ends_with.py
+++ b/src/awkward/operations/str/akstr_ends_with.py
@@ -44,7 +44,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.ends_with")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.ends_with,

--- a/src/awkward/operations/str/akstr_find_substring.py
+++ b/src/awkward/operations/str/akstr_find_substring.py
@@ -46,7 +46,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.find_substring")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.find_substring,

--- a/src/awkward/operations/str/akstr_find_substring_regex.py
+++ b/src/awkward/operations/str/akstr_find_substring_regex.py
@@ -48,7 +48,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.find_substring_regex")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.find_substring_regex,

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -5,9 +5,12 @@ __all__ = ("index_in",)
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+cpu = NumpyBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -56,7 +59,7 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
     import pyarrow.compute as pc
 
     behavior = behavior_of(array, value_set, behavior=behavior)
-    backend = backend_of(array, value_set, coerce_to_common=True)
+    backend = backend_of(array, value_set, coerce_to_common=True, default=cpu)
 
     layout = ak.to_layout(array, allow_record=False).to_backend(backend)
     value_set_layout = ak.to_layout(value_set, allow_record=False).to_backend(backend)

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -4,6 +4,7 @@ __all__ = ("index_in",)
 
 
 import awkward as ak
+from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -54,13 +55,14 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
 
     import pyarrow.compute as pc
 
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
-    value_set_layout = ak.to_layout(value_set, allow_record=False, allow_other=True)
+    behavior = behavior_of(array, value_set, behavior=behavior)
+    backend = backend_of(array, value_set, coerce_to_common=True)
+
+    layout = ak.to_layout(array, allow_record=False).to_backend(backend)
+    value_set_layout = ak.to_layout(value_set, allow_record=False).to_backend(backend)
 
     if not _is_maybe_optional_list_of_string(value_set_layout):
         raise TypeError("`value_set` must be 1D array of (possibly missing) strings")
-
-    behavior = behavior_of(array, value_set, behavior=behavior)
 
     def apply(layout, **kwargs):
         if _is_maybe_optional_list_of_string(layout):

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -5,9 +5,12 @@ __all__ = ("is_in",)
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+cpu = NumpyBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -55,7 +58,7 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
     import pyarrow.compute as pc
 
     behavior = behavior_of(array, value_set, behavior=behavior)
-    backend = backend_of(array, value_set, coerce_to_common=True)
+    backend = backend_of(array, value_set, coerce_to_common=True, default=cpu)
 
     layout = ak.to_layout(array, allow_record=False).to_backend(backend)
     value_set_layout = ak.to_layout(value_set, allow_record=False).to_backend(backend)

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -4,6 +4,7 @@ __all__ = ("is_in",)
 
 
 import awkward as ak
+from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -53,13 +54,14 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
 
     import pyarrow.compute as pc
 
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
-    value_set_layout = ak.to_layout(value_set, allow_record=False, allow_other=True)
+    behavior = behavior_of(array, value_set, behavior=behavior)
+    backend = backend_of(array, value_set, coerce_to_common=True)
+
+    layout = ak.to_layout(array, allow_record=False).to_backend(backend)
+    value_set_layout = ak.to_layout(value_set, allow_record=False).to_backend(backend)
 
     if not _is_maybe_optional_list_of_string(value_set_layout):
         raise TypeError("`value_set` must be 1D array of (possibly missing) strings")
-
-    behavior = behavior_of(array, value_set, behavior=behavior)
 
     def apply(layout, **kwargs):
         if _is_maybe_optional_list_of_string(layout):

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -4,9 +4,12 @@ __all__ = ("join",)
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+cpu = NumpyBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -58,7 +61,7 @@ def _impl(array, separator, highlevel, behavior):
     import pyarrow.compute as pc
 
     behavior = behavior_of(array, separator, behavior=behavior)
-    backend = backend_of(array, separator, coerce_to_common=True)
+    backend = backend_of(array, separator, coerce_to_common=True, default=cpu)
 
     layout = ak.to_layout(array, allow_record=False).to_backend(backend)
     if isinstance(separator, (bytes, str)):

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -3,6 +3,7 @@
 __all__ = ("join_element_wise",)
 
 import awkward as ak
+from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -51,8 +52,9 @@ def _impl(arrays, highlevel, behavior):
     if len(arrays) < 1:
         raise TypeError("at least one array is required")
 
-    layouts = [ak.to_layout(x) for x in arrays]
     behavior = behavior_of(*arrays, behavior=behavior)
+    backend = backend_of(*arrays, coerce_to_common=True)
+    layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
 
     def action(layouts, **kwargs):
         if all(

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -4,9 +4,12 @@ __all__ = ("join_element_wise",)
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+cpu = NumpyBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -53,7 +56,7 @@ def _impl(arrays, highlevel, behavior):
         raise TypeError("at least one array is required")
 
     behavior = behavior_of(*arrays, behavior=behavior)
-    backend = backend_of(*arrays, coerce_to_common=True)
+    backend = backend_of(*arrays, coerce_to_common=True, default=cpu)
     layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
 
     def action(layouts, **kwargs):

--- a/src/awkward/operations/str/akstr_match_like.py
+++ b/src/awkward/operations/str/akstr_match_like.py
@@ -49,7 +49,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.match_like")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.match_like,

--- a/src/awkward/operations/str/akstr_match_substring.py
+++ b/src/awkward/operations/str/akstr_match_substring.py
@@ -46,7 +46,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.match_substring")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.match_substring,

--- a/src/awkward/operations/str/akstr_match_substring_regex.py
+++ b/src/awkward/operations/str/akstr_match_substring_regex.py
@@ -47,7 +47,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
 
     pc = import_pyarrow_compute("ak.str.match_substring_regex")
 
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.match_substring_regex,

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -5,6 +5,7 @@ __all__ = ("repeat",)
 import numbers
 
 import awkward as ak
+from awkward._backends.dispatch import backend_of
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -18,7 +19,8 @@ def repeat(array, num_repeats, *, highlevel=True, behavior=None):
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
-        num_repeats: Array-like data (anything #ak.to_layout recognizes).
+        num_repeats: (int, or an array of them to broadcast): number of times
+            to repeat each element
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -52,31 +54,13 @@ def _impl(array, num_repeats, highlevel, behavior):
     import pyarrow.compute as pc
 
     layout = ak.operations.to_layout(array)
-    behavior = behavior_of(array, behavior=behavior)
 
-    num_repeats_layout = ak.operations.to_layout(num_repeats, allow_other=True)
+    behavior = behavior_of(array, num_repeats, behavior=behavior)
+    backend = backend_of(array, num_repeats, coerce_to_common=True)
 
-    if not isinstance(num_repeats_layout, ak.contents.Content):
-        if not isinstance(num_repeats, numbers.Integral):
-            raise TypeError(
-                "num_repeats must be an integer or broadcastable to integers"
-            )
-
-        def action(layout, **kwargs):
-            if layout.is_list and layout.parameter("__array__") in (
-                "string",
-                "bytestring",
-            ):
-                return from_arrow(
-                    pc.binary_repeat(
-                        to_arrow(layout, extensionarray=False), num_repeats
-                    ),
-                    highlevel=False,
-                )
-
-        out = ak._do.recursively_apply(layout, action, behavior)
-
-    else:
+    num_repeats_layout = ak.operations.to_layout(num_repeats)
+    if isinstance(num_repeats_layout, ak.contents.Content):
+        num_repeats_layout = num_repeats_layout.to_backend(backend)
 
         def action(inputs, **kwargs):
             if inputs[0].is_list and inputs[0].parameter("__array__") in (
@@ -104,5 +88,25 @@ def _impl(array, num_repeats, highlevel, behavior):
         )
         assert isinstance(out, tuple) and len(out) == 1
         out = out[0]
+
+    else:
+        if not isinstance(num_repeats, numbers.Integral):
+            raise TypeError(
+                "num_repeats must be an integer or broadcastable to integers"
+            )
+
+        def action(layout, **kwargs):
+            if layout.is_list and layout.parameter("__array__") in (
+                "string",
+                "bytestring",
+            ):
+                return from_arrow(
+                    pc.binary_repeat(
+                        to_arrow(layout, extensionarray=False), num_repeats
+                    ),
+                    highlevel=False,
+                )
+
+        out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -61,7 +61,7 @@ def _impl(array, num_repeats, highlevel, behavior):
     behavior = behavior_of(array, num_repeats, behavior=behavior)
     backend = backend_of(array, num_repeats, coerce_to_common=True, default=cpu)
 
-    num_repeats_layout = ak.operations.to_layout(num_repeats)
+    num_repeats_layout = ak.operations.to_layout(num_repeats, allow_other=True)
     if isinstance(num_repeats_layout, ak.contents.Content):
         num_repeats_layout = num_repeats_layout.to_backend(backend)
 

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -6,10 +6,13 @@ import numbers
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of
+from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
+
+cpu = NumpyBackend.instance()
 
 np = NumpyMetadata.instance()
 
@@ -56,7 +59,7 @@ def _impl(array, num_repeats, highlevel, behavior):
     layout = ak.operations.to_layout(array)
 
     behavior = behavior_of(array, num_repeats, behavior=behavior)
-    backend = backend_of(array, num_repeats, coerce_to_common=True)
+    backend = backend_of(array, num_repeats, coerce_to_common=True, default=cpu)
 
     num_repeats_layout = ak.operations.to_layout(num_repeats)
     if isinstance(num_repeats_layout, ak.contents.Content):

--- a/src/awkward/operations/str/akstr_starts_with.py
+++ b/src/awkward/operations/str/akstr_starts_with.py
@@ -44,7 +44,7 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
 
     pc = import_pyarrow_compute("ak.str.starts_with")
-    layout = ak.to_layout(array, allow_record=False, allow_other=True)
+    layout = ak.to_layout(array, allow_record=False)
     behavior = behavior_of(array, behavior=behavior)
     apply = ak.operations.str._get_ufunc_action(
         pc.starts_with,

--- a/tests/test_2678_same_backend.py
+++ b/tests/test_2678_same_backend.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np  # noqa: F401
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_where():
+    result = ak.where(
+        [True, False, False], ak.to_backend([1, 2, 3], "typetracer"), [4, 5, 6]
+    )
+    assert ak.backend(result) == "typetracer"
+
+
+def test_almost_equal():
+    assert not ak.almost_equal(
+        [True, False, False], ak.to_backend([True, False, False], "typetracer")
+    )


### PR DESCRIPTION
This PR ensures that `broadcast_and_apply` throws an error if the given arrays do not share the same backend. 

At a high level, all `ak.XXX` operations that accept multiple array arguments should effectively compute
```python
backend = backend_of(*args, default=..., coerce_to_common=True)
layouts = [ak.to_layout(x).to_backend(backend) for x in args]
```

We _could_ add a helper to do this, although given that each `ak.XXX` function needs to set different layout conversion flags, this is probably best avoided.

There's an argument to be made for making `broadcast_and_apply` be more permissive and perform the coercion itself. However, I *think* we want to coerce to the same backend in the highlevel `ak.XXX` functions ASAP, i.e. before broadcasting. 

Whilst I was here, I cleaned up some of the routines that use `backend_of`.