### PR TITLE
ci: fix oldest-supported-dependencies test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,20 +80,15 @@ jobs:
           python -m pip install build
           python -m build -w awkward-cpp
 
-      - name: Install awkward-cpp
-        run: python -m pip install -v @(get-childitem -path awkward-cpp/dist/*.whl)
-
-      - name: Build & install awkward
-        run: python -m pip install -v .
+      - name: Install awkward, awkward-cpp, and dependencies
+        run: >-
+          python -m pip install --only-binary "numpy,pandas,pyarrow,numexpr,numexpr"
+          -v . @(get-childitem -path awkward-cpp/dist/*.whl)
+          pytest-github-actions-annotate-failures
+          -r requirements-test.txt
 
       - name: Print versions
         run: python -m pip list
-
-      - name: Check if kernel specification is sorted
-        run: pipx run nox -s diagnostics -- --check-spec-sorted
-
-      - name: Install test requirements
-        run: python -m pip install -v -r requirements-test.txt pytest-github-actions-annotate-failures
 
       - name: Test specification
         if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
@@ -156,20 +151,16 @@ jobs:
           python -m pip install build
           python -m build -w ./awkward-cpp
 
-      - name: Install awkward-cpp
-        run: python -m pip install -v ./awkward-cpp/dist/*.whl
-
-      - name: Build & install awkward
-        run: python -m pip install -v .
+      - name: Install awkward, awkward-cpp, dask-awkward, and dependencies
+        run: >-
+          python -m pip install --only-binary "numpy,pandas,pyarrow,numexpr"
+          -v . ./awkward-cpp/dist/*.whl
+          pytest-github-actions-annotate-failures
+          dask-awkward
+          -r requirements-test.txt
 
       - name: Print versions
         run: python -m pip list
-
-      - name: Check if kernel specification is sorted
-        run: pipx run nox -s diagnostics -- --check-spec-sorted
-
-      - name: Install test requirements
-        run: python -m pip install -v -r requirements-test.txt pytest-github-actions-annotate-failures
 
       - name: Test specification
         if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
@@ -190,24 +181,16 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
-          - '3.8'
-        numpy-package:
-          - "numpy"
-        pyarrow-package:
-          - "pyarrow"
+        extra-pip-constraints:
+          - "-r requirements-test.txt"
         include:
+          # Lower bounds
           - python-version: '3.8'
-            numpy-package: "numpy==1.18.0"
-            pyarrow-package: "pyarrow"
-          - python-version: '3.8'
-            numpy-package: "numpy"
-            pyarrow-package: "pyarrow==7.0.0"
-          - python-version: '3.12'
-            numpy-package: "numpy>=1.26.0b1"
-            pyarrow-package: "pyarrow;python_version<'3.12'"
+            extra-pip-constraints: "-r requirements-test-minimal.txt"
 
     runs-on: ubuntu-22.04
 
@@ -246,20 +229,20 @@ jobs:
           python -m pip install build
           python -m build -w ./awkward-cpp
 
-      - name: Install awkward-cpp
-        run: python -m pip install -v ./awkward-cpp/dist/*.whl "${{ matrix.numpy-package }}" "${{ matrix.pyarrow-package }}"
-
-      - name: Build & install awkward
-        run: python -m pip install -v .
+      - name: Install awkward, awkward-cpp, and dependencies
+        run: >-
+          python -m pip install --only-binary "numpy,pandas,pyarrow,numexpr"
+          -v . ./awkward-cpp/dist/*.whl
+          pytest-github-actions-annotate-failures
+          ${{ matrix.extra-pip-constraints }}
 
       - name: Print versions
         run: python -m pip list
 
       - name: Check if kernel specification is sorted
+        # We don't need to run this all the time
+        if: matrix.python-version == '3.12'
         run: pipx run nox -s diagnostics -- --check-spec-sorted
-
-      - name: Install test requirements
-        run: python -m pip install -v -r requirements-test.txt pytest-github-actions-annotate-failures
 
       - name: Test specification
         if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
@@ -332,20 +315,16 @@ jobs:
           python3 -m pip install build
           python3 -m build -w ./awkward-cpp
 
-      - name: Install awkward-cpp
-        run: python3 -m pip install -v ./awkward-cpp/dist/*.whl
-
-      - name: Build & install awkward
-        run: python3 -m pip install -v .
-
-      - name: Also install dask-awkward
-        run: python3 -m pip install dask-awkward
+      - name: Install awkward, awkward-cpp, dask-awkward, and dependencies
+        run: >-
+          python -m pip install --only-binary "numpy,pandas,pyarrow,numexpr"
+          -v . ./awkward-cpp/dist/*.whl
+          pytest-github-actions-annotate-failures
+          dask-awkward
+          -r requirements-test.txt
 
       - name: Print versions
         run: python -m pip list
-
-      - name: Install test requirements
-        run: python -m pip install -v -r requirements-test.txt pytest-github-actions-annotate-failures
 
       - name: Test
         run: python -m pytest -vv -rs tests

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,0 +1,5 @@
+numpy==1.18.0
+pyarrow==7.0.0
+pytest>=6
+pytest-cov
+pytest-xdist

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,3 +1,4 @@
+fsspec;sys_platform != "win32"
 numpy==1.18.0
 pyarrow==7.0.0
 pytest>=6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,10 @@
 fsspec;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.12"
 numba>=0.50.0,!=0.58.0rc1;python_version < "3.12"
-numexpr; python_version < "3.12"
+numexpr>=2.7; python_version < "3.12"
 pandas>=0.24.0;sys_platform != "win32" and python_version < "3.12"
 pyarrow>=7.0.0;sys_platform != "win32" and python_version < "3.12"
 pytest>=6
 pytest-cov
 pytest-xdist
-uproot
+uproot>=5

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import math
+from functools import lru_cache
 
 import numpy
+import packaging.version
 
 from awkward._nplikes.numpylike import (
     ArrayLike,
@@ -18,6 +20,20 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._typing import Any, Final, Literal
 
 np = NumpyMetadata.instance()
+NUMPY_HAS_NEP_50 = packaging.version.Version(
+    numpy.__version__
+) >= packaging.version.Version("1.24")
+
+
+@lru_cache
+def _nplike_concatenate_has_casting(module: Any) -> bool:
+    x = module.zeros(2)
+    try:
+        module.concatenate((x, x), casting="same_kind")
+    except TypeError:
+        return False
+    else:
+        return True
 
 
 class ArrayModuleNumpyLike(NumpyLike):
@@ -128,12 +144,15 @@ class ArrayModuleNumpyLike(NumpyLike):
 
     def array_equal(
         self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
-    ) -> ArrayLike:
+    ) -> bool:
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        return self._module.asarray(
-            self._module.array_equal(x1, x2, equal_nan=equal_nan)
-        )
+        if equal_nan:
+            both_nan = self._module.logical_and(x1 == np.nan, x2 == np.nan)
+            both_equal = x1 == x2
+            return self._module.all(self._module.logical_or(both_equal, both_nan))
+        else:
+            return self._module.array_equal(x1, x2)
 
     def searchsorted(
         self,
@@ -157,21 +176,28 @@ class ArrayModuleNumpyLike(NumpyLike):
         args: list[Any],
         kwargs: dict[str, Any] | None = None,
     ) -> ArrayLike | tuple[ArrayLike]:
-        # Determine input argument dtypes
-        input_arg_dtypes = [getattr(obj, "dtype", type(obj)) for obj in args]
-        # Resolve these for the given ufunc
-        arg_dtypes = tuple(input_arg_dtypes + [None] * ufunc.nout)
-        resolved_dtypes = ufunc.resolve_dtypes(arg_dtypes)
-        # Interpret the arguments under these dtypes
-        resolved_args = [
-            self.asarray(arg, dtype=dtype) for arg, dtype in zip(args, resolved_dtypes)
-        ]
-        # Broadcast these resolved arguments
-        broadcasted_args = self.broadcast_arrays(*resolved_args)
+        # Does NumPy support value-less ufunc resolution?
+        if NUMPY_HAS_NEP_50:
+            # Determine input argument dtypes
+            input_arg_dtypes = [getattr(obj, "dtype", type(obj)) for obj in args]
+            # Resolve these for the given ufunc
+            arg_dtypes = tuple(input_arg_dtypes + [None] * ufunc.nout)
+            resolved_dtypes = ufunc.resolve_dtypes(arg_dtypes)
+            # Interpret the arguments under these dtypes
+            resolved_args = [
+                self.asarray(arg, dtype=dtype)
+                for arg, dtype in zip(args, resolved_dtypes)
+            ]
+        else:
+            # Otherwise, perform default NumPy coercion (value-dependent)
+            resolved_args = [
+                self.asarray(arg, dtype=arg.dtype) if hasattr(arg, "dtype") else arg
+                for arg in args
+            ]
         # Allow other nplikes to replace implementation
         impl = self.prepare_ufunc(ufunc)
         # Compute the result
-        return impl(*broadcasted_args, **kwargs)
+        return impl(*resolved_args, **(kwargs or {}))
 
     def broadcast_arrays(self, *arrays: ArrayLike) -> list[ArrayLike]:
         assert not any(isinstance(x, PlaceholderArray) for x in arrays)
@@ -327,7 +353,10 @@ class ArrayModuleNumpyLike(NumpyLike):
         axis: int | None = 0,
     ) -> ArrayLike:
         assert not any(isinstance(x, PlaceholderArray) for x in arrays)
-        return self._module.concatenate(arrays, axis=axis, casting="same_kind")
+        if _nplike_concatenate_has_casting(self._module):
+            return self._module.concatenate(arrays, axis=axis, casting="same_kind")
+        else:
+            return self._module.concatenate(arrays, axis=axis)
 
     def repeat(
         self,
@@ -507,10 +536,11 @@ class ArrayModuleNumpyLike(NumpyLike):
         return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def count_nonzero(
-        self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
+        self, x: ArrayLike, *, axis: int | tuple[int, ...] | None = None
     ) -> ArrayLike:
         assert not isinstance(x, PlaceholderArray)
-        return self._module.count_nonzero(x, axis=axis, keepdims=keepdims)
+        assert isinstance(axis, int) or axis is None
+        return self._module.count_nonzero(x, axis=axis)
 
     def cumsum(
         self,

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -47,13 +47,15 @@ class Cupy(ArrayModuleNumpyLike):
         np_array = numpy.frombuffer(buffer, dtype=dtype, count=count)
         return self._module.asarray(np_array)
 
-    def array_equal(self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False):
+    def array_equal(
+        self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
+    ) -> bool:
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
         if x1.shape != x2.shape:
             return False
         else:
-            return self._module.all(x1 - x2 == 0)
+            return self._module.array_equal(x1, x2, equal_nan=equal_nan).get()
 
     def repeat(
         self, x: ArrayLike, repeats: ArrayLike | int, *, axis: int | None = None
@@ -106,13 +108,10 @@ class Cupy(ArrayModuleNumpyLike):
             return out
 
     def count_nonzero(
-        self,
-        x: ArrayLike,
-        *,
-        axis: int | tuple[int, ...] | None = None,
-        keepdims: bool = False,
+        self, x: ArrayLike, *, axis: int | tuple[int, ...] | None = None
     ) -> ArrayLike:
         assert not isinstance(x, PlaceholderArray)
+        assert isinstance(axis, int) or axis is None
         out = self._module.count_nonzero(x, axis=axis)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()

--- a/src/awkward/_nplikes/numpylike.py
+++ b/src/awkward/_nplikes/numpylike.py
@@ -639,7 +639,7 @@ class NumpyLike(PublicSingleton, Protocol):
 
     @abstractmethod
     def count_nonzero(
-        self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
+        self, x: ArrayLike, *, axis: int | tuple[int, ...] | None = None
     ) -> ArrayLike:
         ...
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -5,6 +5,7 @@ from numbers import Number
 from typing import Callable
 
 import numpy
+import packaging.version
 
 import awkward as ak
 from awkward._nplikes.dispatch import register_nplike
@@ -30,6 +31,9 @@ from awkward._typing import (
 )
 
 np = NumpyMetadata.instance()
+NUMPY_HAS_NEP_50 = packaging.version.Version(
+    numpy.__version__
+) >= packaging.version.Version("1.24")
 
 
 def is_unknown_length(array: Any) -> bool:
@@ -516,26 +520,46 @@ class TypeTracer(NumpyLike):
 
         # Unwrap options, assume they don't occur
         args = [x.content if isinstance(x, MaybeNone) else x for x in args]
-        # Determine input argument dtypes
-        input_arg_dtypes = [getattr(obj, "dtype", type(obj)) for obj in args]
-        # Resolve these for the given ufunc
-        arg_dtypes = tuple(input_arg_dtypes + [None] * ufunc.nout)
-        resolved_dtypes = ufunc.resolve_dtypes(arg_dtypes)
-        # Interpret the arguments under these dtypes
-        resolved_args = [
-            self.asarray(arg, dtype=dtype) for arg, dtype in zip(args, resolved_dtypes)
-        ]
-        # Broadcast these resolved arguments
-        broadcasted_args = self.broadcast_arrays(*resolved_args)
-        result_dtypes = resolved_dtypes[ufunc.nin :]
+        if NUMPY_HAS_NEP_50:
+            # Determine input argument dtypes
+            input_arg_dtypes = [getattr(obj, "dtype", type(obj)) for obj in args]
+            # Resolve these for the given ufunc
+            arg_dtypes = tuple(input_arg_dtypes + [None] * ufunc.nout)
+            resolved_dtypes = ufunc.resolve_dtypes(arg_dtypes)
+            # Interpret the arguments under these dtypes
+            resolved_args = [
+                self.asarray(arg, dtype=dtype)
+                for arg, dtype in zip(args, resolved_dtypes)
+            ]
+            # Broadcast these resolved arguments
+            broadcasted_args = self.broadcast_arrays(*resolved_args)
+            broadcasted_shape = broadcasted_args[0].shape
+            result_dtypes = resolved_dtypes[ufunc.nin :]
+        else:
+            array_like_args = [
+                self.asarray(arg, dtype=arg.dtype)
+                for arg in args
+                if hasattr(arg, "dtype")
+            ]
+            broadcasted_args = self.broadcast_arrays(*array_like_args)
+            broadcasted_shape = broadcasted_args[0].shape
+
+            numpy_args = [
+                (numpy.empty(0, dtype=x.dtype) if hasattr(x, "dtype") else x)
+                for x in args
+            ]
+            numpy_result = ufunc(*numpy_args, **(kwargs or {}))
+            if ufunc.nout == 1:
+                result_dtypes = [numpy_result.dtype]
+            else:
+                result_dtypes = [x.dtype for x in numpy_result]
+
         if len(result_dtypes) == 1:
-            return TypeTracerArray._new(
-                result_dtypes[0], shape=broadcasted_args[0].shape
-            )
+            return TypeTracerArray._new(result_dtypes[0], shape=broadcasted_shape)
         else:
             return (
-                TypeTracerArray._new(dtype, shape=b.shape)
-                for dtype, b in zip(result_dtypes, broadcasted_args)
+                TypeTracerArray._new(dtype, shape=broadcasted_shape)
+                for dtype in result_dtypes
             )
 
     def _axis_is_valid(self, axis: int, ndim: int) -> bool:
@@ -1321,7 +1345,7 @@ class TypeTracer(NumpyLike):
             raise NotImplementedError
 
     def count_nonzero(
-        self, x: ArrayLike, *, axis: int | None = None, keepdims: bool = False
+        self, x: ArrayLike, *, axis: int | None = None
     ) -> TypeTracerArray:
         assert not isinstance(x, PlaceholderArray)
         try_touch_data(x)

--- a/tests/test_2649_dlpack_support.py
+++ b/tests/test_2649_dlpack_support.py
@@ -2,8 +2,14 @@
 
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import awkward as ak
+
+if parse_version(np.__version__) < parse_version("1.23.0"):
+    pytest.skip(
+        "NumPy 1.23 or greater is required for DLPack testing", allow_module_level=True
+    )
 
 
 def test_from_dlpack_numpy():

--- a/tests/test_2793_nep_70_gradual_support.py
+++ b/tests/test_2793_nep_70_gradual_support.py
@@ -1,0 +1,39 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import packaging.version
+import pytest
+
+import awkward as ak
+
+NUMPY_HAS_NEP_50 = packaging.version.parse(np.__version__) >= packaging.version.Version(
+    "1.24.0"
+)
+
+
+@pytest.mark.skipif(NUMPY_HAS_NEP_50, reason="NEP-50 requires NumPy >= 1.24.0")
+def test_with_nep_50():
+    array = ak.from_numpy(np.arange(255, dtype=np.uint8))
+    assert array.layout.dtype == np.dtype(np.uint8)
+
+    typed_scalar = np.uint64(0)
+    assert (array + typed_scalar).layout.dtype == np.dtype(np.uint64)
+
+    # With NEP-50, we can ask NumPy to use value-less type resolution
+    untyped_scalar = 512
+    assert (array + untyped_scalar).layout.dtype == np.dtype(np.uint8)
+
+
+@pytest.mark.skipif(not NUMPY_HAS_NEP_50, reason="NumPy >= 1.24.0 has NEP-50 support")
+def test_without_nep_50():
+    array = ak.from_numpy(np.arange(255, dtype=np.uint8))
+    assert array.layout.dtype == np.dtype(np.uint8)
+
+    # Without NEP-50, we still don't drop type information for typed-scalars,
+    # unlike NumPy.
+    typed_scalar = np.uint64(0)
+    assert (array + typed_scalar).layout.dtype == np.dtype(np.uint64)
+
+    # But, with untyped scalars, we're forced to rely on NumPy's ufunc loop resolution
+    untyped_scalar = 512
+    assert (array + untyped_scalar).layout.dtype == np.dtype(np.uint16)

--- a/tests/test_2793_nep_70_gradual_support.py
+++ b/tests/test_2793_nep_70_gradual_support.py
@@ -1,4 +1,5 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+import contextlib
 
 import numpy as np
 import packaging.version
@@ -11,22 +12,30 @@ NUMPY_HAS_NEP_50 = packaging.version.parse(np.__version__) >= packaging.version.
 )
 
 
-@pytest.mark.skipif(NUMPY_HAS_NEP_50, reason="NEP-50 requires NumPy >= 1.24.0")
-def test_with_nep_50():
-    array = ak.from_numpy(np.arange(255, dtype=np.uint8))
+@pytest.mark.skipif(not NUMPY_HAS_NEP_50, reason="NEP-50 requires NumPy >= 1.24.0")
+@pytest.mark.parametrize("backend", ["cpu", "typetracer"])
+def test_with_nep_50(backend):
+    array = ak.to_backend(np.arange(255, dtype=np.uint8), backend)
     assert array.layout.dtype == np.dtype(np.uint8)
 
     typed_scalar = np.uint64(0)
     assert (array + typed_scalar).layout.dtype == np.dtype(np.uint64)
 
     # With NEP-50, we can ask NumPy to use value-less type resolution
-    untyped_scalar = 512
-    assert (array + untyped_scalar).layout.dtype == np.dtype(np.uint8)
+    warn_context = (
+        pytest.warns(DeprecationWarning, match="out-of-bound Python integers")
+        if backend == "cpu"
+        else contextlib.nullcontext()
+    )
+    with warn_context:
+        untyped_scalar = 512
+        assert (array + untyped_scalar).layout.dtype == np.dtype(np.uint8)
 
 
-@pytest.mark.skipif(not NUMPY_HAS_NEP_50, reason="NumPy >= 1.24.0 has NEP-50 support")
-def test_without_nep_50():
-    array = ak.from_numpy(np.arange(255, dtype=np.uint8))
+@pytest.mark.skipif(NUMPY_HAS_NEP_50, reason="NumPy >= 1.24.0 has NEP-50 support")
+@pytest.mark.parametrize("backend", ["cpu", "typetracer"])
+def test_without_nep_50(backend):
+    array = ak.to_backend(np.arange(255, dtype=np.uint8), backend)
     assert array.layout.dtype == np.dtype(np.uint8)
 
     # Without NEP-50, we still don't drop type information for typed-scalars,


### PR DESCRIPTION
It turns out that our CI wasn't properly testing the package combinations that we'd asked it to — there were subsequent install steps that overwrote the intended variations. This means that #2767 was not properly tested against older versions of NumPy, leading to a bug.

Although it's possible to use multiple install steps, it best reflects our intentions if we use a single install command.

In future, we probably just want to have a single `requirements.txt` file, and a separate `constraints.txt` that pins these dependency versions on our lower-bound configuration. However, we don't currently test *all* dependencies at the lower bound. This PR only runs core tests (NumPy + PyArrow) in the 3.8 tests.

Fixes #2784 