### PR TITLE
fix: support typetracer in `ak.str.` operations

### DIFF
--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -3,89 +3,121 @@
 # This set of string-manipulation routines is strongly inspired by Arrow:
 
 
-# string predicates
-# https://arrow.apache.org/docs/python/api/compute.html#string-predicates
-from awkward.operations.str.akstr_is_alnum import *
-from awkward.operations.str.akstr_is_alpha import *
-from awkward.operations.str.akstr_is_decimal import *
-from awkward.operations.str.akstr_is_digit import *
-from awkward.operations.str.akstr_is_lower import *
-from awkward.operations.str.akstr_is_numeric import *
-from awkward.operations.str.akstr_is_printable import *
-from awkward.operations.str.akstr_is_space import *
-from awkward.operations.str.akstr_is_upper import *
-from awkward.operations.str.akstr_is_title import *
-from awkward.operations.str.akstr_is_ascii import *
-
 # string transforms
 # https://arrow.apache.org/docs/python/api/compute.html#string-transforms
 from awkward.operations.str.akstr_capitalize import *
-from awkward.operations.str.akstr_length import *
-from awkward.operations.str.akstr_lower import *
-from awkward.operations.str.akstr_swapcase import *
-from awkward.operations.str.akstr_title import *
-from awkward.operations.str.akstr_upper import *
-from awkward.operations.str.akstr_repeat import *
-from awkward.operations.str.akstr_replace_slice import *
-from awkward.operations.str.akstr_reverse import *
-from awkward.operations.str.akstr_replace_substring import *
-from awkward.operations.str.akstr_replace_substring_regex import *
 
 # string padding
 # https://arrow.apache.org/docs/python/api/compute.html#string-padding
 from awkward.operations.str.akstr_center import *
-from awkward.operations.str.akstr_lpad import *
-from awkward.operations.str.akstr_rpad import *
-
-# string trimming
-# https://arrow.apache.org/docs/python/api/compute.html#string-trimming
-from awkward.operations.str.akstr_ltrim import *
-from awkward.operations.str.akstr_ltrim_whitespace import *
-from awkward.operations.str.akstr_rtrim import *
-from awkward.operations.str.akstr_rtrim_whitespace import *
-from awkward.operations.str.akstr_trim import *
-from awkward.operations.str.akstr_trim_whitespace import *
-
-# string splitting
-# https://arrow.apache.org/docs/python/api/compute.html#string-splitting
-from awkward.operations.str.akstr_split_whitespace import *
-from awkward.operations.str.akstr_split_pattern import *
-from awkward.operations.str.akstr_split_pattern_regex import *
-
-# string component extraction
-# https://arrow.apache.org/docs/python/api/compute.html#string-component-extraction
-from awkward.operations.str.akstr_extract_regex import *
-
-# string joining
-# https://arrow.apache.org/docs/python/api/compute.html#string-joining
-from awkward.operations.str.akstr_join import *
-from awkward.operations.str.akstr_join_element_wise import *
-
-# string slicing
-# https://arrow.apache.org/docs/python/api/compute.html#string-slicing
-from awkward.operations.str.akstr_slice import *
 
 # containment tests
 # https://arrow.apache.org/docs/python/api/compute.html#containment-tests
 from awkward.operations.str.akstr_count_substring import *
 from awkward.operations.str.akstr_count_substring_regex import *
 from awkward.operations.str.akstr_ends_with import *
+
+# string component extraction
+# https://arrow.apache.org/docs/python/api/compute.html#string-component-extraction
+from awkward.operations.str.akstr_extract_regex import *
 from awkward.operations.str.akstr_find_substring import *
 from awkward.operations.str.akstr_find_substring_regex import *
 from awkward.operations.str.akstr_index_in import *
+
+# string predicates
+# https://arrow.apache.org/docs/python/api/compute.html#string-predicates
+from awkward.operations.str.akstr_is_alnum import *
+from awkward.operations.str.akstr_is_alpha import *
+from awkward.operations.str.akstr_is_ascii import *
+from awkward.operations.str.akstr_is_decimal import *
+from awkward.operations.str.akstr_is_digit import *
 from awkward.operations.str.akstr_is_in import *
+from awkward.operations.str.akstr_is_lower import *
+from awkward.operations.str.akstr_is_numeric import *
+from awkward.operations.str.akstr_is_printable import *
+from awkward.operations.str.akstr_is_space import *
+from awkward.operations.str.akstr_is_title import *
+from awkward.operations.str.akstr_is_upper import *
+
+# string joining
+# https://arrow.apache.org/docs/python/api/compute.html#string-joining
+from awkward.operations.str.akstr_join import *
+from awkward.operations.str.akstr_join_element_wise import *
+from awkward.operations.str.akstr_length import *
+from awkward.operations.str.akstr_lower import *
+from awkward.operations.str.akstr_lpad import *
+
+# string trimming
+# https://arrow.apache.org/docs/python/api/compute.html#string-trimming
+from awkward.operations.str.akstr_ltrim import *
+from awkward.operations.str.akstr_ltrim_whitespace import *
 from awkward.operations.str.akstr_match_like import *
 from awkward.operations.str.akstr_match_substring import *
 from awkward.operations.str.akstr_match_substring_regex import *
+from awkward.operations.str.akstr_repeat import *
+from awkward.operations.str.akstr_replace_slice import *
+from awkward.operations.str.akstr_replace_substring import *
+from awkward.operations.str.akstr_replace_substring_regex import *
+from awkward.operations.str.akstr_reverse import *
+from awkward.operations.str.akstr_rpad import *
+from awkward.operations.str.akstr_rtrim import *
+from awkward.operations.str.akstr_rtrim_whitespace import *
+
+# string slicing
+# https://arrow.apache.org/docs/python/api/compute.html#string-slicing
+from awkward.operations.str.akstr_slice import *
+from awkward.operations.str.akstr_split_pattern import *
+from awkward.operations.str.akstr_split_pattern_regex import *
+
+# string splitting
+# https://arrow.apache.org/docs/python/api/compute.html#string-splitting
+from awkward.operations.str.akstr_split_whitespace import *
 from awkward.operations.str.akstr_starts_with import *
+from awkward.operations.str.akstr_swapcase import *
+from awkward.operations.str.akstr_title import *
 
 # dictionary-encoding (exclusively for strings)
 # https://arrow.apache.org/docs/python/api/compute.html#associative-transforms
 from awkward.operations.str.akstr_to_categorical import *
+from awkward.operations.str.akstr_trim import *
+from awkward.operations.str.akstr_trim_whitespace import *
+from awkward.operations.str.akstr_upper import *
+
+
+def _drop_option_preserving_form(layout):
+    from awkward._do import recursively_apply
+    from awkward.contents import UnmaskedArray, IndexedOptionArray, IndexedArray
+
+    def action(_, continuation, **kwargs):
+        this = continuation()
+
+        if not this.is_option:
+            return this
+        elif isinstance(this, UnmaskedArray):
+            return this.content
+        else:
+            index_nplike = this.backend.index_nplike
+            assert not (
+                index_nplike.known_data
+                and index_nplike.any(this.mask_as_bool(valid_when=False))
+            ), "did not expect option type, but arrow returned a non-erasable option"
+            # Re-write indexed options as indexed
+            if isinstance(this, IndexedOptionArray):
+                return IndexedArray(this.index, this.content)
+            else:
+                return this.content
+
+    return recursively_apply(layout, action, return_simplified=False)
 
 
 def _apply_through_arrow(
-    operation, /, layout, *args, generate_bitmasks=False, **kwargs
+    operation,
+    /,
+    layout,
+    *args,
+    generate_bitmasks=False,
+    expect_option_type=False,
+    **kwargs,
 ):
     from awkward.operations.ak_from_arrow import from_arrow
     from awkward.operations.ak_to_arrow import to_arrow
@@ -103,15 +135,19 @@ def _apply_through_arrow(
             ),
             generate_bitmasks=generate_bitmasks,
             highlevel=False,
-        )
-        return out.to_typetracer(forget_length=True)
+        ).to_typetracer(forget_length=True)
 
     else:
-        return from_arrow(
+        out = from_arrow(
             operation(to_arrow(layout, extensionarray=False), *args, **kwargs),
             generate_bitmasks=generate_bitmasks,
             highlevel=False,
         )
+
+    if expect_option_type:
+        return out
+    else:
+        return _drop_option_preserving_form(out)
 
 
 def _get_ufunc_action(
@@ -120,6 +156,7 @@ def _get_ufunc_action(
     *args,
     generate_bitmasks=False,
     bytestring_to_string=False,
+    expect_option_type=False,
     **kwargs,
 ):
     def action(layout, **absorb):
@@ -129,6 +166,7 @@ def _get_ufunc_action(
                 layout,
                 *args,
                 generate_bitmasks=generate_bitmasks,
+                expect_option_type=expect_option_type,
                 **kwargs,
             )
 
@@ -142,11 +180,9 @@ def _get_ufunc_action(
                     ),
                     *args,
                     generate_bitmasks=generate_bitmasks,
+                    expect_option_type=expect_option_type,
                     **kwargs,
                 )
-
-                if out.is_option:
-                    out = out.content
                 if out.is_list and out.parameter("__array__") == "string":
                     out = out.copy(
                         content=out.content.copy(parameters={"__array__": "byte"}),
@@ -160,6 +196,7 @@ def _get_ufunc_action(
                     layout,
                     *args,
                     generate_bitmasks=generate_bitmasks,
+                    expect_option_type=expect_option_type,
                     **kwargs,
                 )
 
@@ -188,58 +225,95 @@ def _get_split_action(
     bytestring_to_string=False,
     **kwargs,
 ):
-    def action(layout, **absorb):
-        if layout.is_list and layout.parameter("__array__") == "string":
-            return _erase_list_option(
-                _apply_through_arrow(
-                    utf8_function,
-                    layout,
-                    *args,
-                    generate_bitmasks=generate_bitmasks,
-                    **kwargs,
-                )
-            )
+    from awkward._backends.typetracer import TypeTracerBackend
+    from awkward.forms import ListOffsetForm, NumpyForm
 
-        elif layout.is_list and layout.parameter("__array__") == "bytestring":
-            if bytestring_to_string:
-                out = _erase_list_option(
-                    _apply_through_arrow(
-                        ascii_function,
-                        layout.copy(
-                            content=layout.content.copy(
-                                parameters={"__array__": "char"}
-                            ),
+    typetracer = TypeTracerBackend.instance()
+
+    # FIXME: this workaround for typetracer is required because
+    #        split_XXX does not support length-zero arrays
+    #        c.f. https://github.com/apache/arrow/issues/37437
+    def action(layout, **_):
+        if layout.backend is typetracer:
+            if layout.is_list and layout.parameter("__array__") == "string":
+                return (
+                    ListOffsetForm(
+                        "i32",
+                        ListOffsetForm(
+                            layout.form.offsets,
+                            NumpyForm("uint8", parameters={"__array__": "char"}),
                             parameters={"__array__": "string"},
                         ),
-                        *args,
-                        generate_bitmasks=generate_bitmasks,
-                        **kwargs,
                     )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
                 )
-                assert out.is_list
 
-                assert (
-                    out.content.is_list
-                    and out.content.parameter("__array__") == "string"
-                )
-                return out.copy(
-                    content=out.content.copy(
-                        content=out.content.content.copy(
-                            parameters={"__array__": "byte"}
+            elif layout.is_list and layout.parameter("__array__") == "bytestring":
+                return (
+                    ListOffsetForm(
+                        "i32",
+                        ListOffsetForm(
+                            layout.form.offsets,
+                            NumpyForm("uint8", parameters={"__array__": "byte"}),
+                            parameters={"__array__": "bytestring"},
                         ),
-                        parameters={"__array__": "bytestring"},
-                    ),
+                    )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
                 )
-
-            else:
-                return _erase_list_option(
+        else:
+            if layout.is_list and layout.parameter("__array__") == "string":
+                return _drop_option_preserving_form(
                     _apply_through_arrow(
-                        ascii_function,
+                        utf8_function,
                         layout,
                         *args,
                         generate_bitmasks=generate_bitmasks,
                         **kwargs,
                     )
                 )
+
+            elif layout.is_list and layout.parameter("__array__") == "bytestring":
+                if bytestring_to_string:
+                    out = _drop_option_preserving_form(
+                        _apply_through_arrow(
+                            ascii_function,
+                            layout.copy(
+                                content=layout.content.copy(
+                                    parameters={"__array__": "char"}
+                                ),
+                                parameters={"__array__": "string"},
+                            ),
+                            *args,
+                            generate_bitmasks=generate_bitmasks,
+                            **kwargs,
+                        )
+                    )
+                    assert out.is_list
+
+                    assert (
+                        out.content.is_list
+                        and out.content.parameter("__array__") == "string"
+                    )
+                    return out.copy(
+                        content=out.content.copy(
+                            content=out.content.content.copy(
+                                parameters={"__array__": "byte"}
+                            ),
+                            parameters={"__array__": "bytestring"},
+                        ),
+                    )
+
+                else:
+                    return _drop_option_preserving_form(
+                        _apply_through_arrow(
+                            ascii_function,
+                            layout,
+                            *args,
+                            generate_bitmasks=generate_bitmasks,
+                            **kwargs,
+                        )
+                    )
 
     return action

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -103,7 +103,9 @@ def _drop_option_preserving_form(layout):
             ), "did not expect option type, but arrow returned a non-erasable option"
             # Re-write indexed options as indexed
             if isinstance(this, IndexedOptionArray):
-                return IndexedArray(this.index, this.content)
+                return IndexedArray(
+                    this.index, this.content, parameters=this._parameters
+                )
             else:
                 return this.content
 
@@ -201,20 +203,6 @@ def _get_ufunc_action(
                 )
 
     return action
-
-
-def _erase_list_option(layout):
-    from awkward.contents.unmaskedarray import UnmaskedArray
-
-    if layout.is_option:
-        layout = layout.content
-
-    assert layout.is_list
-    if layout.content.is_option:
-        assert isinstance(layout.content, UnmaskedArray)
-        return layout.copy(content=layout.content.content)
-    else:
-        return layout
 
 
 def _get_split_action(

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -118,36 +118,31 @@ def _get_ufunc_action(
     utf8_function,
     ascii_function,
     *args,
+    generate_bitmasks=False,
     bytestring_to_string=False,
     **kwargs,
 ):
-    from awkward.operations.ak_from_arrow import from_arrow
-    from awkward.operations.ak_to_arrow import to_arrow
-
     def action(layout, **absorb):
         if layout.is_list and layout.parameter("__array__") == "string":
-            return from_arrow(
-                utf8_function(to_arrow(layout, extensionarray=False), *args, **kwargs),
-                highlevel=False,
+            return _apply_through_arrow(
+                utf8_function,
+                layout,
+                *args,
+                generate_bitmasks=generate_bitmasks,
+                **kwargs,
             )
 
         elif layout.is_list and layout.parameter("__array__") == "bytestring":
             if bytestring_to_string:
-                out = from_arrow(
-                    ascii_function(
-                        to_arrow(
-                            layout.copy(
-                                content=layout.content.copy(
-                                    parameters={"__array__": "char"}
-                                ),
-                                parameters={"__array__": "string"},
-                            ),
-                            extensionarray=False,
-                        ),
-                        *args,
-                        **kwargs,
+                out = _apply_through_arrow(
+                    ascii_function,
+                    layout.copy(
+                        content=layout.content.copy(parameters={"__array__": "char"}),
+                        parameters={"__array__": "string"},
                     ),
-                    highlevel=False,
+                    *args,
+                    generate_bitmasks=generate_bitmasks,
+                    **kwargs,
                 )
 
                 if out.is_option:
@@ -160,11 +155,12 @@ def _get_ufunc_action(
                 return out
 
             else:
-                return from_arrow(
-                    ascii_function(
-                        to_arrow(layout, extensionarray=False), *args, **kwargs
-                    ),
-                    highlevel=False,
+                return _apply_through_arrow(
+                    ascii_function,
+                    layout,
+                    *args,
+                    generate_bitmasks=generate_bitmasks,
+                    **kwargs,
                 )
 
     return action
@@ -185,42 +181,39 @@ def _erase_list_option(layout):
 
 
 def _get_split_action(
-    utf8_function, ascii_function, *args, bytestring_to_string=False, **kwargs
+    utf8_function,
+    ascii_function,
+    *args,
+    generate_bitmasks=False,
+    bytestring_to_string=False,
+    **kwargs,
 ):
-    from awkward.operations.ak_from_arrow import from_arrow
-    from awkward.operations.ak_to_arrow import to_arrow
-
     def action(layout, **absorb):
         if layout.is_list and layout.parameter("__array__") == "string":
             return _erase_list_option(
-                from_arrow(
-                    utf8_function(
-                        to_arrow(layout, extensionarray=False),
-                        *args,
-                        **kwargs,
-                    ),
-                    highlevel=False,
+                _apply_through_arrow(
+                    utf8_function,
+                    layout,
+                    *args,
+                    generate_bitmasks=generate_bitmasks,
+                    **kwargs,
                 )
             )
 
         elif layout.is_list and layout.parameter("__array__") == "bytestring":
             if bytestring_to_string:
                 out = _erase_list_option(
-                    from_arrow(
-                        ascii_function(
-                            to_arrow(
-                                layout.copy(
-                                    content=layout.content.copy(
-                                        parameters={"__array__": "char"}
-                                    ),
-                                    parameters={"__array__": "string"},
-                                ),
-                                extensionarray=False,
+                    _apply_through_arrow(
+                        ascii_function,
+                        layout.copy(
+                            content=layout.content.copy(
+                                parameters={"__array__": "char"}
                             ),
-                            *args,
-                            **kwargs,
+                            parameters={"__array__": "string"},
                         ),
-                        highlevel=False,
+                        *args,
+                        generate_bitmasks=generate_bitmasks,
+                        **kwargs,
                     )
                 )
                 assert out.is_list
@@ -240,11 +233,12 @@ def _get_split_action(
 
             else:
                 return _erase_list_option(
-                    from_arrow(
-                        ascii_function(
-                            to_arrow(layout, extensionarray=False), *args, **kwargs
-                        ),
-                        highlevel=False,
+                    _apply_through_arrow(
+                        ascii_function,
+                        layout,
+                        *args,
+                        generate_bitmasks=generate_bitmasks,
+                        **kwargs,
                     )
                 )
 

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -73,6 +73,7 @@ def _impl(array, pattern, highlevel, behavior):
             pattern,
             generate_bitmasks=True,
             bytestring_to_string=False,
+            expect_option_type=True,
         ),
         behavior,
     )

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -68,7 +68,11 @@ def _impl(array, pattern, highlevel, behavior):
     out = ak._do.recursively_apply(
         ak.operations.to_layout(array),
         ak.operations.str._get_ufunc_action(
-            pc.extract_regex, pc.extract_regex, pattern, bytestring_to_string=False
+            pc.extract_regex,
+            pc.extract_regex,
+            pattern,
+            generate_bitmasks=True,
+            bytestring_to_string=False,
         ),
         behavior,
     )

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -6,11 +6,13 @@ __all__ = ("index_in",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
+from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
+typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -54,9 +56,9 @@ def _is_maybe_optional_list_of_string(layout):
 
 
 def _impl(array, value_set, skip_nones, highlevel, behavior):
-    import awkward._connect.pyarrow  # noqa: F401, I001
+    from awkward._connect.pyarrow import import_pyarrow_compute
 
-    import pyarrow.compute as pc
+    pc = import_pyarrow_compute("ak.str.index_in")
 
     behavior = behavior_of(array, value_set, behavior=behavior)
     backend = backend_of(array, value_set, coerce_to_common=True, default=cpu)
@@ -69,14 +71,32 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
 
     def apply(layout, **kwargs):
         if _is_maybe_optional_list_of_string(layout):
-            return ak.from_arrow(
-                pc.index_in(
-                    ak.to_arrow(layout, extensionarray=False),
-                    ak.to_arrow(value_set_layout, extensionarray=False),
-                    skip_nulls=skip_nones,
-                ),
-                highlevel=False,
-            )
+            if layout.backend is typetracer:
+                return ak.from_arrow(
+                    pc.index_in(
+                        ak.to_arrow(
+                            layout.form.length_zero_array(highlevel=False),
+                            extensionarray=False,
+                        ),
+                        ak.to_arrow(
+                            value_set_layout.form.length_zero_array(highlevel=False),
+                            extensionarray=False,
+                        ),
+                        skip_nulls=skip_nones,
+                    ),
+                    highlevel=False,
+                    generate_bitmasks=True,
+                ).to_typetracer(forget_length=True)
+            else:
+                return ak.from_arrow(
+                    pc.index_in(
+                        ak.to_arrow(layout, extensionarray=False),
+                        ak.to_arrow(value_set_layout, extensionarray=False),
+                        skip_nulls=skip_nones,
+                    ),
+                    highlevel=False,
+                    generate_bitmasks=True,
+                )
 
     out = ak._do.recursively_apply(layout, apply, behavior=behavior)
 

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -6,11 +6,13 @@ __all__ = ("is_in",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
+from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
 cpu = NumpyBackend.instance()
+typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -53,9 +55,9 @@ def _is_maybe_optional_list_of_string(layout):
 
 
 def _impl(array, value_set, skip_nones, highlevel, behavior):
-    import awkward._connect.pyarrow  # noqa: F401, I001
+    from awkward._connect.pyarrow import import_pyarrow_compute
 
-    import pyarrow.compute as pc
+    pc = import_pyarrow_compute("ak.str.is_in")
 
     behavior = behavior_of(array, value_set, behavior=behavior)
     backend = backend_of(array, value_set, coerce_to_common=True, default=cpu)
@@ -68,14 +70,30 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
 
     def apply(layout, **kwargs):
         if _is_maybe_optional_list_of_string(layout):
-            return ak.from_arrow(
-                pc.is_in(
-                    ak.to_arrow(layout, extensionarray=False),
-                    ak.to_arrow(value_set_layout, extensionarray=False),
-                    skip_nulls=skip_nones,
-                ),
-                highlevel=False,
-            )
+            if layout.backend is typetracer:
+                return ak.from_arrow(
+                    pc.is_in(
+                        ak.to_arrow(
+                            layout.form.length_zero_array(highlevel=False),
+                            extensionarray=False,
+                        ),
+                        ak.to_arrow(
+                            value_set_layout.form.length_zero_array(highlevel=False),
+                            extensionarray=False,
+                        ),
+                        skip_nulls=skip_nones,
+                    ),
+                    highlevel=False,
+                ).to_typetracer(forget_length=True)
+            else:
+                return ak.from_arrow(
+                    pc.is_in(
+                        ak.to_arrow(layout, extensionarray=False),
+                        ak.to_arrow(value_set_layout, extensionarray=False),
+                        skip_nulls=skip_nones,
+                    ),
+                    highlevel=False,
+                )
 
     out = ak._do.recursively_apply(layout, apply, behavior=behavior)
 

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -49,8 +49,7 @@ def join_element_wise(*arrays, highlevel=True, behavior=None):
 
 def _impl(arrays, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
-    from awkward.operations.ak_from_arrow import from_arrow
-    from awkward.operations.ak_to_arrow import to_arrow
+    from awkward.operations.str import _apply_through_arrow
 
     pc = import_pyarrow_compute("ak.str.join_element_wise")
 
@@ -66,30 +65,7 @@ def _impl(arrays, highlevel, behavior):
             x.is_list and x.parameter("__array__") in ("string", "bytestring")
             for x in layouts
         ):
-            if layouts[0].backend is typetracer:
-                return (
-                    from_arrow(
-                        pc.binary_join_element_wise(
-                            *[
-                                to_arrow(
-                                    x.form.length_zero_array(highlevel=False),
-                                    extensionarray=False,
-                                )
-                                for x in layouts
-                            ]
-                        ),
-                        highlevel=False,
-                    ).to_typetracer(forget_length=True),
-                )
-            else:
-                return (
-                    from_arrow(
-                        pc.binary_join_element_wise(
-                            *[to_arrow(x, extensionarray=False) for x in layouts]
-                        ),
-                        highlevel=False,
-                    ),
-                )
+            return (_apply_through_arrow(pc.binary_join_element_wise, *layouts),)
 
     (out,) = ak._broadcasting.broadcast_and_apply(layouts, action, behavior)
 

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -7,13 +7,14 @@ import numbers
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
+from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpylike import NumpyMetadata
 
 cpu = NumpyBackend.instance()
-
+typetracer = TypeTracerBackend.instance()
 np = NumpyMetadata.instance()
 
 
@@ -50,16 +51,16 @@ def repeat(array, num_repeats, *, highlevel=True, behavior=None):
 
 
 def _impl(array, num_repeats, highlevel, behavior):
-    import awkward._connect.pyarrow  # noqa: F401, I001
+    from awkward._connect.pyarrow import import_pyarrow_compute
     from awkward.operations.ak_from_arrow import from_arrow
     from awkward.operations.ak_to_arrow import to_arrow
+    from awkward.operations.str import _apply_through_arrow
 
-    import pyarrow.compute as pc
-
-    layout = ak.operations.to_layout(array)
+    pc = import_pyarrow_compute("ak.str.repeat")
 
     behavior = behavior_of(array, num_repeats, behavior=behavior)
     backend = backend_of(array, num_repeats, coerce_to_common=True, default=cpu)
+    layout = ak.operations.to_layout(array).to_backend(backend)
 
     num_repeats_layout = ak.operations.to_layout(num_repeats, allow_other=True)
     if isinstance(num_repeats_layout, ak.contents.Content):
@@ -76,15 +77,33 @@ def _impl(array, num_repeats, highlevel, behavior):
                     raise TypeError(
                         "num_repeats must be an integer or broadcastable to integers"
                     )
-                return (
-                    from_arrow(
-                        pc.binary_repeat(
-                            to_arrow(inputs[0], extensionarray=False),
-                            to_arrow(inputs[1], extensionarray=False),
+
+                if inputs[0].backend is typetracer:
+                    return (
+                        from_arrow(
+                            pc.binary_repeat(
+                                to_arrow(
+                                    inputs[0].form.length_zero_array(highlevel=False),
+                                    extensionarray=False,
+                                ),
+                                to_arrow(
+                                    inputs[1].form.length_zero_array(highlevel=False),
+                                    extensionarray=False,
+                                ),
+                            ),
+                            highlevel=False,
+                        ).to_typetracer(forget_length=True),
+                    )
+                else:
+                    return (
+                        from_arrow(
+                            pc.binary_repeat(
+                                to_arrow(inputs[0], extensionarray=False),
+                                to_arrow(inputs[1], extensionarray=False),
+                            ),
+                            highlevel=False,
                         ),
-                        highlevel=False,
-                    ),
-                )
+                    )
 
         out = ak._broadcasting.broadcast_and_apply(
             (layout, num_repeats_layout), action, behavior
@@ -103,12 +122,7 @@ def _impl(array, num_repeats, highlevel, behavior):
                 "string",
                 "bytestring",
             ):
-                return from_arrow(
-                    pc.binary_repeat(
-                        to_arrow(layout, extensionarray=False), num_repeats
-                    ),
-                    highlevel=False,
-                )
+                return _apply_through_arrow(pc.binary_repeat, layout, num_repeats)
 
         out = ak._do.recursively_apply(layout, action, behavior)
 

--- a/src/awkward/operations/str/akstr_slice.py
+++ b/src/awkward/operations/str/akstr_slice.py
@@ -48,21 +48,17 @@ def slice(array, start, stop=None, step=1, *, highlevel=True, behavior=None):
 
 
 def _impl(array, start, stop, step, highlevel, behavior):
-    import awkward._connect.pyarrow  # noqa: F401, I001
-    from awkward.operations.ak_from_arrow import from_arrow
-    from awkward.operations.ak_to_arrow import to_arrow
+    from awkward._connect.pyarrow import import_pyarrow_compute
+    from awkward.operations.str import _apply_through_arrow
 
-    import pyarrow.compute as pc
+    pc = import_pyarrow_compute("ak.str.slice")
 
     behavior = behavior_of(array, behavior=behavior)
 
     def action(layout, **absorb):
         if layout.is_list and layout.parameter("__array__") == "string":
-            return from_arrow(
-                pc.utf8_slice_codeunits(
-                    to_arrow(layout, extensionarray=False), start, stop, step
-                ),
-                highlevel=False,
+            return _apply_through_arrow(
+                pc.utf8_slice_codeunits, layout, start, stop, step
             )
 
         elif layout.is_list and layout.parameter("__array__") == "bytestring":

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -4,12 +4,9 @@ __all__ = ("split_pattern",)
 
 
 import awkward as ak
-from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
-
-typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -55,52 +52,14 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array)
 
-    if layout.backend is typetracer:
-        # FIXME: this workaround for typetracer is required because
-        #        split_whitespace does not support length-zero arrays
-        #        c.f. https://github.com/apache/arrow/issues/37437
-        def action(layout, **kwargs):
-            if layout.is_list and layout.parameter("__array__") == "string":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "char"}
-                            ),
-                            parameters={"__array__": "string"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-            elif layout.is_list and layout.parameter("__array__") == "bytestring":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "byte"}
-                            ),
-                            parameters={"__array__": "bytestring"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-    else:
-        action = ak.operations.str._get_split_action(
-            pc.split_pattern,
-            pc.split_pattern,
-            pattern=pattern,
-            max_splits=max_splits,
-            reverse=reverse,
-            bytestring_to_string=False,
-        )
+    action = ak.operations.str._get_split_action(
+        pc.split_pattern,
+        pc.split_pattern,
+        pattern=pattern,
+        max_splits=max_splits,
+        reverse=reverse,
+        bytestring_to_string=False,
+    )
     out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -4,9 +4,12 @@ __all__ = ("split_pattern",)
 
 
 import awkward as ak
+from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -50,14 +53,54 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior):
 
     pc = import_pyarrow_compute("ak.str.split_pattern")
     behavior = behavior_of(array, behavior=behavior)
-    action = ak.operations.str._get_split_action(
-        pc.split_pattern,
-        pc.split_pattern,
-        pattern=pattern,
-        max_splits=max_splits,
-        reverse=reverse,
-        bytestring_to_string=False,
-    )
-    out = ak._do.recursively_apply(ak.operations.to_layout(array), action, behavior)
+    layout = ak.to_layout(array)
+
+    if layout.backend is typetracer:
+        # FIXME: this workaround for typetracer is required because
+        #        split_whitespace does not support length-zero arrays
+        #        c.f. https://github.com/apache/arrow/issues/37437
+        def action(layout, **kwargs):
+            if layout.is_list and layout.parameter("__array__") == "string":
+                return (
+                    ak.forms.ListOffsetForm(
+                        "i32",
+                        ak.forms.ListOffsetForm(
+                            layout.form.offsets,
+                            ak.forms.NumpyForm(
+                                "uint8", parameters={"__array__": "char"}
+                            ),
+                            parameters={"__array__": "string"},
+                        ),
+                    )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
+                )
+
+            elif layout.is_list and layout.parameter("__array__") == "bytestring":
+                return (
+                    ak.forms.ListOffsetForm(
+                        "i32",
+                        ak.forms.ListOffsetForm(
+                            layout.form.offsets,
+                            ak.forms.NumpyForm(
+                                "uint8", parameters={"__array__": "byte"}
+                            ),
+                            parameters={"__array__": "bytestring"},
+                        ),
+                    )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
+                )
+
+    else:
+        action = ak.operations.str._get_split_action(
+            pc.split_pattern,
+            pc.split_pattern,
+            pattern=pattern,
+            max_splits=max_splits,
+            reverse=reverse,
+            bytestring_to_string=False,
+        )
+    out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern_regex.py
+++ b/src/awkward/operations/str/akstr_split_pattern_regex.py
@@ -4,12 +4,9 @@ __all__ = ("split_pattern_regex",)
 
 
 import awkward as ak
-from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
-
-typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -50,62 +47,23 @@ def split_pattern_regex(
 
 
 def _impl(array, pattern, max_splits, reverse, highlevel, behavior):
-    from awkward._connect.pyarrow import import_pyarrow, import_pyarrow_compute
+    from awkward._connect.pyarrow import import_pyarrow_compute
 
-    pyarrow = import_pyarrow("ak.str.split_pattern_regex")
     pc = import_pyarrow_compute("ak.str.split_pattern_regex")
     behavior = behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array)
 
-    if layout.backend is typetracer:
-        if reverse:
-            raise pyarrow.ArrowNotImplementedError("Cannot split in reverse with regex")
+    if reverse:
+        raise ValueError("Cannot split in reverse with regex")
 
-        # FIXME: this workaround for typetracer is required because
-        #        split_whitespace does not support length-zero arrays
-        #        c.f. https://github.com/apache/arrow/issues/37437
-        def action(layout, **kwargs):
-            if layout.is_list and layout.parameter("__array__") == "string":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "char"}
-                            ),
-                            parameters={"__array__": "string"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-            elif layout.is_list and layout.parameter("__array__") == "bytestring":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "byte"}
-                            ),
-                            parameters={"__array__": "bytestring"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-    else:
-        action = ak.operations.str._get_split_action(
-            pc.split_pattern_regex,
-            pc.split_pattern_regex,
-            pattern=pattern,
-            max_splits=max_splits,
-            reverse=reverse,
-            bytestring_to_string=False,
-        )
+    action = ak.operations.str._get_split_action(
+        pc.split_pattern_regex,
+        pc.split_pattern_regex,
+        pattern=pattern,
+        max_splits=max_splits,
+        reverse=reverse,
+        bytestring_to_string=False,
+    )
     out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -4,9 +4,12 @@ __all__ = ("split_whitespace",)
 
 
 import awkward as ak
+from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
+
+typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -59,13 +62,53 @@ def _impl(array, max_splits, reverse, highlevel, behavior):
 
     pc = import_pyarrow_compute("ak.str.split_whitespace")
     behavior = behavior_of(array, behavior=behavior)
-    action = ak.operations.str._get_split_action(
-        pc.utf8_split_whitespace,
-        pc.ascii_split_whitespace,
-        max_splits=max_splits,
-        reverse=reverse,
-        bytestring_to_string=True,
-    )
-    out = ak._do.recursively_apply(ak.operations.to_layout(array), action, behavior)
+    layout = ak.to_layout(array)
+
+    if layout.backend is typetracer:
+        # FIXME: this workaround for typetracer is required because
+        #        split_whitespace does not support length-zero arrays
+        #        c.f. https://github.com/apache/arrow/issues/37437
+        def action(layout, **kwargs):
+            if layout.is_list and layout.parameter("__array__") == "string":
+                return (
+                    ak.forms.ListOffsetForm(
+                        "i32",
+                        ak.forms.ListOffsetForm(
+                            layout.form.offsets,
+                            ak.forms.NumpyForm(
+                                "uint8", parameters={"__array__": "char"}
+                            ),
+                            parameters={"__array__": "string"},
+                        ),
+                    )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
+                )
+
+            elif layout.is_list and layout.parameter("__array__") == "bytestring":
+                return (
+                    ak.forms.ListOffsetForm(
+                        "i32",
+                        ak.forms.ListOffsetForm(
+                            layout.form.offsets,
+                            ak.forms.NumpyForm(
+                                "uint8", parameters={"__array__": "byte"}
+                            ),
+                            parameters={"__array__": "bytestring"},
+                        ),
+                    )
+                    .length_zero_array(highlevel=False)
+                    .to_typetracer(forget_length=True)
+                )
+
+    else:
+        action = ak.operations.str._get_split_action(
+            pc.utf8_split_whitespace,
+            pc.ascii_split_whitespace,
+            max_splits=max_splits,
+            reverse=reverse,
+            bytestring_to_string=True,
+        )
+    out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -4,12 +4,9 @@ __all__ = ("split_whitespace",)
 
 
 import awkward as ak
-from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
-
-typetracer = TypeTracerBackend.instance()
 
 
 @high_level_function(module="ak.str")
@@ -64,51 +61,13 @@ def _impl(array, max_splits, reverse, highlevel, behavior):
     behavior = behavior_of(array, behavior=behavior)
     layout = ak.to_layout(array)
 
-    if layout.backend is typetracer:
-        # FIXME: this workaround for typetracer is required because
-        #        split_whitespace does not support length-zero arrays
-        #        c.f. https://github.com/apache/arrow/issues/37437
-        def action(layout, **kwargs):
-            if layout.is_list and layout.parameter("__array__") == "string":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "char"}
-                            ),
-                            parameters={"__array__": "string"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-            elif layout.is_list and layout.parameter("__array__") == "bytestring":
-                return (
-                    ak.forms.ListOffsetForm(
-                        "i32",
-                        ak.forms.ListOffsetForm(
-                            layout.form.offsets,
-                            ak.forms.NumpyForm(
-                                "uint8", parameters={"__array__": "byte"}
-                            ),
-                            parameters={"__array__": "bytestring"},
-                        ),
-                    )
-                    .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
-                )
-
-    else:
-        action = ak.operations.str._get_split_action(
-            pc.utf8_split_whitespace,
-            pc.ascii_split_whitespace,
-            max_splits=max_splits,
-            reverse=reverse,
-            bytestring_to_string=True,
-        )
+    action = ak.operations.str._get_split_action(
+        pc.utf8_split_whitespace,
+        pc.ascii_split_whitespace,
+        max_splits=max_splits,
+        reverse=reverse,
+        bytestring_to_string=True,
+    )
     out = ak._do.recursively_apply(layout, action, behavior)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -59,13 +59,8 @@ def _impl(array, highlevel, behavior):
 
     def action(layout, **kwargs):
         if layout.is_list and layout.parameter("__array__") in {"string", "bytestring"}:
-            result = _apply_through_arrow(pc.dictionary_encode, layout)
-            # Arrow _always_ adds an option here, even though we know that
-            # no values are null. Therefore, we can safely replace the indexed
-            # option-type with an indexed type.
-            assert isinstance(result, ak.contents.IndexedOptionArray)
-            return ak.contents.IndexedArray(
-                result.index, result.content, parameters=result._parameters
+            return _apply_through_arrow(
+                pc.dictionary_encode, layout, expect_option_type=False
             )
 
     out = ak._do.recursively_apply(

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -52,16 +52,14 @@ def to_categorical(array, *, highlevel=True, behavior=None):
 
 def _impl(array, highlevel, behavior):
     from awkward._connect.pyarrow import import_pyarrow_compute
+    from awkward.operations.str import _apply_through_arrow
 
     pc = import_pyarrow_compute("ak.str.to_categorical")
     behavior = behavior_of(array, behavior=behavior)
 
     def action(layout, **kwargs):
         if layout.is_list and layout.parameter("__array__") in {"string", "bytestring"}:
-            result = ak.from_arrow(
-                pc.dictionary_encode(ak.to_arrow(layout, extensionarray=False)),
-                highlevel=False,
-            )
+            result = _apply_through_arrow(pc.dictionary_encode, layout)
             # Arrow _always_ adds an option here, even though we know that
             # no values are null. Therefore, we can safely replace the indexed
             # option-type with an indexed type.

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -60,6 +60,14 @@ def test_is_alnum():
         [],
         [False, False, True],
     ]
+    assert (
+        ak.str.is_alnum(string).layout.form
+        == ak.str.is_alnum(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_alnum(bytestring).layout.form
+        == ak.str.is_alnum(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_alpha():
@@ -73,6 +81,14 @@ def test_is_alpha():
         [],
         [False, False, True],
     ]
+    assert (
+        ak.str.is_alpha(string).layout.form
+        == ak.str.is_alpha(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_alpha(bytestring).layout.form
+        == ak.str.is_alpha(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_decimal():
@@ -86,6 +102,14 @@ def test_is_decimal():
         [],
         [False, False, False],
     ]
+    assert (
+        ak.str.is_decimal(string).layout.form
+        == ak.str.is_decimal(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_decimal(bytestring).layout.form
+        == ak.str.is_decimal(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_digit():
@@ -100,6 +124,15 @@ def test_is_digit():
         [False, False, False],
     ]
 
+    assert (
+        ak.str.is_digit(string).layout.form
+        == ak.str.is_digit(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_digit(bytestring).layout.form
+        == ak.str.is_digit(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
+
 
 def test_is_lower():
     assert ak.str.is_lower(string).tolist() == [
@@ -112,6 +145,14 @@ def test_is_lower():
         [],
         [False, True, True],
     ]
+    assert (
+        ak.str.is_lower(string).layout.form
+        == ak.str.is_lower(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_lower(bytestring).layout.form
+        == ak.str.is_lower(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_numeric():
@@ -125,6 +166,14 @@ def test_is_numeric():
         [],
         [False, False, False],
     ]
+    assert (
+        ak.str.is_numeric(string).layout.form
+        == ak.str.is_numeric(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_numeric(bytestring).layout.form
+        == ak.str.is_numeric(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_printable():
@@ -138,6 +187,14 @@ def test_is_printable():
         [],
         [False, False, True],
     ]
+    assert (
+        ak.str.is_printable(string).layout.form
+        == ak.str.is_printable(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_printable(bytestring).layout.form
+        == ak.str.is_printable(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_space():
@@ -151,6 +208,14 @@ def test_is_space():
         [],
         [False, False, False],
     ]
+    assert (
+        ak.str.is_space(string).layout.form
+        == ak.str.is_space(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_space(bytestring).layout.form
+        == ak.str.is_space(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_upper():
@@ -164,6 +229,14 @@ def test_is_upper():
         [],
         [False, False, False],
     ]
+    assert (
+        ak.str.is_upper(string).layout.form
+        == ak.str.is_upper(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_upper(bytestring).layout.form
+        == ak.str.is_upper(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_title():
@@ -177,6 +250,14 @@ def test_is_title():
         [],
         [False, False, False],
     ]
+    assert (
+        ak.str.is_title(string).layout.form
+        == ak.str.is_title(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_title(bytestring).layout.form
+        == ak.str.is_title(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_is_ascii():
@@ -190,6 +271,14 @@ def test_is_ascii():
         [],
         [False, False, True],
     ]
+    assert (
+        ak.str.is_ascii(string).layout.form
+        == ak.str.is_ascii(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.is_ascii(bytestring).layout.form
+        == ak.str.is_ascii(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_capitalize():
@@ -203,6 +292,14 @@ def test_capitalize():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"Abc"],
     ]
+    assert (
+        ak.str.capitalize(string).layout.form
+        == ak.str.capitalize(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.capitalize(bytestring).layout.form
+        == ak.str.capitalize(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_length():
@@ -216,6 +313,14 @@ def test_length():
         [],
         [10, 7, 3],
     ]
+    assert (
+        ak.str.length(string).layout.form
+        == ak.str.length(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.length(bytestring).layout.form
+        == ak.str.length(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_lower():
@@ -229,6 +334,14 @@ def test_lower():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.lower(string).layout.form
+        == ak.str.lower(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.lower(bytestring).layout.form
+        == ak.str.lower(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_swapcase():
@@ -242,6 +355,14 @@ def test_swapcase():
         [],
         ["→δε←".encode(), "ζZ Zζ".encode(), b"ABC"],
     ]
+    assert (
+        ak.str.swapcase(string).layout.form
+        == ak.str.swapcase(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.swapcase(bytestring).layout.form
+        == ak.str.swapcase(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_title():
@@ -255,6 +376,14 @@ def test_title():
         [],
         ["→δε←".encode(), "ζZ Zζ".encode(), b"Abc"],
     ]
+    assert (
+        ak.str.title(string).layout.form
+        == ak.str.title(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.title(bytestring).layout.form
+        == ak.str.title(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_upper():
@@ -268,6 +397,14 @@ def test_upper():
         [],
         ["→δε←".encode(), "ζZ Zζ".encode(), b"ABC"],
     ]
+    assert (
+        ak.str.upper(string).layout.form
+        == ak.str.upper(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.upper(bytestring).layout.form
+        == ak.str.upper(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_repeat():
@@ -325,6 +462,18 @@ def test_replace_slice():
         [],
         [b"\xe2qj\x92\xce\xb4\xce\xb5\xe2\x86\x90"],
     ]
+    assert (
+        ak.str.replace_slice(string[:, :1], 1, 2, "qj").layout.form
+        == ak.str.replace_slice(
+            ak.to_backend(string, "typetracer")[:, :1], 1, 2, "qj"
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_slice(bytestring[:, :1], 1, 2, b"qj").layout.form
+        == ak.str.replace_slice(
+            ak.to_backend(bytestring, "typetracer")[:, :1], 1, 2, b"qj"
+        ).layout.form
+    )
 
 
 def test_reverse():
@@ -338,6 +487,14 @@ def test_reverse():
         [],
         ["→δε←".encode()[::-1], "ζz zζ".encode()[::-1], b"abc"[::-1]],
     ]
+    assert (
+        ak.str.reverse(string).layout.form
+        == ak.str.reverse(ak.to_backend(string, "typetracer")).layout.form
+    )
+    assert (
+        ak.str.reverse(bytestring).layout.form
+        == ak.str.reverse(ak.to_backend(bytestring, "typetracer")).layout.form
+    )
 
 
 def test_replace_substring():
@@ -351,6 +508,18 @@ def test_replace_substring():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.replace_substring(string, "βγ", "HELLO").layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(string, "typetracer"), "βγ", "HELLO"
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_substring(bytestring, "βγ".encode(), b"HELLO").layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(bytestring, "typetracer"), "βγ".encode(), b"HELLO"
+        ).layout.form
+    )
 
     assert ak.str.replace_substring(
         string, "βγ", "HELLO", max_replacements=0
@@ -366,6 +535,23 @@ def test_replace_substring():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.replace_substring(string, "βγ", "HELLO", max_replacements=0).layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(string, "typetracer"), "βγ", "HELLO", max_replacements=0
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_substring(
+            bytestring, "βγ".encode(), b"HELLO", max_replacements=0
+        ).layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(bytestring, "typetracer"),
+            "βγ".encode(),
+            b"HELLO",
+            max_replacements=0,
+        ).layout.form
+    )
 
 
 def test_replace_substring_regex():
@@ -381,6 +567,18 @@ def test_replace_substring_regex():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.replace_substring(string, "βγ", "HELLO").layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(string, "typetracer"), "βγ", "HELLO"
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_substring(bytestring, "βγ".encode(), b"HELLO").layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(bytestring, "typetracer"), "βγ".encode(), b"HELLO"
+        ).layout.form
+    )
 
     assert ak.str.replace_substring_regex(
         string, "βγ", "HELLO", max_replacements=0
@@ -396,6 +594,51 @@ def test_replace_substring_regex():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.replace_substring(string, "βγ", "HELLO", max_replacements=0).layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(string, "typetracer"), "βγ", "HELLO", max_replacements=0
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_substring(
+            bytestring, "βγ".encode(), b"HELLO", max_replacements=0
+        ).layout.form
+        == ak.str.replace_substring(
+            ak.to_backend(bytestring, "typetracer"),
+            "βγ".encode(),
+            b"HELLO",
+            max_replacements=0,
+        ).layout.form
+    )
+
+    # Check regex
+    assert ak.str.replace_substring_regex(
+        [["aaaa1bb1c2ddddd"], ["fff"], []], r"[a-zA-Z]+", "FOO"
+    ).tolist() == [["FOO1FOO1FOO2FOO"], ["FOO"], []]
+    assert ak.str.replace_substring_regex(
+        [[b"aaaa1bb1c2ddddd"], [b"fff"], []], rb"[a-zA-Z]+", b"FOO"
+    ).tolist() == [[b"FOO1FOO1FOO2FOO"], [b"FOO"], []]
+    assert (
+        ak.str.replace_substring_regex(
+            [["aaaa1bb1c2ddddd"], ["fff"], []], r"[a-zA-Z]+", "FOO"
+        ).layout.form
+        == ak.str.replace_substring_regex(
+            ak.to_backend([["aaaa1bb1c2ddddd"], ["fff"], []], "typetracer"),
+            r"[a-zA-Z]+",
+            "FOO",
+        ).layout.form
+    )
+    assert (
+        ak.str.replace_substring_regex(
+            [[b"aaaa1bb1c2ddddd"], [b"fff"], []], rb"[a-zA-Z]+", b"FOO"
+        ).layout.form
+        == ak.str.replace_substring_regex(
+            ak.to_backend([[b"aaaa1bb1c2ddddd"], [b"fff"], []], "typetracer"),
+            rb"[a-zA-Z]+",
+            b"FOO",
+        ).layout.form
+    )
 
 
 def test_center():
@@ -404,9 +647,6 @@ def test_center():
         [],
         ["     →δε←      ", "     ζz zζ     ", "      abc      "],
     ]
-
-    print(ak.str.center(bytestring, 15, " ").tolist())
-
     assert ak.str.center(bytestring, 15, b" ").tolist() == [
         [b"    \xce\xb1\xce\xb2\xce\xb3     ", b"               "],
         [],
@@ -416,6 +656,14 @@ def test_center():
             b"      abc      ",
         ],
     ]
+    assert (
+        ak.str.center(string, 15, " ").layout.form
+        == ak.str.center(ak.to_backend(string, "typetracer"), 15, " ").layout.form
+    )
+    assert (
+        ak.str.center(bytestring, 15, b" ").layout.form
+        == ak.str.center(ak.to_backend(bytestring, "typetracer"), 15, b" ").layout.form
+    )
 
 
 def test_lpad():
@@ -424,9 +672,6 @@ def test_lpad():
         [],
         ["           →δε←", "          ζz zζ", "            abc"],
     ]
-
-    print(ak.str.lpad(bytestring, 15, " ").tolist())
-
     assert ak.str.lpad(bytestring, 15, b" ").tolist() == [
         [b"         \xce\xb1\xce\xb2\xce\xb3", b"               "],
         [],
@@ -436,6 +681,14 @@ def test_lpad():
             b"            abc",
         ],
     ]
+    assert (
+        ak.str.lpad(string, 15, " ").layout.form
+        == ak.str.lpad(ak.to_backend(string, "typetracer"), 15, " ").layout.form
+    )
+    assert (
+        ak.str.lpad(bytestring, 15, b" ").layout.form
+        == ak.str.lpad(ak.to_backend(bytestring, "typetracer"), 15, b" ").layout.form
+    )
 
 
 def test_rpad():
@@ -444,9 +697,6 @@ def test_rpad():
         [],
         ["→δε←           ", "ζz zζ          ", "abc            "],
     ]
-
-    print(ak.str.rpad(bytestring, 15, " ").tolist())
-
     assert ak.str.rpad(bytestring, 15, b" ").tolist() == [
         [b"\xce\xb1\xce\xb2\xce\xb3         ", b"               "],
         [],
@@ -456,6 +706,14 @@ def test_rpad():
             b"abc            ",
         ],
     ]
+    assert (
+        ak.str.rpad(string, 15, " ").layout.form
+        == ak.str.rpad(ak.to_backend(string, "typetracer"), 15, " ").layout.form
+    )
+    assert (
+        ak.str.rpad(bytestring, 15, b" ").layout.form
+        == ak.str.rpad(ak.to_backend(bytestring, "typetracer"), 15, b" ").layout.form
+    )
 
 
 def test_ltrim():
@@ -469,6 +727,16 @@ def test_ltrim():
         [],
         ["→δε←   ".encode(), "ζz zζ    ".encode(), b"abc      "],
     ]
+    assert (
+        ak.str.ltrim(string_padded, " ").layout.form
+        == ak.str.ltrim(ak.to_backend(string_padded, "typetracer"), " ").layout.form
+    )
+    assert (
+        ak.str.ltrim(bytestring_padded, b" ").layout.form
+        == ak.str.ltrim(
+            ak.to_backend(bytestring_padded, "typetracer"), b" "
+        ).layout.form
+    )
 
 
 def test_ltrim_whitespace():
@@ -482,6 +750,18 @@ def test_ltrim_whitespace():
         [],
         ["→δε←   ".encode(), "ζz zζ    ".encode(), b"abc      "],
     ]
+    assert (
+        ak.str.ltrim_whitespace(string_padded).layout.form
+        == ak.str.ltrim_whitespace(
+            ak.to_backend(string_padded, "typetracer")
+        ).layout.form
+    )
+    assert (
+        ak.str.ltrim_whitespace(bytestring_padded).layout.form
+        == ak.str.ltrim_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer")
+        ).layout.form
+    )
 
 
 def test_rtrim():
@@ -495,6 +775,16 @@ def test_rtrim():
         [],
         ["  →δε←".encode(), "    ζz zζ".encode(), b"      abc"],
     ]
+    assert (
+        ak.str.rtrim(string_padded, " ").layout.form
+        == ak.str.rtrim(ak.to_backend(string_padded, "typetracer"), " ").layout.form
+    )
+    assert (
+        ak.str.rtrim(bytestring_padded, b" ").layout.form
+        == ak.str.rtrim(
+            ak.to_backend(bytestring_padded, "typetracer"), b" "
+        ).layout.form
+    )
 
 
 def test_rtrim_whitespace():
@@ -508,6 +798,18 @@ def test_rtrim_whitespace():
         [],
         ["  →δε←".encode(), "    ζz zζ".encode(), b"      abc"],
     ]
+    assert (
+        ak.str.rtrim_whitespace(string_padded).layout.form
+        == ak.str.rtrim_whitespace(
+            ak.to_backend(string_padded, "typetracer")
+        ).layout.form
+    )
+    assert (
+        ak.str.rtrim_whitespace(bytestring_padded).layout.form
+        == ak.str.rtrim_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer")
+        ).layout.form
+    )
 
 
 def test_trim():
@@ -521,6 +823,14 @@ def test_trim():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.trim(string_padded, " ").layout.form
+        == ak.str.trim(ak.to_backend(string_padded, "typetracer"), " ").layout.form
+    )
+    assert (
+        ak.str.trim(bytestring_padded, b" ").layout.form
+        == ak.str.trim(ak.to_backend(bytestring_padded, "typetracer"), b" ").layout.form
+    )
 
 
 def test_trim_whitespace():
@@ -534,6 +844,20 @@ def test_trim_whitespace():
         [],
         ["→δε←".encode(), "ζz zζ".encode(), b"abc"],
     ]
+    assert (
+        ak.str.trim_whitespace(string_padded).layout.form
+        == ak.str.trim_whitespace(
+            ak.to_backend(string_padded, "typetracer")
+        ).layout.form
+    )
+
+
+assert (
+    ak.str.trim_whitespace(bytestring_padded).layout.form
+    == ak.str.trim_whitespace(
+        ak.to_backend(bytestring_padded, "typetracer")
+    ).layout.form
+)
 
 
 def test_slice():
@@ -1009,11 +1333,24 @@ def test_count_substring():
         [0, 0, 0],
         [],
     ]
+    assert (
+        ak.str.count_substring(string_repeats, "BA").layout.form
+        == ak.str.count_substring(
+            ak.to_backend(string_repeats, "typetracer"), "BA"
+        ).layout.form
+    )
+
     assert ak.str.count_substring(string_repeats, "BA", ignore_case=True).tolist() == [
         [2, 0, 1],
         [0, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring(string_repeats, "BA", ignore_case=True).layout.form
+        == ak.str.count_substring(
+            ak.to_backend(string_repeats, "typetracer"), "BA", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.count_substring(bytestring_repeats, b"BA").tolist() == [
@@ -1021,6 +1358,13 @@ def test_count_substring():
         [0, 0, 0],
         [],
     ]
+    assert (
+        ak.str.count_substring(bytestring_repeats, b"BA").layout.form
+        == ak.str.count_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"BA"
+        ).layout.form
+    )
+
     assert ak.str.count_substring(
         bytestring_repeats, b"BA", ignore_case=True
     ).tolist() == [
@@ -1028,6 +1372,12 @@ def test_count_substring():
         [0, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring(bytestring_repeats, b"BA", ignore_case=True).layout.form
+        == ak.str.count_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"BA", ignore_case=True
+        ).layout.form
+    )
 
 
 def test_count_substring_regex():
@@ -1036,6 +1386,13 @@ def test_count_substring_regex():
         [0, 0, 0],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(string_repeats, r"BA\d*").layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"BA\d*"
+        ).layout.form
+    )
+
     assert ak.str.count_substring_regex(
         string_repeats, r"BA\d*", ignore_case=True
     ).tolist() == [
@@ -1043,11 +1400,26 @@ def test_count_substring_regex():
         [0, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(
+            string_repeats, r"BA\d*", ignore_case=True
+        ).layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"BA\d*", ignore_case=True
+        ).layout.form
+    )
+
     assert ak.str.count_substring_regex(string_repeats, r"\d{1,}").tolist() == [
         [2, 0, 0],
         [1, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(string_repeats, r"\d{1,}").layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"\d{1,}"
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.count_substring_regex(bytestring_repeats, rb"BA\d*").tolist() == [
@@ -1055,6 +1427,13 @@ def test_count_substring_regex():
         [0, 0, 0],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(bytestring_repeats, rb"BA\d*").layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), rb"BA\d*"
+        ).layout.form
+    )
+
     assert ak.str.count_substring_regex(
         bytestring_repeats, rb"BA\d*", ignore_case=True
     ).tolist() == [
@@ -1062,11 +1441,26 @@ def test_count_substring_regex():
         [0, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(
+            bytestring_repeats, rb"BA\d*", ignore_case=True
+        ).layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), rb"BA\d*", ignore_case=True
+        ).layout.form
+    )
+
     assert ak.str.count_substring_regex(bytestring_repeats, rb"\d{1,}").tolist() == [
         [2, 0, 0],
         [1, 1, 1],
         [],
     ]
+    assert (
+        ak.str.count_substring_regex(bytestring_repeats, rb"\d{1,}").layout.form
+        == ak.str.count_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), rb"\d{1,}"
+        ).layout.form
+    )
 
 
 def test_ends_with():
@@ -1075,11 +1469,24 @@ def test_ends_with():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.ends_with(string_repeats, "BAR").layout.form
+        == ak.str.ends_with(
+            ak.to_backend(string_repeats, "typetracer"), "BAR"
+        ).layout.form
+    )
+
     assert ak.str.ends_with(string_repeats, "BAR", ignore_case=True).tolist() == [
         [False, False, True],
         [False, True, True],
         [],
     ]
+    assert (
+        ak.str.ends_with(string_repeats, "BAR", ignore_case=True).layout.form
+        == ak.str.ends_with(
+            ak.to_backend(string_repeats, "typetracer"), "BAR", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.ends_with(bytestring_repeats, b"BAR").tolist() == [
@@ -1087,11 +1494,24 @@ def test_ends_with():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.ends_with(bytestring_repeats, b"BAR").layout.form
+        == ak.str.ends_with(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"BAR"
+        ).layout.form
+    )
+
     assert ak.str.ends_with(bytestring_repeats, b"BAR", ignore_case=True).tolist() == [
         [False, False, True],
         [False, True, True],
         [],
     ]
+    assert (
+        ak.str.ends_with(bytestring_repeats, b"BAR", ignore_case=True).layout.form
+        == ak.str.ends_with(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"BAR", ignore_case=True
+        ).layout.form
+    )
 
 
 def test_starts_with():
@@ -1100,11 +1520,24 @@ def test_starts_with():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.starts_with(string_repeats, "FOO").layout.form
+        == ak.str.starts_with(
+            ak.to_backend(string_repeats, "typetracer"), "FOO"
+        ).layout.form
+    )
+
     assert ak.str.starts_with(string_repeats, "FOO", ignore_case=True).tolist() == [
         [True, True, False],
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.starts_with(string_repeats, "FOO", ignore_case=True).layout.form
+        == ak.str.starts_with(
+            ak.to_backend(string_repeats, "typetracer"), "FOO", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.starts_with(bytestring_repeats, b"FOO").tolist() == [
@@ -1112,6 +1545,13 @@ def test_starts_with():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.starts_with(bytestring_repeats, b"FOO").layout.form
+        == ak.str.starts_with(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO"
+        ).layout.form
+    )
+
     assert ak.str.starts_with(
         bytestring_repeats, b"FOO", ignore_case=True
     ).tolist() == [
@@ -1119,6 +1559,12 @@ def test_starts_with():
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.starts_with(bytestring_repeats, b"FOO", ignore_case=True).layout.form
+        == ak.str.starts_with(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO", ignore_case=True
+        ).layout.form
+    )
 
 
 def test_find_substring():
@@ -1127,11 +1573,24 @@ def test_find_substring():
         [-1, -1, -1],
         [],
     ]
+    assert (
+        ak.str.find_substring(string_repeats, "FOO").layout.form
+        == ak.str.find_substring(
+            ak.to_backend(string_repeats, "typetracer"), "FOO"
+        ).layout.form
+    )
+
     assert ak.str.find_substring(string_repeats, "FOO", ignore_case=True).tolist() == [
         [0, 0, -1],
         [3, -1, 0],
         [],
     ]
+    assert (
+        ak.str.find_substring(string_repeats, "FOO", ignore_case=True).layout.form
+        == ak.str.find_substring(
+            ak.to_backend(string_repeats, "typetracer"), "FOO", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.find_substring(bytestring_repeats, b"FOO").tolist() == [
@@ -1139,6 +1598,13 @@ def test_find_substring():
         [-1, -1, -1],
         [],
     ]
+    assert (
+        ak.str.find_substring(bytestring_repeats, b"FOO").layout.form
+        == ak.str.find_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO"
+        ).layout.form
+    )
+
     assert ak.str.find_substring(
         bytestring_repeats, b"FOO", ignore_case=True
     ).tolist() == [
@@ -1146,6 +1612,12 @@ def test_find_substring():
         [3, -1, 0],
         [],
     ]
+    assert (
+        ak.str.find_substring(bytestring_repeats, b"FOO", ignore_case=True).layout.form
+        == ak.str.find_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO", ignore_case=True
+        ).layout.form
+    )
 
 
 def test_find_substring_regex():
@@ -1154,6 +1626,13 @@ def test_find_substring_regex():
         [-1, -1, -1],
         [],
     ]
+    assert (
+        ak.str.find_substring_regex(string_repeats, r"FOO\d+").layout.form
+        == ak.str.find_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"FOO\d+"
+        ).layout.form
+    )
+
     assert ak.str.find_substring_regex(
         string_repeats, r"FOO\d+", ignore_case=True
     ).tolist() == [
@@ -1161,6 +1640,14 @@ def test_find_substring_regex():
         [-1, -1, 0],
         [],
     ]
+    assert (
+        ak.str.find_substring_regex(
+            string_repeats, r"FOO\d+", ignore_case=True
+        ).layout.form
+        == ak.str.find_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"FOO\d+", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.find_substring_regex(bytestring_repeats, rb"FOO\d+").tolist() == [
@@ -1168,6 +1655,13 @@ def test_find_substring_regex():
         [-1, -1, -1],
         [],
     ]
+    assert (
+        ak.str.find_substring_regex(bytestring_repeats, rb"FOO\d+").layout.form
+        == ak.str.find_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), rb"FOO\d+"
+        ).layout.form
+    )
+
     assert ak.str.find_substring_regex(
         bytestring_repeats, rb"FOO\d+", ignore_case=True
     ).tolist() == [
@@ -1175,6 +1669,16 @@ def test_find_substring_regex():
         [-1, -1, 0],
         [],
     ]
+    assert (
+        ak.str.find_substring_regex(
+            bytestring_repeats, rb"FOO\d+", ignore_case=True
+        ).layout.form
+        == ak.str.find_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"),
+            rb"FOO\d+",
+            ignore_case=True,
+        ).layout.form
+    )
 
 
 def test_match_like():
@@ -1183,11 +1687,24 @@ def test_match_like():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_like(string_repeats, "FOO%BA%").layout.form
+        == ak.str.match_like(
+            ak.to_backend(string_repeats, "typetracer"), "FOO%BA%"
+        ).layout.form
+    )
+
     assert ak.str.match_like(string_repeats, "FOO%BA%", ignore_case=True).tolist() == [
         [True, False, False],
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.match_like(string_repeats, "FOO%BA%", ignore_case=True).layout.form
+        == ak.str.match_like(
+            ak.to_backend(string_repeats, "typetracer"), "FOO%BA%", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.match_like(bytestring_repeats, b"FOO%BA%").tolist() == [
@@ -1195,6 +1712,13 @@ def test_match_like():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_like(bytestring_repeats, b"FOO%BA%").layout.form
+        == ak.str.match_like(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO%BA%"
+        ).layout.form
+    )
+
     assert ak.str.match_like(
         bytestring_repeats, b"FOO%BA%", ignore_case=True
     ).tolist() == [
@@ -1202,6 +1726,14 @@ def test_match_like():
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.match_like(bytestring_repeats, b"FOO%BA^", ignore_case=True).layout.form
+        == ak.str.match_like(
+            ak.to_backend(bytestring_repeats, "typetracer"),
+            b"FOO%BA^",
+            ignore_case=True,
+        ).layout.form
+    )
 
 
 def test_match_substring():
@@ -1210,11 +1742,24 @@ def test_match_substring():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_substring(string_repeats, "FOO").layout.form
+        == ak.str.match_substring(
+            ak.to_backend(string_repeats, "typetracer"), "FOO"
+        ).layout.form
+    )
+
     assert ak.str.match_substring(string_repeats, "FOO", ignore_case=True).tolist() == [
         [True, True, False],
         [True, False, True],
         [],
     ]
+    assert (
+        ak.str.match_substring(string_repeats, "FOO", ignore_case=True).layout.form
+        == ak.str.match_substring(
+            ak.to_backend(string_repeats, "typetracer"), "FOO", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.match_substring(bytestring_repeats, b"FOO").tolist() == [
@@ -1222,6 +1767,13 @@ def test_match_substring():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_substring(bytestring_repeats, b"FOO").layout.form
+        == ak.str.match_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO"
+        ).layout.form
+    )
+
     assert ak.str.match_substring(
         bytestring_repeats, b"FOO", ignore_case=True
     ).tolist() == [
@@ -1229,6 +1781,12 @@ def test_match_substring():
         [True, False, True],
         [],
     ]
+    assert (
+        ak.str.match_substring(bytestring_repeats, b"FOO", ignore_case=True).layout.form
+        == ak.str.match_substring(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"FOO", ignore_case=True
+        ).layout.form
+    )
 
 
 def test_match_substring_regex():
@@ -1237,6 +1795,13 @@ def test_match_substring_regex():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_substring_regex(string_repeats, r"FOO\d+").layout.form
+        == ak.str.match_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"FOO\d+"
+        ).layout.form
+    )
+
     assert ak.str.match_substring_regex(
         string_repeats, r"FOO\d+", ignore_case=True
     ).tolist() == [
@@ -1244,6 +1809,14 @@ def test_match_substring_regex():
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.match_substring_regex(
+            string_repeats, r"FOO\d+", ignore_case=True
+        ).layout.form
+        == ak.str.match_substring_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"FOO\d+", ignore_case=True
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.match_substring_regex(bytestring_repeats, rb"FOO\d+").tolist() == [
@@ -1251,6 +1824,13 @@ def test_match_substring_regex():
         [False, False, False],
         [],
     ]
+    assert (
+        ak.str.match_substring_regex(bytestring_repeats, rb"FOO\d+").layout.form
+        == ak.str.match_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), rb"FOO\d+"
+        ).layout.form
+    )
+
     assert ak.str.match_substring_regex(
         bytestring_repeats, rb"FOO\d+", ignore_case=True
     ).tolist() == [
@@ -1258,6 +1838,16 @@ def test_match_substring_regex():
         [False, False, True],
         [],
     ]
+    assert (
+        ak.str.match_substring_regex(
+            bytestring_repeats, rb"FOO\d+", ignore_case=True
+        ).layout.form
+        == ak.str.match_substring_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"),
+            rb"FOO\d+",
+            ignore_case=True,
+        ).layout.form
+    )
 
 
 def test_is_in():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -699,6 +699,19 @@ def test_extract_regex():
         [],
         [None, {"vowel": "e", "number": "5"}],
     ]
+    assert (
+        ak.str.extract_regex(
+            ak.Array([["one1", "two2", "three3"], [], ["four4", "five5"]]),
+            "(?P<vowel>[aeiou])(?P<number>[0-9]+)",
+        ).layout.form
+        == ak.str.extract_regex(
+            ak.Array(
+                [["one1", "two2", "three3"], [], ["four4", "five5"]],
+                backend="typetracer",
+            ),
+            "(?P<vowel>[aeiou])(?P<number>[0-9]+)",
+        ).layout.form
+    )
 
     assert ak.str.extract_regex(
         ak.Array([[b"one1", b"two2", b"three3"], [], [b"four4", b"five5"]]),
@@ -712,6 +725,19 @@ def test_extract_regex():
         [],
         [None, {"vowel": b"e", "number": b"5"}],
     ]
+    assert (
+        ak.str.extract_regex(
+            ak.Array([[b"one1", b"two2", b"three3"], [], [b"four4", b"five5"]]),
+            b"(?P<vowel>[aeiou])(?P<number>[0-9]+)",
+        ).layout.form
+        == ak.str.extract_regex(
+            ak.Array(
+                [[b"one1", b"two2", b"three3"], [], [b"four4", b"five5"]],
+                backend="typetracer",
+            ),
+            b"(?P<vowel>[aeiou])(?P<number>[0-9]+)",
+        ).layout.form
+    )
 
 
 def test_join():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -851,13 +851,12 @@ def test_trim_whitespace():
         ).layout.form
     )
 
-
-assert (
-    ak.str.trim_whitespace(bytestring_padded).layout.form
-    == ak.str.trim_whitespace(
-        ak.to_backend(bytestring_padded, "typetracer")
-    ).layout.form
-)
+    assert (
+        ak.str.trim_whitespace(bytestring_padded).layout.form
+        == ak.str.trim_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer")
+        ).layout.form
+    )
 
 
 def test_slice():
@@ -1099,9 +1098,7 @@ def test_split_pattern_regex():
         ).layout.form
     )
 
-    with pytest.raises(
-        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
-    ):
+    with pytest.raises(ValueError, match=r"split in reverse with regex"):
         assert ak.str.split_pattern_regex(
             string_repeats, r"\d{3}", max_splits=1, reverse=True
         ).tolist() == [
@@ -1109,9 +1106,7 @@ def test_split_pattern_regex():
             [["", "foo"], ["", "bar"], ["foo", "456bar"]],
             [],
         ]
-    with pytest.raises(
-        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
-    ):
+    with pytest.raises(ValueError, match=r"split in reverse with regex"):
         ak.str.split_pattern_regex(
             ak.to_backend(string_repeats, "typetracer"),
             r"\d{3}",
@@ -1152,9 +1147,7 @@ def test_split_pattern_regex():
         ).layout.form
     )
 
-    with pytest.raises(
-        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
-    ):
+    with pytest.raises(ValueError, match=r"split in reverse with regex"):
         assert ak.str.split_pattern_regex(
             bytestring_repeats, rb"\d{3}", max_splits=1, reverse=True
         ).tolist() == [
@@ -1162,9 +1155,7 @@ def test_split_pattern_regex():
             [[b"", b"foo"], [b"", b"bar"], [b"foo", b"456bar"]],
             [],
         ]
-    with pytest.raises(
-        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
-    ):
+    with pytest.raises(ValueError, match=r"split in reverse with regex"):
         ak.str.split_pattern_regex(
             ak.to_backend(bytestring_repeats, "typetracer"),
             r"\d{3}",

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -726,6 +726,13 @@ def test_split_pattern_regex():
         [["", "foo"], ["", "bar"], ["foo", "456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern_regex(string_repeats, r"\d{3}", max_splits=1).layout.form
+        == ak.str.split_pattern_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"\d{3}", max_splits=1
+        ).layout.form
+    )
+
     with pytest.raises(
         pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
     ):
@@ -736,6 +743,16 @@ def test_split_pattern_regex():
             [["", "foo"], ["", "bar"], ["foo", "456bar"]],
             [],
         ]
+    with pytest.raises(
+        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
+    ):
+        ak.str.split_pattern_regex(
+            ak.to_backend(string_repeats, "typetracer"),
+            r"\d{3}",
+            max_splits=1,
+            reverse=True,
+        )
+
     assert ak.str.split_pattern_regex(
         string_repeats, r"\d{3}", max_splits=None
     ).tolist() == [
@@ -743,6 +760,14 @@ def test_split_pattern_regex():
         [["", "foo"], ["", "bar"], ["foo", "", "bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern_regex(
+            string_repeats, r"\d{3}", max_splits=None
+        ).layout.form
+        == ak.str.split_pattern_regex(
+            ak.to_backend(string_repeats, "typetracer"), r"\d{3}", max_splits=None
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.split_pattern_regex(
@@ -752,6 +777,15 @@ def test_split_pattern_regex():
         [[b"", b"foo"], [b"", b"bar"], [b"foo", b"456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern_regex(
+            bytestring_repeats, r"\d{3}", max_splits=1
+        ).layout.form
+        == ak.str.split_pattern_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), r"\d{3}", max_splits=1
+        ).layout.form
+    )
+
     with pytest.raises(
         pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
     ):
@@ -762,6 +796,16 @@ def test_split_pattern_regex():
             [[b"", b"foo"], [b"", b"bar"], [b"foo", b"456bar"]],
             [],
         ]
+    with pytest.raises(
+        pyarrow.ArrowNotImplementedError, match=r"split in reverse with regex"
+    ):
+        ak.str.split_pattern_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"),
+            r"\d{3}",
+            max_splits=1,
+            reverse=True,
+        )
+
     assert ak.str.split_pattern_regex(
         bytestring_repeats, rb"\d{3}", max_splits=None
     ).tolist() == [
@@ -769,6 +813,14 @@ def test_split_pattern_regex():
         [[b"", b"foo"], [b"", b"bar"], [b"foo", b"", b"bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern_regex(
+            bytestring_repeats, r"\d{3}", max_splits=None
+        ).layout.form
+        == ak.str.split_pattern_regex(
+            ak.to_backend(bytestring_repeats, "typetracer"), r"\d{3}", max_splits=None
+        ).layout.form
+    )
 
 
 def test_extract_regex():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -749,9 +749,17 @@ def test_join():
         ]
     )
     assert ak.str.join(array1, "-").tolist() == ["this-that", "", "foo-bar-baz"]
+    assert (
+        ak.str.join(array1, "-").layout.form
+        == ak.str.join(ak.to_backend(array1, "typetracer"), "-").layout.form
+    )
 
     separator = ak.Array(["→", "↑", "←"])
     assert ak.str.join(array1, separator).tolist() == ["this→that", "", "foo←bar←baz"]
+    assert (
+        ak.str.join(array1, separator).layout.form
+        == ak.str.join(ak.to_backend(array1, "typetracer"), separator).layout.form
+    )
 
     array2 = ak.Array(
         [
@@ -761,13 +769,21 @@ def test_join():
         ]
     )
     assert ak.str.join(array2, b"-").tolist() == [b"this-that", b"", b"foo-bar-baz"]
+    assert (
+        ak.str.join(array2, b"-").layout.form
+        == ak.str.join(ak.to_backend(array2, "typetracer"), b"-").layout.form
+    )
 
-    separator = ak.Array(["→".encode(), "↑".encode(), "←".encode()])
-    assert ak.str.join(array2, separator).tolist() == [
+    separator2 = ak.Array(["→".encode(), "↑".encode(), "←".encode()])
+    assert ak.str.join(array2, separator2).tolist() == [
         "this→that".encode(),
         b"",
         "foo←bar←baz".encode(),
     ]
+    assert (
+        ak.str.join(array2, separator2).layout.form
+        == ak.str.join(ak.to_backend(array2, "typetracer"), separator2).layout.form
+    )
 
 
 def test_join_element_wise():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -1055,6 +1055,13 @@ def test_is_in():
         [True, False, False],
         [],
     ]
+    assert (
+        ak.str.is_in(string_repeats, ["123foo", "foo"]).layout.form
+        == ak.str.is_in(
+            ak.to_backend(string_repeats, "typetracer"), ["123foo", "foo"]
+        ).layout.form
+    )
+
     assert ak.str.is_in(
         [
             ["foo123bar123baz", "foo", "bar"],
@@ -1067,6 +1074,28 @@ def test_is_in():
         [True, False, False],
         [True],
     ]
+    assert (
+        ak.str.is_in(
+            [
+                ["foo123bar123baz", "foo", "bar"],
+                ["123foo", "456bar", "foo123456bar"],
+                [None],
+            ],
+            ["123foo", "foo", None],
+        ).layout.form
+        == ak.str.is_in(
+            ak.to_backend(
+                [
+                    ["foo123bar123baz", "foo", "bar"],
+                    ["123foo", "456bar", "foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            ["123foo", "foo", None],
+        ).layout.form
+    )
+
     assert ak.str.is_in(
         [
             ["foo123bar123baz", "foo", "bar"],
@@ -1080,14 +1109,43 @@ def test_is_in():
         [True, False, False],
         [False],
     ]
+    assert (
+        ak.str.is_in(
+            [
+                ["foo123bar123baz", "foo", "bar"],
+                ["123foo", "456bar", "foo123456bar"],
+                [None],
+            ],
+            ["123foo", "foo", None],
+            skip_nones=True,
+        ).layout.form
+        == ak.str.is_in(
+            ak.to_backend(
+                [
+                    ["foo123bar123baz", "foo", "bar"],
+                    ["123foo", "456bar", "foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            ["123foo", "foo", None],
+            skip_nones=True,
+        ).layout.form
+    )
 
     # Bytestrings
-
-    assert ak.str.is_in(string_repeats, [b"123foo", b"foo"]).tolist() == [
+    assert ak.str.is_in(bytestring_repeats, [b"123foo", b"foo"]).tolist() == [
         [False, True, False],
         [True, False, False],
         [],
     ]
+    assert (
+        ak.str.is_in(bytestring_repeats, [b"123foo", b"foo"]).layout.form
+        == ak.str.is_in(
+            ak.to_backend(bytestring_repeats, "typetracer"), [b"123foo", b"foo"]
+        ).layout.form
+    )
+
     assert ak.str.is_in(
         [
             [b"foo123bar123baz", b"foo", b"bar"],
@@ -1100,6 +1158,28 @@ def test_is_in():
         [True, False, False],
         [True],
     ]
+    assert (
+        ak.str.is_in(
+            [
+                [b"foo123bar123baz", b"foo", b"bar"],
+                [b"123foo", b"456bar", b"foo123456bar"],
+                [None],
+            ],
+            [b"123foo", b"foo", None],
+        ).layout.form
+        == ak.str.is_in(
+            ak.to_backend(
+                [
+                    [b"foo123bar123baz", b"foo", b"bar"],
+                    [b"123foo", b"456bar", b"foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            [b"123foo", b"foo", None],
+        ).layout.form
+    )
+
     assert ak.str.is_in(
         [
             [b"foo123bar123baz", b"foo", b"bar"],
@@ -1113,6 +1193,29 @@ def test_is_in():
         [True, False, False],
         [False],
     ]
+    assert (
+        ak.str.is_in(
+            [
+                [b"foo123bar123baz", b"foo", b"bar"],
+                [b"123foo", b"456bar", b"foo123456bar"],
+                [None],
+            ],
+            [b"123foo", b"foo", None],
+            skip_nones=True,
+        ).layout.form
+        == ak.str.is_in(
+            ak.to_backend(
+                [
+                    [b"foo123bar123baz", b"foo", b"bar"],
+                    [b"123foo", b"456bar", b"foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            [b"123foo", b"foo", None],
+            skip_nones=True,
+        ).layout.form
+    )
 
 
 def test_index_in():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -547,6 +547,14 @@ def test_slice():
         [],
         ["→δε←".encode()[1:3], "ζz zζ".encode()[1:3], b"abc"[1:3]],
     ]
+    assert (
+        ak.str.slice(string, 1, 3).layout.form
+        == ak.str.slice(ak.to_backend(string, "typetracer"), 1, 3).layout.form
+    )
+    assert (
+        ak.str.slice(bytestring, 1, 3).layout.form
+        == ak.str.slice(ak.to_backend(bytestring, "typetracer"), 1, 3).layout.form
+    )
 
     # ArrowInvalid: Negative buffer resize: -40 (looks like an Arrow bug)
     # assert ak.str.slice(string, 1).tolist() == [
@@ -554,11 +562,19 @@ def test_slice():
     #     [],
     #     ["→δε←"[1:], "ζz zζ"[1:], "abc"[1:]],
     # ]
+    # assert (
+    #     ak.str.slice(string, 1).layout.form
+    #     == ak.str.slice(ak.to_backend(string, "typetracer"), 1).layout.form
+    # )
     assert ak.str.slice(bytestring, 1).tolist() == [
         ["αβγ".encode()[1:], b""[1:]],
         [],
         ["→δε←".encode()[1:], "ζz zζ".encode()[1:], b"abc"[1:]],
     ]
+    assert (
+        ak.str.slice(bytestring, 1).layout.form
+        == ak.str.slice(ak.to_backend(bytestring, "typetracer"), 1).layout.form
+    )
 
 
 def test_split_whitespace():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -924,25 +924,41 @@ def test_join():
 
 
 def test_join_element_wise():
-    array1 = ak.Array([["one", "two", "three"], [], ["four", "five"]])
-    array2 = ak.Array([["111", "222", "333"], [], ["444", "555"]])
-    separator = ak.Array(["→", "↑", "←"])
+    first1 = ak.Array([["one", "two", "three"], [], ["four", "five"]])
+    second1 = ak.Array([["111", "222", "333"], [], ["444", "555"]])
+    separator1 = ak.Array(["→", "↑", "←"])
 
-    assert ak.str.join_element_wise(array1, array2, separator).tolist() == [
+    assert ak.str.join_element_wise(first1, second1, separator1).tolist() == [
         ["one→111", "two→222", "three→333"],
         [],
         ["four←444", "five←555"],
     ]
+    assert (
+        ak.str.join_element_wise(first1, second1, separator1).layout.form
+        == ak.str.join_element_wise(
+            ak.to_backend(first1, "typetracer"),
+            ak.to_backend(second1, "typetracer"),
+            ak.to_backend(separator1, "typetracer"),
+        ).layout.form
+    )
 
-    array1 = ak.Array([[b"one", b"two", b"three"], [], [b"four", b"five"]])
-    array2 = ak.Array([[b"111", b"222", b"333"], [], [b"444", b"555"]])
-    separator = ak.Array(["→".encode(), "↑".encode(), "←".encode()])
+    first2 = ak.Array([[b"one", b"two", b"three"], [], [b"four", b"five"]])
+    second2 = ak.Array([[b"111", b"222", b"333"], [], [b"444", b"555"]])
+    separator2 = ak.Array(["→".encode(), "↑".encode(), "←".encode()])
 
-    assert ak.str.join_element_wise(array1, array2, separator).tolist() == [
+    assert ak.str.join_element_wise(first2, second2, separator2).tolist() == [
         ["one→111".encode(), "two→222".encode(), "three→333".encode()],
         [],
         ["four←444".encode(), "five←555".encode()],
     ]
+    assert (
+        ak.str.join_element_wise(first2, second2, separator2).layout.form
+        == ak.str.join_element_wise(
+            ak.to_backend(first2, "typetracer"),
+            ak.to_backend(second2, "typetracer"),
+            ak.to_backend(separator2, "typetracer"),
+        ).layout.form
+    )
 
 
 def test_count_substring():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -634,6 +634,13 @@ def test_split_pattern():
         [["", "foo"], ["456bar"], ["foo", "456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(string_repeats, "123", max_splits=1).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(string_repeats, "typetracer"), "123", max_splits=1
+        ).layout.form
+    )
+
     assert ak.str.split_pattern(
         string_repeats, "123", max_splits=1, reverse=True
     ).tolist() == [
@@ -641,11 +648,28 @@ def test_split_pattern():
         [["", "foo"], ["456bar"], ["foo", "456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(
+            string_repeats, "123", max_splits=1, reverse=True
+        ).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(string_repeats, "typetracer"),
+            "123",
+            max_splits=1,
+            reverse=True,
+        ).layout.form
+    )
     assert ak.str.split_pattern(string_repeats, "123", max_splits=None).tolist() == [
         [["foo", "bar", "baz"], ["foo"], ["bar"]],
         [["", "foo"], ["456bar"], ["foo", "456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(string_repeats, "123", max_splits=None).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(string_repeats, "typetracer"), "123", max_splits=None
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.split_pattern(bytestring_repeats, b"123", max_splits=1).tolist() == [
@@ -653,6 +677,13 @@ def test_split_pattern():
         [[b"", b"foo"], [b"456bar"], [b"foo", b"456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(bytestring_repeats, b"123", max_splits=1).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"123", max_splits=1
+        ).layout.form
+    )
+
     assert ak.str.split_pattern(
         bytestring_repeats, b"123", max_splits=1, reverse=True
     ).tolist() == [
@@ -660,6 +691,18 @@ def test_split_pattern():
         [[b"", b"foo"], [b"456bar"], [b"foo", b"456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(
+            bytestring_repeats, b"123", max_splits=1, reverse=True
+        ).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(bytestring_repeats, "typetracer"),
+            b"123",
+            max_splits=1,
+            reverse=True,
+        ).layout.form
+    )
+
     assert ak.str.split_pattern(
         bytestring_repeats, b"123", max_splits=None
     ).tolist() == [
@@ -667,6 +710,12 @@ def test_split_pattern():
         [[b"", b"foo"], [b"456bar"], [b"foo", b"456bar"]],
         [],
     ]
+    assert (
+        ak.str.split_pattern(bytestring_repeats, b"123", max_splits=None).layout.form
+        == ak.str.split_pattern(
+            ak.to_backend(bytestring_repeats, "typetracer"), b"123", max_splits=None
+        ).layout.form
+    )
 
 
 def test_split_pattern_regex():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -2186,3 +2186,12 @@ def test_index_in():
             skip_nones=True,
         ).layout.form
     )
+
+
+def test_to_categorical():
+    assert (
+        ak.str.to_categorical(["foo", "bar", "bar", "fee"]).layout.form
+        == ak.str.to_categorical(
+            ak.to_backend(["foo", "bar", "bar", "fee"], "typetracer")
+        ).layout.form
+    )

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -281,6 +281,14 @@ def test_repeat():
         [],
         ["→δε←→δε←→δε←".encode(), "ζz zζζz zζζz zζ".encode(), b"abcabcabc"],
     ]
+    assert (
+        ak.str.repeat(string, 3).layout.form
+        == ak.str.repeat(ak.to_backend(string, "typetracer"), 3).layout.form
+    )
+    assert (
+        ak.str.repeat(bytestring, 3).layout.form
+        == ak.str.repeat(ak.to_backend(bytestring, "typetracer"), 3).layout.form
+    )
 
     assert ak.str.repeat(string, [[3, 3], [], [2, 0, 1]]).tolist() == [
         ["αβγαβγαβγ", ""],
@@ -292,6 +300,18 @@ def test_repeat():
         [],
         ["→δε←→δε←".encode(), b"", b"abc"],
     ]
+    assert (
+        ak.str.repeat(string, [[3, 3], [], [2, 0, 1]]).layout.form
+        == ak.str.repeat(
+            ak.to_backend(string, "typetracer"), [[3, 3], [], [2, 0, 1]]
+        ).layout.form
+    )
+    assert (
+        ak.str.repeat(bytestring, [[3, 3], [], [2, 0, 1]]).layout.form
+        == ak.str.repeat(
+            ak.to_backend(bytestring, "typetracer"), [[3, 3], [], [2, 0, 1]]
+        ).layout.form
+    )
 
 
 def test_replace_slice():

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -1224,6 +1224,13 @@ def test_index_in():
         [0, None, None],
         [],
     ]
+    assert (
+        ak.str.index_in(string_repeats, ["123foo", "foo"]).layout.form
+        == ak.str.index_in(
+            ak.to_backend(string_repeats, "typetracer"), ["123foo", "foo"]
+        ).layout.form
+    )
+
     assert ak.str.index_in(
         [
             ["foo123bar123baz", "foo", "bar"],
@@ -1236,6 +1243,28 @@ def test_index_in():
         [0, None, None],
         [2],
     ]
+    assert (
+        ak.str.index_in(
+            [
+                ["foo123bar123baz", "foo", "bar"],
+                ["123foo", "456bar", "foo123456bar"],
+                [None],
+            ],
+            ["123foo", "foo", None],
+        ).layout.form
+        == ak.str.index_in(
+            ak.to_backend(
+                [
+                    ["foo123bar123baz", "foo", "bar"],
+                    ["123foo", "456bar", "foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            ["123foo", "foo", None],
+        ).layout.form
+    )
+
     assert ak.str.index_in(
         [
             ["foo123bar123baz", "foo", "bar"],
@@ -1249,14 +1278,43 @@ def test_index_in():
         [0, None, None],
         [None],
     ]
+    assert (
+        ak.str.index_in(
+            [
+                ["foo123bar123baz", "foo", "bar"],
+                ["123foo", "456bar", "foo123456bar"],
+                [None],
+            ],
+            ["123foo", "foo", None],
+            skip_nones=True,
+        ).layout.form
+        == ak.str.index_in(
+            ak.to_backend(
+                [
+                    ["foo123bar123baz", "foo", "bar"],
+                    ["123foo", "456bar", "foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            ["123foo", "foo", None],
+            skip_nones=True,
+        ).layout.form
+    )
 
     # Bytestrings
-
     assert ak.str.index_in(string_repeats, [b"123foo", b"foo"]).tolist() == [
         [None, 1, None],
         [0, None, None],
         [],
     ]
+    assert (
+        ak.str.index_in(bytestring_repeats, [b"123foo", b"foo"]).layout.form
+        == ak.str.index_in(
+            ak.to_backend(bytestring_repeats, "typetracer"), [b"123foo", b"foo"]
+        ).layout.form
+    )
+
     assert ak.str.index_in(
         [
             [b"foo123bar123baz", b"foo", b"bar"],
@@ -1269,6 +1327,28 @@ def test_index_in():
         [0, None, None],
         [2],
     ]
+    assert (
+        ak.str.index_in(
+            [
+                [b"foo123bar123baz", b"foo", b"bar"],
+                [b"123foo", b"456bar", b"foo123456bar"],
+                [None],
+            ],
+            [b"123foo", b"foo", None],
+        ).layout.form
+        == ak.str.index_in(
+            ak.to_backend(
+                [
+                    [b"foo123bar123baz", b"foo", b"bar"],
+                    [b"123foo", b"456bar", b"foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            [b"123foo", b"foo", None],
+        ).layout.form
+    )
+
     assert ak.str.index_in(
         [
             [b"foo123bar123baz", b"foo", b"bar"],
@@ -1282,3 +1362,26 @@ def test_index_in():
         [0, None, None],
         [None],
     ]
+    assert (
+        ak.str.index_in(
+            [
+                [b"foo123bar123baz", b"foo", b"bar"],
+                [b"123foo", b"456bar", b"foo123456bar"],
+                [None],
+            ],
+            [b"123foo", b"foo", None],
+            skip_nones=True,
+        ).layout.form
+        == ak.str.index_in(
+            ak.to_backend(
+                [
+                    [b"foo123bar123baz", b"foo", b"bar"],
+                    [b"123foo", b"456bar", b"foo123456bar"],
+                    [None],
+                ],
+                "typetracer",
+            ),
+            [b"123foo", b"foo", None],
+            skip_nones=True,
+        ).layout.form
+    )

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -583,6 +583,13 @@ def test_split_whitespace():
         [],
         [["", "→δε←      "], ["", "ζz zζ     "], ["", "abc      "]],
     ]
+    assert (
+        ak.str.split_whitespace(string_padded, max_splits=1).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(string_padded, "typetracer"), max_splits=1
+        ).layout.form
+    )
+
     assert ak.str.split_whitespace(
         string_padded, max_splits=1, reverse=True
     ).tolist() == [
@@ -590,11 +597,24 @@ def test_split_whitespace():
         [],
         [["     →δε←", ""], ["     ζz zζ", ""], ["      abc", ""]],
     ]
+    assert (
+        ak.str.split_whitespace(string_padded, max_splits=1, reverse=True).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(string_padded, "typetracer"), max_splits=1, reverse=True
+        ).layout.form
+    )
+
     assert ak.str.split_whitespace(string_padded, max_splits=None).tolist() == [
         [["", "αβγ", "", ""], ["", "", ""]],
         [],
         [["", "→δε←", "", ""], ["", "ζz", "zζ", "", ""], ["", "abc", "", ""]],
     ]
+    assert (
+        ak.str.split_whitespace(string_padded, max_splits=None).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(string_padded, "typetracer"), max_splits=None
+        ).layout.form
+    )
 
     # Bytestrings
     assert ak.str.split_whitespace(bytestring_padded, max_splits=1).tolist() == [
@@ -606,6 +626,13 @@ def test_split_whitespace():
             [b"", b"abc      "],
         ],
     ]
+    assert (
+        ak.str.split_whitespace(bytestring_padded, max_splits=1).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer"), max_splits=1
+        ).layout.form
+    )
+
     assert ak.str.split_whitespace(
         bytestring_padded, max_splits=1, reverse=True
     ).tolist() == [
@@ -617,6 +644,15 @@ def test_split_whitespace():
             [b"      abc", b""],
         ],
     ]
+    assert (
+        ak.str.split_whitespace(
+            bytestring_padded, max_splits=1, reverse=True
+        ).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer"), max_splits=1, reverse=True
+        ).layout.form
+    )
+
     assert ak.str.split_whitespace(bytestring_padded, max_splits=None).tolist() == [
         [[b"", "αβγ".encode(), b""], [b"", b""]],
         [],
@@ -626,6 +662,12 @@ def test_split_whitespace():
             [b"", b"abc", b""],
         ],
     ]
+    assert (
+        ak.str.split_whitespace(bytestring_padded, max_splits=None).layout.form
+        == ak.str.split_whitespace(
+            ak.to_backend(bytestring_padded, "typetracer"), max_splits=None
+        ).layout.form
+    )
 
 
 def test_split_pattern():


### PR DESCRIPTION
Fixes #2675 by introducing a typetracer branch in a new `_apply_through_arrow` helper. This helper only handles the single-argument case, because the multi-array cases are more complex (they need finer control over how things get converted to arrow).

Some functions in PyArrow [have bugs](https://github.com/apache/arrow/issues/37437) that require us to workaround by manually creating a layout from a form.