### PR TITLE
fix: support placeholder arrays in `ArrayModuleNumpyLike.frombuffer`

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -55,9 +55,13 @@ class ArrayModuleNumpyLike(NumpyLike):
     def frombuffer(
         self, buffer, *, dtype: np.dtype | None = None, count: int = -1
     ) -> ArrayLike:
-        assert not isinstance(buffer, PlaceholderArray)
-        assert not isinstance(count, PlaceholderArray)
-        return self._module.frombuffer(buffer, dtype=dtype, count=count)
+        if isinstance(buffer, PlaceholderArray):
+            if count == -1:
+                return self.asarray(buffer)
+            else:
+                return self.asarray(buffer[:count])
+        else:
+            return self._module.frombuffer(buffer, dtype=dtype, count=count)
 
     def from_dlpack(self, x: Any) -> ArrayLike:
         return self._module.from_dlpack(x)

--- a/src/awkward/_singleton.py
+++ b/src/awkward/_singleton.py
@@ -9,6 +9,9 @@ class Singleton(Protocol):
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls, *args, **kwargs)
 
+    def __reduce__(self):
+        return type(self).instance, ()
+
     @classmethod
     def instance(cls) -> Self:
         try:

--- a/tests/test_2693_to_buffers_placeholders.py
+++ b/tests/test_2693_to_buffers_placeholders.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import pickle
+
+import numpy as np
+
+import awkward as ak
+from awkward._nplikes.numpy import Numpy
+from awkward.typetracer import PlaceholderArray
+
+nplike = Numpy.instance()
+
+
+def test_round_trip_placeholder():
+    layout = ak.contents.RecordArray(
+        [
+            ak.contents.NumpyArray(
+                PlaceholderArray(nplike, (4,), np.dtype(np.float64))
+            ),
+            ak.contents.NumpyArray([1, 2, 3, 4]),
+        ],
+        ["x", "y"],
+    )
+
+    form, length, container = ak.to_buffers(layout)
+    result = ak.from_buffers(form, length, container, highlevel=False)
+
+    assert isinstance(result.content("x").data, PlaceholderArray)
+
+    assert result.content("x").data.shape == layout.content("x").data.shape
+    assert result.content("x").data.dtype == layout.content("x").data.dtype
+
+
+def test_pickle_nplike():
+    assert pickle.loads(pickle.dumps(nplike)) is nplike


### PR DESCRIPTION
This PR:
- preserves `PlaceholderArray` instances between `ak.to_buffers` and `ak.from_buffers`
- fixes pickling of `Singleton` objects like `NumpyLike` and `Backend`

Fixes #2674 