### PR TITLE
fix: make the examples consistent with the changes in #2553

### DIFF
--- a/header-only/examples/cython/CMakeLists.txt
+++ b/header-only/examples/cython/CMakeLists.txt
@@ -4,7 +4,7 @@ project(demo LANGUAGES CXX C)
 
 # Download headers
 include(FetchContent)
-set(AWKWARD_VERSION "v2.0.10")
+set(AWKWARD_VERSION "v2.4.3")
 FetchContent_Declare(
   awkward-headers
   URL https://github.com/scikit-hep/awkward/releases/download/${AWKWARD_VERSION}/header-only.zip

--- a/header-only/examples/cython/CMakeLists.txt
+++ b/header-only/examples/cython/CMakeLists.txt
@@ -18,9 +18,8 @@ if(NOT awkward-headers_POPULATED)
                    EXCLUDE_FROM_ALL)
 endif()
 
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 find_package(Cython REQUIRED)
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)
 
 # Build demo module
@@ -33,6 +32,7 @@ add_python_library(
   demo_impl.cpp
   LINK_LIBRARIES
   awkward::layout-builder
+  Python::NumPy
   INCLUDE_DIRECTORIES
   include)
 python_extension_module(_demo)

--- a/header-only/examples/cython/CMakeLists.txt
+++ b/header-only/examples/cython/CMakeLists.txt
@@ -22,7 +22,6 @@ find_package(Cython REQUIRED)
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)
-include(UsePythonExtensions)
 
 # Build demo module
 add_cython_target(_demo _demo.pyx PY3 CXX)

--- a/header-only/examples/cython/demo_impl.cpp
+++ b/header-only/examples/cython/demo_impl.cpp
@@ -72,8 +72,8 @@ ArrayBuffers create_demo_array() {
                     NumpyBuilder<int32_t>>>
     > builder(fields_map);
 
-    auto &one_builder = builder.field<Field::one>();
-    auto &two_builder = builder.field<Field::two>();
+    auto &one_builder = builder.content<Field::one>();
+    auto &two_builder = builder.content<Field::two>();
 
     one_builder.append(1.1);
 

--- a/header-only/examples/cython/pyproject.toml
+++ b/header-only/examples/cython/pyproject.toml
@@ -5,5 +5,6 @@ requires = [
     "cmake>=3.18",
     "cython",
     "ninja",
+    "numpy"
 ]
 build-backend = "setuptools.build_meta"

--- a/header-only/examples/pybind11/CMakeLists.txt
+++ b/header-only/examples/pybind11/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 
 # Download headers
 include(FetchContent)
-set(AWKWARD_VERSION "v2.0.10")
+set(AWKWARD_VERSION "v2.4.3")
 FetchContent_Declare(
   awkward-headers
   URL https://github.com/scikit-hep/awkward/releases/download/${AWKWARD_VERSION}/header-only.zip

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -87,8 +87,8 @@ py::object create_demo_array() {
                     NumpyBuilder<int32_t>>>
     > builder(fields_map);
 
-    auto &one_builder = builder.field<Field::one>();
-    auto &two_builder = builder.field<Field::two>();
+    auto &one_builder = builder.content<Field::one>();
+    auto &two_builder = builder.content<Field::two>();
 
     one_builder.append(1.1);
 


### PR DESCRIPTION
I noticed that the header-only C++ examples didn't reflect the changes made in the C++ LayoutBuilder API in #2553. Fixed the code to add the required changes.