### PR TITLE
feat: add `recursive` argument to `expected_from_buffers`

### DIFF
--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -262,7 +262,8 @@ class BitMaskedForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "mask"), index_to_dtype[self._mask])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -225,7 +225,8 @@ class ByteMaskedForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "mask"), index_to_dtype[self._mask])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -151,6 +151,6 @@ class EmptyForm(Form):
             self.__init__(form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield from ()

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -657,18 +657,25 @@ class Form:
         )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         raise NotImplementedError
 
-    def expected_from_buffers(self, buffer_key="{form_key}-{attribute}"):
+    def expected_from_buffers(
+        self, buffer_key="{form_key}-{attribute}", recursive=True
+    ):
         """
         Args:
             buffer_key (str or callable): Python format string containing
                 `"{form_key}"` and/or `"{attribute}"` or a function that takes these
                 as keyword arguments and returns a string to use as a key for a buffer
                 in the `container`.
+            recursive (bool): If True, recurse into subforms; otherwise, yield
+                only the (buffer_key, dtype) pairs for this form object.
+
+        Yield (buffer_key, dtype) pairs describing the expected buffer keys,
+        and their corresponding dtypes, that a call to #ak.from_buffers would
+        be expected to find from the `container` object.
         """
         getkey = regularize_buffer_key(buffer_key)
-
-        return dict(self._expected_from_buffers(getkey))
+        return dict(self._expected_from_buffers(getkey, recursive))

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -229,7 +229,8 @@ class IndexedForm(Form):
             self.__init__(index, content, parameters=parameters, form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "index"), index_to_dtype[self._index])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -210,7 +210,8 @@ class IndexedOptionForm(Form):
             self.__init__(index, content, parameters=parameters, form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "index"), index_to_dtype[self._index])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -236,8 +236,9 @@ class ListForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "starts"), index_to_dtype[self._starts])
         yield (getkey(self, "stops"), index_to_dtype[self._stops])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -198,7 +198,8 @@ class ListOffsetForm(Form):
             self.__init__(offsets, content, parameters=parameters, form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "offsets"), index_to_dtype[self._offsets])
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -293,7 +293,7 @@ class NumpyForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         from awkward.types.numpytype import primitive_to_dtype
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -309,7 +309,7 @@ class RecordForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         for content in self._contents:
             yield from content._expected_from_buffers(getkey)

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -311,5 +311,6 @@ class RecordForm(Form):
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
-        for content in self._contents:
-            yield from content._expected_from_buffers(getkey)
+        if recursive:
+            for content in self._contents:
+                yield from content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -193,6 +193,7 @@ class RegularForm(Form):
             self.__init__(content, size, parameters=parameters, form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -295,7 +295,7 @@ class UnionForm(Form):
             )
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "tags"), index_to_dtype[self._tags])
         yield (getkey(self, "index"), index_to_dtype[self._index])

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -299,5 +299,6 @@ class UnionForm(Form):
     ) -> Iterator[tuple[str, np.dtype]]:
         yield (getkey(self, "tags"), index_to_dtype[self._tags])
         yield (getkey(self, "index"), index_to_dtype[self._index])
-        for content in self._contents:
-            yield from content._expected_from_buffers(getkey)
+        if recursive:
+            for content in self._contents:
+                yield from content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -182,6 +182,7 @@ class UnmaskedForm(Form):
             self.__init__(content, parameters=parameters, form_key=form_key)
 
     def _expected_from_buffers(
-        self, getkey: Callable[[Form, str], str]
+        self, getkey: Callable[[Form, str], str], recursive: bool
     ) -> Iterator[tuple[str, np.dtype]]:
-        yield from self._content._expected_from_buffers(getkey)
+        if recursive:
+            yield from self._content._expected_from_buffers(getkey, recursive)

--- a/tests/test_2724_expected_from_buffers_recursive.py
+++ b/tests/test_2724_expected_from_buffers_recursive.py
@@ -7,8 +7,10 @@ import awkward as ak
 
 # 6.6 and 7.7 are inaccessible
 layout = ak.contents.listoffsetarray.ListOffsetArray(
-    ak.index.Index(np.array([1, 4, 4, 6])),
-    ak.contents.numpyarray.NumpyArray(np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])),
+    ak.index.Index(np.array([1, 4, 4, 6], dtype=np.int64)),
+    ak.contents.numpyarray.NumpyArray(
+        np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7], dtype=np.float64)
+    ),
 )
 
 

--- a/tests/test_2724_expected_from_buffers_recursive.py
+++ b/tests/test_2724_expected_from_buffers_recursive.py
@@ -1,0 +1,27 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+# 6.6 and 7.7 are inaccessible
+layout = ak.contents.listoffsetarray.ListOffsetArray(
+    ak.index.Index(np.array([1, 4, 4, 6])),
+    ak.contents.numpyarray.NumpyArray(np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])),
+)
+
+
+def test_recursive():
+    form, length, container = ak.to_buffers(layout)
+    assert form.expected_from_buffers(recursive=True) == {
+        "node0-offsets": np.dtype("int64"),
+        "node1-data": np.dtype("float64"),
+    }
+
+
+def test_non_recursive():
+    form, length, container = ak.to_buffers(layout)
+    assert form.expected_from_buffers(recursive=False) == {
+        "node0-offsets": np.dtype("int64")
+    }


### PR DESCRIPTION
In the work to support buffer-shape touching in dask-awkward, I found it useful to be able to disable recursion in `expected_from_buffers` in order to identify the buffers associated directly with each form node. I think this has merit, so I've created this PR.