### PR TITLE
feat: add `to_buffer` and helper methods in layout builder

### DIFF
--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -143,6 +143,15 @@ namespace awkward {
             buffers["node" + std::to_string(id_) + "-data"]));
         }
 
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-data"))
+          data_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+      }
+
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
@@ -322,6 +331,17 @@ namespace awkward {
         content_.to_buffers(buffers);
       }
 
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder; otherwise, it searches the builder contents to locate a
+      /// matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-offsets"))
+          offsets_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        content_.to_buffer(buffer, name);
+      }
+
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
@@ -403,6 +423,9 @@ namespace awkward {
 
       void
       to_buffers(std::map<std::string, void*>& /* buffers */) const noexcept {}
+
+      void
+      to_buffer(void* /* buffer */, const char* /* name */) const noexcept {}
 
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
@@ -584,6 +607,17 @@ namespace awkward {
         for (size_t i = 0; i < fields_count_; i++)
           visit_at(contents, i, [&buffers](auto& content) {
             content.builder.to_buffers(buffers);
+          });
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the buffers of the
+      /// builder contents to user-defined pointers if the given node name matches
+      /// with the node associated with that builder.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffer, &name](auto& content) {
+            content.builder.to_buffer(buffer, name);
           });
       }
 
@@ -797,6 +831,17 @@ namespace awkward {
           });
       }
 
+      /// @brief Copies and concatenates the accumulated data in the buffers of the
+      /// builder contents to user-defined pointers if the given node name matches
+      /// with the node associated with that builder.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        for (size_t i = 0; i < fields_count_; i++)
+          visit_at(contents, i, [&buffer, &name](auto& content) {
+            content.to_buffer(buffer, name);
+          });
+      }
+
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
@@ -975,6 +1020,14 @@ namespace awkward {
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the buffers of the
+      /// builder content to user-defined pointers if the given node name matches
+      /// with the node associated with that builder.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        content_.to_buffer(buffer, name);
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -1173,6 +1226,17 @@ namespace awkward {
         content_.to_buffers(buffers);
       }
 
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder; otherwise, it searches the builder contents to locate a
+      /// matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-index"))
+          index_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        content_.to_buffer(buffer, name);
+      }
+
       /// @brief Copies and concatenates all the accumulated data in the builder
       /// to a map of user-allocated buffers.
       ///
@@ -1300,6 +1364,14 @@ namespace awkward {
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the buffers of the
+      /// builder content to user-defined pointers if the given node name matches
+      /// with the node associated with that builder.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        content_.to_buffer(buffer, name);
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -1501,6 +1573,17 @@ namespace awkward {
         mask_.concatenate(reinterpret_cast<int8_t*>(
             buffers["node" + std::to_string(id_) + "-mask"]));
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder; otherwise, it searches the builder contents to locate a
+      /// matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-mask"))
+          mask_.concatenate(reinterpret_cast<int8_t*>(buffer));
+        content_.to_buffer(buffer, name);
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -1756,6 +1839,19 @@ namespace awkward {
         mask_.append(reinterpret_cast<uint8_t*>(
             buffers["node" + std::to_string(id_) + "-mask"]), mask_.length() - 1, 0, 1);
         content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder; otherwise, it searches the builder contents to locate a
+      /// matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-mask")) {
+          mask_.concatenate_from(reinterpret_cast<uint8_t*>(buffer), 0, 1);
+          mask_.append(reinterpret_cast<uint8_t*>(buffer), mask_.length() - 1, 0, 1);
+        }
+        content_.to_buffer(buffer, name);
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -2027,6 +2123,28 @@ namespace awkward {
         for (size_t i = 0; i < contents_count_; i++)
           visit_at(contents_, i, [&buffers](auto& content) {
             content.to_buffers(buffers);
+          });
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the builder buffers to
+      /// user-defined pointers if the given node name matches with any one of the nodes
+      /// associated with the builder; otherwise, it searches the builder contents to
+      /// locate a matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        auto index_sequence((std::index_sequence_for<BUILDERS...>()));
+
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-tags")) {
+          tags_.concatenate(reinterpret_cast<TAGS*>(buffer));
+        }
+
+        else if (std::string(name) == std::string("node" + std::to_string(id_) + "-index")) {
+          index_.concatenate(reinterpret_cast<INDEX*>(buffer));
+        }
+
+        for (size_t i = 0; i < contents_count_; i++)
+          visit_at(contents_, i, [&buffer, &name](auto& content) {
+            content.to_buffer(buffer, name);
           });
       }
 

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -2241,4 +2241,39 @@ namespace awkward {
   }  // namespace LayoutBuilder
 }  // namespace awkward
 
+namespace {
+
+  /// @brief Helper function to retrieve the names of the buffers.
+  template<typename LayoutBuilder>
+  std::vector<std::string> buffer_name_helper(const LayoutBuilder* builder) {
+    std::map <std::string, size_t> names_nbytes = {};
+    std::vector<std::string> buffer_name;
+    builder->buffer_nbytes(names_nbytes);
+    for (auto it: names_nbytes) {
+      buffer_name.push_back(it.first);
+    }
+    return buffer_name;
+  }
+
+  /// @brief Helper function to retrieve the sizes (in bytes) of the buffers.
+  template<typename LayoutBuilder>
+  std::vector<size_t> buffer_size_helper(const LayoutBuilder* builder) {
+    std::map <std::string, size_t> names_nbytes = {};
+    std::vector<size_t> buffer_size;
+    builder->buffer_nbytes(names_nbytes);
+    for (auto it: names_nbytes) {
+      buffer_size.push_back(it.second);
+    }
+    return buffer_size;
+  }
+
+  /// @brief Helper function to retrieve the number of the buffers.
+  template<typename LayoutBuilder>
+  size_t num_buffers_helper(const LayoutBuilder* builder) {
+    std::map <std::string, size_t> names_nbytes = {};
+    builder->buffer_nbytes(names_nbytes);
+    return names_nbytes.size();
+  }
+}
+
 #endif  // AWKWARD_LAYOUTBUILDER_H_

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -141,15 +141,16 @@ namespace awkward {
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
         data_.concatenate(reinterpret_cast<PRIMITIVE*>(
             buffers["node" + std::to_string(id_) + "-data"]));
-        }
+      }
 
       /// @brief Copies and concatenates the accumulated data in the builder buffer to
       /// a user-defined pointer if the given node name matches with the node associated
       /// with the builder.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        if (std::string(name) == std::string("node" + std::to_string(id_) + "-data"))
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-data")) {
           data_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -337,8 +338,9 @@ namespace awkward {
       /// matching node.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        if (std::string(name) == std::string("node" + std::to_string(id_) + "-offsets"))
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-offsets")) {
           offsets_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        }
         content_.to_buffer(buffer, name);
       }
 
@@ -546,10 +548,11 @@ namespace awkward {
       /// field of the record.
       void
       clear() noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [](auto& content) {
             content.builder.clear();
           });
+        }
       }
 
       /// @brief Current number of records in first field.
@@ -591,10 +594,11 @@ namespace awkward {
       void
       buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
           noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&names_nbytes](auto& content) {
             content.builder.buffer_nbytes(names_nbytes);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in each of the
@@ -604,10 +608,11 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffers](auto& content) {
             content.builder.to_buffers(buffers);
           });
+        }
       }
 
       /// @brief Copies and concatenates the accumulated data in the buffers of the
@@ -615,10 +620,11 @@ namespace awkward {
       /// with the node associated with that builder.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffer, &name](auto& content) {
             content.builder.to_buffer(buffer, name);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -627,10 +633,11 @@ namespace awkward {
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
       void
       to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffers](auto& content) {
             content.builder.to_char_buffers(buffers);
           });
+        }
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -766,10 +773,11 @@ namespace awkward {
       /// Discards the accumulated data and the contents at each tuple index.
       void
       clear() noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [](auto& content) {
             content.clear();
           });
+        }
       }
 
       /// @brief Current number of records in the first index of the tuple.
@@ -812,10 +820,11 @@ namespace awkward {
       void
       buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
           noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&names_nbytes](auto& content) {
             content.buffer_nbytes(names_nbytes);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in each of the
@@ -825,10 +834,11 @@ namespace awkward {
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffers](auto& content) {
             content.to_buffers(buffers);
           });
+        }
       }
 
       /// @brief Copies and concatenates the accumulated data in the buffers of the
@@ -836,10 +846,11 @@ namespace awkward {
       /// with the node associated with that builder.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffer, &name](auto& content) {
             content.to_buffer(buffer, name);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -848,10 +859,11 @@ namespace awkward {
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
       void
       to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
-        for (size_t i = 0; i < fields_count_; i++)
+        for (size_t i = 0; i < fields_count_; i++) {
           visit_at(contents, i, [&buffers](auto& content) {
             content.to_char_buffers(buffers);
           });
+        }
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -1232,8 +1244,9 @@ namespace awkward {
       /// matching node.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        if (std::string(name) == std::string("node" + std::to_string(id_) + "-index"))
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-index")) {
           index_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        }
         content_.to_buffer(buffer, name);
       }
 
@@ -1581,8 +1594,9 @@ namespace awkward {
       /// matching node.
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-        if (std::string(name) == std::string("node" + std::to_string(id_) + "-mask"))
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-mask")) {
           mask_.concatenate(reinterpret_cast<int8_t*>(buffer));
+        }
         content_.to_buffer(buffer, name);
       }
 
@@ -1979,8 +1993,9 @@ namespace awkward {
             index_(awkward::GrowableBuffer<INDEX>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           last_valid_index_[i] = -1;
+        }
       }
 
       /// @brief Creates a new Union layout builder by allocating new tags and index
@@ -1993,8 +2008,9 @@ namespace awkward {
             index_(awkward::GrowableBuffer<INDEX>(options)) {
         size_t id = 0;
         set_id(id);
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           last_valid_index_[i] = -1;
+        }
       }
 
       template <std::size_t I>
@@ -2039,8 +2055,9 @@ namespace awkward {
         auto contents_id = [&id](auto& content) {
           content.set_id(id);
         };
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, contents_id);
+        }
       }
 
       /// @brief Discards the accumulated tags and index, and clears
@@ -2049,15 +2066,17 @@ namespace awkward {
       /// Also, resets the last valid index array to `-1`.
       void
       clear() noexcept {
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           last_valid_index_[i] = -1;
+        }
         tags_.clear();
         index_.clear();
         auto clear_contents = [](auto& content) {
           content.clear();
         };
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, clear_contents);
+        }
       }
 
       /// @brief Current length of the `tags` buffer.
@@ -2100,10 +2119,11 @@ namespace awkward {
         names_nbytes["node" + std::to_string(id_) + "-tags"] = tags_.nbytes();
         names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
 
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, [&names_nbytes](auto& content) {
             content.buffer_nbytes(names_nbytes);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in each of the
@@ -2120,10 +2140,11 @@ namespace awkward {
         index_.concatenate(reinterpret_cast<INDEX*>(
             buffers["node" + std::to_string(id_) + "-index"]));
 
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, [&buffers](auto& content) {
             content.to_buffers(buffers);
           });
+        }
       }
 
       /// @brief Copies and concatenates the accumulated data in the builder buffers to
@@ -2137,15 +2158,15 @@ namespace awkward {
         if (std::string(name) == std::string("node" + std::to_string(id_) + "-tags")) {
           tags_.concatenate(reinterpret_cast<TAGS*>(buffer));
         }
-
         else if (std::string(name) == std::string("node" + std::to_string(id_) + "-index")) {
           index_.concatenate(reinterpret_cast<INDEX*>(buffer));
         }
 
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, [&buffer, &name](auto& content) {
             content.to_buffer(buffer, name);
           });
+        }
       }
 
       /// @brief Copies and concatenates all the accumulated data in the builder
@@ -2161,10 +2182,11 @@ namespace awkward {
         index_.concatenate(reinterpret_cast<INDEX*>(
             buffers["node" + std::to_string(id_) + "-index"]));
 
-        for (size_t i = 0; i < contents_count_; i++)
+        for (size_t i = 0; i < contents_count_; i++) {
           visit_at(contents_, i, [&buffers](auto& content) {
             content.to_char_buffers(buffers);
           });
+        }
       }
 
       /// @brief Generates a unique description of the builder and its
@@ -2240,40 +2262,5 @@ namespace awkward {
 
   }  // namespace LayoutBuilder
 }  // namespace awkward
-
-namespace {
-
-  /// @brief Helper function to retrieve the names of the buffers.
-  template<typename LayoutBuilder>
-  std::vector<std::string> buffer_name_helper(const LayoutBuilder* builder) {
-    std::map <std::string, size_t> names_nbytes = {};
-    std::vector<std::string> buffer_name;
-    builder->buffer_nbytes(names_nbytes);
-    for (auto it: names_nbytes) {
-      buffer_name.push_back(it.first);
-    }
-    return buffer_name;
-  }
-
-  /// @brief Helper function to retrieve the sizes (in bytes) of the buffers.
-  template<typename LayoutBuilder>
-  std::vector<size_t> buffer_size_helper(const LayoutBuilder* builder) {
-    std::map <std::string, size_t> names_nbytes = {};
-    std::vector<size_t> buffer_size;
-    builder->buffer_nbytes(names_nbytes);
-    for (auto it: names_nbytes) {
-      buffer_size.push_back(it.second);
-    }
-    return buffer_size;
-  }
-
-  /// @brief Helper function to retrieve the number of the buffers.
-  template<typename LayoutBuilder>
-  size_t num_buffers_helper(const LayoutBuilder* builder) {
-    std::map <std::string, size_t> names_nbytes = {};
-    builder->buffer_nbytes(names_nbytes);
-    return names_nbytes.size();
-  }
-}
 
 #endif  // AWKWARD_LAYOUTBUILDER_H_


### PR DESCRIPTION
Added some methods to be able to the features of `LayoutBuilder.h` in `C` where `std::map` can't be used.
- `to_buffer` method for each builder to copy and concatenate the data of each builder buffer to user-defined pointer based on the given node name instead of passing a map.
- some other helper functions to extract the names, sizes (in bytes) and the number of buffers in a separate namespace.