### PR TITLE
fix: add `highlevel`, `behavior` arguments to composite reducers

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -36,6 +36,31 @@ def wrap_layout(content, behavior=None, highlevel=True, like=None, allow_other=F
     return content
 
 
+def maybe_highlevel_to_lowlevel(obj):
+    """
+    Args:
+        obj: an object
+
+    Calls #ak.to_layout and returns the result iff. the object is a high-level
+    Awkward object, otherwise the object is returned as-is.
+
+    This function should be removed once scalars are properly handled by `to_layout`.
+    """
+    import awkward.highlevel
+
+    if isinstance(
+        obj,
+        (
+            awkward.highlevel.Array,
+            awkward.highlevel.Record,
+            awkward.highlevel.ArrayBuilder,
+        ),
+    ):
+        return awkward.to_layout(obj)
+    else:
+        return obj
+
+
 def from_arraylib(array, regulararray, recordarray):
     from awkward.contents import (
         ByteMaskedArray,

--- a/tests/test_2754_highlevel_behavior_missing.py
+++ b/tests/test_2754_highlevel_behavior_missing.py
@@ -56,13 +56,100 @@ def test_impl(func):
     )
 
 
-def test_covar():
-    ...
-
-
-def test_corr():
-    ...
-
-
-def test_linaer_fit():
-    ...
+@pytest.mark.parametrize("func", [ak.covar, ak.corr, ak.linear_fit])
+def test_covar(func):
+    assert isinstance(
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            [[4, 4, 0, 2], [1], [10]],
+            axis=-1,
+            highlevel=True,
+        ),
+        ak.Array,
+    )
+    assert isinstance(
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            [[4, 4, 0, 2], [1], [10]],
+            axis=-1,
+            highlevel=False,
+        ),
+        ak.contents.Content,
+    )
+    assert (
+        func(
+            ak.Array(
+                [[1, 2, 3, 4], [5], [10]],
+                behavior=behavior_1,
+            ),
+            [[4, 4, 0, 2], [1], [10]],
+            axis=-1,
+            highlevel=True,
+            behavior=behavior_2,
+        ).behavior
+        == behavior_2
+    )
+    assert (
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            ak.Array(
+                [[4, 4, 0, 2], [1], [10]],
+                behavior=behavior_1,
+            ),
+            axis=-1,
+            highlevel=True,
+            behavior=behavior_2,
+        ).behavior
+        == behavior_2
+    )
+    assert (
+        func(
+            ak.Array(
+                [[1, 2, 3, 4], [5], [10]],
+                behavior=behavior_1,
+            ),
+            [[4, 4, 0, 2], [1], [10]],
+            axis=-1,
+            highlevel=True,
+        ).behavior
+        == behavior_1
+    )
+    assert (
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            ak.Array(
+                [[4, 4, 0, 2], [1], [10]],
+                behavior=behavior_1,
+            ),
+            axis=-1,
+            highlevel=True,
+        ).behavior
+        == behavior_1
+    )
+    assert (
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            [[4, 4, 0, 2], [1], [10]],
+            weight=ak.Array(
+                [[1, 2, 3, 2], [1], [1]],
+                behavior=behavior_1,
+            ),
+            axis=-1,
+            highlevel=True,
+            behavior=behavior_2,
+        ).behavior
+        == behavior_2
+    )
+    assert (
+        func(
+            [[1, 2, 3, 4], [5], [10]],
+            [[4, 4, 0, 2], [1], [10]],
+            weight=ak.Array(
+                [[1, 2, 3, 2], [1], [1]],
+                behavior=behavior_1,
+            ),
+            axis=-1,
+            highlevel=True,
+        ).behavior
+        == behavior_1
+    )

--- a/tests/test_2754_highlevel_behavior_missing.py
+++ b/tests/test_2754_highlevel_behavior_missing.py
@@ -1,0 +1,68 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import pytest
+
+import awkward as ak
+
+behavior_1 = {"foo": "bar"}
+behavior_2 = {"baz": "bargh!"}
+behavior = {**behavior_1, **behavior_2}
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        ak.softmax,
+        ak.any,
+        ak.min,
+        ak.argmin,
+        ak.sum,
+        ak.ptp,
+        ak.std,
+        ak.count_nonzero,
+        lambda *args, **kwargs: ak.moment(*args, **kwargs, n=3),
+        ak.argmax,
+        ak.all,
+        ak.mean,
+        ak.max,
+        ak.prod,
+        ak.count,
+        ak.var,
+    ],
+)
+def test_impl(func):
+    assert isinstance(
+        func([[1, 2, 3, 4], [5], [10]], axis=-1, highlevel=True), ak.Array
+    )
+    assert isinstance(
+        func([[1, 2, 3, 4], [5], [10]], axis=-1, highlevel=False), ak.contents.Content
+    )
+    assert (
+        func(
+            ak.Array([[1, 2, 3, 4], [5], [10]], behavior=behavior_1),
+            axis=-1,
+            highlevel=True,
+            behavior=behavior_2,
+        ).behavior
+        == behavior_2
+    )
+    assert (
+        func(
+            ak.Array([[1, 2, 3, 4], [5], [10]], behavior=behavior_1),
+            axis=-1,
+            highlevel=True,
+        ).behavior
+        == behavior_1
+    )
+
+
+def test_covar():
+    ...
+
+
+def test_corr():
+    ...
+
+
+def test_linaer_fit():
+    ...


### PR DESCRIPTION
A number of high-level operations in Awkward Array did not accept the `highlevel` or `behavior` arguments. I don't think we ever explicitly decided upon this, so I assume that it is an oversight in need of correction!