### PR TITLE
fix: update `__class__` for both `layout` and `behavior` consistently

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -378,6 +378,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         if isinstance(layout, ak.contents.Content):
             self._layout = layout
             self._numbaview = None
+            self.__class__ = get_array_class(layout, self._behavior)
         else:
             raise TypeError("layout must be a subclass of ak.contents.Content")
 
@@ -403,8 +404,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
-            self.__class__ = get_array_class(self._layout, behavior)
             self._behavior = behavior
+            self.__class__ = get_array_class(self._layout, behavior)
         else:
             raise TypeError("behavior must be None or a dict")
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -376,9 +376,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.contents.Content):
+            self.__class__ = get_array_class(layout, self._behavior)
             self._layout = layout
             self._numbaview = None
-            self.__class__ = get_array_class(layout, self._behavior)
         else:
             raise TypeError("layout must be a subclass of ak.contents.Content")
 
@@ -404,8 +404,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
-            self._behavior = behavior
             self.__class__ = get_array_class(self._layout, behavior)
+            self._behavior = behavior
+            self._numbaview = None
         else:
             raise TypeError("behavior must be None or a dict")
 
@@ -1715,6 +1716,7 @@ class Record(NDArrayOperatorsMixin):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.record.Record):
+            self.__class__ = get_record_class(layout, self._behavior)
             self._layout = layout
             self._numbaview = None
         else:
@@ -1744,6 +1746,7 @@ class Record(NDArrayOperatorsMixin):
         if behavior is None or isinstance(behavior, Mapping):
             self.__class__ = get_record_class(self._layout, behavior)
             self._behavior = behavior
+            self._numbaview = None
         else:
             raise TypeError("behavior must be None or a dict")
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -376,9 +376,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.contents.Content):
-            self.__class__ = get_array_class(layout, self._behavior)
             self._layout = layout
             self._numbaview = None
+            self.__class__ = get_array_class(layout, self._behavior)
         else:
             raise TypeError("layout must be a subclass of ak.contents.Content")
 
@@ -404,9 +404,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
-            self.__class__ = get_array_class(self._layout, behavior)
             self._behavior = behavior
             self._numbaview = None
+            self.__class__ = get_array_class(self._layout, behavior)
         else:
             raise TypeError("behavior must be None or a dict")
 
@@ -1716,9 +1716,9 @@ class Record(NDArrayOperatorsMixin):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.record.Record):
-            self.__class__ = get_record_class(layout, self._behavior)
             self._layout = layout
             self._numbaview = None
+            self.__class__ = get_record_class(layout, self._behavior)
         else:
             raise TypeError("layout must be a subclass of ak.record.Record")
 
@@ -1744,9 +1744,9 @@ class Record(NDArrayOperatorsMixin):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
-            self.__class__ = get_record_class(self._layout, behavior)
             self._behavior = behavior
             self._numbaview = None
+            self.__class__ = get_record_class(self._layout, behavior)
         else:
             raise TypeError("behavior must be None or a dict")
 

--- a/tests/test_2759_update_class_consistently.py
+++ b/tests/test_2759_update_class_consistently.py
@@ -1,0 +1,53 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+
+import awkward as ak
+
+
+class ArrayBehavior(ak.Array):
+    def impl(self):
+        return True
+
+
+class RecordBehavior(ak.Record):
+    def impl(self):
+        return True
+
+
+BEHAVIOR = {("*", "impl"): ArrayBehavior, "impl": RecordBehavior}
+
+
+def test_array_layout():
+    array = ak.Array([{"x": 1}, {"y": 3}], behavior=BEHAVIOR)
+    assert not isinstance(array, ArrayBehavior)
+
+    array.layout = ak.with_name([{"x": 1}, {"y": 3}], "impl", highlevel=False)
+    assert isinstance(array, ArrayBehavior)
+    assert array.impl()
+
+
+def test_array_behavior():
+    array = ak.Array([{"x": 1}, {"y": 3}], with_name="impl")
+    assert not isinstance(array, ArrayBehavior)
+
+    array.behavior = BEHAVIOR
+    assert isinstance(array, ArrayBehavior)
+    assert array.impl()
+
+
+def test_record_layout():
+    record = ak.Record({"x": 1}, behavior=BEHAVIOR)
+    assert not isinstance(record, RecordBehavior)
+
+    record.layout = ak.with_name({"x": 1}, "impl", highlevel=False)
+    assert isinstance(record, RecordBehavior)
+    assert record.impl()
+
+
+def test_record_behavior():
+    record = ak.Record({"x": 1}, with_name="impl")
+    assert not isinstance(record, RecordBehavior)
+
+    record.behavior = BEHAVIOR
+    assert isinstance(record, RecordBehavior)
+    assert record.impl()


### PR DESCRIPTION
Presently, setting `.behavior` and `.layout` does not consistently update `__class__`. This PR rectifies the behavior such that `__class__` is updated for both attributes!