### PR TITLE
feat!: rework ufunc type promotion handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
   rev: v2.2.5
   hooks:
   - id: codespell
-    args: ["-L", "ue,subjet,parms,fo,numer,thre"]
+    args: ["-L", "ue,subjet,parms,fo,numer,thre,nin,nout"]
 
 - repo: local
   hooks:

--- a/src/awkward/_backends/backend.py
+++ b/src/awkward/_backends/backend.py
@@ -6,9 +6,9 @@ from abc import ABC, abstractmethod
 import awkward as ak
 from awkward._kernels import KernelError
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpylike import ArrayLike, NumpyLike, NumpyMetadata
+from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._singleton import PublicSingleton
-from awkward._typing import Callable, Protocol, Tuple, TypeAlias, TypeVar, Unpack
+from awkward._typing import Callable, Tuple, TypeAlias, TypeVar, Unpack
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -17,11 +17,6 @@ numpy = Numpy.instance()
 T_co = TypeVar("T_co", covariant=True)
 KernelKeyType: TypeAlias = Tuple[str, Unpack[Tuple[np.dtype, ...]]]
 KernelType: TypeAlias = "Callable[..., KernelError | None]"
-
-
-class UfuncLike(Protocol):
-    def __call__(self, *args: ArrayLike, **kwargs) -> ArrayLike:
-        ...
 
 
 class Backend(PublicSingleton, ABC):
@@ -42,9 +37,6 @@ class Backend(PublicSingleton, ABC):
 
     def prepare_reducer(self, reducer: ak._reducers.Reducer) -> ak._reducers.Reducer:
         return reducer
-
-    def prepare_ufunc(self, ufunc: UfuncLike) -> UfuncLike:
-        return ufunc
 
     def format_kernel_error(
         self,

--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import awkward_cpp
 
 import awkward as ak
-from awkward._backends.backend import Backend, KernelKeyType, UfuncLike
+from awkward._backends.backend import Backend, KernelKeyType
 from awkward._backends.dispatch import register_backend
 from awkward._kernels import JaxKernel
 from awkward._nplikes.jax import Jax
@@ -43,8 +43,3 @@ class JaxBackend(Backend):
         from awkward._connect.jax import get_jax_reducer
 
         return get_jax_reducer(reducer)
-
-    def prepare_ufunc(self, ufunc: UfuncLike) -> UfuncLike:
-        from awkward._connect.jax import get_jax_ufunc
-
-        return get_jax_ufunc(ufunc)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -387,13 +387,8 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
                 parameters_intersect, (c._parameters for c in contents)
             )
 
-            args = [x.data if isinstance(x, NumpyArray) else x for x in inputs]
-
-            # Give backend a chance to change the ufunc implementation
-            impl = backend.prepare_ufunc(ufunc)
-
-            # Invoke ufunc
-            result = impl(*args, **kwargs)
+            input_args = [x.data if isinstance(x, NumpyArray) else x for x in inputs]
+            result = backend.nplike.apply_ufunc(ufunc, method, input_args, kwargs)
 
             if isinstance(result, tuple):
                 return tuple(

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
-from awkward._nplikes.numpylike import ArrayLike
+from awkward._nplikes.numpylike import ArrayLike, UfuncLike
 from awkward._nplikes.shape import ShapeItem
 from awkward._typing import Final
 
@@ -17,6 +17,11 @@ class Jax(ArrayModuleNumpyLike):
     def __init__(self):
         jax = ak.jax.import_jax()
         self._module = jax.numpy
+
+    def prepare_ufunc(self, ufunc: UfuncLike) -> UfuncLike:
+        from awkward._connect.jax import get_jax_ufunc
+
+        return get_jax_ufunc(ufunc)
 
     @property
     def ma(self):

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -242,8 +242,32 @@ if hasattr(numpy, "timedelta64"):
     NumpyMetadata.timedelta64 = numpy.timedelta64
 
 
+class UfuncLike(Protocol):
+    nargs: int
+    nin: int
+    nout: int
+
+    def resolve_dtypes(
+        self, dtypes: tuple[numpy.dtype | type, ...]
+    ) -> tuple[numpy.dtype, ...]:
+        ...
+
+    def __call__(self, *args: ArrayLike, **kwargs) -> ArrayLike:
+        ...
+
+
 class NumpyLike(PublicSingleton, Protocol):
     ############################ Awkward features
+
+    @abstractmethod
+    def apply_ufunc(
+        self,
+        ufunc: UfuncLike,
+        method: str,
+        args: list[Any],
+        kwargs: dict[str, Any] | None = None,
+    ) -> ArrayLike | tuple[ArrayLike]:
+        ...
 
     @property
     @abstractmethod

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -137,7 +137,7 @@ def prepare_advanced_indexing(items, backend: Backend):
 
     # Then broadcast the index items
     nplike = backend.index_nplike
-    broadcasted = nplike.broadcast_arrays(*broadcastable)
+    broadcasted = nplike.broadcast_arrays(*[nplike.asarray(x) for x in broadcastable])
 
     # And re-assemble the index with the broadcasted items
     prepared = []


### PR DESCRIPTION
In pursuing recent PRs, the fragility of our ufunc handling became clearer; we've spoken for a while about NEP-50 and value-based promotion, and the complexities of NumPy's type conversion rules. This PR I *believe* makes a pragmatic step in this direction, using https://numpy.org/doc/stable/reference/generated/numpy.ufunc.resolve_dtypes.html to predict the input and output type combination that a ufunc would use. As such, it applies [NEP-50 rules](https://numpy.org/neps/nep-0050-scalar-promotion.html#abstract) which are value-insensitive. 

How does this PR change Awkward?

In `main`, the following behavior is exhibited:
```pycon
>>> import awkward as ak
>>> import numpy as np
>>> x = ak.from_numpy(np.arange(10, dtype=np.uint8)) + np.int64(1)
>>> x.type.show()
10 * uint8
>>> y = ak.from_numpy(np.arange(10, dtype=np.uint8)) + np.int64(2**32 - 1)
>>> y.type.show()
10 * uint32
>>> z = ak.from_numpy(np.arange(10, dtype=np.uint8)) + (2**32 - 1)
>>> z.type.show()
10 * uint32
```

After this PR:

```pycon
>>> import awkward as ak
>>> import numpy as np
>>> x = ak.from_numpy(np.arange(10, dtype=np.uint8)) + np.int64(1)
>>> x.type.show()
10 * int64
>>> y = ak.from_numpy(np.arange(10, dtype=np.uint8)) + np.int64(2**32 - 1)
>>> y.type.show()
10 * int64
>>> z = ak.from_numpy(np.arange(10, dtype=np.uint8)) + (2**32 - 1)
DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 4294967296 to uint8 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)
will give the desired result (the cast overflows).
  return self._module.asarray(obj, dtype=dtype)
>>> z.type.show()
10 * uint8
```

Crucially this means that old code will start throwing warnings if bare Python scalars exceed the size of the array `dtype`. This is probably not all that likely; most of the time we pull values from other array operations, e.g.
```pycon
>>> array_of_large_values = ak.from_numpy(np.array([2**32-20], dtype=np.uint32))
>>> large_value = np.max(array_of_large_values)
>>> w = ak.from_numpy(np.arange(10, dtype=np.uint8)) + large_value
>>> w
<Array [4294967276, 4294967277, ..., 4294967284, 4294967285] type='10 * uint32'>
```

NumPy is going in this direction with NEP-50 (under _consideration_ only so far). The only other way we could do this in a "safer" type agnostic fashion is to _always_ take the default for the Python value kind (e.g. `int64` for integrals, etc.), or the _largest_ type for value kinds. I prefer to align with NumPy, and let warnings inform users.