### PR TITLE
feat: add support for custom picklers

### DIFF
--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,8 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "22"
 dependencies = [
-    "numpy>=1.18.0"
+    "numpy>=1.18.0",
+    "importlib_resources;python_version < \"3.9\""
 ]
 readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
 ]
 dependencies = [
     "awkward_cpp==22",
+    "importlib_metadata>=4.13.0;python_version < \"3.12\"",
     "numpy>=1.18.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
 ]
 dependencies = [
     "awkward_cpp==22",
-    "importlib_resources;python_version < \"3.9\"",
     "numpy>=1.18.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\""

--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -1,0 +1,73 @@
+"""Interface for plugin-configurable pickle __reduce_ex__ implementation"""
+from __future__ import annotations
+
+import sys
+import threading
+import warnings
+
+from awkward._typing import Any, Protocol, runtime_checkable
+
+if sys.version_info < (3, 12):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+
+@runtime_checkable
+class PickleReducer(Protocol):
+    def __call__(self, obj: Any, protocol: int) -> tuple | NotImplemented:
+        ...
+
+
+@runtime_checkable
+class PickleReducerPlugin(PickleReducer, Protocol):
+    rank: int
+
+
+_register_lock = threading.Lock()
+_plugins: tuple[PickleReducerPlugin, ...] | None = None
+_is_registered = False
+
+
+def _load_reduce_plugins() -> tuple[PickleReducerPlugin, ...]:
+    plugins: list[PickleReducerPlugin] = []
+
+    for entry_point in importlib_metadata.entry_points(group="awkward.pickle.reduce"):
+        plugin = entry_point.load()
+
+        try:
+            assert isinstance(plugin, PickleReducerPlugin)
+        except AssertionError:
+            warnings.warn(
+                f"Couldn't load `awkward.pickle.reduce` plugin: {entry_point}",
+                stacklevel=2,
+            )
+            continue
+
+        plugins.append(plugin)
+
+    plugins.sort(key=lambda x: x.rank, reverse=True)
+    return tuple(plugins)
+
+
+def get_custom_reducers() -> tuple[PickleReducer, ...] | None:
+    """
+    Returns the implementation of a custom __reduce_ex__ function for Awkward
+    highlevel objects, or None if none provided
+    """
+    global _is_registered, _plugins
+
+    with _register_lock:
+        if not _is_registered:
+            _plugins = _load_reduce_plugins()
+            _is_registered = True
+
+    return _plugins
+
+
+def custom_reduce(obj, protocol: int) -> tuple | NotImplemented:
+    for plugin in get_custom_reducers():
+        result = plugin(obj, protocol)
+        if result is not NotImplemented:
+            return result
+    return NotImplemented

--- a/tests/test_2682_custom_pickler.py
+++ b/tests/test_2682_custom_pickler.py
@@ -1,0 +1,93 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import multiprocessing
+import os
+import pickle
+import sys
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+
+import awkward as ak
+
+
+def _init_process_with_pickler(pickler_source: str, tmp_path):
+    # Create custom plugin
+    (tmp_path / "impl_pickler.py").write_bytes(pickler_source.encode("UTF-8"))
+    dist_info = tmp_path / "impl_pickler-0.0.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "entry_points.txt").write_bytes(
+        b"[awkward.pickle.reduce]\nimpl = impl_pickler:plugin\n"
+    )
+    sys.path.insert(0, os.fsdecode(tmp_path))
+
+
+def _pickle_complex_array_and_return_form_impl():
+    array = ak.Array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])[[0, 2]]
+    return pickle.loads(pickle.dumps(array)).layout.form
+
+
+def pickle_complex_array_and_return_form(pickler_source, tmp_path):
+    """Create a new (spawned) process, and register the given pickler source
+    via entrypoints"""
+    with ProcessPoolExecutor(
+        1,
+        initializer=_init_process_with_pickler,
+        initargs=(pickler_source, tmp_path),
+        # Don't fork the current process with all of its state
+        mp_context=multiprocessing.get_context("spawn"),
+    ) as executor:
+        pickle_future = executor.submit(_pickle_complex_array_and_return_form_impl)
+        return pickle_future.result()
+
+
+def test_default_pickler():
+    assert _pickle_complex_array_and_return_form_impl() == ak.forms.from_dict(
+        {"class": "ListOffsetArray", "offsets": "i64", "content": "int64"}
+    )
+
+
+def test_noop_pickler(tmp_path):
+    assert (
+        pickle_complex_array_and_return_form(
+            """
+def plugin(obj, protocol: int):
+    return NotImplemented""",
+            tmp_path,
+        )
+        == ak.forms.from_dict(
+            {"class": "ListOffsetArray", "offsets": "i64", "content": "int64"}
+        )
+    )
+
+
+def test_non_packing_pickler(tmp_path):
+    assert (
+        pickle_complex_array_and_return_form(
+            """
+def plugin(obj, protocol):
+    import awkward as ak
+    if isinstance(obj, ak.Array):
+        form, length, container = ak.to_buffers(obj)
+        return (
+            object.__new__,
+            (ak.Array,),
+            (form.to_dict(), length, container, obj.behavior),
+        )
+    else:
+        return NotImplemented""",
+            tmp_path,
+        )
+        == ak.forms.from_dict(
+            {"class": "ListArray", "starts": "i64", "stops": "i64", "content": "int64"}
+        )
+    )
+
+
+def test_malformed_pickler(tmp_path):
+    with pytest.raises(RuntimeError, match=r"malformed pickler!"):
+        pickle_complex_array_and_return_form(
+            """
+def plugin(obj, protocol: int):
+    raise RuntimeError('malformed pickler!')""",
+            tmp_path,
+        )


### PR DESCRIPTION
This PR adds support for customisation of the pickling `__reduce__` implementation by third-party libraries. The intention is to provide a mechanism for `dask-awkward` to intercept serialisation in a form-preserving manner c.f. dask-contrib/dask-awkward#344.

The problem in dask-contrib/dask-awkward#344 is that whilst regular users of Awkward Array are likely not that concerned about the form of an array, Dask requires guarantees that the form does not change during transfer between workers. As such, we need an environment-sensitive serialisation mechanism.

The simplest/decoupled way of doing this is to let dask-awkward handle the serialisation, rather than internally making Awkward aware of `dask-awkward` directly.

With this PR it is possible to define an `awkward.pickle.reduce` entrypoint that exposes a `__reduce_ex__` implementation, e.g. with hatchling:
```toml
[project.entry-points."awkward.pickle.reduce"]
dask-awkward-pickler = "dask_awkward.pickle:plugin"
```
where
```python
def plugin(obj, protocol: int):
    if isinstance(obj, (ak.Array, ak.Record)):
        ...
    else:
        # Allow future extensions of this mechanism
        return NotImplemented
```