### PR TITLE
fix: swap names for `__dlpack__`

### DIFF
--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -145,10 +145,10 @@ class Index:
     def __array_interface__(self):
         return self._data.__array_interface__
 
-    def __dlpack__(self) -> tuple[int, int]:
+    def __dlpack_device__(self) -> tuple[int, int]:
         return self._data.__dlpack_device__()
 
-    def __dlpack_device__(self, stream: Any = None) -> Any:
+    def __dlpack__(self, stream: Any = None) -> Any:
         if stream is None:
             return self._data.__dlpack__()
         else:


### PR DESCRIPTION
Somehow, when authoring #2649, I swapped the names for the query descriptor and the dlpack method itself.