### PR TITLE
feat!: deprecate form key for forms that have no buffers

### DIFF
--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -102,7 +102,7 @@ class EmptyArray(Content):
         return cls(backend=backend)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
-        return self.form_cls(form_key=getkey(self))
+        return self.form_cls()
 
     def _to_buffers(
         self,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -315,12 +315,10 @@ class RecordArray(Content):
         )
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> RecordForm:
-        form_key = getkey(self)
         return self.form_cls(
             [x._form_with_key(getkey) for x in self._contents],
             self._fields,
             parameters=self._parameters,
-            form_key=form_key,
         )
 
     def _to_buffers(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -123,11 +123,8 @@ class UnmaskedArray(Content):
             return cls(content, parameters=parameters)
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> UnmaskedForm:
-        form_key = getkey(self)
         return self.form_cls(
-            self._content._form_with_key(getkey),
-            parameters=self._parameters,
-            form_key=form_key,
+            self._content._form_with_key(getkey), parameters=self._parameters
         )
 
     def _to_buffers(

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -28,33 +28,21 @@ class EmptyForm(Form):
                 f"A non-None form_key parameter is deprecated for {type(self).__name__}",
                 version="2.5.0",
             )
-        if not (parameters is None or len(parameters) == 0):
+        if parameters is not None or len(parameters) != 0:
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
+
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
-        if form_key is not None:
-            deprecate(
-                f"A non-None form_key parameter is deprecated for {type(self).__name__}",
-                version="2.5.0",
-            )
-        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
-            raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
+            parameters=self._parameters if parameters is UNSET else parameters,
             form_key=self._form_key if form_key is UNSET else form_key,
         )
 
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
-        if form_key is not None:
-            deprecate(
-                f"A non-None form_key parameter is deprecated for {cls.__name__}",
-                version="2.5.0",
-            )
-        if not (parameters is None or len(parameters) == 0):
-            raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
 
     def __repr__(self):

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -28,7 +28,7 @@ class EmptyForm(Form):
                 f"A non-None form_key parameter is deprecated for {type(self).__name__}",
                 version="2.5.0",
             )
-        if parameters is not None or len(parameters) != 0:
+        if parameters is not None and len(parameters) != 0:
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
 
         self._init(parameters=parameters, form_key=form_key)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -23,6 +23,11 @@ class EmptyForm(Form):
     is_unknown = True
 
     def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
+        if form_key is not None:
+            deprecate(
+                f"A non-None form_key parameter is deprecated for {type(self).__name__}",
+                version="2.5.0",
+            )
         if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
@@ -30,6 +35,11 @@ class EmptyForm(Form):
     def copy(
         self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
     ) -> EmptyForm:
+        if form_key is not None:
+            deprecate(
+                f"A non-None form_key parameter is deprecated for {type(self).__name__}",
+                version="2.5.0",
+            )
         if not (parameters is UNSET or parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
@@ -38,6 +48,11 @@ class EmptyForm(Form):
 
     @classmethod
     def simplified(cls, *, parameters=None, form_key=None) -> Form:
+        if form_key is not None:
+            deprecate(
+                f"A non-None form_key parameter is deprecated for {cls.__name__}",
+                version="2.5.0",
+            )
         if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
@@ -54,7 +69,7 @@ class EmptyForm(Form):
         return ak.types.UnknownType()
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, EmptyForm) and self._form_key == other._form_key
+        return isinstance(other, EmptyForm)
 
     def to_NumpyForm(self, *args, **kwargs):
         def legacy_impl(dtype):
@@ -136,19 +151,7 @@ class EmptyForm(Form):
         yield 0
 
     def __setstate__(self, state):
-        if isinstance(state, dict):
-            # read data pickled in Awkward 2.x
-            self.__dict__.update(state)
-        else:
-            # read data pickled in Awkward 1.x
-
-            # https://github.com/scikit-hep/awkward/blob/main-v1/src/python/forms.cpp#L240-L244
-            has_identities, parameters, form_key = state
-
-            if form_key is not None:
-                form_key = "part0-" + form_key  # only the first partition
-
-            self.__init__(form_key=form_key)
+        pass
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str]

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -52,7 +52,7 @@ def from_dict(input: Mapping) -> Form:
         )
 
     elif input["class"] == "EmptyArray":
-        return ak.forms.EmptyForm(parameters=parameters, form_key=form_key)
+        return ak.forms.EmptyForm()
 
     elif input["class"] == "RegularArray":
         return ak.forms.RegularForm(
@@ -103,10 +103,7 @@ def from_dict(input: Mapping) -> Form:
             contents = [from_dict(content) for content in input["contents"]]
             fields = None
         return ak.forms.RecordForm(
-            contents=contents,
-            fields=fields,
-            parameters=parameters,
-            form_key=form_key,
+            contents=contents, fields=fields, parameters=parameters
         )
 
     elif input["class"] in (
@@ -155,9 +152,7 @@ def from_dict(input: Mapping) -> Form:
 
     elif input["class"] == "UnmaskedArray":
         return ak.forms.UnmaskedForm(
-            content=from_dict(input["content"]),
-            parameters=parameters,
-            form_key=form_key,
+            content=from_dict(input["content"]), parameters=parameters
         )
 
     elif input["class"] in (

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -5,6 +5,7 @@ __all__ = ("RecordForm",)
 from collections.abc import Callable, Iterable, Iterator
 
 import awkward as ak
+from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
@@ -28,6 +29,12 @@ class RecordForm(Form):
         parameters=None,
         form_key=None,
     ):
+        if form_key is not None:
+            deprecate(
+                f"A non-None form_key parameter is deprecated for {type(self).__name__}",
+                version="2.5.0",
+            )
+
         if not isinstance(contents, Iterable):
             raise TypeError(
                 "{} 'contents' must be iterable, not {}".format(

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -5,6 +5,7 @@ __all__ = ("UnmaskedForm",)
 from collections.abc import Callable, Iterator
 
 import awkward as ak
+from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
 from awkward._typing import JSONSerializable, Self, final
@@ -25,6 +26,11 @@ class UnmaskedForm(Form):
         parameters=None,
         form_key=None,
     ):
+        if form_key is not None:
+            deprecate(
+                f"A non-None form_key parameter is deprecated for {type(self).__name__}",
+                version="2.5.0",
+            )
         if not isinstance(content, Form):
             raise TypeError(
                 "{} all 'contents' must be Form subclasses, not {}".format(

--- a/tests/test_2680_deprecate_form_key.py
+++ b/tests/test_2680_deprecate_form_key.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+
+def test_unmasked_form():
+    with pytest.warns(DeprecationWarning, match=r"form_key"):
+        form = ak.forms.UnmaskedForm(ak.forms.NumpyForm("int64"), form_key="llamas")
+    assert form.form_key == "llamas"
+
+    form_no_key = ak.forms.UnmaskedForm(ak.forms.NumpyForm("int64"))
+    assert form_no_key.form_key is None
+
+
+def test_record_form():
+    with pytest.warns(DeprecationWarning, match=r"form_key"):
+        form = ak.forms.RecordForm([], None, form_key="llamas")
+    assert form.form_key == "llamas"
+
+    form_no_key = ak.forms.RecordForm([], None)
+    assert form_no_key.form_key is None
+
+
+def test_empty_form():
+    with pytest.warns(DeprecationWarning, match=r"form_key"):
+        form = ak.forms.EmptyForm(form_key="llamas")
+    assert form.form_key == "llamas"
+
+    form_no_key = ak.forms.EmptyForm()
+    assert form_no_key.form_key is None


### PR DESCRIPTION
1. Raises `DeprecationWarning` if `form_key` is passed to constructor of non-buffer forms
   - `UnmaskedForm`
   - `EmptyForm`
   - `RecordForm`
2. No longer passes `form_key` to these types from form factories, such as pickle, `form.from_XXX` methods, `Content._form_with_key`
3. No longer outputs `form_key` in `form.to_dict(...)` for these types.