### PR TITLE
chore: bump numba and pyarrow test pins

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,9 @@
 fsspec;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32"
-numba>=0.50.0;python_version < "3.11"
+numba>=0.50.0;python_version <= "3.11"
 numexpr
 pandas>=0.24.0;sys_platform != "win32"
-pyarrow>=7.0.0;sys_platform != "win32" and python_version < "3.11"
+pyarrow>=7.0.0;sys_platform != "win32" and python_version <= "3.11"
 pytest>=6
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
These dependencies now support Python 3.11