### PR TITLE
test: add dask-awkward to at least one of our tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,7 +282,7 @@ jobs:
         uses: codecov/codecov-action@v3
         if: matrix.python-version == '3.9'
 
-  Linux-ROOT:
+  Linux-ROOT-dask-awkward:
     strategy:
       matrix:
         python-version:
@@ -337,6 +337,9 @@ jobs:
 
       - name: Build & install awkward
         run: python3 -m pip install -v .
+
+      - name: Also install dask-awkward
+        run: python3 -m pip install dask-awkward
 
       - name: Print versions
         run: python -m pip list

--- a/tests/test_2682_custom_pickler.py
+++ b/tests/test_2682_custom_pickler.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import importlib.metadata
 import multiprocessing
 import os
 import pickle
@@ -8,6 +9,16 @@ from concurrent.futures import ProcessPoolExecutor
 import pytest
 
 import awkward as ak
+
+
+def has_entry_point():
+    return bool(importlib.metadata.entry_points(group="awkward.pickle.reduce").names)
+
+
+pytestmark = pytest.mark.skipif(
+    has_entry_point(),
+    reason="Custom pickler is already registered!",
+)
 
 
 def _init_process_with_pickler(pickler_source: str, tmp_path):

--- a/tests/test_2682_custom_pickler.py
+++ b/tests/test_2682_custom_pickler.py
@@ -1,10 +1,16 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
-import importlib.metadata
+
+
 import multiprocessing
 import os
 import pickle
 import sys
 from concurrent.futures import ProcessPoolExecutor
+
+if sys.version_info < (3, 12):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
 
 import pytest
 
@@ -12,7 +18,7 @@ import awkward as ak
 
 
 def has_entry_point():
-    return bool(importlib.metadata.entry_points(group="awkward.pickle.reduce").names)
+    return bool(importlib_metadata.entry_points(group="awkward.pickle.reduce").names)
 
 
 pytestmark = pytest.mark.skipif(


### PR DESCRIPTION
We had one special test, `Linux-ROOT`, for testing ROOT (which is based on conda). Rather than add another test runner, I extended `Linux-ROOT` to `Linux-ROOT-dask-awkward`, to test both third-party interactions.

I believe that the set of issues we could face with ROOT and the set of issues we could face with dask-awkward are disjoint—I don't think that ROOT or Dask is augmented in a relevant way by the presence of the other one. (Maybe ROOT will notice that Dask is present and adjust one of its backends, but I don't see how that could affect our tests of `ak.to_rdataframe` and `ak.from_rdataframe`.)