### PR TITLE
ci: improve deployment environment UX

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -169,7 +169,8 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: "deploy-cpp-pypi"
+      name: "pypi"
+      url: "https://pypi.org/project/awkward-cpp/"
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,8 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: "deploy-pypi"
+      name: "pypi"
+      url: "https://pypi.org/project/awkward/"
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -310,7 +310,7 @@ jobs:
       S3_BUCKET: "preview.awkward-array.org"
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
     environment:
-      name: docs-preview
+      name: docs
       url: "${{ env.DEPLOY_URL }}/${{ github.head_ref }}"
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -193,7 +193,6 @@ jobs:
         name: awkward
         path: dist/awkward*.whl
 
-
   build-docs:
     runs-on: ubuntu-22.04
     needs: [awkward-cpp-wasm, awkward-cpp-x86-64, awkward]
@@ -312,7 +311,7 @@ jobs:
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
     environment:
       name: docs-preview
-      url: ${{ env.DEPLOY_URL }}/${{ github.head_ref }}
+      url: "${{ env.DEPLOY_URL }}/${{ github.head_ref }}"
     steps:
     - uses: actions/checkout@v4
     - name: Configure AWS credentials
@@ -343,7 +342,7 @@ jobs:
       PRODUCTION_URL: "http://awkward-array.org"
       CLOUDFRONT_ID: "EFM4QVENUIXHS"
     environment:
-      name: docs-prod
+      name: docs
       url: ${{ env.PRODUCTION_URL }}${{ steps.sync-main.outputs.path || steps.sync-stable.outputs.path }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
           - '3.9'
           - '3.8'
 
-    runs-on: macOS-11
+    runs-on: macos-11
 
     env:
       PIP_ONLY_BINARY: cmake,numpy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,3 +77,9 @@ repos:
   rev: v3.13.0
   hooks:
   - id: pyupgrade
+
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.27.0
+  hooks:
+    - id: check-github-workflows
+      args: ["--verbose"]


### PR DESCRIPTION
After becoming more familiar with environments, prompted by a comment made by @henryiii, I've decided to share our deployment environments across targets, and rename them accordingly. This should slightly improve UX.

I've also added URLs to the PyPI deployments, and a linter for the YML files in GH.