### PR TITLE
fix: remove old argument from `broadcast_and_apply`

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -1009,6 +1009,7 @@ def apply_step(
 def broadcast_and_apply(
     inputs,
     action,
+    *,
     depth_context: dict[str, Any] | None = None,
     lateral_context: dict[str, Any] | None = None,
     allow_records: bool = True,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -296,10 +296,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior):
                 return None
 
         out = ak._broadcasting.broadcast_and_apply(
-            content_or_others,
-            action,
-            allow_records=True,
-            right_broadcast=False,
+            content_or_others, action, allow_records=True, right_broadcast=False
         )[0]
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_mask.py
+++ b/src/awkward/operations/ak_mask.py
@@ -122,10 +122,7 @@ def _impl(array, mask, valid_when, highlevel, behavior):
 
     behavior = behavior_of(array, mask, behavior=behavior)
     out = ak._broadcasting.broadcast_and_apply(
-        [layoutarray, layoutmask],
-        action,
-        numpy_to_regular=True,
-        right_broadcast=False,
+        [layoutarray, layoutmask], action, numpy_to_regular=True, right_broadcast=False
     )
     assert isinstance(out, tuple) and len(out) == 1
     return wrap_layout(out[0], behavior, highlevel)

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -137,9 +137,7 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior):
             return None
 
     out = ak._broadcasting.broadcast_and_apply(
-        [condition_layout, x_layout, y_layout],
-        action,
-        numpy_to_regular=True,
+        [condition_layout, x_layout, y_layout], action, numpy_to_regular=True
     )
 
     return wrap_layout(out[0], behavior, highlevel)

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -165,9 +165,7 @@ def _impl(base, what, where, highlevel, behavior):
                 return None
 
         out = ak._broadcasting.broadcast_and_apply(
-            [base, what],
-            action,
-            right_broadcast=False,
+            [base, what], action, right_broadcast=False
         )
 
         assert isinstance(out, tuple) and len(out) == 1

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -214,7 +214,7 @@ def _impl(
             return None
 
     out = ak._broadcasting.broadcast_and_apply(
-        layouts, action, behavior, right_broadcast=right_broadcast
+        layouts, action, right_broadcast=right_broadcast
     )
     assert isinstance(out, tuple) and len(out) == 1
     out = out[0]

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -118,8 +118,7 @@ def _impl(array, separator, highlevel, behavior):
             )
 
         (out,) = ak._broadcasting.broadcast_and_apply(
-            (layout, separator_layout),
-            apply_binary,
+            (layout, separator_layout), apply_binary
         )
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -79,7 +79,7 @@ def _impl(array, num_repeats, highlevel, behavior):
                 return (_apply_through_arrow(pc.binary_repeat, *inputs),)
 
         (out,) = ak._broadcasting.broadcast_and_apply(
-            (layout, num_repeats_layout), action, behavior
+            (layout, num_repeats_layout), action
         )
 
     else:


### PR DESCRIPTION
A recent PR made this change, but it looks like I missed one usage. I've made the function keyword-only for the non-leading arguments. `broadcast_and_apply` is an internal function, but I also think these functions benefit from this change: future refactors will throw exceptions rather than silently re-interpreting an argument, and it helps readability. Incidentally, that's how most of the usages of `broadcast_and_apply` are written; keyword arguments for the non-leading order args. 

As this fixes a bug that's clearly from a previous PR, and it doesn't change any behaviour, I'm going to merge in the interest of unblocking main.