### PR TITLE
refactor: drop `behavior` broadcasting

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -1,7 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-from collections.abc import Set
+from collections.abc import Collection
 
 from awkward._backends.backend import Backend
 from awkward._nplikes.numpy import Numpy
@@ -46,7 +46,7 @@ def register_backend(primary_nplike_cls: type[NumpyLike]):
     return wrapper
 
 
-def common_backend(backends: Set[Backend]) -> Backend:
+def common_backend(backends: Collection[Backend]) -> Backend:
     # Either we have one nplike, or one + typetracer
     if len(backends) == 1:
         return next(iter(backends))
@@ -68,7 +68,7 @@ def common_backend(backends: Set[Backend]) -> Backend:
             )
 
 
-def _backend_of(obj, default: D = UNSET) -> Backend | D:
+def backend_of_obj(obj, default: D = UNSET) -> Backend | D:
     cls = type(obj)
     try:
         lookup = _type_to_backend_lookup[cls]
@@ -80,7 +80,7 @@ def _backend_of(obj, default: D = UNSET) -> Backend | D:
                 break
         else:
             if default is UNSET:
-                raise TypeError(f"cannot find nplike for {cls.__name__}")
+                raise TypeError(f"cannot find backend for {cls.__name__}")
             else:
                 return default
         _type_to_backend_lookup[cls] = maybe_lookup
@@ -101,7 +101,7 @@ def backend_of(
     no default is given.
     """
     unique_backends = frozenset(
-        b for b in (_backend_of(o, default=None) for o in objects) if b is not None
+        b for b in (backend_of_obj(o, default=None) for o in objects) if b is not None
     )
 
     if len(unique_backends) == 0:

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -1032,7 +1032,8 @@ def broadcast_and_apply(
     function_name: str | None = None,
     broadcast_parameters_rule=BroadcastParameterRule.INTERSECT,
 ):
-    backend = backend_of(*inputs)
+    # Expect arrays to already have common backend
+    backend = backend_of(*inputs, coerce_to_common=False)
     isscalar = []
     out = apply_step(
         backend,

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -411,7 +411,6 @@ def apply_step(
     depth: int,
     depth_context,
     lateral_context,
-    behavior,
     options: BroadcastOptions,
 ):
     # This happens when descending anyway, but setting the option does it before action.
@@ -451,7 +450,6 @@ def apply_step(
                     depth,
                     depth_context,
                     lateral_context,
-                    behavior,
                     options,
                 )
 
@@ -517,7 +515,6 @@ def apply_step(
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
-                    behavior,
                     options,
                 )
             )
@@ -636,7 +633,6 @@ def apply_step(
                 depth + 1,
                 copy.copy(depth_context),
                 lateral_context,
-                behavior,
                 options,
             )
             assert isinstance(outcontent, tuple)
@@ -701,7 +697,6 @@ def apply_step(
                 depth + 1,
                 copy.copy(depth_context),
                 lateral_context,
-                behavior,
                 options,
             )
             assert isinstance(outcontent, tuple)
@@ -758,7 +753,6 @@ def apply_step(
             depth,
             copy.copy(depth_context),
             lateral_context,
-            behavior,
             options,
         )
         assert isinstance(outcontent, tuple)
@@ -815,7 +809,6 @@ def apply_step(
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
-                        behavior,
                         options,
                     )
                 )
@@ -884,7 +877,6 @@ def apply_step(
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
-                        behavior,
                         options,
                     )
                 )
@@ -923,7 +915,6 @@ def apply_step(
             depth,
             copy.copy(depth_context),
             lateral_context,
-            behavior,
             options,
         )
 
@@ -938,7 +929,6 @@ def apply_step(
             depth,
             copy.copy(depth_context),
             lateral_context,
-            behavior,
             options,
         )
 
@@ -954,7 +944,6 @@ def apply_step(
             depth,
             copy.copy(depth_context),
             lateral_context,
-            behavior,
             options,
         )
 
@@ -1000,7 +989,6 @@ def apply_step(
         depth_context=depth_context,
         lateral_context=lateral_context,
         continuation=continuation,
-        behavior=behavior,
         backend=backend,
         options=options,
     )
@@ -1021,7 +1009,6 @@ def apply_step(
 def broadcast_and_apply(
     inputs,
     action,
-    behavior,
     depth_context: dict[str, Any] | None = None,
     lateral_context: dict[str, Any] | None = None,
     allow_records: bool = True,
@@ -1042,7 +1029,6 @@ def broadcast_and_apply(
         0,
         depth_context,
         lateral_context,
-        behavior,
         {
             "allow_records": allow_records,
             "left_broadcast": left_broadcast,

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -110,9 +110,7 @@ def evaluate(
             return None
 
     behavior = behavior_of(*arrays)
-    out = ak._broadcasting.broadcast_and_apply(
-        arrays, action, behavior, allow_records=False
-    )
+    out = ak._broadcasting.broadcast_and_apply(arrays, action, allow_records=False)
     assert isinstance(out, tuple) and len(out) == 1
     return wrap_layout(out[0], behavior)
 
@@ -153,8 +151,6 @@ def re_evaluate(local_dict=None):
             return None
 
     behavior = behavior_of(*arrays)
-    out = ak._broadcasting.broadcast_and_apply(
-        arrays, action, behavior, allow_records=False
-    )
+    out = ak._broadcasting.broadcast_and_apply(arrays, action, allow_records=False)
     assert isinstance(out, tuple) and len(out) == 1
     return wrap_layout(out[0], behavior)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -428,7 +428,7 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
         return None
 
     out = ak._broadcasting.broadcast_and_apply(
-        inputs, action, behavior, allow_records=False, function_name=ufunc.__name__
+        inputs, action, allow_records=False, function_name=ufunc.__name__
     )
 
     if len(out) == 1:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -11,7 +11,7 @@ import numpy
 
 import awkward as ak
 from awkward._backends.backend import Backend
-from awkward._backends.dispatch import backend_of, common_backend
+from awkward._backends.dispatch import backend_of, backend_of_obj, common_backend
 from awkward._behavior import (
     behavior_of,
     find_custom_cast,
@@ -45,7 +45,7 @@ def _find_backends(args: Iterable) -> Iterator[Backend]:
     while stack:
         arg = stack.popleft()
         # If the argument declares a backend, easy!
-        backend = backend_of(arg, default=None)
+        backend = backend_of_obj(arg, default=None)
         if backend is not None:
             yield backend
         # Otherwise, traverse into supported sequence types
@@ -55,7 +55,7 @@ def _find_backends(args: Iterable) -> Iterator[Backend]:
 
 def _to_rectilinear(arg, backend: Backend):
     # Is this object something we already associate with a backend?
-    arg_backend = backend_of(arg, default=None)
+    arg_backend = backend_of_obj(arg, default=None)
     if arg_backend is not None:
         arg_nplike = arg_backend.nplike
         # Is this argument already in a backend-supported form?

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -190,10 +190,10 @@ class OperationErrorContext(ErrorContext):
     def any_backend_is_delayed(
         self, iterable: Iterable, *, depth: int = 1, depth_limit: int = 2
     ) -> bool:
-        from awkward._backends.dispatch import backend_of
+        from awkward._backends.dispatch import backend_of_obj
 
         for obj in iterable:
-            backend = backend_of(obj, default=None)
+            backend = backend_of_obj(obj, default=None)
             # Do we not recognise this as an object with a backend?
             if backend is None:
                 # Is this an iterable object, and are we permitted to recurse?
@@ -292,12 +292,13 @@ class SlicingErrorContext(ErrorContext):
     _width = 80 - 4
 
     def __init__(self, array, where):
-        from awkward._backends.dispatch import backend_of
+        from awkward._backends.dispatch import backend_of_obj
         from awkward._backends.numpy import NumpyBackend
 
         numpy_backend = NumpyBackend.instance()
         if self.primary() is not None or all(
-            backend_of(x, default=numpy_backend).nplike.is_eager for x in (array, where)
+            backend_of_obj(x, default=numpy_backend).nplike.is_eager
+            for x in (array, where)
         ):
             # if primary is not None: we won't be setting an ErrorContext
             # if all nplikes are eager: no accumulation of large arrays

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
-from awkward._nplikes.dispatch import nplike_of
+from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyMetadata
@@ -73,7 +73,7 @@ def from_arraylib(array, regulararray, recordarray):
     from awkward.index import Index8, Index64
 
     # overshadows global NumPy import for nplike-safety
-    nplike = nplike_of(array)
+    nplike = nplike_of_obj(array)
 
     def recurse(array, mask=None):
         cls = type(array)

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -4,7 +4,7 @@ import awkward._nplikes.cupy
 import awkward._nplikes.jax
 import awkward._nplikes.numpy
 import awkward._nplikes.typetracer
-from awkward._nplikes.dispatch import nplike_of
+from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ def to_nplike(
     array: ArrayLike, nplike: NumpyLike, *, from_nplike: NumpyLike | None = None
 ) -> ArrayLike:
     if from_nplike is None:
-        from_nplike = nplike_of(array, default=None)
+        from_nplike = nplike_of_obj(array, default=None)
         if from_nplike is None:
             raise TypeError(
                 f"internal error: expected an array supported by an existing nplike, got {type(array).__name__!r}"

--- a/src/awkward/_nplikes/dispatch.py
+++ b/src/awkward/_nplikes/dispatch.py
@@ -19,7 +19,7 @@ def register_nplike(cls: N) -> N:
     return cls
 
 
-def nplike_of(obj, *, default: D = UNSET) -> NumpyLike | D:
+def nplike_of_obj(obj, *, default: D = UNSET) -> NumpyLike | D:
     """
     Args:
         *arrays: iterable of possible array objects

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -6,7 +6,7 @@ import operator
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._nplikes import to_nplike
-from awkward._nplikes.dispatch import nplike_of
+from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -276,7 +276,7 @@ def normalise_item(item, backend: Backend) -> SliceItem:
     # Fallback for sized objects
     elif is_sized_iterable(item):
         # Do we have an array
-        nplike = nplike_of(item, default=None)
+        nplike = nplike_of_obj(item, default=None)
         # We can end up with non-array objects associated with an nplike
         if nplike is not None and nplike.is_own_array(item):
             # Is it a scalar, not array?

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -17,7 +17,7 @@ from awkward._behavior import get_array_class, get_record_class
 from awkward._kernels import KernelError
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
-from awkward._nplikes.dispatch import nplike_of
+from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
@@ -648,7 +648,7 @@ class Content:
 
         elif is_sized_iterable(where):
             # Do we have an array
-            nplike = nplike_of(where, default=None)
+            nplike = nplike_of_obj(where, default=None)
             # We can end up with non-array objects associated with an nplike
             if nplike is not None and nplike.is_own_array(where):
                 # Is it a scalar, not array?

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -5,7 +5,7 @@ import copy
 
 from awkward._nplikes import to_nplike
 from awkward._nplikes.cupy import Cupy
-from awkward._nplikes.dispatch import nplike_of
+from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
@@ -41,7 +41,7 @@ class Index:
     def __init__(self, data, *, metadata=None, nplike=None):
         assert not isinstance(data, Index)
         if nplike is None:
-            nplike = nplike_of(data, default=Numpy.instance())
+            nplike = nplike_of_obj(data, default=Numpy.instance())
         self._nplike = nplike
         if metadata is not None and not isinstance(metadata, dict):
             raise TypeError("Index metadata must be None or a dict")

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -232,7 +232,6 @@ def _impl(
     out = ak._broadcasting.broadcast_and_apply(
         inputs,
         action,
-        behavior,
         left_broadcast=left_broadcast,
         right_broadcast=right_broadcast,
         broadcast_parameters_rule=broadcast_parameters_rule,

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -3,7 +3,7 @@ __all__ = ("broadcast_arrays",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import behavior_of
+from awkward._behavior import behavior_of_obj
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
@@ -228,7 +228,6 @@ def _impl(
         else:
             return None
 
-    behavior = behavior_of(*arrays, behavior=behavior)
     out = ak._broadcasting.broadcast_and_apply(
         inputs,
         action,
@@ -238,7 +237,14 @@ def _impl(
         numpy_to_regular=True,
     )
     assert isinstance(out, tuple)
-    return [wrap_layout(x, behavior, highlevel) for x in out]
+    return [
+        wrap_layout(
+            content,
+            behavior=behavior_of_obj(array, behavior=behavior),
+            highlevel=highlevel,
+        )
+        for content, array in zip(out, arrays)
+    ]
 
 
 @ak._connect.numpy.implements("broadcast_arrays")

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -3,7 +3,7 @@ __all__ = ("broadcast_fields",)
 import awkward as ak
 from awkward._backends.dispatch import backend_of
 from awkward._backends.numpy import NumpyBackend
-from awkward._behavior import behavior_of
+from awkward._behavior import behavior_of_obj
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 
@@ -58,7 +58,6 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None):
 def _impl(arrays, highlevel, behavior):
     backend = backend_of(*arrays, default=cpu, coerce_to_common=True)
     layouts = [ak.to_layout(x).to_backend(backend) for x in arrays]
-    behavior = behavior_of(*arrays, behavior=behavior)
 
     def identity(content):
         return content
@@ -156,5 +155,10 @@ def _impl(arrays, highlevel, behavior):
         return [pull(layout) for pull, layout in zip(pullbacks, inner_layouts)]
 
     return [
-        wrap_layout(x, highlevel=highlevel, behavior=behavior) for x in recurse(layouts)
+        wrap_layout(
+            content,
+            behavior=behavior_of_obj(array, behavior=behavior),
+            highlevel=highlevel,
+        )
+        for content, array in zip(recurse(layouts), arrays)
     ]

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -390,7 +390,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 return None
 
         out = ak._broadcasting.broadcast_and_apply(
-            new_layouts, apply_build_record, behavior, right_broadcast=False
+            new_layouts, apply_build_record, right_broadcast=False
         )
         assert isinstance(out, tuple) and len(out) == 1
         result = out[0]

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -295,7 +295,6 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
         out = ak._broadcasting.broadcast_and_apply(
             content_or_others,
             action,
-            behavior=behavior,
             allow_records=True,
             right_broadcast=False,
         )[0]

--- a/src/awkward/operations/ak_isclose.py
+++ b/src/awkward/operations/ak_isclose.py
@@ -55,7 +55,7 @@ def _impl(a, b, rtol, atol, equal_nan, highlevel, behavior):
             )
 
     behavior = behavior_of(a, b, behavior=behavior)
-    out = ak._broadcasting.broadcast_and_apply([one, two], action, behavior)
+    out = ak._broadcasting.broadcast_and_apply([one, two], action)
     assert isinstance(out, tuple) and len(out) == 1
 
     return wrap_layout(out[0], behavior, highlevel)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -120,7 +120,6 @@ def _impl(array, mask, valid_when, highlevel, behavior):
     out = ak._broadcasting.broadcast_and_apply(
         [layoutarray, layoutmask],
         action,
-        behavior,
         numpy_to_regular=True,
         right_broadcast=False,
     )

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -117,7 +117,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
             else:
                 return None
 
-        out = ak._broadcasting.broadcast_and_apply(broadcasting, action, behavior)
+        out = ak._broadcasting.broadcast_and_apply(broadcasting, action)
         assert isinstance(out, tuple) and len(out) == 1
         out = out[0]
 

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -568,7 +568,6 @@ def _impl(
             0,
             copy.copy(depth_context),
             lateral_context,
-            behavior,
             options,
         )
         assert isinstance(out, tuple)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -139,7 +139,6 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
     out = ak._broadcasting.broadcast_and_apply(
         [condition_layout, x_layout, y_layout],
         action,
-        behavior,
         numpy_to_regular=True,
     )
 

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -160,7 +160,6 @@ def _impl(base, what, where, highlevel, behavior):
         out = ak._broadcasting.broadcast_and_apply(
             [base, what],
             action,
-            behavior,
             right_broadcast=False,
         )
 

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -120,7 +120,6 @@ def _impl(array, separator, highlevel, behavior):
         (out,) = ak._broadcasting.broadcast_and_apply(
             (layout, separator_layout),
             apply_binary,
-            behavior,
         )
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -67,6 +67,6 @@ def _impl(arrays, highlevel, behavior):
         ):
             return (_apply_through_arrow(pc.binary_join_element_wise, *layouts),)
 
-    (out,) = ak._broadcasting.broadcast_and_apply(layouts, action, behavior)
+    (out,) = ak._broadcasting.broadcast_and_apply(layouts, action)
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -95,6 +95,6 @@ def _impl(array, num_repeats, highlevel, behavior):
             ):
                 return _apply_through_arrow(pc.binary_repeat, layout, num_repeats)
 
-        out = ak._do.recursively_apply(layout, action, behavior)
+        out = ak._do.recursively_apply(layout, action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/tests/test_1415_behaviour_forwarding.py
+++ b/tests/test_1415_behaviour_forwarding.py
@@ -49,14 +49,19 @@ def test_behavior_forwarding_structure(operation_behavior):
         == merged_behavior
     )
     assert (
-        ak.operations.argsort(one, behavior=operation_behavior)[0].behavior
+        ak.operations.argsort(one, behavior=operation_behavior).behavior
         == merged_behavior
     )
 
-    assert (
-        ak.operations.broadcast_arrays(5, one, behavior=operation_behavior)[0].behavior
-        == merged_behavior
+    left_broadcast, right_broadcast = ak.operations.broadcast_arrays(5, one)
+    assert left_broadcast.behavior is None
+    assert right_broadcast.behavior is local_behavior
+
+    left_broadcast, right_broadcast = ak.operations.broadcast_arrays(
+        5, one, behavior=operation_behavior
     )
+    assert left_broadcast.behavior is operation_behavior
+    assert right_broadcast.behavior == merged_behavior
 
     assert (
         ak.operations.cartesian([one], behavior=operation_behavior).behavior


### PR DESCRIPTION
The `behavior` for one array given to broadcasting functions no longer _needs_ to be broadcast against the other array behaviors. Thus, let's remove that restriction.

This would break users who introduce behaviors on array X, and expect `ak.broadcast_arrays` to merge them.