### PR TITLE
feat: expose `ak.from_non_simplified_buffers`

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2515,7 +2515,7 @@ class ArrayBuilder(Sized):
         form = ak.forms.from_json(formstr)
 
         with ak._errors.OperationErrorContext("ak.ArrayBuilder.snapshot", [], {}):
-            return ak.operations.ak_from_buffers._impl(
+            return ak.operations.from_non_simplified_buffers(
                 form,
                 length,
                 container,
@@ -2524,7 +2524,6 @@ class ArrayBuilder(Sized):
                 byteorder=ak._util.native_byteorder,
                 highlevel=True,
                 behavior=self._behavior,
-                simplify=True,
             )
 
     def null(self):

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -37,6 +37,7 @@ from awkward.operations.ak_from_dlpack import *
 from awkward.operations.ak_from_iter import *
 from awkward.operations.ak_from_jax import *
 from awkward.operations.ak_from_json import *
+from awkward.operations.ak_from_non_simplified_buffers import *
 from awkward.operations.ak_from_numpy import *
 from awkward.operations.ak_from_parquet import *
 from awkward.operations.ak_from_rdataframe import *

--- a/src/awkward/operations/ak_from_non_simplified_buffers.py
+++ b/src/awkward/operations/ak_from_non_simplified_buffers.py
@@ -1,0 +1,76 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+from __future__ import annotations
+
+__all__ = ("from_non_simplified_buffers",)
+
+from awkward._dispatch import high_level_function
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward.operations.ak_from_buffers import from_buffers as from_buffers_impl
+
+np = NumpyMetadata.instance()
+numpy = Numpy.instance()
+
+
+@high_level_function()
+def from_non_simplified_buffers(
+    form,
+    length,
+    container,
+    buffer_key="{form_key}-{attribute}",
+    *,
+    backend="cpu",
+    byteorder="<",
+    highlevel=True,
+    behavior=None,
+):
+    """
+    Args:
+        form (#ak.forms.Form or str/dict equivalent): The (maybe non-simplified)
+            form of the Awkward Array to reconstitute from named buffers.
+        length (int): Length of the array. (The output of this function is always
+            single-partition.)
+        container (Mapping, such as dict): The str \u2192 Python buffers that
+            represent the decomposed Awkward Array. This `container` is only
+            assumed to have a `__getitem__` method that accepts strings as keys.
+        buffer_key (str or callable): Python format string containing
+            `"{form_key}"` and/or `"{attribute}"` or a function that takes these
+            as keyword arguments and returns a string to use as a key for a buffer
+            in the `container`.
+        backend (str): Library to use to generate values that are
+            put into the new array. The default, cpu, makes NumPy
+            arrays, which are in main memory (e.g. not GPU). If all the values in
+            `container` have the same `backend` as this, they won't be copied.
+        byteorder (`"<"`, `">"`): Endianness of buffers read from `container`.
+            If the byteorder does not match the current system byteorder, the
+            arrays will be copied.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    Reconstitutes an Awkward Array from a Form, length, and a collection of memory
+    buffers, so that data can be losslessly read from file formats and storage
+    devices that only map names to binary blobs (such as a filesystem directory).
+
+    Unlike #ak.from_buffers, this function readily accepts non-simplified forms,
+    i.e. forms which will be simplified by Awkward Array into "canonical"
+    representations, e.g. `option[option[...]]` → `option[...]`. As such, this
+    function may produce an array whose form differs from the input form.
+
+    For a complete description of the other arguments of this function, see
+    #ak.from_buffers.
+
+    See also #ak.from_buffers, and #ak.to_buffers for examples.
+    """
+    return from_buffers_impl(
+        form,
+        length,
+        container,
+        buffer_key,
+        backend,
+        byteorder,
+        highlevel,
+        behavior,
+        True,
+    )

--- a/src/awkward/operations/ak_from_non_simplified_buffers.py
+++ b/src/awkward/operations/ak_from_non_simplified_buffers.py
@@ -6,7 +6,7 @@ __all__ = ("from_non_simplified_buffers",)
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
-from awkward.operations.ak_from_buffers import from_buffers as from_buffers_impl
+from awkward.operations.ak_from_buffers import _impl as from_buffers_impl
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()

--- a/src/awkward/operations/ak_from_non_simplified_buffers.py
+++ b/src/awkward/operations/ak_from_non_simplified_buffers.py
@@ -58,6 +58,11 @@ def from_non_simplified_buffers(
     representations, e.g. `option[option[...]]` → `option[...]`. As such, this
     function may produce an array whose form differs from the input form.
 
+    The non-simplified forms that this function accepts can be produced by the
+    low-level ArrayBuilder `snapshot()` method. In order for a non-simplified
+    form to be considered valid, it should be one that the #ak.contents.Content
+    layout classes could produce iff. the simplification rules were removed.
+
     For a complete description of the other arguments of this function, see
     #ak.from_buffers.
 

--- a/tests/test_2700_non_simplified_from_buffers.py
+++ b/tests/test_2700_non_simplified_from_buffers.py
@@ -1,0 +1,124 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test_union_simplification():
+    array = ak.Array(
+        ak.contents.UnionArray(
+            ak.index.Index8(np.arange(64, dtype=np.int8) % 2),
+            ak.index.Index64(np.arange(64, dtype=np.int64) // 2),
+            [
+                ak.contents.RecordArray(
+                    [ak.contents.NumpyArray(np.arange(64, dtype=np.int64))], ["x"]
+                ),
+                ak.contents.RecordArray(
+                    [
+                        ak.contents.NumpyArray(np.arange(64, dtype=np.int64)),
+                        ak.contents.NumpyArray(np.arange(64, dtype=np.int8)),
+                    ],
+                    ["x", "y"],
+                ),
+            ],
+        )
+    )
+
+    form, length, container = ak.to_buffers(array)
+
+    assert form.to_dict() == {
+        "class": "UnionArray",
+        "tags": "i8",
+        "index": "i64",
+        "contents": [
+            {
+                "class": "RecordArray",
+                "fields": ["x"],
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "node2",
+                    }
+                ],
+                "parameters": {},
+                "form_key": "node1",
+            },
+            {
+                "class": "RecordArray",
+                "fields": ["x", "y"],
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "node4",
+                    },
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int8",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "node5",
+                    },
+                ],
+                "parameters": {},
+                "form_key": "node3",
+            },
+        ],
+        "parameters": {},
+        "form_key": "node0",
+    }
+
+    projected_form = {
+        "class": "UnionArray",
+        "tags": "i8",
+        "index": "i64",
+        "contents": [
+            {
+                "class": "RecordArray",
+                "fields": ["x"],
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "node2",
+                    }
+                ],
+                "parameters": {},
+                "form_key": "node1",
+            },
+            {
+                "class": "RecordArray",
+                "fields": ["x"],
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": "node4",
+                    }
+                ],
+                "parameters": {},
+                "form_key": "node3",
+            },
+        ],
+        "parameters": {},
+        "form_key": "node0",
+    }
+    container.pop("node5-data")
+    projected = ak.from_non_simplified_buffers(projected_form, length, container)
+    assert projected.layout.form.to_dict(verbose=False) == {
+        "class": "IndexedArray",
+        "index": "i64",
+        "content": {"class": "RecordArray", "fields": ["x"], "contents": ["int64"]},
+    }
+    assert ak.almost_equal(array[["x"]], projected)


### PR DESCRIPTION
Over in bluesky/tiled#549, there's a need to perform a minimal read of an Awkward Array that's already in `to_buffers` form. This scenario, slicing an array on the server itself, differs from the dask-awkward partial-read case, in that the array form is allowed (and expected) to change with the slice operation.

Our simplification logic has the ability to merge buffers e.g. if a union is no longer canonical. This means that this simplification step needs to happen _after_ the data have been read from disk. Upon discussing this with @jpivarski, we concluded that it would be useful to manipulate the form on the client, and perform a `from_buffers` that performs this simplification during reading.

This PR adds `ak.from_non_simplified_buffers`. @jpivarski suggested making this "hidden" as an L2 function. Whilst it still remains L2 by designation, I think the name is sufficient to export it in the `ak.operations` namespace and to publish the documentation. Our L2 layouts already introduce the `simplified` convention, so it should be clear what this function does.