### PR TITLE
chore: set `pyupgrade` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
   rev: v3.13.0
   hooks:
   - id: pyupgrade
+    args: [--py38-plus]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.27.0


### PR DESCRIPTION
When we invoke `pyupgrade`, it should be given the minimum Python version explicitly; it doesn't read `pyproject.toml`.