### PR TITLE
fix: add policy for length erasure

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1465,7 +1465,7 @@ def typetracer_with_report(
     forget_length: bool = True,
 ) -> tuple[ak.contents.Content, TypeTracerReport]:
     layout = form.length_zero_array(highlevel=False).to_typetracer(
-        forget_length=forget_length
+        length_policy="drop_recursive" if forget_length else "keep"
     )
     report = TypeTracerReport()
     _attach_report(layout, form, report, getkey)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -17,7 +17,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import Content
@@ -307,13 +315,18 @@ class BitMaskedArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         tt = TypeTracer.instance()
+        mask = self._mask.to_nplike(tt)
         return BitMaskedArray(
-            self._mask.to_nplike(tt),
-            self._content._to_typetracer(False),
+            mask.forget_length() if length_policy != "keep" else mask,
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             self._valid_when,
-            unknown_length if forget_length else self.length,
+            unknown_length if length_policy != "keep" else self.length,
             self._lsb_order,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -19,7 +19,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -229,12 +237,16 @@ class ByteMaskedArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         tt = TypeTracer.instance()
         mask = self._mask.to_nplike(tt)
         return ByteMaskedArray(
-            mask.forget_length() if forget_length else mask,
-            self._content._to_typetracer(False),
+            mask.forget_length() if length_policy != "keep" else mask,
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             self._valid_when,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -238,7 +238,7 @@ class Content:
         self,
         forget_length: bool = UNSET,
         *,
-        length_policy: Literal["keep", "drop_outer", "drop_recursive"] = "drop_outer",
+        length_policy: Literal["keep", "drop_outer", "drop_recursive"] = "keep",
     ) -> Self:
         if forget_length is not UNSET:
             deprecate(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -14,6 +14,7 @@ from awkward._backends.dispatch import (
     regularize_backend,
 )
 from awkward._behavior import get_array_class, get_record_class
+from awkward._errors import deprecate
 from awkward._kernels import KernelError
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
@@ -233,10 +234,25 @@ class Content:
     def form_cls(self) -> type[Form]:
         raise NotImplementedError
 
-    def to_typetracer(self, forget_length: bool = False) -> Self:
-        return self._to_typetracer(forget_length)
+    def to_typetracer(
+        self,
+        forget_length: bool = UNSET,
+        *,
+        length_policy: Literal["keep", "drop_outer", "drop_recursive"] = "drop_outer",
+    ) -> Self:
+        if forget_length is not UNSET:
+            deprecate(
+                "The `forget_length` argument of `Content.to_typetracer` is deprecated. "
+                "It has been replaced with `length_policy`, which can take the values of"
+                "'keep', 'drop_outer', or 'drop_recursive'",
+                version="2.6.0",
+            )
+            length_policy = "drop_outer"
+        return self._to_typetracer(length_policy)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         raise NotImplementedError
 
     def _touch_data(self, recursive: bool):

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -14,7 +14,15 @@ from awkward._nplikes.numpylike import ArrayLike, IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -122,7 +130,9 @@ class EmptyArray(Content):
     ):
         assert isinstance(form, self.form_cls)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         return EmptyArray(
             backend=TypeTracerBackend.instance(),
         )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -18,7 +18,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -220,11 +228,15 @@ class IndexedArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         index = self._index.to_nplike(TypeTracer.instance())
         return IndexedArray(
-            index.forget_length() if forget_length else index,
-            self._content._to_typetracer(False),
+            index.forget_length() if length_policy != "keep" else index,
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -18,7 +18,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -209,11 +217,15 @@ class IndexedOptionArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         index = self._index.to_nplike(TypeTracer.instance())
         return IndexedOptionArray(
-            index.forget_length() if forget_length else index,
-            self._content._to_typetracer(False),
+            index.forget_length() if length_policy != "keep" else index,
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -16,7 +16,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.contents.listoffsetarray import ListOffsetArray
@@ -222,13 +230,17 @@ class ListArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         tt = TypeTracer.instance()
         starts = self._starts.to_nplike(tt)
         return ListArray(
-            starts.forget_length() if forget_length else starts,
+            starts.forget_length() if length_policy != "keep" else starts,
             self._stops.to_nplike(tt),
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -16,7 +16,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -207,11 +215,15 @@ class ListOffsetArray(Content):
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
         return ListOffsetArray(
-            offsets.forget_length() if forget_length else offsets,
-            self._content._to_typetracer(False),
+            offsets.forget_length() if length_policy != "keep" else offsets,
+            self._content._to_typetracer(
+                "keep" if length_policy == "drop_outer" else length_policy
+            ),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -23,7 +23,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -204,11 +212,13 @@ class NumpyArray(Content):
             self._raw(backend.nplike), byteorder
         )
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         backend = TypeTracerBackend.instance()
         data = self._raw(backend.nplike)
         return NumpyArray(
-            data.forget_length() if forget_length else data,
+            data.forget_length() if length_policy != "keep" else data,
             parameters=self._parameters,
             backend=backend,
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -19,7 +19,15 @@ from awkward._parameters import (
     type_parameters_equal,
 )
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -349,13 +357,18 @@ class RecordArray(Content):
                     form.content(field), getkey, container, backend, byteorder
                 )
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         backend = TypeTracerBackend.instance()
-        contents = [x._to_typetracer(forget_length) for x in self._contents]
+        contents = [
+            x._to_typetracer("keep" if length_policy == "drop_outer" else length_policy)
+            for x in self._contents
+        ]
         return RecordArray(
             contents,
             self._fields,
-            unknown_length if forget_length else self._length,
+            unknown_length if length_policy != "keep" else self._length,
             parameters=self._parameters,
             backend=backend,
         )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -17,7 +17,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.forms.form import Form
@@ -224,11 +232,13 @@ class RegularArray(Content):
         assert isinstance(form, self.form_cls)
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         return RegularArray(
-            self._content._to_typetracer(forget_length),
+            self._content._to_typetracer(length_policy),
             self._size,
-            unknown_length if forget_length else self._length,
+            unknown_length if length_policy != "keep" else self._length,
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -19,7 +19,15 @@ from awkward._parameters import (
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
-from awkward._typing import TYPE_CHECKING, Callable, Final, Self, SupportsIndex, final
+from awkward._typing import (
+    TYPE_CHECKING,
+    Callable,
+    Final,
+    Literal,
+    Self,
+    SupportsIndex,
+    final,
+)
 from awkward._util import UNSET
 from awkward.contents.content import Content
 from awkward.errors import AxisError
@@ -141,9 +149,11 @@ class UnmaskedArray(Content):
         assert isinstance(form, self.form_cls)
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
-    def _to_typetracer(self, forget_length: bool) -> Self:
+    def _to_typetracer(
+        self, length_policy: Literal["keep", "drop_outer", "drop_recursive"]
+    ) -> Self:
         return UnmaskedArray(
-            self._content._to_typetracer(forget_length),
+            self._content._to_typetracer(length_policy),
             parameters=self._parameters,
         )
 

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -147,7 +147,7 @@ def _apply_through_arrow(
             operation(*converted_args, **kwargs),
             generate_bitmasks=generate_bitmasks,
             highlevel=False,
-        ).to_typetracer(forget_length=True)
+        ).to_typetracer(length_policy="drop_recursive")
 
     else:
         converted_args = [
@@ -255,7 +255,7 @@ def _get_split_action(
                         ),
                     )
                     .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
+                    .to_typetracer(length_policy="drop_recursive")
                 )
 
             elif layout.is_list and layout.parameter("__array__") == "bytestring":
@@ -269,7 +269,7 @@ def _get_split_action(
                         ),
                     )
                     .length_zero_array(highlevel=False)
-                    .to_typetracer(forget_length=True)
+                    .to_typetracer(length_policy="drop_recursive")
                 )
         else:
             if layout.is_list and layout.parameter("__array__") == "string":

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -86,7 +86,7 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
                     ),
                     highlevel=False,
                     generate_bitmasks=True,
-                ).to_typetracer(forget_length=True)
+                ).to_typetracer(length_policy="drop_recursive")
             else:
                 return ak.from_arrow(
                     pc.index_in(

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -84,7 +84,7 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
                         skip_nulls=skip_nones,
                     ),
                     highlevel=False,
-                ).to_typetracer(forget_length=True)
+                ).to_typetracer(length_policy="drop_recursive")
             else:
                 return ak.from_arrow(
                     pc.is_in(

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -178,6 +178,8 @@ def typetracer_from_form(form, *, highlevel: bool = True, behavior=None):
             "'form' argument must be a Form or its Python dict/JSON string representation"
         )
 
-    layout = form.length_zero_array(highlevel=False).to_typetracer(forget_length=True)
+    layout = form.length_zero_array(highlevel=False).to_typetracer(
+        length_policy="drop_recursive"
+    )
 
     return wrap_layout(layout, behavior=behavior, highlevel=highlevel)

--- a/tests/test_1110_type_tracer_1.py
+++ b/tests/test_1110_type_tracer_1.py
@@ -25,22 +25,28 @@ def test_getitem_at():
 
 def test_EmptyArray():
     a = ak.contents.emptyarray.EmptyArray()
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
 
 
 def test_NumpyArray():
     a = ak.contents.numpyarray.NumpyArray(
         np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     b = ak.contents.numpyarray.NumpyArray(
         np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
-    assert b.to_typetracer(forget_length=True).data.shape[1:] == (3, 5)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
+    assert b.to_typetracer(length_policy="drop_recursive").data.shape[1:] == (3, 5)
 
 
 def test_RegularArray_NumpyArray():
@@ -51,14 +57,18 @@ def test_RegularArray_NumpyArray():
         ),
         3,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     b = ak.contents.regulararray.RegularArray(
         ak.contents.emptyarray.EmptyArray(), 0, zeros_length=10
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ListArray_NumpyArray():
@@ -71,8 +81,10 @@ def test_ListArray_NumpyArray():
             np.array([6.6, 4.4, 5.5, 7.7, 1.1, 2.2, 3.3, 8.8])
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ListOffsetArray_NumpyArray():
@@ -83,8 +95,10 @@ def test_ListOffsetArray_NumpyArray():
             np.array([6.6, 1.1, 2.2, 3.3, 4.4, 5.5, 7.7])
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_RecordArray_NumpyArray():
@@ -96,8 +110,10 @@ def test_RecordArray_NumpyArray():
         ],
         ["x", "y"],
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     # 5.5 is inaccessible
     b = ak.contents.recordarray.RecordArray(
@@ -107,16 +123,22 @@ def test_RecordArray_NumpyArray():
         ],
         None,
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
     c = ak.contents.recordarray.RecordArray([], [], 10)
-    assert c.to_typetracer().form == c.to_typetracer(forget_length=True).form
-    assert is_unknown_length(c.to_typetracer(forget_length=True).length)
+    assert (
+        c.to_typetracer().form == c.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(c.to_typetracer(length_policy="drop_recursive").length)
 
     d = ak.contents.recordarray.RecordArray([], None, 10)
-    assert d.to_typetracer().form == d.to_typetracer(forget_length=True).form
-    assert is_unknown_length(d.to_typetracer(forget_length=True).length)
+    assert (
+        d.to_typetracer().form == d.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(d.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_IndexedArray_NumpyArray():
@@ -125,8 +147,10 @@ def test_IndexedArray_NumpyArray():
         ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
         ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_IndexedOptionArray_NumpyArray():
@@ -135,8 +159,10 @@ def test_IndexedOptionArray_NumpyArray():
         ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
         ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ByteMaskedArray_NumpyArray():
@@ -146,8 +172,10 @@ def test_ByteMaskedArray_NumpyArray():
         ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
         valid_when=True,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     # 2.2, 4.4, and 6.6 are inaccessible
     b = ak.contents.bytemaskedarray.ByteMaskedArray(
@@ -155,8 +183,10 @@ def test_ByteMaskedArray_NumpyArray():
         ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6])),
         valid_when=False,
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_BitMaskedArray_NumpyArray():
@@ -193,8 +223,10 @@ def test_BitMaskedArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     b = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -229,8 +261,10 @@ def test_BitMaskedArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     c = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -268,8 +302,10 @@ def test_BitMaskedArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    assert c.to_typetracer().form == c.to_typetracer(forget_length=True).form
-    assert is_unknown_length(c.to_typetracer(forget_length=True).length)
+    assert (
+        c.to_typetracer().form == c.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(c.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     d = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -307,8 +343,10 @@ def test_BitMaskedArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    assert d.to_typetracer().form == d.to_typetracer(forget_length=True).form
-    assert is_unknown_length(d.to_typetracer(forget_length=True).length)
+    assert (
+        d.to_typetracer().form == d.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(d.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_UnmaskedArray_NumpyArray():
@@ -332,8 +370,10 @@ def test_UnmaskedArray_NumpyArray():
     assert len(a[2:]) == 2
     with pytest.raises(IndexError):
         a["bad"]
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_UnionArray_NumpyArray():
@@ -347,8 +387,10 @@ def test_UnionArray_NumpyArray():
             ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
         ],
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_RegularArray_RecordArray_NumpyArray():
@@ -364,8 +406,10 @@ def test_RegularArray_RecordArray_NumpyArray():
         ),
         3,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     b = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
@@ -387,8 +431,10 @@ def test_RegularArray_RecordArray_NumpyArray():
     assert len(b["nest"][7:100]) == 3
     with pytest.raises(IndexError):
         b["nest"]["bad"]
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ListArray_RecordArray_NumpyArray():
@@ -406,8 +452,10 @@ def test_ListArray_RecordArray_NumpyArray():
             ["nest"],
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ListOffsetArray_RecordArray_NumpyArray():
@@ -423,8 +471,10 @@ def test_ListOffsetArray_RecordArray_NumpyArray():
             ["nest"],
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_IndexedArray_RecordArray_NumpyArray():
@@ -440,8 +490,10 @@ def test_IndexedArray_RecordArray_NumpyArray():
             ["nest"],
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_IndexedOptionArray_RecordArray_NumpyArray():
@@ -457,8 +509,10 @@ def test_IndexedOptionArray_RecordArray_NumpyArray():
             ["nest"],
         ),
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_ByteMaskedArray_RecordArray_NumpyArray():
@@ -475,8 +529,10 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
         ),
         valid_when=True,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     # 2.2, 4.4, and 6.6 are inaccessible
     b = ak.contents.bytemaskedarray.ByteMaskedArray(
@@ -491,8 +547,10 @@ def test_ByteMaskedArray_RecordArray_NumpyArray():
         ),
         valid_when=False,
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_BitMaskedArray_RecordArray_NumpyArray():
@@ -548,8 +606,10 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     b = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -604,8 +664,10 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=False,
     )
-    assert b.to_typetracer().form == b.to_typetracer(forget_length=True).form
-    assert is_unknown_length(b.to_typetracer(forget_length=True).length)
+    assert (
+        b.to_typetracer().form == b.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(b.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     c = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -663,8 +725,10 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    assert c.to_typetracer().form == c.to_typetracer(forget_length=True).form
-    assert is_unknown_length(c.to_typetracer(forget_length=True).length)
+    assert (
+        c.to_typetracer().form == c.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(c.to_typetracer(length_policy="drop_recursive").length)
 
     # 4.0, 5.0, 6.0, 7.0, 2.2, 4.4, and 6.6 are inaccessible
     d = ak.contents.bitmaskedarray.BitMaskedArray(
@@ -722,8 +786,10 @@ def test_BitMaskedArray_RecordArray_NumpyArray():
         length=13,
         lsb_order=True,
     )
-    assert d.to_typetracer().form == d.to_typetracer(forget_length=True).form
-    assert is_unknown_length(d.to_typetracer(forget_length=True).length)
+    assert (
+        d.to_typetracer().form == d.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(d.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_UnmaskedArray_RecordArray_NumpyArray():
@@ -737,8 +803,10 @@ def test_UnmaskedArray_RecordArray_NumpyArray():
             ["nest"],
         )
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)
 
 
 def test_UnionArray_RecordArray_NumpyArray():
@@ -761,5 +829,7 @@ def test_UnionArray_RecordArray_NumpyArray():
             ),
         ],
     )
-    assert a.to_typetracer().form == a.to_typetracer(forget_length=True).form
-    assert is_unknown_length(a.to_typetracer(forget_length=True).length)
+    assert (
+        a.to_typetracer().form == a.to_typetracer(length_policy="drop_recursive").form
+    )
+    assert is_unknown_length(a.to_typetracer(length_policy="drop_recursive").length)

--- a/tests/test_1703_fill_none_typetracer.py
+++ b/tests/test_1703_fill_none_typetracer.py
@@ -12,6 +12,6 @@ def test():
     result = ak.fill_none(array, 0)
     assert result.to_list() == [1, 2, 0]
 
-    array_tt = ak.Array(array.layout.to_typetracer(forget_length=True))
+    array_tt = ak.Array(array.layout.to_typetracer(length_policy="drop_recursive"))
     result_tt = ak.fill_none(array_tt, 0)
     assert is_unknown_length(result_tt.layout.length)

--- a/tests/test_2115_fix_up_typetracers.py
+++ b/tests/test_2115_fix_up_typetracers.py
@@ -21,7 +21,7 @@ def test_repr():
 
     array2 = ak.Array(
         ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]]).layout.to_typetracer(
-            forget_length=True
+            length_policy="drop_recursive"
         )
     )
     assert repr(array2) == "<Array-typetracer [...] type='## * var * float64'>"

--- a/tests/test_2150_typetracer_high_level_ufunc.py
+++ b/tests/test_2150_typetracer_high_level_ufunc.py
@@ -10,7 +10,9 @@ from awkward._nplikes.typetracer import MaybeNone, is_unknown_scalar
 
 def test():
     array = ak.Array([1, 2, 3, 4])
-    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    typetracer_array = ak.Array(
+        array.layout.to_typetracer(length_policy="drop_recursive")
+    )
     typetracer_result = np.sqrt(typetracer_array)
 
     assert typetracer_result.type == ak.types.ArrayType(
@@ -21,8 +23,12 @@ def test():
 def test_add():
     left = ak.Array([1, 2, 3, 4])
     right = ak.Array([1, 2, 3, 4.0])
-    typetracer_left = ak.Array(left.layout.to_typetracer(forget_length=True))
-    typetracer_right = ak.Array(right.layout.to_typetracer(forget_length=True))
+    typetracer_left = ak.Array(
+        left.layout.to_typetracer(length_policy="drop_recursive")
+    )
+    typetracer_right = ak.Array(
+        right.layout.to_typetracer(length_policy="drop_recursive")
+    )
     typetracer_result = np.add(typetracer_left, typetracer_right)
 
     assert typetracer_result.type == ak.types.ArrayType(
@@ -32,7 +38,9 @@ def test_add():
 
 def test_add_scalar():
     array = ak.Array([1, 2, 3, 4])
-    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    typetracer_array = ak.Array(
+        array.layout.to_typetracer(length_policy="drop_recursive")
+    )
     other = ak.min(typetracer_array, mask_identity=False, initial=10)
     assert is_unknown_scalar(other)
 
@@ -44,7 +52,9 @@ def test_add_scalar():
 
 def test_add_none_scalar():
     array = ak.Array([1, 2, 3, 4])
-    typetracer_array = ak.Array(array.layout.to_typetracer(forget_length=True))
+    typetracer_array = ak.Array(
+        array.layout.to_typetracer(length_policy="drop_recursive")
+    )
     other = ak.min(typetracer_array, mask_identity=True, initial=10)
     assert isinstance(other, MaybeNone)
     assert is_unknown_scalar(other.content)

--- a/tests/test_2181_with_name_len.py
+++ b/tests/test_2181_with_name_len.py
@@ -5,6 +5,6 @@ import awkward as ak
 
 
 def test():
-    layout = ak.to_layout([{"x": 10}]).to_typetracer(forget_length=True)
+    layout = ak.to_layout([{"x": 10}]).to_typetracer(length_policy="drop_recursive")
     named = ak.with_name(layout, "x_like")
     assert ak.parameters(named) == {"__record__": "x_like"}

--- a/tests/test_2229_getitem_range_slice.py
+++ b/tests/test_2229_getitem_range_slice.py
@@ -7,7 +7,7 @@ from awkward._nplikes.shape import unknown_length
 
 
 def test_known_scalar_regularization():
-    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(forget_length=False)
+    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(length_policy="keep")
     assert layout[:].length == 6
     assert layout[:3].length == 3
     assert layout[2:4].length == 2
@@ -15,21 +15,23 @@ def test_known_scalar_regularization():
 
 
 def test_unknown_length_regularization():
-    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(forget_length=False)
+    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(length_policy="keep")
     assert layout[unknown_length::].length == unknown_length
     assert layout[:unknown_length:].length == unknown_length
     assert layout[::unknown_length].length == unknown_length
 
 
 def test_unknown_scalar_regularization():
-    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(forget_length=False)
+    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(length_policy="keep")
     assert layout[layout[0] : :].length == unknown_length
     assert layout[: layout[0]].length == unknown_length
     assert layout[:: layout[0]].length == unknown_length
 
 
 def test_slice_regularization_unknown_length():
-    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(forget_length=True)
+    layout = ak.to_layout([1, 2, 3, 4, 5, 6]).to_typetracer(
+        length_policy="drop_recursive"
+    )
     assert layout[:].length == unknown_length
     assert layout[:3].length == unknown_length
     assert layout[2:4].length == unknown_length

--- a/tests/test_2293_unflatten_typetracer.py
+++ b/tests/test_2293_unflatten_typetracer.py
@@ -17,10 +17,10 @@ def test_array_without_length():
     array = ak.Array(
         ak.to_layout(
             [[100.0, 200.0, 22.0], [4.0, 5.0], [8.0, 9.0, 10.0, 11.0]]
-        ).to_typetracer(forget_length=True)
+        ).to_typetracer(length_policy="drop_recursive")
     )
     counts = ak.Array(
-        ak.to_layout([2, 1, 1, 1, 2, 2]).to_typetracer(forget_length=True)
+        ak.to_layout([2, 1, 1, 1, 2, 2]).to_typetracer(length_policy="drop_recursive")
     )
     ak.unflatten(array, counts)
 
@@ -36,7 +36,7 @@ def test_scalar():
 def test_unknown_scalar():
     array = ak.Array(
         ak.to_layout([[100, 200, 22], [4, 5, 5], [8, 9, 10]]).to_typetracer(
-            forget_length=True
+            length_policy="drop_recursive"
         )
     )
     ak.unflatten(array, array[0, 0])
@@ -46,6 +46,6 @@ def test_unknown_length():
     array = ak.Array(
         ak.to_layout(
             [[100.0, 200.0, 22.0], [4.0, 5.0, 5.0], [8.0, 9.0, 10.0]]
-        ).to_typetracer(forget_length=True)
+        ).to_typetracer(length_policy="drop_recursive")
     )
     ak.unflatten(array, array.layout.length)

--- a/tests/test_2417_bytemasked_singletons.py
+++ b/tests/test_2417_bytemasked_singletons.py
@@ -21,6 +21,6 @@ def test():
     assert (
         ak.singletons(array, highlevel=False).form
         == ak.singletons(
-            array.layout.to_typetracer(forget_length=True), highlevel=False
+            array.layout.to_typetracer(length_policy="drop_recursive"), highlevel=False
         ).form
     )

--- a/tests/test_2418_union_broadcast_unknown.py
+++ b/tests/test_2418_union_broadcast_unknown.py
@@ -8,7 +8,7 @@ def test():
     array = ak.Array([1, [2, 3]])
     result = array + array
 
-    array_tt = ak.Array(array.layout.to_typetracer(forget_length=True))
+    array_tt = ak.Array(array.layout.to_typetracer(length_policy="drop_recursive"))
     result_tt = array_tt + array_tt
 
     assert result_tt.layout.form == result.layout.form

--- a/tests/test_2495_concatenate_typetracer.py
+++ b/tests/test_2495_concatenate_typetracer.py
@@ -9,10 +9,10 @@ from awkward._nplikes.shape import unknown_length
 
 def test_mixed_known_lengths():
     first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
-    first_tt = first.to_typetracer(forget_length=False)
+    first_tt = first.to_typetracer(length_policy="keep")
 
     second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
-    second_tt = second.to_typetracer(forget_length=True)
+    second_tt = second.to_typetracer(length_policy="drop_recursive")
 
     result_tt = ak.concatenate((first_tt, second_tt), axis=1)
     result = ak.concatenate((first, second), axis=1)
@@ -23,10 +23,10 @@ def test_mixed_known_lengths():
 
 def test_known_lengths():
     first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
-    first_tt = first.to_typetracer(forget_length=False)
+    first_tt = first.to_typetracer(length_policy="keep")
 
     second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
-    second_tt = second.to_typetracer(forget_length=False)
+    second_tt = second.to_typetracer(length_policy="keep")
 
     result_tt = ak.concatenate((first_tt, second_tt), axis=1)
     result = ak.concatenate((first, second), axis=1)
@@ -37,10 +37,10 @@ def test_known_lengths():
 
 def test_unknown_lengths():
     first = ak.from_numpy(np.arange(3 * 4).reshape(3, 4), highlevel=False)
-    first_tt = first.to_typetracer(forget_length=True)
+    first_tt = first.to_typetracer(length_policy="drop_recursive")
 
     second = ak.from_numpy(6 - np.arange(3 * 4).reshape(3, 4) * 2, highlevel=False)
-    second_tt = second.to_typetracer(forget_length=True)
+    second_tt = second.to_typetracer(length_policy="drop_recursive")
 
     result_tt = ak.concatenate((first_tt, second_tt), axis=1)
     result = ak.concatenate((first, second), axis=1)

--- a/tests/test_2560_minimal_listarray.py
+++ b/tests/test_2560_minimal_listarray.py
@@ -8,7 +8,7 @@ from awkward._nplikes.shape import unknown_length
 
 def test():
     layout = ak.to_layout([[1, 2, 3, 4], [5, 6, 7, 8], [4, 5, 6, 9]]).to_typetracer(
-        forget_length=True
+        length_policy="drop_recursive"
     )
     result = layout.to_RegularArray()
     assert result.size is unknown_length

--- a/tests/test_2656_unflatten_axis_typetracer.py
+++ b/tests/test_2656_unflatten_axis_typetracer.py
@@ -81,7 +81,9 @@ def test():
 
     form = ak.forms.from_dict(fromjson)
 
-    ttlayout = form.length_zero_array(highlevel=False).to_typetracer(forget_length=True)
+    ttlayout = form.length_zero_array(highlevel=False).to_typetracer(
+        length_policy="drop_recursive"
+    )
 
     ttarray = ak.Array(ttlayout, behavior=ak.behavior)
     backend = ttlayout.backend

--- a/tests/test_2764_length_policy.py
+++ b/tests/test_2764_length_policy.py
@@ -1,0 +1,221 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+inner_layout = ak.contents.ListOffsetArray(
+    ak.index.Index64([0, 3, 4, 4]), ak.contents.NumpyArray(np.arange(4))
+)
+
+
+def test_drop_outer_listoffset():
+    layout = ak.contents.ListOffsetArray(ak.index.Index64([0, 2, 2]), inner_layout)
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_list():
+    layout = ak.contents.ListArray(
+        ak.index.Index64([0, 2]), ak.index.Index64([2, 2]), inner_layout
+    )
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_regular():
+    layout = ak.contents.RegularArray(
+        ak.contents.RegularArray(
+            ak.contents.NumpyArray(
+                np.arange(12),
+            ),
+            3,
+        ),
+        2,
+    )
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_unmasked():
+    layout = ak.contents.UnmaskedArray(inner_layout)
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_bytemasked():
+    layout = ak.contents.ByteMaskedArray(
+        ak.index.Index8([1, 0]),
+        inner_layout,
+        valid_when=True,
+    )
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_bitmasked():
+    layout = ak.contents.BitMaskedArray(
+        ak.index.IndexU8([1, 0]),
+        inner_layout,
+        valid_when=True,
+        length=2,
+        lsb_order=True,
+    )
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_indexed_option():
+    layout = ak.contents.IndexedOptionArray(ak.index.Index64([0, 1]), inner_layout)
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_indexed():
+    layout = ak.contents.IndexedArray(ak.index.Index64([0, 1]), inner_layout)
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is not unknown_length
+    assert layout_tt.content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    assert layout_tt.content.length is unknown_length
+    assert layout_tt.content.content.length is unknown_length
+
+
+def test_drop_outer_record():
+    layout = ak.contents.RecordArray([inner_layout, inner_layout], ["x", "y"])
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    for content in layout_tt.contents:
+        assert content.length is not unknown_length
+        assert content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    for content in layout_tt.contents:
+        assert content.length is not unknown_length
+        assert content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    for content in layout_tt.contents:
+        assert content.length is unknown_length
+        assert content.content.length is unknown_length
+
+
+def test_drop_outer_union():
+    layout = ak.contents.UnionArray(
+        ak.index.Index8([0, 0, 1, 1]),
+        ak.index.Index64([0, 1, 0, 1]),
+        [inner_layout, inner_layout],
+    )
+    layout_tt = layout.to_typetracer(length_policy="keep")
+    assert layout_tt.length is not unknown_length
+    for content in layout_tt.contents:
+        assert content.length is not unknown_length
+        assert content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_outer")
+    assert layout_tt.length is unknown_length
+    for content in layout_tt.contents:
+        assert content.length is not unknown_length
+        assert content.content.length is not unknown_length
+
+    layout_tt = layout.to_typetracer(length_policy="drop_recursive")
+    assert layout_tt.length is unknown_length
+    for content in layout_tt.contents:
+        assert content.length is unknown_length
+        assert content.content.length is unknown_length


### PR DESCRIPTION
Fix #2764 by adding support for recursive erasure of length information. 

Instead of `forget_length: bool`, we have `forget_length: Literal["keep", "drop_outer", "drop_recursive"]`, which enables us to decide how deep the lengths are forgotten. For the `Form → Content` case, we always want recursively to drop lengths.

> **Warning**
> This PR introduces a deprecation in the `forget_length` argument.