### PR TITLE
fix: don't use `np.asarray` on `Index` or `Content` objects

### DIFF
--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -141,8 +141,13 @@ def re_evaluate(local_dict=None):
             or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
+            input_primitives = [
+                x.data if isinstance(x, ak.contents.NumpyArray) else x for x in inputs
+            ]
             return (
-                ak.contents.NumpyArray(numexpr.re_evaluate(dict(zip(names, inputs)))),
+                ak.contents.NumpyArray(
+                    numexpr.re_evaluate(dict(zip(names, input_primitives)))
+                ),
             )
         else:
             return None

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -91,11 +91,14 @@ def evaluate(
             or not isinstance(x, ak.contents.Content)
             for x in inputs
         ):
+            input_primitives = [
+                x.data if isinstance(x, ak.contents.NumpyArray) else x for x in inputs
+            ]
             return (
                 ak.contents.NumpyArray(
                     numexpr.evaluate(
                         expression,
-                        dict(zip(names, inputs)),
+                        dict(zip(names, input_primitives)),
                         {},
                         order=order,
                         casting=casting,

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -220,8 +220,8 @@ def _array_ufunc_categorical(
         assert method == "__call__"
         one, two = inputs
 
-        one_index = numpy.asarray(one.index)
-        two_index = numpy.asarray(two.index)
+        one_index = numpy.asarray(one.index.data)
+        two_index = numpy.asarray(two.index.data)
         one_content = wrap_layout(one.content, behavior)
         two_content = wrap_layout(two.content, behavior)
 
@@ -280,12 +280,17 @@ def _array_ufunc_string_likes(
         right = ak.without_parameters(right, highlevel=False)
 
         # first condition: string lengths must be the same
-        counts1 = nplike.asarray(
-            ak._do.reduce(left, ak._reducers.Count(), axis=-1, mask=False)
+        left_counts_layout = ak._do.reduce(
+            left, ak._reducers.Count(), axis=-1, mask=False
         )
-        counts2 = nplike.asarray(
-            ak._do.reduce(right, ak._reducers.Count(), axis=-1, mask=False)
+        assert left_counts_layout.is_numpy
+        right_counts_layout = ak._do.reduce(
+            right, ak._reducers.Count(), axis=-1, mask=False
         )
+        assert right_counts_layout.is_numpy
+
+        counts1 = nplike.asarray(left_counts_layout.data)
+        counts2 = nplike.asarray(right_counts_layout.data)
 
         out = counts1 == counts2
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -151,9 +151,6 @@ class EmptyArray(Content):
             backend=backend,
         )
 
-    def __array__(self, **kwargs):
-        return numpy.empty(0, dtype=np.float64)
-
     def __iter__(self):
         return iter([])
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1518,7 +1518,7 @@ class IndexedOptionArray(Content):
             )
 
     def _to_arrow(self, pyarrow, mask_node, validbytes, length, options):
-        index = numpy.asarray(self._index, copy=True)
+        index = numpy.asarray(self._index.data, copy=True)
         this_validbytes = self.mask_as_bool(valid_when=True)
         index[~this_validbytes] = 0
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -273,9 +273,6 @@ class NumpyArray(Content):
     def maybe_to_NumpyArray(self) -> Self:
         return self
 
-    def __array__(self, dtype=None):
-        return self._backend.nplike.asarray(self._data, dtype=dtype)
-
     def __iter__(self):
         return iter(self._data)
 

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -264,8 +264,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
 
                 for x in nextinputs:
                     o, f = x._offsets_and_flattened(1, 1)
-                    o = backend.index_nplike.asarray(o)
-                    c = o[1:] - o[:-1]
+                    c = o.data[1:] - o.data[:-1]
                     backend.index_nplike.add(counts, c, maybe_out=counts)
                     all_counts.append(c)
                     all_flatten.append(f)

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -430,8 +430,8 @@ def _record_to_complex(layout, complex_record_fields):
                     ):
                         with numpy._module.errstate(invalid="ignore"):
                             return ak.contents.NumpyArray(
-                                node.backend.nplike.asarray(real)
-                                + node.backend.nplike.asarray(imag) * 1j
+                                node.backend.nplike.asarray(real.data)
+                                + node.backend.nplike.asarray(imag.data) * 1j
                             )
                     else:
                         raise ValueError(

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -100,8 +100,8 @@ def mask(array, mask, *, valid_when=True, highlevel=True, behavior=None):
 def _impl(array, mask, valid_when, highlevel, behavior):
     def action(inputs, backend, **kwargs):
         layoutarray, layoutmask = inputs
-        if isinstance(layoutmask, ak.contents.NumpyArray):
-            m = backend.nplike.asarray(layoutmask)
+        if layoutmask.is_numpy:
+            m = backend.nplike.asarray(layoutmask.data)
             if not issubclass(m.dtype.type, (bool, np.bool_)):
                 raise ValueError(f"mask must have boolean type, not {m.dtype!r}")
             bytemask = ak.index.Index8(m.view(np.int8))

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -156,10 +156,12 @@ def _impl(array, highlevel, behavior):
                 nextcontent, _ = lengths_of(ak.highlevel.Array(layout), None)
                 return ak.contents.NumpyArray(nextcontent)
 
-            if not isinstance(layout, (ak.contents.NumpyArray, ak.contents.EmptyArray)):
+            if layout.is_unknown:
+                layout = layout.to_NumpyArray(np.float64)
+            elif not layout.is_numpy:
                 raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
-            nextcontent, _ = lengths_of(backend.nplike.asarray(layout), None)
+            nextcontent, _ = lengths_of(backend.nplike.asarray(layout.data), None)
             return ak.contents.NumpyArray(nextcontent)
 
         elif layout.branch_depth == (False, 2):
@@ -197,9 +199,9 @@ def _impl(array, highlevel, behavior):
             if content.is_indexed:
                 content = content.project()
 
-            if not isinstance(
-                content, (ak.contents.NumpyArray, ak.contents.EmptyArray)
-            ):
+            if content.is_unknown:
+                content = content.to_NumpyArray(np.float64)
+            elif not content.is_numpy:
                 raise NotImplementedError(
                     "run_lengths on "
                     + type(layout).__name__
@@ -208,7 +210,7 @@ def _impl(array, highlevel, behavior):
                 )
 
             nextcontent, nextoffsets = lengths_of(
-                backend.nplike.asarray(content), offsets - offsets[0]
+                backend.nplike.asarray(content.data), offsets - offsets[0]
             )
             return ak.contents.ListOffsetArray(
                 ak.index.Index64(nextoffsets),

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -105,7 +105,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
     def action(inputs, **kwargs):
         condition, x, y = inputs
         if isinstance(condition, ak.contents.NumpyArray):
-            npcondition = backend.index_nplike.asarray(condition)
+            npcondition = backend.index_nplike.asarray(condition.data)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(
                 backend.index_nplike.arange(tags.length, dtype=np.int64),

--- a/tests/test_0002_minimal_listarray.py
+++ b/tests/test_0002_minimal_listarray.py
@@ -56,17 +56,17 @@ def test():
         11,
     ]
 
-    assert np.asarray(array[0].data).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert ak.to_numpy(array[0]).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7]]
     assert array.to_typetracer()[0].form == array[0].form
-    assert np.asarray(array[1].data).tolist() == []
+    assert ak.to_numpy(array[1]).tolist() == []
     assert array.to_typetracer()[1].form == array[1].form
-    assert np.asarray(array[2].data).tolist() == [[8, 9, 10, 11]]
+    assert ak.to_numpy(array[2]).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[2].form == array[2].form
-    assert np.asarray(array[1:3][0].data).tolist() == []
+    assert ak.to_numpy(array[1:3][0]).tolist() == []
     assert array.to_typetracer()[1:3][0].form == array[1:3][0].form
-    assert np.asarray(array[1:3][1].data).tolist() == [[8, 9, 10, 11]]
+    assert ak.to_numpy(array[1:3][1]).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[1:3][1].form == array[1:3][1].form
-    assert np.asarray(array[2:3][0].data).tolist() == [[8, 9, 10, 11]]
+    assert ak.to_numpy(array[2:3][0]).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[2:3][0].form == array[2:3][0].form
 
 
@@ -86,7 +86,7 @@ def test_members():
     new = ak.contents.ListOffsetArray(offsets, array)
 
     assert np.asarray(array.offsets.data).tolist() == [0, 2, 2, 3]
-    assert np.asarray(array.content.data).tolist() == [
+    assert ak.to_numpy(array.content).tolist() == [
         [0, 1, 2, 3],
         [4, 5, 6, 7],
         [8, 9, 10, 11],
@@ -94,7 +94,7 @@ def test_members():
 
     assert np.asarray(new.offsets.data).tolist() == [0, 2, 2, 3]
     assert np.asarray(new.content.offsets.data).tolist() == [0, 2, 2, 3]
-    assert np.asarray(new.content.content.data).tolist() == [
+    assert ak.to_numpy(new.content.content).tolist() == [
         [0, 1, 2, 3],
         [4, 5, 6, 7],
         [8, 9, 10, 11],

--- a/tests/test_0002_minimal_listarray.py
+++ b/tests/test_0002_minimal_listarray.py
@@ -10,7 +10,7 @@ def test():
     data = np.array([0, 2, 2, 3], dtype="i8")
     offsets = ak.index.Index64(data)
 
-    assert np.asarray(offsets).tolist() == [0, 2, 2, 3]
+    assert np.asarray(offsets.data).tolist() == [0, 2, 2, 3]
     assert offsets[0] == 0
     assert offsets[1] == 2
     assert offsets[2] == 2
@@ -21,7 +21,7 @@ def test():
     data = np.array([0, 2, 2, 3], dtype="i4")
     offsets = ak.index.Index32(data)
 
-    assert np.asarray(offsets).tolist() == [0, 2, 2, 3]
+    assert np.asarray(offsets.data).tolist() == [0, 2, 2, 3]
     assert offsets[0] == 0
     assert offsets[1] == 2
     assert offsets[2] == 2
@@ -34,12 +34,12 @@ def test():
     offsets = ak.index.Index32(data)
     array = ak.contents.ListOffsetArray(offsets, content)
 
-    assert np.asarray(content).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
-    assert np.asarray(content[0]).tolist() == [0, 1, 2, 3]
+    assert ak.to_numpy(content).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+    assert ak.to_numpy(content[0]).tolist() == [0, 1, 2, 3]
     assert content.to_typetracer()[0].form == content[0].form
-    assert np.asarray(content[1]).tolist() == [4, 5, 6, 7]
+    assert ak.to_numpy(content[1]).tolist() == [4, 5, 6, 7]
     assert content.to_typetracer()[1].form == content[1].form
-    assert np.asarray(content[2]).tolist() == [8, 9, 10, 11]
+    assert ak.to_numpy(content[2]).tolist() == [8, 9, 10, 11]
     assert content.to_typetracer()[2].form == content[2].form
     assert [content[i][j] for i in range(3) for j in range(4)] == [
         0,
@@ -56,17 +56,17 @@ def test():
         11,
     ]
 
-    assert np.asarray(array[0]).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert np.asarray(array[0].data).tolist() == [[0, 1, 2, 3], [4, 5, 6, 7]]
     assert array.to_typetracer()[0].form == array[0].form
-    assert np.asarray(array[1]).tolist() == []
+    assert np.asarray(array[1].data).tolist() == []
     assert array.to_typetracer()[1].form == array[1].form
-    assert np.asarray(array[2]).tolist() == [[8, 9, 10, 11]]
+    assert np.asarray(array[2].data).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[2].form == array[2].form
-    assert np.asarray(array[1:3][0]).tolist() == []
+    assert np.asarray(array[1:3][0].data).tolist() == []
     assert array.to_typetracer()[1:3][0].form == array[1:3][0].form
-    assert np.asarray(array[1:3][1]).tolist() == [[8, 9, 10, 11]]
+    assert np.asarray(array[1:3][1].data).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[1:3][1].form == array[1:3][1].form
-    assert np.asarray(array[2:3][0]).tolist() == [[8, 9, 10, 11]]
+    assert np.asarray(array[2:3][0].data).tolist() == [[8, 9, 10, 11]]
     assert array.to_typetracer()[2:3][0].form == array[2:3][0].form
 
 
@@ -85,16 +85,16 @@ def test_members():
     array = ak.contents.ListOffsetArray(offsets, content)
     new = ak.contents.ListOffsetArray(offsets, array)
 
-    assert np.asarray(array.offsets).tolist() == [0, 2, 2, 3]
-    assert np.asarray(array.content).tolist() == [
+    assert np.asarray(array.offsets.data).tolist() == [0, 2, 2, 3]
+    assert np.asarray(array.content.data).tolist() == [
         [0, 1, 2, 3],
         [4, 5, 6, 7],
         [8, 9, 10, 11],
     ]
 
-    assert np.asarray(new.offsets).tolist() == [0, 2, 2, 3]
-    assert np.asarray(new.content.offsets).tolist() == [0, 2, 2, 3]
-    assert np.asarray(new.content.content).tolist() == [
+    assert np.asarray(new.offsets.data).tolist() == [0, 2, 2, 3]
+    assert np.asarray(new.content.offsets.data).tolist() == [0, 2, 2, 3]
+    assert np.asarray(new.content.content.data).tolist() == [
         [0, 1, 2, 3],
         [4, 5, 6, 7],
         [8, 9, 10, 11],

--- a/tests/test_0006_deep_iteration.py
+++ b/tests/test_0006_deep_iteration.py
@@ -12,4 +12,4 @@ def test_iterator():
     array = ak.contents.ListOffsetArray(offsets, content)
 
     assert list(content) == [1.1, 2.2, 3.3]
-    assert [np.asarray(x).tolist() for x in array] == [[1.1, 2.2], [], [3.3]]
+    assert [ak.to_numpy(x).tolist() for x in array] == [[1.1, 2.2], [], [3.3]]

--- a/tests/test_0074_argsort_and_sort.py
+++ b/tests/test_0074_argsort_and_sort.py
@@ -117,18 +117,18 @@ def test_NumpyArray():
 
     assert to_list(
         ak.operations.sort(array2, axis=1, ascending=True, stable=False)
-    ) == to_list(np.sort(np.asarray(array2), axis=1))
+    ) == to_list(np.sort(ak.to_numpy(array2), axis=1))
     assert to_list(
         ak.operations.sort(array2, axis=0, ascending=True, stable=False)
-    ) == to_list(np.sort(np.asarray(array2), axis=0))
+    ) == to_list(np.sort(ak.to_numpy(array2), axis=0))
 
     assert to_list(
         ak.operations.argsort(array2, axis=1, ascending=True, stable=False)
-    ) == to_list(np.argsort(np.asarray(array2), 1))
+    ) == to_list(np.argsort(ak.to_numpy(array2), 1))
 
     assert to_list(
         ak.operations.argsort(array2, axis=0, ascending=True, stable=False)
-    ) == to_list(np.argsort(np.asarray(array2), 0))
+    ) == to_list(np.argsort(ak.to_numpy(array2), 0))
 
     with pytest.raises(ValueError) as err:
         ak.operations.argsort(array2, axis=2, ascending=True, stable=False)
@@ -344,20 +344,20 @@ def test_3d():
     )  # 5
 
     sorted = ak.operations.argsort(array, axis=1, ascending=True, stable=False)
-    assert to_list(sorted) == to_list(np.argsort(np.asarray(array), 1))
+    assert to_list(sorted) == to_list(np.argsort(np.asarray(array.data), 1))
 
     sorted = ak.operations.argsort(array, axis=2, ascending=True, stable=False)
-    assert to_list(sorted) == to_list(np.argsort(np.asarray(array), 2))
+    assert to_list(sorted) == to_list(np.argsort(np.asarray(array.data), 2))
 
     sorted = ak.operations.sort(array, axis=2, ascending=True, stable=False)
-    assert to_list(sorted) == to_list(np.sort(np.asarray(array), 2))
+    assert to_list(sorted) == to_list(np.sort(np.asarray(array.data), 2))
 
     sorted = ak.operations.argsort(array, axis=1, ascending=True, stable=False)
 
-    assert to_list(sorted) == to_list(np.argsort(np.asarray(array), 1))
+    assert to_list(sorted) == to_list(np.argsort(np.asarray(array.data), 1))
 
     sorted = ak.operations.sort(array, axis=1, ascending=True, stable=False)
-    assert to_list(sorted) == to_list(np.sort(np.asarray(array), 1))
+    assert to_list(sorted) == to_list(np.sort(np.asarray(array.data), 1))
 
     sorted = ak.operations.sort(array, axis=1, ascending=False, stable=False)
     assert to_list(sorted) == [
@@ -374,11 +374,11 @@ def test_3d():
     ]
 
     sorted = ak.operations.sort(array, axis=0, ascending=True, stable=False)
-    assert to_list(sorted) == to_list(np.sort(np.asarray(array), 0))
+    assert to_list(sorted) == to_list(np.sort(np.asarray(array.data), 0))
 
     assert to_list(
         ak.operations.argsort(array, axis=0, ascending=True, stable=False)
-    ) == to_list(np.argsort(np.asarray(array), 0))
+    ) == to_list(np.argsort(np.asarray(array.data), 0))
 
 
 def test_ByteMaskedArray():

--- a/tests/test_0093_simplify_uniontypes_and_optiontypes.py
+++ b/tests/test_0093_simplify_uniontypes_and_optiontypes.py
@@ -60,11 +60,11 @@ def test_numpyarray_merge():
             one = ak.contents.NumpyArray(np.array([1, 2, 3], dtype=x))
             two = ak.contents.NumpyArray(np.array([4, 5], dtype=y))
             three = one._mergemany([two])
-            assert np.asarray(three).dtype == np.dtype(z), "{} {} {} {}".format(
-                x, y, z, np.asarray(three).dtype.type
+            assert ak.to_numpy(three).dtype == np.dtype(z), "{} {} {} {}".format(
+                x, y, z, ak.to_numpy(three).dtype.type
             )
             assert to_list(three) == to_list(
-                np.concatenate([np.asarray(one), np.asarray(two)])
+                np.concatenate([ak.to_numpy(one), ak.to_numpy(two)])
             )
             assert to_list(one._mergemany([emptyarray])) == to_list(one)
             assert to_list(emptyarray._mergemany([one])) == to_list(one)
@@ -927,7 +927,7 @@ def test_indexedarray_simplify():
     index2 = ak.index.Index64(np.array([2, 2, 1, 6, 5], dtype=np.int64))
 
     array2 = ak.contents.IndexedArray.simplified(index2, array)
-    assert np.asarray(array.index).tolist() == [0, 1, -1, 2, -1, -1, 3, 4]
+    assert np.asarray(array.index.data).tolist() == [0, 1, -1, 2, -1, -1, 3, 4]
     assert to_list(array2) == to_list(array2) == [None, None, "two", "four", None]
 
     assert array2.to_typetracer().form == array2.form

--- a/tests/test_0115_generic_reducer_operation.py
+++ b/tests/test_0115_generic_reducer_operation.py
@@ -1411,11 +1411,11 @@ def test_sumprod_types_FIXME():
     depth1 = ak.contents.ListOffsetArray(offsets3, content2)
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
 
 
@@ -1445,11 +1445,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1465,11 +1465,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1485,11 +1485,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1505,11 +1505,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1525,11 +1525,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1545,11 +1545,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1565,11 +1565,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))
@@ -1585,11 +1585,11 @@ def test_sumprod_types():
 
     assert (
         np.sum(array, axis=-1).dtype
-        == np.asarray(ak.sum(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.sum(depth1, axis=-1, highlevel=False)).dtype
     )
     assert (
         np.prod(array, axis=-1).dtype
-        == np.asarray(ak.prod(depth1, axis=-1, highlevel=False)).dtype
+        == ak.to_numpy(ak.prod(depth1, axis=-1, highlevel=False)).dtype
     )
     assert sum(to_list(np.sum(array, axis=-1))) == sum(
         to_list(ak.sum(depth1, axis=-1, highlevel=False))

--- a/tests/test_0184_concatenate_operation.py
+++ b/tests/test_0184_concatenate_operation.py
@@ -275,9 +275,9 @@ def test_numpyarray_concatenate_axis0():
         np.concatenate([np1, np2, np1, np2], 0)
     )
     assert to_list(ak.operations.concatenate([ak1, ak2], 0)) == to_list(
-        np.concatenate([np.asarray(ak1), np.asarray(ak2)], 0)
+        np.concatenate([ak.to_numpy(ak1), ak.to_numpy(ak2)], 0)
     )
-    assert to_list(np.concatenate([np.asarray(ak1), np.asarray(ak2)], 0)) == to_list(
+    assert to_list(np.concatenate([ak.to_numpy(ak1), ak.to_numpy(ak2)], 0)) == to_list(
         ak.operations.concatenate([np1, np2], 0)
     )
 

--- a/tests/test_1072_sort.py
+++ b/tests/test_1072_sort.py
@@ -244,7 +244,7 @@ def test_numpyarray_sort():
     v2_array = ak.operations.from_numpy(
         np.array([3.3, 2.2, 1.1, 5.5, 4.4]), regulararray=True, highlevel=False
     )
-    assert to_list(np.sort(np.asarray(v2_array))) == [
+    assert to_list(np.sort(ak.to_numpy(v2_array))) == [
         1.1,
         2.2,
         3.3,
@@ -265,7 +265,7 @@ def test_numpyarray_sort():
 
 
 def test_3d():
-    array = ak.Array(
+    array = ak.to_layout(
         np.array(
             [
                 # axis 2:    0       1       2       3       4         # axis 1:
@@ -285,18 +285,18 @@ def test_3d():
 
     assert to_list(
         ak.operations.argsort(array, axis=2, ascending=True, stable=False)
-    ) == to_list(np.argsort(array, 2))
+    ) == to_list(np.argsort(ak.to_numpy(array), 2))
     assert to_list(
         ak.operations.sort(array, axis=2, ascending=True, stable=False)
-    ) == to_list(np.sort(np.asarray(array), 2))
+    ) == to_list(np.sort(ak.to_numpy(array), 2))
     assert to_list(
         ak.operations.argsort(array, axis=1, ascending=True, stable=False)
-    ) == to_list(np.argsort(np.asarray(array), 1))
+    ) == to_list(np.argsort(ak.to_numpy(array), 1))
     assert to_list(
         ak.operations.sort(array, axis=1, ascending=True, stable=False)
-    ) == to_list(np.sort(np.asarray(array), 1))
+    ) == to_list(np.sort(ak.to_numpy(array), 1))
     assert to_list(
-        ak.operations.sort(np.asarray(array), axis=1, ascending=False, stable=False)
+        ak.operations.sort(ak.to_numpy(array), axis=1, ascending=False, stable=False)
     ) == [
         [
             [11.11, 12.12, 13.13, 14.14, 15.15],
@@ -311,10 +311,10 @@ def test_3d():
     ]
     assert to_list(
         ak.operations.sort(array, axis=0, ascending=True, stable=False)
-    ) == to_list(np.sort(np.asarray(array), 0))
+    ) == to_list(np.sort(ak.to_numpy(array), 0))
     assert to_list(
         ak.operations.argsort(array, axis=0, ascending=True, stable=False)
-    ) == to_list(np.argsort(np.asarray(array), 0))
+    ) == to_list(np.argsort(ak.to_numpy(array), 0))
 
 
 def test_bool_sort():

--- a/tests/test_1142_numbers_to_type.py
+++ b/tests/test_1142_numbers_to_type.py
@@ -12,250 +12,250 @@ def test_numbers_to_type():
         ak.highlevel.Array([4, 5]).layout,
     )
 
-    assert np.asarray(ak._do.numbers_to_type(one, "bool", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "bool", False)).dtype == np.dtype(
         np.bool_
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "int8", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "int8", False)).dtype == np.dtype(
         np.int8
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint8", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint8", False)).dtype == np.dtype(
         np.uint8
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "int16", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "int16", False)).dtype == np.dtype(
         np.int16
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint16", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint16", False)).dtype == np.dtype(
         np.uint16
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "int32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "int32", False)).dtype == np.dtype(
         np.int32
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint32", False)).dtype == np.dtype(
         np.uint32
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "int64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "int64", False)).dtype == np.dtype(
         np.int64
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "uint64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint64", False)).dtype == np.dtype(
         np.uint64
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "float32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "float32", False)).dtype == np.dtype(
         np.float32
     )
-    assert np.asarray(ak._do.numbers_to_type(one, "float64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(one, "float64", False)).dtype == np.dtype(
         np.float64
     )
     assert np.asarray(
-        ak._do.numbers_to_type(one, "complex64", False)
+        ak._do.numbers_to_type(one, "complex64", False).data
     ).dtype == np.dtype(np.complex64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "complex128", False)
+        ak._do.numbers_to_type(one, "complex128", False).data
     ).dtype == np.dtype(np.complex128)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64", False)
+        ak._do.numbers_to_type(one, "datetime64", False).data
     ).dtype == np.dtype(np.datetime64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[Y]", False)
+        ak._do.numbers_to_type(one, "datetime64[Y]", False).data
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[M]", False)
+        ak._do.numbers_to_type(one, "datetime64[M]", False).data
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[W]", False)
+        ak._do.numbers_to_type(one, "datetime64[W]", False).data
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[D]", False)
+        ak._do.numbers_to_type(one, "datetime64[D]", False).data
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[h]", False)
+        ak._do.numbers_to_type(one, "datetime64[h]", False).data
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[m]", False)
+        ak._do.numbers_to_type(one, "datetime64[m]", False).data
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[s]", False)
+        ak._do.numbers_to_type(one, "datetime64[s]", False).data
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ms]", False)
+        ak._do.numbers_to_type(one, "datetime64[ms]", False).data
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[us]", False)
+        ak._do.numbers_to_type(one, "datetime64[us]", False).data
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ns]", False)
+        ak._do.numbers_to_type(one, "datetime64[ns]", False).data
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ps]", False)
+        ak._do.numbers_to_type(one, "datetime64[ps]", False).data
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[fs]", False)
+        ak._do.numbers_to_type(one, "datetime64[fs]", False).data
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[as]", False)
+        ak._do.numbers_to_type(one, "datetime64[as]", False).data
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64", False)
+        ak._do.numbers_to_type(one, "timedelta64", False).data
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[Y]", False)
+        ak._do.numbers_to_type(one, "timedelta64[Y]", False).data
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[M]", False)
+        ak._do.numbers_to_type(one, "timedelta64[M]", False).data
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[W]", False)
+        ak._do.numbers_to_type(one, "timedelta64[W]", False).data
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[D]", False)
+        ak._do.numbers_to_type(one, "timedelta64[D]", False).data
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[h]", False)
+        ak._do.numbers_to_type(one, "timedelta64[h]", False).data
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[m]", False)
+        ak._do.numbers_to_type(one, "timedelta64[m]", False).data
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[s]", False)
+        ak._do.numbers_to_type(one, "timedelta64[s]", False).data
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ms]", False)
+        ak._do.numbers_to_type(one, "timedelta64[ms]", False).data
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[us]", False)
+        ak._do.numbers_to_type(one, "timedelta64[us]", False).data
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ns]", False)
+        ak._do.numbers_to_type(one, "timedelta64[ns]", False).data
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ps]", False)
+        ak._do.numbers_to_type(one, "timedelta64[ps]", False).data
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[fs]", False)
+        ak._do.numbers_to_type(one, "timedelta64[fs]", False).data
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[as]", False)
+        ak._do.numbers_to_type(one, "timedelta64[as]", False).data
     ).dtype == np.dtype("timedelta64[as]")
 
-    assert np.asarray(ak._do.numbers_to_type(two, "bool", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "bool", False)).dtype == np.dtype(
         np.bool_
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "int8", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "int8", False)).dtype == np.dtype(
         np.int8
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint8", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint8", False)).dtype == np.dtype(
         np.uint8
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "int16", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "int16", False)).dtype == np.dtype(
         np.int16
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint16", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint16", False)).dtype == np.dtype(
         np.uint16
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "int32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "int32", False)).dtype == np.dtype(
         np.int32
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint32", False)).dtype == np.dtype(
         np.uint32
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "int64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "int64", False)).dtype == np.dtype(
         np.int64
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "uint64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint64", False)).dtype == np.dtype(
         np.uint64
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "float32", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "float32", False)).dtype == np.dtype(
         np.float32
     )
-    assert np.asarray(ak._do.numbers_to_type(two, "float64", False)).dtype == np.dtype(
+    assert ak.to_numpy(ak._do.numbers_to_type(two, "float64", False)).dtype == np.dtype(
         np.float64
     )
     assert np.asarray(
-        ak._do.numbers_to_type(two, "complex64", False)
+        ak._do.numbers_to_type(two, "complex64", False).data
     ).dtype == np.dtype(np.complex64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "complex128", False)
+        ak._do.numbers_to_type(two, "complex128", False).data
     ).dtype == np.dtype(np.complex128)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64", False)
+        ak._do.numbers_to_type(two, "datetime64", False).data
     ).dtype == np.dtype(np.datetime64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[Y]", False)
+        ak._do.numbers_to_type(two, "datetime64[Y]", False).data
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[M]", False)
+        ak._do.numbers_to_type(two, "datetime64[M]", False).data
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[W]", False)
+        ak._do.numbers_to_type(two, "datetime64[W]", False).data
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[D]", False)
+        ak._do.numbers_to_type(two, "datetime64[D]", False).data
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[h]", False)
+        ak._do.numbers_to_type(two, "datetime64[h]", False).data
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[m]", False)
+        ak._do.numbers_to_type(two, "datetime64[m]", False).data
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[s]", False)
+        ak._do.numbers_to_type(two, "datetime64[s]", False).data
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ms]", False)
+        ak._do.numbers_to_type(two, "datetime64[ms]", False).data
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[us]", False)
+        ak._do.numbers_to_type(two, "datetime64[us]", False).data
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ns]", False)
+        ak._do.numbers_to_type(two, "datetime64[ns]", False).data
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ps]", False)
+        ak._do.numbers_to_type(two, "datetime64[ps]", False).data
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[fs]", False)
+        ak._do.numbers_to_type(two, "datetime64[fs]", False).data
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[as]", False)
+        ak._do.numbers_to_type(two, "datetime64[as]", False).data
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64", False)
+        ak._do.numbers_to_type(two, "timedelta64", False).data
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[Y]", False)
+        ak._do.numbers_to_type(two, "timedelta64[Y]", False).data
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[M]", False)
+        ak._do.numbers_to_type(two, "timedelta64[M]", False).data
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[W]", False)
+        ak._do.numbers_to_type(two, "timedelta64[W]", False).data
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[D]", False)
+        ak._do.numbers_to_type(two, "timedelta64[D]", False).data
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[h]", False)
+        ak._do.numbers_to_type(two, "timedelta64[h]", False).data
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[m]", False)
+        ak._do.numbers_to_type(two, "timedelta64[m]", False).data
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[s]", False)
+        ak._do.numbers_to_type(two, "timedelta64[s]", False).data
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ms]", False)
+        ak._do.numbers_to_type(two, "timedelta64[ms]", False).data
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[us]", False)
+        ak._do.numbers_to_type(two, "timedelta64[us]", False).data
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ns]", False)
+        ak._do.numbers_to_type(two, "timedelta64[ns]", False).data
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ps]", False)
+        ak._do.numbers_to_type(two, "timedelta64[ps]", False).data
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[fs]", False)
+        ak._do.numbers_to_type(two, "timedelta64[fs]", False).data
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[as]", False)
+        ak._do.numbers_to_type(two, "timedelta64[as]", False).data
     ).dtype == np.dtype("timedelta64[as]")


### PR DESCRIPTION
`nplike.asarray` ultimately delegates to the underlying NumPy-like library's `asarray`. For NumPy, this invokes `obj.__array__()`. If our object is e.g. an `Index` that wraps a placeholder, this conversion fails because NumPy et al. are not aware of our placeholder type, and eagerly tries to convert it to a buffer.

This would also fail during typetracing time, but it may well be that there are branches where this gets skipped.

We could add our own protocol to the `Content` and `Index` types that permits `Content` and `Index` objects to pass through `asarray`, e.g.
```python
class Numpy:
    ...
    def asarray(self, obj, *, ...):
        if hasattr(obj, "_awkward_asarray_"):
            return obj._awkward_asarray_(self, ...)
        else:
            return numpy.asarray(obj, ...)

class Index:
    ...
    def _awkward_asarray_(self, nplike, ...):
        return nplike.asarray(self.data, ...)
```

but on balance I think it might be easier just to pull out `.data` by hand, because most of the time we should know that we have a `Content` / `Index` object.

At the same time, we've long prohibited `np.asarray` on e.g. `RegularArray`, and I think we should just do this for all Content nodes to be more thorough. Thus, this PR removes `NumpyArray.__array__`, and the same for `EmptyArray` et al.

I didn't change `Index`, because I suspect that's used _everywhere_ in the wild (in legitimate NumPy-only cases), and the argument for `ak.Array` being the high-level `np.asarray` interface does not apply. Thus, library authors must take care not to use `asarray` even in NumPy-only contexts iff. there's a chance that the incoming array is a placeholder.

So, this PR changes two things:
1. Don't pass in `Content` or `Index` arguments to `nplike.asarray`, as they nest the true buffers within themselves.
2. Don't support `Content.__array__` for any content type, for the reason discussed above.
