### PR TITLE
fix: support placeholders in `from_buffers`

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -53,15 +53,11 @@ class ArrayModuleNumpyLike(NumpyLike):
             return self._module.ascontiguousarray(x)
 
     def frombuffer(
-        self, buffer, *, dtype: np.dtype | None = None, count: int = -1
+        self, buffer, *, dtype: np.dtype | None = None, count: ShapeItem = -1
     ) -> ArrayLike:
         if isinstance(buffer, PlaceholderArray):
-            if count == -1:
-                return self.asarray(buffer)
-            else:
-                return self.asarray(buffer[:count])
-        else:
-            return self._module.frombuffer(buffer, dtype=dtype, count=count)
+            raise TypeError("placeholder arrays are not supported in `frombuffer`")
+        return self._module.frombuffer(buffer, dtype=dtype, count=count)
 
     def from_dlpack(self, x: Any) -> ArrayLike:
         return self._module.from_dlpack(x)

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -17,7 +17,7 @@ class PlaceholderArray(ArrayLike):
     ):
         self._nplike = nplike
         self._shape = shape
-        self._dtype = dtype
+        self._dtype = np.dtype(dtype)
 
     @property
     def dtype(self) -> np.dtype:

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -71,7 +71,7 @@ class PlaceholderArray(ArrayLike):
         if isinstance(index, slice):
             length = self._shape[0]
 
-            # Unknown-length placeholders never need a known shape, so return unknown!
+            # Unknown-length placeholders should not be sliced (as their shapes would be touched(
             if length is unknown_length:
                 raise AssertionError(
                     "placeholder arrays that are sliced should have known shapes"

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -37,7 +37,7 @@ class PlaceholderArray(ArrayLike):
 
     @property
     def nbytes(self) -> int:
-        return self.size * self._dtype.itemsize
+        return 0
 
     @property
     def strides(self) -> tuple[int, ...]:

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -46,7 +46,12 @@ def from_dict(input: Mapping) -> Form:
 
     if input["class"] == "NumpyArray":
         primitive = input["primitive"]
-        inner_shape = input.get("inner_shape", [])
+        inner_shape = tuple(
+            [
+                unknown_length if item is None else item
+                for item in input.get("inner_shape", [])
+            ]
+        )
         return ak.forms.NumpyForm(
             primitive, inner_shape, parameters=parameters, form_key=form_key
         )

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -47,10 +47,8 @@ def from_dict(input: Mapping) -> Form:
     if input["class"] == "NumpyArray":
         primitive = input["primitive"]
         inner_shape = tuple(
-            [
-                unknown_length if item is None else item
-                for item in input.get("inner_shape", [])
-            ]
+            unknown_length if item is None else item
+            for item in input.get("inner_shape", [])
         )
         return ak.forms.NumpyForm(
             primitive, inner_shape, parameters=parameters, form_key=form_key

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable, Iterator
 import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable, Self, final
 from awkward._util import UNSET
@@ -139,7 +140,10 @@ class NumpyForm(Form):
                 "primitive": self._primitive,
             }
             if verbose or len(self._inner_shape) > 0:
-                out["inner_shape"] = list(self._inner_shape)
+                out["inner_shape"] = [
+                    None if item is unknown_length else item
+                    for item in self._inner_shape
+                ]
             return self._to_dict_extra(out, verbose)
 
     @property

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -178,10 +178,8 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
             byteorder=byteorder,
         )
         if form.inner_shape != ():
-            if data.shape[0] is unknown_length or data.shape[0] != 0:
-                data = backend.nplike.reshape(data, (length, *form.inner_shape))
-            else:
-                data = backend.nplike.reshape(data, (-1, *form.inner_shape))
+            data = backend.nplike.reshape(data, (length, *form.inner_shape))
+
         return ak.contents.NumpyArray(
             data, parameters=form._parameters, backend=backend
         )

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -406,7 +406,7 @@ def _reconstitute(form, length, container, getkey, backend, byteorder, simplify)
             count=length,
             byteorder=byteorder,
         )
-        if isinstance(index, PlaceholderArray):
+        if isinstance(index, PlaceholderArray) or isinstance(tags, PlaceholderArray):
             lengths = [unknown_length] * len(form.contents)
         else:
             lengths = []

--- a/tests/test_2714_from_buffers_placeholders.py
+++ b/tests/test_2714_from_buffers_placeholders.py
@@ -1,0 +1,450 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.placeholder import PlaceholderArray
+from awkward._nplikes.shape import unknown_length
+
+numpy = Numpy.instance()
+
+
+def test_numpyarray():
+    layout = ak.from_buffers(
+        {"class": "NumpyArray", "primitive": "int64", "form_key": "node0"},
+        10,
+        {"node0-data": PlaceholderArray(numpy, (10,), np.int64)},
+        highlevel=False,
+    )
+    assert layout.length == 10
+
+    # Content too small
+    with pytest.raises(TypeError, match=r"is less than size of form"):
+        ak.from_buffers(
+            {"class": "NumpyArray", "primitive": "int64", "form_key": "node0"},
+            10,
+            {"node0-data": PlaceholderArray(numpy, (9,), np.int64)},
+            highlevel=False,
+        )
+
+    # Unknown length content at top-level
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {"class": "NumpyArray", "primitive": "int64", "form_key": "node0"},
+            10,
+            {"node0-data": PlaceholderArray(numpy, (unknown_length,), np.int64)},
+            highlevel=False,
+        )
+
+
+def test_listoffsetarray_numpyarray():
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "ListOffsetArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "offsets": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-offsets": np.array([0, 1, 2], dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (10,), dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length == 2
+
+    # Unknown offsets
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "ListOffsetArray",
+                "content": {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                "offsets": "i64",
+                "form_key": "node0",
+            },
+            2,
+            {
+                "node0-offsets": PlaceholderArray(numpy, (3,), dtype=np.int64),
+                "node1-data": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64
+                ),
+            },
+            highlevel=False,
+        )
+
+    # Unknown offsets and unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "ListOffsetArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "offsets": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-offsets": PlaceholderArray(numpy, (3,), dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (10,), dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length is unknown_length
+
+
+def test_listarray_numpyarray():
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "ListArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "starts": "i64",
+            "stops": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-starts": np.array([0, 1], dtype=np.int64),
+            "node0-stops": np.array([1, 2], dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (10,), dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length == 2
+
+    # Unknown offsets
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "ListArray",
+                "content": {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                "starts": "i64",
+                "stops": "i64",
+                "form_key": "node0",
+            },
+            2,
+            {
+                "node0-starts": PlaceholderArray(numpy, (2,), dtype=np.int64),
+                "node0-stops": PlaceholderArray(numpy, (2,), dtype=np.int64),
+                "node1-data": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64
+                ),
+            },
+            highlevel=False,
+        )
+
+    # Unknown offsets and unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "ListArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "starts": "i64",
+            "stops": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-starts": PlaceholderArray(numpy, (2,), dtype=np.int64),
+            "node0-stops": PlaceholderArray(numpy, (2,), dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (10,), dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length is unknown_length
+
+
+def test_indexedoptionarray():
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedOptionArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": np.array([0, 1, 2], dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (3,), np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length == 3
+
+    # Unknown index
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "IndexedOptionArray",
+                "index": "i64",
+                "content": {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                "form_key": "node0",
+            },
+            3,
+            {
+                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+                "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
+            },
+            highlevel=False,
+        )
+
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedOptionArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+            "node1-data": PlaceholderArray(numpy, (6,), np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length is unknown_length
+
+
+def test_indexedarray():
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": np.array([0, 1, 2], dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (3,), np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length == 3
+
+    # Unknown index
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "IndexedArray",
+                "index": "i64",
+                "content": {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                "form_key": "node0",
+            },
+            3,
+            {
+                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+                "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
+            },
+            highlevel=False,
+        )
+
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
+            },
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+            "node1-data": PlaceholderArray(numpy, (6,), np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length is unknown_length
+
+
+def test_unionarray():
+    # Unknown data
+    layout = ak.from_buffers(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                {
+                    "class": "NumpyArray",
+                    "primitive": "datetime64[D]",
+                    "form_key": "node2",
+                },
+            ],
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-tags": np.array([0, 0, 1], dtype=np.int8),
+            "node0-index": np.array([0, 1, 0], dtype=np.int64),
+            "node1-data": PlaceholderArray(numpy, (3,), np.int64),
+            "node2-data": PlaceholderArray(numpy, (6,), np.dtype("datetime64[D]")),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.contents[0].length == 2
+    assert layout.contents[1].length == 1
+
+    # Unknown tags
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "UnionArray",
+                "tags": "i8",
+                "index": "i64",
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "form_key": "node1",
+                    },
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "datetime64[D]",
+                        "form_key": "node2",
+                    },
+                ],
+                "form_key": "node0",
+            },
+            3,
+            {
+                "node0-tags": PlaceholderArray(numpy, (3,), np.int8),
+                "node0-index": np.array([0, 1, 0], dtype=np.int64),
+                "node1-data": np.array([0, 1, 2], np.int64),
+                "node2-data": np.array(
+                    [0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")
+                ),
+            },
+            highlevel=False,
+        )
+
+    # Unknown index
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "UnionArray",
+                "tags": "i8",
+                "index": "i64",
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "form_key": "node1",
+                    },
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "datetime64[D]",
+                        "form_key": "node2",
+                    },
+                ],
+                "form_key": "node0",
+            },
+            3,
+            {
+                "node0-tags": np.array([0, 0, 1], dtype=np.int8),
+                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+                "node1-data": np.array([0, 1, 2], np.int64),
+                "node2-data": np.array(
+                    [0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")
+                ),
+            },
+            highlevel=False,
+        )
+
+    # Unknown content length
+    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
+        ak.from_buffers(
+            {
+                "class": "UnionArray",
+                "tags": "i8",
+                "index": "i64",
+                "contents": [
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "int64",
+                        "form_key": "node1",
+                    },
+                    {
+                        "class": "NumpyArray",
+                        "primitive": "datetime64[D]",
+                        "form_key": "node2",
+                    },
+                ],
+                "form_key": "node0",
+            },
+            3,
+            {
+                "node0-tags": np.array([0, 0, 1], dtype=np.int8),
+                "node0-index": np.array([0, 1, 0], dtype=np.int64),
+                "node1-data": PlaceholderArray(numpy, (unknown_length,), np.int64),
+                "node2-data": PlaceholderArray(numpy, (6,), np.dtype("datetime64[D]")),
+            },
+            highlevel=False,
+        )


### PR DESCRIPTION
With #2693 we support writing placeholder arrays using `to_buffers`, which is used for pickling re-hydrated arrays. This PR supports reading such arrays.

By design, this routine throws an error if a placeholder has an unknown length but a known length can be determined by the recursion; the caller should ensure that placeholders have valid lengths. We can relax this in future, but for now it makes things easier to reason about.