### PR TITLE
chore: run mypy in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,10 @@ repos:
   hooks:
     - id: check-github-workflows
       args: ["--verbose"]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.6.1
+  hooks:
+    - id: mypy
+      additional_dependencies:
+        - numpy>=1.24

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,5 +71,6 @@ repos:
   rev: v1.6.1
   hooks:
     - id: mypy
+      files: src
       additional_dependencies:
         - numpy>=1.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,40 +220,21 @@ disable = [
 
 [tool.mypy]
 files = ["src/awkward/**/*.py"]
-exclude = ["^src/awkward/[^/]+\\.py$"]
 plugins = [
     "numpy.typing.mypy_plugin"
 ]
 python_version = "3.11"
+ignore_errors = true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    'awkward.__init__',
-    'awkward._connect.*',
-    'awkward._cpu_kernels',
-    'awkward._errors',
-    'awkward._kernel_signatures',
-    'awkward._libawkward',
-    'awkward._util',
-    'awkward.forms',
-    'awkward.forth',
-    'awkward.highlevel',
-    'awkward.nplike',
-    'awkward.numba',
-    'awkward.types',
-    'awkward.types._awkward_datashape_parser',
-    'numba.*',
-    'llvmlite.*',
-    'ROOT.*',
-    'cppyy.*',
-    'jax.*',
-    'pandas.*',
-    'cupy.*',
-    'pyarrow.*',
-    'fsspec.*',
-    'numexpr.*',
+    'awkward._nplikes.*',
+    'awkward._behavior.*',
+    'awkward._backends.*',
+    'awkward.forms.*',
 ]
-ignore_errors = true
+ignore_errors = false
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -306,6 +287,7 @@ mccabe.max-complexity = 100
 [tool.ruff.lint.per-file-ignores]
 "dev/*" = ["T20", "TID251"]
 "src/awkward/numba/*" = ["TID251"]
+"src/awkward/_typing.py" = ["TID251"]
 "src/awkward/_errors.py" = ["TID251"]
 "src/awkward/errors.py" = ["TID251"]
 "src/awkward/_connect/*" = ["TID251"]

--- a/src/awkward/_backends/backend.py
+++ b/src/awkward/_backends/backend.py
@@ -2,20 +2,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import awkward as ak
 from awkward._kernels import KernelError
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpylike import NumpyLike, NumpyMetadata
 from awkward._singleton import PublicSingleton
-from awkward._typing import Callable, Tuple, TypeAlias, TypeVar, Unpack
+from awkward._typing import Callable, Tuple, TypeAlias, TypeVar
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
 T_co = TypeVar("T_co", covariant=True)
-KernelKeyType: TypeAlias = Tuple[str, Unpack[Tuple[np.dtype, ...]]]
+KernelKeyType: TypeAlias = Tuple[Any, ...]
 KernelType: TypeAlias = "Callable[..., KernelError | None]"
 
 
@@ -49,6 +50,7 @@ class Backend(PublicSingleton, ABC):
                 errors="surrogateescape"
             ).lstrip("\n").lstrip("(")
 
+        assert error.str is not None
         message = error.str.decode(errors="surrogateescape")
 
         if error.attempt != ak._util.kSliceNone:

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@register_backend(Cupy)
+@register_backend(Cupy)  # type: ignore[type-abstract]
 class CupyBackend(Backend):
     name: Final[str] = "cuda"
 

--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -16,7 +16,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@register_backend(Jax)
+@register_backend(Jax)  # type: ignore[type-abstract]
 class JaxBackend(Backend):
     name: Final[str] = "jax"
 

--- a/src/awkward/_backends/numpy.py
+++ b/src/awkward/_backends/numpy.py
@@ -14,7 +14,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@register_backend(Numpy)
+@register_backend(Numpy)  # type: ignore[type-abstract]
 class NumpyBackend(Backend):
     name: Final[str] = "cpu"
 

--- a/src/awkward/_backends/typetracer.py
+++ b/src/awkward/_backends/typetracer.py
@@ -13,7 +13,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@register_backend(TypeTracer)
+@register_backend(TypeTracer)  # type: ignore[type-abstract]
 class TypeTracerBackend(Backend):
     name: Final[str] = "typetracer"
 

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -2,14 +2,22 @@
 from __future__ import annotations
 
 from collections import ChainMap
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 import awkward as ak
 from awkward._nplikes import ufuncs
-from awkward._typing import Any
+from awkward._typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from awkward._nplikes.numpylike import UfuncLike
+    from awkward._reducers import Reducer
+    from awkward.contents.content import Content
+    from awkward.highlevel import Array
+    from awkward.highlevel import Record as HighLevelRecord
+    from awkward.record import Record
 
 
-def overlay_behavior(behavior: dict | None) -> Mapping:
+def overlay_behavior(behavior: Mapping | None) -> Mapping:
     """
     Args:
         behavior: behavior dictionary, or None
@@ -19,10 +27,11 @@ def overlay_behavior(behavior: dict | None) -> Mapping:
     """
     if behavior is None:
         return ak.behavior
-    return ChainMap(behavior, ak.behavior)
+    else:
+        return ChainMap(behavior, ak.behavior)  # type: ignore[arg-type]
 
 
-def get_array_class(layout, behavior):
+def get_array_class(layout: Content, behavior: Mapping | None) -> type[Array]:
     from awkward.highlevel import Array
 
     behavior = overlay_behavior(behavior)
@@ -39,7 +48,7 @@ def get_array_class(layout, behavior):
     return Array
 
 
-def get_record_class(layout, behavior):
+def get_record_class(layout: Record, behavior: Mapping | None) -> type[HighLevelRecord]:
     from awkward.highlevel import Record
 
     behavior = overlay_behavior(behavior)
@@ -51,14 +60,20 @@ def get_record_class(layout, behavior):
     return Record
 
 
-def find_record_reducer(reducer, layout, behavior):
+def find_record_reducer(
+    reducer: Reducer, layout: Record, behavior: Mapping | None
+) -> Callable[[Array, bool], Any] | None:
     behavior = overlay_behavior(behavior)
     rec = layout.parameter("__record__")
     if isinstance(rec, str):
         return behavior.get((reducer.highlevel_function(), rec))
+    else:
+        return None
 
 
-def find_custom_cast(obj, behavior):
+def find_custom_cast(
+    obj: Any, behavior: Mapping | None
+) -> Callable[[Any], Content | Record] | None:
     behavior = overlay_behavior(behavior)
     for cls in type(obj).__mro__:
         fcn = behavior.get(("__cast__", cls))
@@ -67,7 +82,9 @@ def find_custom_cast(obj, behavior):
     return None
 
 
-def find_ufunc_generic(ufunc, layout, behavior):
+def find_ufunc_generic(
+    ufunc: UfuncLike, layout: Content, behavior: Mapping | None
+) -> Callable[[UfuncLike, str, list, dict], Any] | None:
     behavior = overlay_behavior(behavior)
     custom = layout.parameter("__list__")
     if custom is None:
@@ -81,8 +98,8 @@ def find_ufunc_generic(ufunc, layout, behavior):
         return None
 
 
-def find_ufunc(behavior, signature: tuple):
-    if not any(s is None for s in signature):
+def find_ufunc(behavior: Mapping | None, signature: tuple) -> UfuncLike | None:
+    if all(s is not None for s in signature):
         behavior = overlay_behavior(behavior)
 
         # Special case all strings or hashable types.
@@ -105,13 +122,14 @@ def find_ufunc(behavior, signature: tuple):
                     )
                 ):
                     return custom
+    return None
 
 
 def find_record_typestr(
     behavior: None | Mapping,
     parameters: None | Mapping[str, Any],
     default: str | None = None,
-):
+) -> str | None:
     if parameters is None:
         return default
     behavior = overlay_behavior(behavior)
@@ -122,14 +140,14 @@ def find_array_typestr(
     behavior: None | Mapping,
     parameters: None | Mapping[str, Any],
     default: str | None = None,
-):
+) -> str | None:
     if parameters is None:
         return default
     behavior = overlay_behavior(behavior)
     return behavior.get(("__typestr__", parameters.get("__list__")), default)
 
 
-def behavior_of_obj(obj, behavior: Mapping | None = None) -> Mapping | None:
+def behavior_of_obj(obj: Any, behavior: Mapping | None = None) -> Mapping | None:
     from awkward.highlevel import Array, ArrayBuilder, Record
 
     if behavior is not None:
@@ -140,7 +158,7 @@ def behavior_of_obj(obj, behavior: Mapping | None = None) -> Mapping | None:
         return None
 
 
-def behavior_of(*arrays, behavior: Mapping | None = None) -> Mapping | None:
+def behavior_of(*arrays: Any, behavior: Mapping | None = None) -> Mapping | None:
     if behavior is not None:
         # An explicit 'behavior' always wins.
         return behavior
@@ -158,5 +176,6 @@ def behavior_of(*arrays, behavior: Mapping | None = None) -> Mapping | None:
             behavior.update(x_behavior)
             copied = True
         else:
+            assert isinstance(behavior, dict)
             behavior.update(x_behavior)
     return behavior

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -21,8 +21,8 @@ metadata = NumpyMetadata.instance()
 
 
 class KernelError(Protocol):
-    filename: str | None  # pylint: disable=E0602
-    str: str | None
+    filename: bytes | None  # pylint: disable=E0602
+    str: bytes | None
     attempt: int
     id: int
 

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -33,6 +33,6 @@ def to_nplike(
     if isinstance(from_nplike, awkward._nplikes.cupy.Cupy) and not isinstance(
         nplike, awkward._nplikes.cupy.Cupy
     ):
-        array = array.get()
+        array = array.get()  # type: ignore[attr-defined]
 
     return nplike.asarray(array)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -17,7 +17,10 @@ from awkward._nplikes.numpylike import (
 )
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._typing import Any, cast, Final, Literal, DType
+from awkward._typing import TYPE_CHECKING, Any, Final, Literal, cast
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
 
 np = NumpyMetadata.instance()
 NUMPY_HAS_NEP_50 = packaging.version.Version(
@@ -49,7 +52,7 @@ class ArrayModuleNumpyLike(NumpyLike):
         self,
         obj,
         *,
-        dtype: DType | None = None,
+        dtype: DTypeLike | None = None,
         copy: bool | None = None,
     ) -> ArrayLike:
         if isinstance(obj, PlaceholderArray):
@@ -74,7 +77,7 @@ class ArrayModuleNumpyLike(NumpyLike):
             return self._module.ascontiguousarray(x)
 
     def frombuffer(
-        self, buffer, *, dtype: DType | None = None, count: ShapeItem = -1
+        self, buffer, *, dtype: DTypeLike | None = None, count: ShapeItem = -1
     ) -> ArrayLike:
         if isinstance(buffer, PlaceholderArray):
             raise TypeError("placeholder arrays are not supported in `frombuffer`")
@@ -84,17 +87,26 @@ class ArrayModuleNumpyLike(NumpyLike):
         return self._module.from_dlpack(x)
 
     def zeros(
-        self, shape: ShapeItem | tuple[ShapeItem, ...], *, dtype: DType | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: DTypeLike | None = None,
     ) -> ArrayLike:
         return self._module.zeros(shape, dtype=dtype)
 
     def ones(
-        self, shape: ShapeItem | tuple[ShapeItem, ...], *, dtype: DType | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: DTypeLike | None = None,
     ) -> ArrayLike:
         return self._module.ones(shape, dtype=dtype)
 
     def empty(
-        self, shape: ShapeItem | tuple[ShapeItem, ...], *, dtype: DType | None = None
+        self,
+        shape: ShapeItem | tuple[ShapeItem, ...],
+        *,
+        dtype: DTypeLike | None = None,
     ) -> ArrayLike:
         return self._module.empty(shape, dtype=dtype)
 
@@ -103,24 +115,24 @@ class ArrayModuleNumpyLike(NumpyLike):
         shape: ShapeItem | tuple[ShapeItem, ...],
         fill_value,
         *,
-        dtype: DType | None = None,
+        dtype: DTypeLike | None = None,
     ) -> ArrayLike:
         return self._module.full(shape, fill_value, dtype=dtype)
 
-    def zeros_like(self, x: ArrayLike, *, dtype: DType | None = None) -> ArrayLike:
+    def zeros_like(self, x: ArrayLike, *, dtype: DTypeLike | None = None) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
             return self.zeros(x.shape, dtype=dtype or x.dtype)
         else:
             return self._module.zeros_like(x, dtype=dtype)
 
-    def ones_like(self, x: ArrayLike, *, dtype: DType | None = None) -> ArrayLike:
+    def ones_like(self, x: ArrayLike, *, dtype: DTypeLike | None = None) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
             return self.ones(x.shape, dtype=dtype or x.dtype)
         else:
             return self._module.ones_like(x, dtype=dtype)
 
     def full_like(
-        self, x: ArrayLike, fill_value, *, dtype: DType | None = None
+        self, x: ArrayLike, fill_value, *, dtype: DTypeLike | None = None
     ) -> ArrayLike:
         if isinstance(x, PlaceholderArray):
             return self.full(x.shape, fill_value, dtype=dtype or x.dtype)
@@ -133,7 +145,7 @@ class ArrayModuleNumpyLike(NumpyLike):
         stop: float | int | None = None,
         step: float | int = 1,
         *,
-        dtype: DType | None = None,
+        dtype: DTypeLike | None = None,
     ) -> ArrayLike:
         assert not isinstance(start, PlaceholderArray)
         assert not isinstance(stop, PlaceholderArray)
@@ -212,14 +224,13 @@ class ArrayModuleNumpyLike(NumpyLike):
         ) -> ArrayLike | tuple[ArrayLike]:
             # Convert np.generic to scalar arrays
             resolved_args = [
-                self.asarray(arg, dtype=arg.dtype) if hasattr(arg, "dtype") else arg
+                self.asarray(arg, dtype=arg.dtype if hasattr(arg, "dtype") else None)
                 for arg in args
             ]
             broadcasted_args = self.broadcast_arrays(*resolved_args)
             # Choose the broadcasted argument if it wasn't a Python scalar
             non_generic_value_promoted_args = [
-                y if hasattr(x, "ndim") else x
-                for x, y in zip(resolved_args, broadcasted_args)
+                y if hasattr(x, "ndim") else x for x, y in zip(args, broadcasted_args)
             ]
             # Allow other nplikes to replace implementation
             impl = self.prepare_ufunc(ufunc)
@@ -436,7 +447,7 @@ class ArrayModuleNumpyLike(NumpyLike):
     def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
         if isinstance(x, PlaceholderArray):
             # Assume contiguous
-            strides: tuple[int, ...] = (x.itemsize,)
+            strides: tuple[ShapeItem, ...] = (x.dtype.itemsize,)
             for item in x.shape[-1:0:-1]:
                 strides = (item * strides[0], *strides)
             return strides
@@ -598,12 +609,12 @@ class ArrayModuleNumpyLike(NumpyLike):
         )
 
     def astype(
-        self, x: ArrayLike, dtype: numpy.dtype, *, copy: bool | None = True
+        self, x: ArrayLike, dtype: DTypeLike, *, copy: bool | None = True
     ) -> ArrayLike:
         assert not isinstance(x, PlaceholderArray)
-        return x.astype(dtype, copy=copy)  # type: ignore
+        return x.astype(dtype, copy=copy)  # type: ignore[attr-defined]
 
-    def can_cast(self, from_: DType | ArrayLike, to: DType | ArrayLike) -> bool:
+    def can_cast(self, from_: DTypeLike | ArrayLike, to: DTypeLike | ArrayLike) -> bool:
         return self._module.can_cast(from_, to, casting="same_kind")
 
     @classmethod

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -8,7 +8,11 @@ from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpylike import ArrayLike
 from awkward._nplikes.placeholder import PlaceholderArray
-from awkward._typing import Final
+from awkward._nplikes.shape import ShapeItem
+from awkward._typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
 
 
 @register_nplike
@@ -40,7 +44,7 @@ class Cupy(ArrayModuleNumpyLike):
         return self._module.ndarray
 
     def frombuffer(
-        self, buffer, *, dtype: numpy.dtype | None = None, count: int = -1
+        self, buffer, *, dtype: DTypeLike | None = None, count: ShapeItem = -1
     ) -> ArrayLike:
         assert not isinstance(buffer, PlaceholderArray)
         assert not isinstance(count, PlaceholderArray)
@@ -81,7 +85,7 @@ class Cupy(ArrayModuleNumpyLike):
         self,
         x: ArrayLike,
         *,
-        axis: int | tuple[int, ...] | None = None,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
@@ -96,7 +100,7 @@ class Cupy(ArrayModuleNumpyLike):
         self,
         x: ArrayLike,
         *,
-        axis: int | tuple[int, ...] | None = None,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
@@ -108,7 +112,7 @@ class Cupy(ArrayModuleNumpyLike):
             return out
 
     def count_nonzero(
-        self, x: ArrayLike, *, axis: int | tuple[int, ...] | None = None
+        self, x: ArrayLike, *, axis: ShapeItem | tuple[ShapeItem, ...] | None = None
     ) -> ArrayLike:
         assert not isinstance(x, PlaceholderArray)
         assert isinstance(axis, int) or axis is None
@@ -122,7 +126,7 @@ class Cupy(ArrayModuleNumpyLike):
         self,
         x: ArrayLike,
         *,
-        axis: int | tuple[int, ...] | None = None,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
@@ -137,7 +141,7 @@ class Cupy(ArrayModuleNumpyLike):
         self,
         x: ArrayLike,
         *,
-        axis: int | tuple[int, ...] | None = None,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
@@ -164,4 +168,4 @@ class Cupy(ArrayModuleNumpyLike):
         if isinstance(x, PlaceholderArray):
             return True
         else:
-            return x.flags["C_CONTIGUOUS"]
+            return x.flags["C_CONTIGUOUS"]  # type: ignore[attr-defined]

--- a/src/awkward/_nplikes/dispatch.py
+++ b/src/awkward/_nplikes/dispatch.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from awkward._nplikes.numpylike import NumpyLike
-from awkward._typing import TypeVar
-from awkward._util import UNSET
+from awkward._typing import Any, TypeVar, cast
+from awkward._util import UNSET, Sentinel
 
 D = TypeVar("D")
 
@@ -19,7 +19,7 @@ def register_nplike(cls: N) -> N:
     return cls
 
 
-def nplike_of_obj(obj, *, default: D = UNSET) -> NumpyLike | D:
+def nplike_of_obj(obj: Any, *, default: D | Sentinel = UNSET) -> NumpyLike | D:
     """
     Args:
         *arrays: iterable of possible array objects
@@ -44,6 +44,6 @@ def nplike_of_obj(obj, *, default: D = UNSET) -> NumpyLike | D:
             if default is UNSET:
                 raise TypeError(f"cannot find nplike for {cls.__name__}")
             else:
-                return default
+                return cast(D, default)
         _type_to_nplike[cls] = nplike
         return nplike

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -5,8 +5,7 @@ import awkward as ak
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpylike import ArrayLike, UfuncLike
-from awkward._nplikes.shape import ShapeItem
-from awkward._typing import Final
+from awkward._typing import Final, cast
 
 
 @register_nplike
@@ -82,9 +81,8 @@ class Jax(ArrayModuleNumpyLike):
     def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
         return x
 
-    def strides(self, x: ArrayLike) -> tuple[ShapeItem, ...]:
-        x.touch_shape()
-        out = (x._dtype.itemsize,)
-        for item in x._shape[-1:0:-1]:
+    def strides(self, x: ArrayLike) -> tuple[int, ...]:
+        out: tuple[int, ...] = (x.dtype.itemsize,)
+        for item in cast(tuple[int, ...], x.shape[-1:0:-1]):
             out = (item * out[0], *out)
         return out

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -47,7 +47,7 @@ class Numpy(ArrayModuleNumpyLike):
         if isinstance(x, PlaceholderArray):
             return True
         else:
-            return x.flags["C_CONTIGUOUS"]
+            return x.flags["C_CONTIGUOUS"]  # type: ignore[attr-defined]
 
     def packbits(
         self,
@@ -57,7 +57,7 @@ class Numpy(ArrayModuleNumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ):
         assert not isinstance(x, PlaceholderArray)
-        return numpy.packbits(x, axis=axis, bitorder=bitorder)
+        return numpy.packbits(x, axis=axis, bitorder=bitorder)  # type: ignore[arg-type]
 
     def unpackbits(
         self,
@@ -68,4 +68,4 @@ class Numpy(ArrayModuleNumpyLike):
         bitorder: Literal["big", "little"] = "big",
     ):
         assert not isinstance(x, PlaceholderArray)
-        return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
+        return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)  # type: ignore[arg-type]

--- a/src/awkward/_nplikes/shape.py
+++ b/src/awkward/_nplikes/shape.py
@@ -2,15 +2,20 @@
 from __future__ import annotations
 
 from awkward._singleton import PrivateSingleton
-from awkward._typing import Self, TypeAlias
+from awkward._typing import TYPE_CHECKING, Self, TypeAlias
 
-ShapeItem: TypeAlias = "int | type[unknown_length]"
+__all__ = ("ShapeItem", "UnknownLength", "unknown_length")
+
+ShapeItem: TypeAlias = "int | UnknownLength"
+
+if TYPE_CHECKING:
+    from types import NotImplementedType
 
 
-class _UnknownLength(PrivateSingleton):
+class UnknownLength(PrivateSingleton):
     _instance_name: str
 
-    def __add__(self, other) -> Self | NotImplemented:
+    def __add__(self, other) -> Self | NotImplementedType:
         if isinstance(other, int) or other is self:
             return self
         else:
@@ -19,7 +24,7 @@ class _UnknownLength(PrivateSingleton):
     __radd__ = __add__
     __iadd__ = __add__
 
-    def __sub__(self, other) -> Self | NotImplemented:
+    def __sub__(self, other) -> Self | NotImplementedType:
         if isinstance(other, int) or other is self:
             return self
         else:
@@ -28,7 +33,7 @@ class _UnknownLength(PrivateSingleton):
     __rsub__ = __sub__
     __isub__ = __sub__
 
-    def __mul__(self, other) -> Self | NotImplemented:
+    def __mul__(self, other) -> Self | NotImplementedType:
         if isinstance(other, int) or other is self:
             return self
         else:
@@ -37,7 +42,7 @@ class _UnknownLength(PrivateSingleton):
     __rmul__ = __mul__
     __imul__ = __mul__
 
-    def __floordiv__(self, other) -> Self | NotImplemented:
+    def __floordiv__(self, other) -> Self | NotImplementedType:
         if isinstance(other, int) or other is self:
             return self
         else:
@@ -81,7 +86,7 @@ class _UnknownLength(PrivateSingleton):
 
 
 # Inform the singleton if its module name
-_UnknownLength._instance_name = f"{__name__}.unknown_length"
+UnknownLength._instance_name = f"{__name__}.unknown_length"
 
 # Ensure we have a single instance
-unknown_length = _UnknownLength._new()
+unknown_length = UnknownLength._new()

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -2,10 +2,11 @@
 # ruff: noqa: PLE0604
 from __future__ import annotations
 
-import numpy
 import sys
 import typing
 from typing import *  # noqa: F403
+
+import numpy
 
 __all__ = list(
     {
@@ -16,6 +17,7 @@ __all__ = list(
         "Protocol",
         "Unpack",
         "TypeAlias",
+        "TypeGuard",
         "runtime_checkable",
         "AxisMaybeNone",
         "TypedDict",
@@ -37,6 +39,7 @@ if sys.version_info < (3, 11):
         Self,
         TypeAlias,
         TypedDict,
+        TypeGuard,
         Unpack,
         final,
     )
@@ -50,6 +53,7 @@ else:
         SupportsIndex,
         TypeAlias,
         TypedDict,
+        TypeGuard,
         Unpack,
         final,
         runtime_checkable,
@@ -61,4 +65,4 @@ JSONSerializable: TypeAlias = (
 )
 JSONMapping: TypeAlias = "dict[str, JSONSerializable]"
 
-DType = TypeVar("DType", bound=numpy.dtype)
+DType: TypeAlias = numpy.dtype

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form, index_to_dtype
+from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
 np = NumpyMetadata.instance()
 
@@ -187,22 +187,10 @@ class ByteMaskedForm(Form):
         if next_content is None:
             return None
         else:
-            return ByteMaskedForm(
-                self._mask,
-                next_content,
-                self._valid_when,
-                parameters=self._parameters,
-                form_key=self._form_key,
-            )
+            return self.copy(content=next_content)
 
-    def _select_columns(self, match_specifier):
-        return ByteMaskedForm(
-            self._mask,
-            self._content._select_columns(match_specifier),
-            self._valid_when,
-            parameters=self._parameters,
-            form_key=self._form_key,
-        )
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
+        return self.copy(content=self._content._select_columns(match_specifier))
 
     def _column_types(self):
         return self._content._column_types()
@@ -226,7 +214,7 @@ class ByteMaskedForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         yield (getkey(self, "mask"), index_to_dtype[self._mask])
         if recursive:
             yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -10,9 +10,9 @@ import awkward as ak
 from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import Iterator, JSONSerializable, Self, final
-from awkward._util import UNSET
-from awkward.forms.form import Form, JSONMapping
+from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._util import UNSET, Sentinel
+from awkward.forms.form import Form, JSONMapping, _SpecifierMatcher
 
 np = NumpyMetadata.instance()
 
@@ -22,22 +22,29 @@ class EmptyForm(Form):
     is_numpy = True
     is_unknown = True
 
-    def __init__(self, *, parameters: JSONMapping | None = None, form_key=None):
+    def __init__(
+        self, *, parameters: JSONMapping | None = None, form_key: str | None = None
+    ):
         if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         self._init(parameters=parameters, form_key=form_key)
 
     def copy(
-        self, *, parameters: JSONMapping | None = UNSET, form_key=UNSET
+        self,
+        *,
+        parameters: JSONMapping | Sentinel | None = UNSET,
+        form_key: str | Sentinel | None = UNSET,
     ) -> EmptyForm:
-        if not (parameters is UNSET or parameters is None or len(parameters) == 0):
+        if not (parameters is UNSET or parameters is None or len(parameters) == 0):  # type: ignore[arg-type]
             raise TypeError(f"{type(self).__name__} cannot contain parameters")
         return EmptyForm(
-            form_key=self._form_key if form_key is UNSET else form_key,
+            form_key=self._form_key if form_key is UNSET else form_key,  # type: ignore[arg-type]
         )
 
     @classmethod
-    def simplified(cls, *, parameters=None, form_key=None) -> Form:
+    def simplified(
+        cls, *, parameters: JSONMapping | None = None, form_key: str | None = None
+    ) -> Form:
         if not (parameters is None or len(parameters) == 0):
             raise TypeError(f"{cls.__name__} cannot contain parameters")
         return cls(parameters=parameters, form_key=form_key)
@@ -123,7 +130,7 @@ class EmptyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
         return self
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Self:
@@ -152,5 +159,5 @@ class EmptyForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         yield from ()

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form, index_to_dtype
+from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
 np = NumpyMetadata.instance()
 
@@ -176,20 +176,10 @@ class IndexedOptionForm(Form):
         if next_content is None:
             return None
         else:
-            return IndexedOptionForm(
-                self._index,
-                next_content,
-                parameters=self._parameters,
-                form_key=self._form_key,
-            )
+            return self.copy(content=next_content)
 
-    def _select_columns(self, match_specifier):
-        return IndexedOptionForm(
-            self._index,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
-        )
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
+        return self.copy(content=self._content._select_columns(match_specifier))
 
     def _column_types(self):
         return self._content._column_types()
@@ -211,7 +201,7 @@ class IndexedOptionForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         yield (getkey(self, "index"), index_to_dtype[self._index])
         if recursive:
             yield from self._content._expected_from_buffers(getkey, recursive)

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Iterator, JSONSerializable, final
+from awkward._typing import DType, Iterator, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form, index_to_dtype
+from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
 np = NumpyMetadata.instance()
 
@@ -190,27 +190,15 @@ class ListForm(Form):
             path = (*path, list_indicator)
         self._content._columns(path, output, list_indicator)
 
-    def _prune_columns(self, is_inside_record_or_union: bool):
+    def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
         next_content = self._content._prune_columns(is_inside_record_or_union)
         if next_content is None:
             return None
         else:
-            return ListForm(
-                self._starts,
-                self._stops,
-                next_content,
-                parameters=self._parameters,
-                form_key=self._form_key,
-            )
+            return self.copy(content=next_content)
 
-    def _select_columns(self, match_specifier):
-        return ListForm(
-            self._starts,
-            self._stops,
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
-        )
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
+        return self.copy(content=self._content._select_columns(match_specifier))
 
     def _column_types(self):
         if self.parameter("__array__") in ("string", "bytestring"):
@@ -237,7 +225,7 @@ class ListForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         yield (getkey(self, "starts"), index_to_dtype[self._starts])
         yield (getkey(self, "stops"), index_to_dtype[self._stops])
         if recursive:

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -9,14 +9,19 @@ from awkward._errors import deprecate
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
-from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward._typing import DType, JSONMapping, JSONSerializable, Self, final
+from awkward._util import UNSET, Sentinel
+from awkward.forms.form import Form, _SpecifierMatcher
 
 np = NumpyMetadata.instance()
 
 
-def from_dtype(dtype, parameters=None, *, time_units_as_parameter: bool = UNSET):
+def from_dtype(
+    dtype,
+    parameters: JSONMapping | None = None,
+    *,
+    time_units_as_parameter: bool | Sentinel = UNSET,
+):
     if dtype.subdtype is None:
         inner_shape = ()
     else:
@@ -182,6 +187,7 @@ class NumpyForm(Form):
             for key in keys:
                 if key in self._parameters:
                     return self._parameters[key]
+        return None
 
     @property
     def purelist_isregular(self):
@@ -219,7 +225,7 @@ class NumpyForm(Form):
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))
 
-    def _select_columns(self, match_specifier):
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
         return self
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Self:
@@ -294,7 +300,7 @@ class NumpyForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         from awkward.types.numpytype import primitive_to_dtype
 
         yield (getkey(self, "data"), primitive_to_dtype(self.primitive))

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -7,9 +7,9 @@ from collections.abc import Callable, Iterator
 import awkward as ak
 from awkward._nplikes.numpylike import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import JSONSerializable, Self, final
+from awkward._typing import DType, JSONSerializable, Self, final
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, _SpecifierMatcher
 
 np = NumpyMetadata.instance()
 
@@ -150,18 +150,10 @@ class UnmaskedForm(Form):
         if next_content is None:
             return None
         else:
-            return UnmaskedForm(
-                next_content,
-                parameters=self._parameters,
-                form_key=self._form_key,
-            )
+            return self.copy(content=next_content)
 
-    def _select_columns(self, match_specifier):
-        return UnmaskedForm(
-            self._content._select_columns(match_specifier),
-            parameters=self._parameters,
-            form_key=self._form_key,
-        )
+    def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
+        return self.copy(content=self._content._select_columns(match_specifier))
 
     def _column_types(self):
         return self._content._column_types()
@@ -183,6 +175,6 @@ class UnmaskedForm(Form):
 
     def _expected_from_buffers(
         self, getkey: Callable[[Form, str], str], recursive: bool
-    ) -> Iterator[tuple[str, np.dtype]]:
+    ) -> Iterator[tuple[str, DType]]:
         if recursive:
             yield from self._content._expected_from_buffers(getkey, recursive)


### PR DESCRIPTION
This PR enables `mypy` checks on a subset of the codebase and runs it as part of CI.
Right now, we don't publicly declare type-hints via `py.typed`, so these are only used internally.

Some things don't type super well; the `Sentinel` singleton doesn't seem very easy to handle. The closest we could get I *think* is to use e.g. 
```python
import enum
from typing import Literal


class Unset(enum.Enum):
    TOKEN = enum.auto()


def func_with_defaults(x: int, y: int | Literal[Unset.TOKEN]):
    ...
```

But for now, we'll just ignore this part of the typing.

We're not running in strict mode, so this only checks places where we declare types.