### PR TITLE
fix: reduction with `axis=None`, `keepdims=True`

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -201,6 +201,7 @@ def remove_structure(
     drop_nones: bool = True,
     keepdims: bool = False,
     allow_records: bool = False,
+    list_to_regular: bool = False,
 ):
     if isinstance(layout, Record):
         return remove_structure(
@@ -224,6 +225,7 @@ def remove_structure(
                 "drop_nones": drop_nones,
                 "keepdims": keepdims,
                 "allow_records": allow_records,
+                "list_to_regular": list_to_regular,
             },
         )
         return tuple(arrays)
@@ -272,6 +274,7 @@ def reduce(
             drop_nones=False,
             keepdims=keepdims,
             allow_records=True,
+            list_to_regular=True,
         )
 
         if len(parts) > 1:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2069,7 +2069,7 @@ class ListOffsetArray(Content):
                     return [
                         ak.contents.RegularArray(
                             c,
-                            size=backend.index_nplike.shape_item_as_index(c.length),
+                            size=c.length,
                             zeros_length=1,
                             parameters=self._parameters,
                         )

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2065,18 +2065,34 @@ class ListOffsetArray(Content):
             content = self._content[self._offsets[0] : self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
-                return [
-                    ListOffsetArray(
-                        Index64(
-                            backend.index_nplike.asarray(
-                                [0, backend.index_nplike.shape_item_as_index(c.length)]
-                            )
-                        ),
-                        c,
-                        parameters=self._parameters,
-                    )
-                    for c in contents
-                ]
+                if options["list_to_regular"]:
+                    return [
+                        ak.contents.RegularArray(
+                            c,
+                            size=backend.index_nplike.shape_item_as_index(c.length),
+                            zeros_length=1,
+                            parameters=self._parameters,
+                        )
+                        for c in contents
+                    ]
+                else:
+                    return [
+                        ListOffsetArray(
+                            Index64(
+                                backend.index_nplike.asarray(
+                                    [
+                                        0,
+                                        backend.index_nplike.shape_item_as_index(
+                                            c.length
+                                        ),
+                                    ]
+                                )
+                            ),
+                            c,
+                            parameters=self._parameters,
+                        )
+                        for c in contents
+                    ]
             else:
                 return contents
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1085,7 +1085,7 @@ class RegularArray(Content):
                 )
             )
 
-            if self._size > 0:
+            if self._size is not unknown_length and self._size > 0:
                 nextstarts = ak.index.Index64(
                     index_nplike.arange(0, nextlen, self._size),
                     nplike=index_nplike,
@@ -1151,7 +1151,11 @@ class RegularArray(Content):
                     )
 
                     trimmed = outcontent.content._getitem_range(start, stop)
-                    assert len(trimmed) == self._size * outcontent.length
+                    assert (
+                        trimmed.length is unknown_length
+                        or outcontent.length is unknown_length
+                        or trimmed.length == self._size * outcontent.length
+                    )
 
                     outcontent = ak.contents.RegularArray(
                         trimmed,

--- a/tests/test_2727_remove_structure_regular.py
+++ b/tests/test_2727_remove_structure_regular.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 import numpy as np
-import pytest  # noqa: F401
+import pytest
 
 import awkward as ak
 

--- a/tests/test_2727_remove_structure_regular.py
+++ b/tests/test_2727_remove_structure_regular.py
@@ -1,0 +1,23 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array([[[1, 2], [1]], [[1], [1], [1]]])
+    assert ak.almost_equal(
+        ak.mean(array, axis=None, keepdims=True),
+        ak.contents.RegularArray(
+            ak.contents.RegularArray(
+                ak.contents.NumpyArray(
+                    np.mean([1, 2, 1, 1, 1, 1], dtype=np.float64, keepdims=True)
+                ),
+                size=1,
+            ),
+            size=1,
+        ),
+        check_regular=True,
+    )

--- a/tests/test_2727_remove_structure_regular.py
+++ b/tests/test_2727_remove_structure_regular.py
@@ -21,3 +21,9 @@ def test():
         ),
         check_regular=True,
     )
+
+
+def test_original_problem():
+    array = ak.Array([[[1, 2], [1]], [[1], [1], [1]]])
+    assert ak.mean(array) == pytest.approx(1.1666666666666667)
+    assert ak.var(array) == pytest.approx(0.13888888888888887)


### PR DESCRIPTION
Fixes #2727 

Ass discussed in https://github.com/scikit-hep/awkward/issues/2727#issuecomment-1738032109, the cause of this bug is that `keepdims=True` for `axis=None` doesn't introduce regular nodes, unlike `axis!=None` which replaces the node at `axis` with a regular one. 

This makes sense; unlike `axis=None`, `axis=N` only operates upon a single dimension. We _probably_ want to replace list nodes with regular nodes in `_remove_structure`.

This PR adds `list_to_regular` as an argument to `ak._do.remove_structure`. As this is an L3 function, we don't need to worry about whether this is too niche (i.e. whether `list_to_ragged` should also be an argument).