### PR TITLE
fix: drop lengths recursively

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -311,7 +311,7 @@ class BitMaskedArray(Content):
         tt = TypeTracer.instance()
         return BitMaskedArray(
             self._mask.to_nplike(tt),
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             self._valid_when,
             unknown_length if forget_length else self.length,
             self._lsb_order,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -234,7 +234,7 @@ class ByteMaskedArray(Content):
         mask = self._mask.to_nplike(tt)
         return ByteMaskedArray(
             mask.forget_length() if forget_length else mask,
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             self._valid_when,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -224,7 +224,7 @@ class IndexedArray(Content):
         index = self._index.to_nplike(TypeTracer.instance())
         return IndexedArray(
             index.forget_length() if forget_length else index,
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -213,7 +213,7 @@ class IndexedOptionArray(Content):
         index = self._index.to_nplike(TypeTracer.instance())
         return IndexedOptionArray(
             index.forget_length() if forget_length else index,
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -228,7 +228,7 @@ class ListArray(Content):
         return ListArray(
             starts.forget_length() if forget_length else starts,
             self._stops.to_nplike(tt),
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -211,7 +211,7 @@ class ListOffsetArray(Content):
         offsets = self._offsets.to_nplike(TypeTracer.instance())
         return ListOffsetArray(
             offsets.forget_length() if forget_length else offsets,
-            self._content._to_typetracer(False),
+            self._content._to_typetracer(forget_length),
             parameters=self._parameters,
         )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -486,7 +486,7 @@ class UnionArray(Content):
         return UnionArray(
             tags.forget_length() if forget_length else tags,
             self._index.to_nplike(tt),
-            [x._to_typetracer(False) for x in self._contents],
+            [x._to_typetracer(forget_length) for x in self._contents],
             parameters=self._parameters,
         )
 

--- a/tests/test_2765_slice_from_typetracer.py
+++ b/tests/test_2765_slice_from_typetracer.py
@@ -1,0 +1,15 @@
+import awkward as ak
+
+
+def test():
+    array = ak.typetracer.typetracer_from_form(
+        ak.forms.from_type(
+            ak.types.from_datashape("{x: var * {y:int64}}", highlevel=False)
+        )
+    )
+    sliced = array[0, "x", 0]
+    assert sliced.type.is_equal_to(
+        ak.types.ScalarType(
+            ak.types.RecordType([ak.types.NumpyType("int64")], ["y"]), None
+        )
+    )


### PR DESCRIPTION
As discussed in https://github.com/scikit-hep/awkward/pull/2765#issuecomment-1780771826, it doesn't make sense for us to retain interior (buffer) lengths when the outer length is not known. If we think about layouts as being built in a `from_buffers` style, we *must* know parent lengths to know child lengths. 

Fixes #2764