### PR TITLE
fix: update cppyy module

### DIFF
--- a/src/awkward/cppyy.py
+++ b/src/awkward/cppyy.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
-import awkward as ak
+import packaging.version
 
 _has_checked_version = False
 
@@ -25,7 +25,9 @@ Note that this must be in a different venv or conda environment from ROOT, if yo
         ) from err
 
     if not _has_checked_version:
-        if ak._util.parse_version(cppyy.__version__) < ak._util.parse_version("3.0.1"):
+        if packaging.version.Version(cppyy.__version__) < packaging.version.Version(
+            "3.0.1"
+        ):
             raise ImportError(
                 "Awkward Array can only work with cppyy 3.0.1 or later "
                 f"(you have version {cppyy.__version__})"

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1548,9 +1548,11 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         See [cppyy documentation](https://cppyy.readthedocs.io/en/latest/index.html)
         on types and signatures.
         """
-        ak.cppyy.register_and_check()
+        ak.cppyy.register_and_check()  # noqa: F823
 
         import cppyy
+
+        import awkward._connect.cling  # noqa: F401
 
         if self._cpp_type is None:
             self._generator = ak._connect.cling.togenerator(


### PR DESCRIPTION
cppyy module relied on ak._utils to check the version.
Also we need to import cling. I'm not sure this is the best place, but it works:
```python 
import awkward._connect.cling  # noqa: F401
```