### PR TITLE
feat: add `buffer_key` to `typetracer_with_report`

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1431,7 +1431,7 @@ def _attach_report(
 
     elif isinstance(layout, ak.contents.NumpyArray):
         assert isinstance(form, ak.forms.NumpyForm)
-        layout.data.form_key = form.form_key
+        layout.data.form_key = getkey(form.form_key, "data")
         layout.data.report = report
 
     elif isinstance(layout, ak.contents.RecordArray):

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from numbers import Number
+from typing import Callable
 
 import numpy
 
@@ -610,7 +611,7 @@ class TypeTracer(NumpyLike):
                     if has_seen_leaf:
                         if len(node) != shape[dim - 1]:
                             raise ValueError(
-                                f"sequence at dimension {dim} does not match shape {shape[dim-1]}"
+                                f"sequence at dimension {dim} does not match shape {shape[dim - 1]}"
                             )
                     else:
                         shape.append(len(node))
@@ -1394,36 +1395,39 @@ class TypeTracer(NumpyLike):
 
 
 def _attach_report(
-    layout: ak.contents.Content, form: ak.forms.Form, report: TypeTracerReport
+    layout: ak.contents.Content,
+    form: ak.forms.Form,
+    report: TypeTracerReport,
+    getkey: Callable[[ak.forms.form, str], str],
 ):
     if isinstance(layout, (ak.contents.BitMaskedArray, ak.contents.ByteMaskedArray)):
         assert isinstance(form, (ak.forms.BitMaskedForm, ak.forms.ByteMaskedForm))
-        layout.mask.data.form_key = form.form_key
+        layout.mask.data.form_key = getkey(form, "mask")
         layout.mask.data.report = report
-        _attach_report(layout.content, form.content, report)
+        _attach_report(layout.content, form.content, report, getkey)
 
     elif isinstance(layout, ak.contents.EmptyArray):
         assert isinstance(form, ak.forms.EmptyForm)
 
     elif isinstance(layout, (ak.contents.IndexedArray, ak.contents.IndexedOptionArray)):
         assert isinstance(form, (ak.forms.IndexedForm, ak.forms.IndexedOptionForm))
-        layout.index.data.form_key = form.form_key
+        layout.index.data.form_key = getkey(form, "index")
         layout.index.data.report = report
-        _attach_report(layout.content, form.content, report)
+        _attach_report(layout.content, form.content, report, getkey)
 
     elif isinstance(layout, ak.contents.ListArray):
         assert isinstance(form, ak.forms.ListForm)
-        layout.starts.data.form_key = form.form_key
+        layout.starts.data.form_key = getkey(form, "starts")
         layout.starts.data.report = report
-        layout.stops.data.form_key = form.form_key
+        layout.stops.data.form_key = getkey(form, "stops")
         layout.stops.data.report = report
-        _attach_report(layout.content, form.content, report)
+        _attach_report(layout.content, form.content, report, getkey)
 
     elif isinstance(layout, ak.contents.ListOffsetArray):
         assert isinstance(form, ak.forms.ListOffsetForm)
-        layout.offsets.data.form_key = form.form_key
+        layout.offsets.data.form_key = getkey(form, "offsets")
         layout.offsets.data.report = report
-        _attach_report(layout.content, form.content, report)
+        _attach_report(layout.content, form.content, report, getkey)
 
     elif isinstance(layout, ak.contents.NumpyArray):
         assert isinstance(form, ak.forms.NumpyForm)
@@ -1433,31 +1437,33 @@ def _attach_report(
     elif isinstance(layout, ak.contents.RecordArray):
         assert isinstance(form, ak.forms.RecordForm)
         for x, y in zip(layout.contents, form.contents):
-            _attach_report(x, y, report)
+            _attach_report(x, y, report, getkey)
 
     elif isinstance(layout, (ak.contents.RegularArray, ak.contents.UnmaskedArray)):
         assert isinstance(form, (ak.forms.RegularForm, ak.forms.UnmaskedForm))
-        _attach_report(layout.content, form.content, report)
+        _attach_report(layout.content, form.content, report, getkey)
 
     elif isinstance(layout, ak.contents.UnionArray):
         assert isinstance(form, ak.forms.UnionForm)
-        layout.tags.data.form_key = form.form_key
+        layout.tags.data.form_key = getkey(form, "tags")
         layout.tags.data.report = report
-        layout.index.data.form_key = form.form_key
+        layout.index.data.form_key = getkey(form, "index")
         layout.index.data.report = report
         for x, y in zip(layout.contents, form.contents):
-            _attach_report(x, y, report)
+            _attach_report(x, y, report, getkey)
 
     else:
         raise AssertionError(f"unrecognized layout type {type(layout)}")
 
 
 def typetracer_with_report(
-    form: ak.forms.Form, forget_length: bool = True
+    form: ak.forms.Form,
+    getkey: Callable[[ak.forms.form, str], str],
+    forget_length: bool = True,
 ) -> tuple[ak.contents.Content, TypeTracerReport]:
     layout = form.length_zero_array(highlevel=False).to_typetracer(
         forget_length=forget_length
     )
     report = TypeTracerReport()
-    _attach_report(layout, form, report)
+    _attach_report(layout, form, report, getkey)
     return layout, report

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1431,7 +1431,7 @@ def _attach_report(
 
     elif isinstance(layout, ak.contents.NumpyArray):
         assert isinstance(form, ak.forms.NumpyForm)
-        layout.data.form_key = getkey(form.form_key, "data")
+        layout.data.form_key = getkey(form, "data")
         layout.data.report = report
 
     elif isinstance(layout, ak.contents.RecordArray):

--- a/tests/test_2719_typetracer_buffer_key.py
+++ b/tests/test_2719_typetracer_buffer_key.py
@@ -1,0 +1,53 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+form_dict = {
+    "class": "RecordArray",
+    "fields": ["x"],
+    "contents": [
+        {
+            "class": "ListArray",
+            "starts": "i64",
+            "stops": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "inner_shape": [],
+                "parameters": {},
+                "form_key": "x.list.content",
+            },
+            "parameters": {},
+            "form_key": "x.list",
+        }
+    ],
+    "parameters": {},
+}
+
+
+def test_without_attribute():
+    form = ak.forms.from_dict(form_dict)
+    array, report = ak.typetracer.typetracer_with_report(
+        form, buffer_key="{form_key}", highlevel=True
+    )
+    ak.typetracer.touch_data(array)
+    assert set(report.data_touched) == {
+        "x.list",
+        "x.list.content",
+    }
+
+
+def test_with_attribute():
+    form = ak.forms.from_dict(form_dict)
+    array, report = ak.typetracer.typetracer_with_report(
+        form, buffer_key="{form_key}-{attribute}", highlevel=True
+    )
+    ak.typetracer.touch_data(array)
+    assert set(report.data_touched) == {
+        "x.list-starts",
+        "x.list-stops",
+        "x.list.content",
+    }

--- a/tests/test_2719_typetracer_buffer_key.py
+++ b/tests/test_2719_typetracer_buffer_key.py
@@ -49,5 +49,5 @@ def test_with_attribute():
     assert set(report.data_touched) == {
         "x.list-starts",
         "x.list-stops",
-        "x.list.content",
+        "x.list.content-data",
     }


### PR DESCRIPTION
This PR makes it possible to format the `form_key`s assigned to typetracer buffers via `ak.typetracer.typetracer_with_report`. Although the default behaviour is unchanged, this permits us to ensure that buffer keys are unique within a typetracer layout.