### PR TITLE
feat: infer unknown lengths from context in `from_buffers`

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -249,7 +249,6 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
 
     @property
     def ndim(self) -> int:
-        self.touch_shape()
         return len(self._shape)
 
     @property

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -147,13 +147,12 @@ class BitMaskedArray(Content):
                     type(self).__name__, repr(valid_when)
                 )
             )
-        if length is not unknown_length:
-            if not (is_integer(length) and length >= 0):
-                raise TypeError(
-                    "{} 'length' must be a non-negative integer, not {}".format(
-                        type(self).__name__, length
-                    )
+        if length is not unknown_length and not (is_integer(length) and length >= 0):
+            raise TypeError(
+                "{} 'length' must be a non-negative integer, not {}".format(
+                    type(self).__name__, length
                 )
+            )
         if not isinstance(lsb_order, bool):
             raise TypeError(
                 "{} 'lsb_order' must be boolean, not {}".format(
@@ -161,7 +160,9 @@ class BitMaskedArray(Content):
                 )
             )
         if (
-            not (length is unknown_length or mask.length is unknown_length)
+            content.backend.index_nplike.known_data
+            and length is not unknown_length
+            and mask.length is not unknown_length
             and length > mask.length * 8
         ):
             raise ValueError(
@@ -170,7 +171,9 @@ class BitMaskedArray(Content):
                 )
             )
         if (
-            not (length is unknown_length or content.length is unknown_length)
+            content.backend.index_nplike.known_data
+            and length is not unknown_length
+            and mask.length is not unknown_length
             and length > content.length * 8
         ):
             raise ValueError(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -121,7 +121,9 @@ class ByteMaskedArray(Content):
                 )
             )
         if (
-            not (mask.length is unknown_length or content.length is unknown_length)
+            content.backend.index_nplike.known_data
+            and mask.length is not unknown_length
+            and content.length is not unknown_length
             and mask.length > content.length
         ):
             raise ValueError(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -126,11 +126,7 @@ class ListArray(Content):
                     type(self).__name__, repr(content)
                 )
             )
-        if (
-            starts.nplike.known_data
-            and stops.nplike.known_data
-            and starts.length > stops.length
-        ):
+        if content.backend.index_nplike.known_data and starts.length > stops.length:
             raise ValueError(
                 "{} len(starts) ({}) must be <= len(stops) ({})".format(
                     type(self).__name__, starts.length, stops.length

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -114,7 +114,11 @@ class ListOffsetArray(Content):
                     type(self).__name__, repr(content)
                 )
             )
-        if offsets.length is not unknown_length and offsets.length == 0:
+        if (
+            content.backend.index_nplike.known_data
+            and offsets.length is not unknown_length
+            and offsets.length == 0
+        ):
             raise ValueError(
                 f"{type(self).__name__} len(offsets) ({offsets.length}) must be >= 1"
             )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -120,28 +120,21 @@ class RegularArray(Content):
                         type(self).__name__
                     )
                 )
-        else:
-            if not (is_integer(size) and size >= 0):
-                raise TypeError(
-                    "{} 'size' must be a non-negative integer, not {}".format(
-                        type(self).__name__, size
-                    )
+        elif not (is_integer(size) and size >= 0):
+            raise TypeError(
+                "{} 'size' must be a non-negative integer, not {}".format(
+                    type(self).__name__, size
                 )
+            )
 
-        if zeros_length is unknown_length:
-            if content.backend.index_nplike.known_data:
-                raise TypeError(
-                    "{} 'zeros_length' must be a non-negative integer for backends with known shapes, not None".format(
-                        type(self).__name__
-                    )
+        if zeros_length is not unknown_length and not (
+            is_integer(zeros_length) and zeros_length >= 0
+        ):
+            raise TypeError(
+                "{} 'zeros_length' must be a non-negative integer, not {}".format(
+                    type(self).__name__, zeros_length
                 )
-        else:
-            if not (is_integer(zeros_length) and zeros_length >= 0):
-                raise TypeError(
-                    "{} 'zeros_length' must be a non-negative integer, not {}".format(
-                        type(self).__name__, zeros_length
-                    )
-                )
+            )
 
         if parameters is not None and parameters.get("__array__") == "string":
             if not content.is_numpy or not content.parameter("__array__") == "char":

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -148,16 +148,6 @@ class UnionArray(Content):
                 "try {0}.simplified instead".format(type(self).__name__)
             )
 
-        if (
-            not (tags.length is unknown_length or index.length is unknown_length)
-            and tags.length > index.length
-        ):
-            raise ValueError(
-                "{} len(tags) ({}) must be <= len(index) ({})".format(
-                    type(self).__name__, tags.length, index.length
-                )
-            )
-
         backend = None
         for content in contents:
             if backend is None:
@@ -170,6 +160,18 @@ class UnionArray(Content):
                         type(content.backend).__name__,
                     )
                 )
+
+        if (
+            backend.index_nplike.known_data
+            and tags.length is not unknown_length
+            and index.length is not unknown_length
+            and tags.length > index.length
+        ):
+            raise ValueError(
+                "{} len(tags) ({}) must be <= len(index) ({})".format(
+                    type(self).__name__, tags.length, index.length
+                )
+            )
 
         assert tags.nplike is backend.index_nplike
         assert index.nplike is backend.index_nplike

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -149,9 +149,8 @@ def _from_buffer(
     # for the parent of this node. Thus, this node and its children *must* only
     # contain placeholders
     if count is unknown_length:
-        # Only placeholders can have unknown lengths
-        if not isinstance(buffer, PlaceholderArray):
-            raise AssertionError("Encountered unknown length for concrete buffer")
+        # We may actually have a known buffer here, but as we do not know the length,
+        # we cannot safely trim it. Thus, introduce a placeholder anyway
         return PlaceholderArray(nplike, (unknown_length,), dtype)
     # Known-length information implies that we should have known-length buffers here
     # We could choose to make this an error, and have the caller re-implement some

--- a/tests/test_2714_from_buffers_placeholders.py
+++ b/tests/test_2714_from_buffers_placeholders.py
@@ -64,27 +64,26 @@ def test_listoffsetarray_numpyarray():
     assert layout.content.length == 2
 
     # Unknown offsets above known data
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "ListOffsetArray",
-                "content": {
-                    "class": "NumpyArray",
-                    "primitive": "int64",
-                    "form_key": "node1",
-                },
-                "offsets": "i64",
-                "form_key": "node0",
+    layout = ak.from_buffers(
+        {
+            "class": "ListOffsetArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
             },
-            2,
-            {
-                "node0-offsets": PlaceholderArray(numpy, (3,), dtype=np.int64),
-                "node1-data": np.array(
-                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64
-                ),
-            },
-            highlevel=False,
-        )
+            "offsets": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-offsets": PlaceholderArray(numpy, (3,), dtype=np.int64),
+            "node1-data": np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length is unknown_length
 
     # Unknown offsets and unknown data
     layout = ak.from_buffers(
@@ -157,29 +156,28 @@ def test_listarray_numpyarray():
     assert layout.content.length == 2
 
     # Unknown offsets
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "ListArray",
-                "content": {
-                    "class": "NumpyArray",
-                    "primitive": "int64",
-                    "form_key": "node1",
-                },
-                "starts": "i64",
-                "stops": "i64",
-                "form_key": "node0",
+    layout = ak.from_buffers(
+        {
+            "class": "ListArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
             },
-            2,
-            {
-                "node0-starts": PlaceholderArray(numpy, (2,), dtype=np.int64),
-                "node0-stops": PlaceholderArray(numpy, (2,), dtype=np.int64),
-                "node1-data": np.array(
-                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64
-                ),
-            },
-            highlevel=False,
-        )
+            "starts": "i64",
+            "stops": "i64",
+            "form_key": "node0",
+        },
+        2,
+        {
+            "node0-starts": PlaceholderArray(numpy, (2,), dtype=np.int64),
+            "node0-stops": PlaceholderArray(numpy, (2,), dtype=np.int64),
+            "node1-data": np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 2
+    assert layout.content.length is unknown_length
 
     # Unknown offsets and unknown data
     layout = ak.from_buffers(
@@ -254,25 +252,26 @@ def test_indexedoptionarray():
     assert layout.content.length == 3
 
     # Unknown index
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "IndexedOptionArray",
-                "index": "i64",
-                "content": {
-                    "class": "NumpyArray",
-                    "primitive": "int64",
-                    "form_key": "node1",
-                },
-                "form_key": "node0",
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedOptionArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
             },
-            3,
-            {
-                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
-                "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
-            },
-            highlevel=False,
-        )
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+            "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length is unknown_length
 
     # Unknown index and data
     layout = ak.from_buffers(
@@ -343,25 +342,26 @@ def test_indexedarray():
     assert layout.content.length == 3
 
     # Unknown index
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "IndexedArray",
-                "index": "i64",
-                "content": {
-                    "class": "NumpyArray",
-                    "primitive": "int64",
-                    "form_key": "node1",
-                },
-                "form_key": "node0",
+    layout = ak.from_buffers(
+        {
+            "class": "IndexedArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "node1",
             },
-            3,
-            {
-                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
-                "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
-            },
-            highlevel=False,
-        )
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+            "node1-data": np.array([0, 1, 2, 3, 4, 5], dtype=np.int64),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.content.length is unknown_length
 
     # Unknown data
     layout = ak.from_buffers(
@@ -443,70 +443,70 @@ def test_unionarray():
     assert layout.contents[1].length == 1
 
     # Unknown tags
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "UnionArray",
-                "tags": "i8",
-                "index": "i64",
-                "contents": [
-                    {
-                        "class": "NumpyArray",
-                        "primitive": "int64",
-                        "form_key": "node1",
-                    },
-                    {
-                        "class": "NumpyArray",
-                        "primitive": "datetime64[D]",
-                        "form_key": "node2",
-                    },
-                ],
-                "form_key": "node0",
-            },
-            3,
-            {
-                "node0-tags": PlaceholderArray(numpy, (3,), np.int8),
-                "node0-index": np.array([0, 1, 0], dtype=np.int64),
-                "node1-data": np.array([0, 1, 2], np.int64),
-                "node2-data": np.array(
-                    [0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")
-                ),
-            },
-            highlevel=False,
-        )
+    layout = ak.from_buffers(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                {
+                    "class": "NumpyArray",
+                    "primitive": "datetime64[D]",
+                    "form_key": "node2",
+                },
+            ],
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-tags": PlaceholderArray(numpy, (3,), np.int8),
+            "node0-index": np.array([0, 1, 0], dtype=np.int64),
+            "node1-data": np.array([0, 1, 2], np.int64),
+            "node2-data": np.array([0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.contents[0].length is unknown_length
+    assert layout.contents[1].length is unknown_length
 
     # Unknown index
-    with pytest.raises(AssertionError, match=r"Encountered unknown length"):
-        ak.from_buffers(
-            {
-                "class": "UnionArray",
-                "tags": "i8",
-                "index": "i64",
-                "contents": [
-                    {
-                        "class": "NumpyArray",
-                        "primitive": "int64",
-                        "form_key": "node1",
-                    },
-                    {
-                        "class": "NumpyArray",
-                        "primitive": "datetime64[D]",
-                        "form_key": "node2",
-                    },
-                ],
-                "form_key": "node0",
-            },
-            3,
-            {
-                "node0-tags": np.array([0, 0, 1], dtype=np.int8),
-                "node0-index": PlaceholderArray(numpy, (3,), np.int64),
-                "node1-data": np.array([0, 1, 2], np.int64),
-                "node2-data": np.array(
-                    [0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")
-                ),
-            },
-            highlevel=False,
-        )
+    layout = ak.from_buffers(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {
+                    "class": "NumpyArray",
+                    "primitive": "int64",
+                    "form_key": "node1",
+                },
+                {
+                    "class": "NumpyArray",
+                    "primitive": "datetime64[D]",
+                    "form_key": "node2",
+                },
+            ],
+            "form_key": "node0",
+        },
+        3,
+        {
+            "node0-tags": np.array([0, 0, 1], dtype=np.int8),
+            "node0-index": PlaceholderArray(numpy, (3,), np.int64),
+            "node1-data": np.array([0, 1, 2], np.int64),
+            "node2-data": np.array([0, 1, 2, 3, 4, 5, 6], np.dtype("datetime64[D]")),
+        },
+        highlevel=False,
+    )
+    assert layout.length == 3
+    assert layout.contents[0].length is unknown_length
+    assert layout.contents[1].length is unknown_length
 
     # Unknown content length
     layout = ak.from_buffers(


### PR DESCRIPTION
This PR follows up from #2718 by relaxing some rules:

- Placeholder arrays no longer need known lengths if `from_buffers` is able to deduce the length. 
   This requirement was originally made for safety reasons — if something went wrong during rehydration etc., we would see placeholders without known lengths in contexts where they should be known. However, by imposing this restriction, the caller would need to recreate much of `from_buffers` to compute lengths from offset buffers. Thus, we relax this rule, and permit `from_buffers` to update placeholders (via a new placeholder) with new _known_ lengths.
- Non-placeholder arrays can be encountered in contexts where the outer length is not known.
   Originally we wanted this to be an error so that we could clearly identify strange touching behaviour. However, in general it should be possible to refer to the same buffer multiple times within a form, so we should remove this rule.
   
