### PR TITLE
fix: protect RecordForm against len(fields) != len(contents)

### DIFF
--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -48,6 +48,8 @@ class RecordForm(Form):
 
         self._fields = None if fields is None else list(fields)
         self._contents = list(contents)
+        if fields is not None:
+            assert len(self._fields) == len(self._contents)
         self._init(parameters=parameters, form_key=form_key)
 
     @property


### PR DESCRIPTION
Noticed this while @ioanaif was debugging an issue in Uproot.

No time pressure; just thought I'd fix it while we see it.

If you approve, @agoose77, go ahead and merge it.