### PR TITLE
fix: add `truediv` support for `unknown_length`

### DIFF
--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -37,6 +37,15 @@ class _UnknownLength(PrivateSingleton):
     __rmul__ = __mul__
     __imul__ = __mul__
 
+    def __truediv__(self, other) -> Self | NotImplemented:
+        if isinstance(other, int) or other is self:
+            return self
+        else:
+            return NotImplemented
+
+    __rtruediv__ = __truediv__
+    __itruediv__ = __truediv__
+
     def __floordiv__(self, other) -> Self | NotImplemented:
         if isinstance(other, int) or other is self:
             return self


### PR DESCRIPTION
Comes from working on https://github.com/dask-contrib/dask-awkward/issues/396, I found that unknown_length objects cannot be `truediv`ed!

`Scalar / Scalar` operations in dask-awkward are unoptimizable because the optimization only graph eventually hits `unkown_length / unknown_length` if the `Scalar` comes from a `dak.num(..., axis=0)`