### PR TITLE
fix: don't call asarray on `Index` objects internally

### DIFF
--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -262,7 +262,7 @@ class IndexedArray(Content):
             self._index, self._content, parameters=self._parameters
         )
 
-    def mask_as_bool(self, valid_when=True):
+    def mask_as_bool(self, valid_when: bool = True) -> ArrayLike:
         if valid_when:
             return self._index.data >= 0
         else:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -284,7 +284,7 @@ class IndexedOptionArray(Content):
             valid_when, lsb_order
         )
 
-    def mask_as_bool(self, valid_when=True):
+    def mask_as_bool(self, valid_when: bool = True) -> ArrayLike:
         if valid_when:
             return self._index.raw(self._backend.index_nplike) >= 0
         else:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -210,7 +210,7 @@ class UnmaskedArray(Content):
             parameters=self._parameters,
         )
 
-    def mask_as_bool(self, valid_when=True):
+    def mask_as_bool(self, valid_when: bool = True) -> ArrayLike:
         if valid_when:
             return self._backend.index_nplike.ones(self._content.length, dtype=np.bool_)
         else:

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -198,9 +198,9 @@ def _impl(array, axis, highlevel, behavior):
                 ):
                     return layout
 
-                tags = backend.index_nplike.asarray(layout.tags)
+                tags = backend.index_nplike.asarray(layout.tags.data)
                 index = backend.index_nplike.asarray(
-                    backend.nplike.asarray(layout.index), copy=True
+                    backend.nplike.asarray(layout.index.data), copy=True
                 )
                 bigmask = backend.index_nplike.empty(len(index), dtype=np.bool_)
                 for tag, content in enumerate(layout.contents):

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -161,7 +161,7 @@ def _impl(array, highlevel, behavior):
             elif not layout.is_numpy:
                 raise NotImplementedError("run_lengths on " + type(layout).__name__)
 
-            nextcontent, _ = lengths_of(backend.nplike.asarray(layout.data), None)
+            nextcontent, _ = lengths_of(layout.data, None)
             return ak.contents.NumpyArray(nextcontent)
 
         elif layout.branch_depth == (False, 2):
@@ -178,23 +178,25 @@ def _impl(array, highlevel, behavior):
                 # We also want to trim the _upper_ bound of content,
                 # so we manually convert the list type to zero-based
                 listoffsetarray = layout.to_ListOffsetArray64(False)
-                offsets = backend.index_nplike.asarray(listoffsetarray.offsets)
-                content = listoffsetarray.content[offsets[0] : offsets[-1]]
+                content = listoffsetarray.content[
+                    listoffsetarray.offsets[0] : listoffsetarray.offsets[-1]
+                ]
 
                 if content.is_indexed:
                     content = content.project()
 
+                offsets = listoffsetarray.offsets.data
                 nextcontent, nextoffsets = lengths_of(
                     ak.highlevel.Array(content), offsets - offsets[0]
                 )
                 return ak.contents.ListOffsetArray(
-                    ak.index.Index64(nextoffsets),
-                    ak.contents.NumpyArray(nextcontent),
+                    ak.index.Index64(nextoffsets), ak.contents.NumpyArray(nextcontent)
                 )
 
             listoffsetarray = layout.to_ListOffsetArray64(False)
-            offsets = backend.index_nplike.asarray(listoffsetarray.offsets)
-            content = listoffsetarray.content[offsets[0] : offsets[-1]]
+            content = listoffsetarray.content[
+                listoffsetarray.offsets[0] : listoffsetarray.offsets[-1]
+            ]
 
             if content.is_indexed:
                 content = content.project()
@@ -209,12 +211,10 @@ def _impl(array, highlevel, behavior):
                     + type(content).__name__
                 )
 
-            nextcontent, nextoffsets = lengths_of(
-                backend.nplike.asarray(content.data), offsets - offsets[0]
-            )
+            offsets = listoffsetarray.offsets.data
+            nextcontent, nextoffsets = lengths_of(content.data, offsets - offsets[0])
             return ak.contents.ListOffsetArray(
-                ak.index.Index64(nextoffsets),
-                ak.contents.NumpyArray(nextcontent),
+                ak.index.Index64(nextoffsets), ak.contents.NumpyArray(nextcontent)
             )
         else:
             return None

--- a/src/awkward/operations/ak_to_categorical.py
+++ b/src/awkward/operations/ak_to_categorical.py
@@ -129,13 +129,13 @@ def _impl(array, highlevel, behavior):
                     mapping[i] = j
 
             if layout.is_indexed and layout.is_option:
-                original_index = numpy.asarray(layout.index)
+                original_index = numpy.asarray(layout.index.data)
                 index = mapping[original_index]
                 index[original_index < 0] = -1
                 index = ak.index.Index64(index)
 
             elif layout.is_indexed:
-                original_index = numpy.asarray(layout.index)
+                original_index = numpy.asarray(layout.index.data)
                 index = ak.index.Index64(mapping[original_index])
 
             elif layout.is_option:

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -168,8 +168,7 @@ or
 
         elif layout.purelist_depth > 1:
             offsets, flattened = layout._offsets_and_flattened(axis=1, depth=1)
-            offsets = numpy.asarray(offsets)
-            starts, stops = offsets[:-1], offsets[1:]
+            starts, stops = offsets.data[:-1], offsets.data[1:]
             counts = stops - starts
             if ak._util.win or ak._util.bits32:
                 counts = layout.backend.index_nplike.astype(counts, np.int32)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -188,30 +188,28 @@ def _impl(array, counts, axis, highlevel, behavior):
             if posaxis == depth and layout.is_list:
                 # We are one *above* the level where we want to apply this.
                 listoffsetarray = layout.to_ListOffsetArray64(True)
-                outeroffsets = backend.index_nplike.asarray(listoffsetarray.offsets)
+                outeroffsets = listoffsetarray.offsets
 
                 content = unflatten_this_layout(
                     listoffsetarray.content[: outeroffsets[-1]]
                 )
                 if isinstance(content, ak.contents.ByteMaskedArray):
-                    inneroffsets = backend.index_nplike.asarray(content.content.offsets)
+                    inneroffsets = content.content.offsets
                 elif isinstance(content, ak.contents.RegularArray):
-                    inneroffsets = backend.index_nplike.asarray(
-                        content.to_ListOffsetArray64(True).offsets
-                    )
+                    inneroffsets = content.to_ListOffsetArray64(True).offsets
                 else:
-                    inneroffsets = backend.index_nplike.asarray(content.offsets)
+                    inneroffsets = content.offsets
 
                 positions = (
                     backend.index_nplike.searchsorted(
-                        inneroffsets, outeroffsets, side="right"
+                        inneroffsets.data, outeroffsets.data, side="right"
                     )
                     - 1
                 )
                 if (
                     backend.index_nplike.known_data
                     and not backend.index_nplike.array_equal(
-                        inneroffsets[positions], outeroffsets
+                        inneroffsets.data[positions], outeroffsets
                     )
                 ):
                     raise ValueError(

--- a/tests/test_1850_bytemasked_array_to_bytemaskedarray.py
+++ b/tests/test_1850_bytemasked_array_to_bytemaskedarray.py
@@ -15,7 +15,13 @@ def test():
     result = layout.to_ByteMaskedArray(False)
     assert layout.to_list() == [None, 1, None, 3, None]
     assert result.to_list() == [None, 1, None, 3, None]
-    assert layout.backend.index_nplike.asarray(result.mask).tolist() == [1, 0, 1, 0, 1]
+    assert layout.backend.index_nplike.asarray(result.mask.data).tolist() == [
+        1,
+        0,
+        1,
+        0,
+        1,
+    ]
 
     # Check this works
     layout.to_typetracer().to_ByteMaskedArray(False)


### PR DESCRIPTION
This PR follows #2740. I've updated that PR's description for context, but let me restart the problem here!

`nplike.asarray` ultimately invokes NumPy's array interface mechanisms when it acts upon an `Index` or `Content` object. If we don't make this PR change, an array with placeholders that hits this codepath will lead to an exception being thrown.

As outlined in #2740, we *could* update `nplike.asarray` to handle these types, but I'm really in favour of having our internals be strict where possible; both to do less work, but also to make it easier to reason about.

So, this PR replaces any as-yet uncaught uses of `nplike.asarray(index)` with `index.data` if the `nplike` is unchanged, or `nplike.asarray(index.data)` if not.

I haven't been exhaustive; anything that isn't being run in our test suite won't have been caught, but I'm happy enough with our coverage that those will hopefully not be too many that we can't deal with them as they come in.

I haven't added anything to the test suite to catch this. I'm slightly reluctant to e.g. add a strict-mode for our test suite that throws an exception if `Index._array_interface_` is inspected. We could do this, though, and I'd welcome @jpivarski thoughts!