### PR TITLE
fix: support scalar strings in `fill_none`

### DIFF
--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -89,7 +89,8 @@ def _impl(array, value, axis, highlevel, behavior):
     elif isinstance(valuelayout, ak.contents.Content):
         valuelayout = valuelayout[np.newaxis, ...]
     else:
-        # Now we know we've got Python scalars/strings, we can promote without
+        # Now that we know `valuelayout` isn't a low-level type, we must have scalars
+        # Thus, we can safely promote these scalars to a layout without
         # adding a new axis
         valuelayout = ak.operations.to_layout(
             value,

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -81,6 +81,7 @@ def _impl(array, value, axis, highlevel, behavior):
         allow_unknown=False,
         use_from_iter=True,
         primitive_policy="pass-through",
+        string_policy="pass-through",
     )
 
     if isinstance(valuelayout, ak.record.Record):
@@ -88,12 +89,15 @@ def _impl(array, value, axis, highlevel, behavior):
     elif isinstance(valuelayout, ak.contents.Content):
         valuelayout = valuelayout[np.newaxis, ...]
     else:
+        # Now we know we've got Python scalars/strings, we can promote without
+        # adding a new axis
         valuelayout = ak.operations.to_layout(
             value,
             allow_record=True,
             allow_unknown=False,
             use_from_iter=True,
             primitive_policy="promote",
+            string_policy="promote",
         )
     valuelayout = valuelayout.to_backend(backend)
 

--- a/tests/test_2763_to_layout_granularity.py
+++ b/tests/test_2763_to_layout_granularity.py
@@ -71,3 +71,28 @@ def test_with_field():
             ["x"],
         )
     )
+
+
+def test_fill_none():
+    array = ak.Array([None, 1, 2, None])
+    result = ak.fill_none(array, "hello world!")
+    assert result.layout.is_equal_to(
+        ak.contents.UnionArray(
+            ak.index.Index8([1, 0, 0, 1]),
+            ak.index.Index64([0, 0, 1, 0]),
+            [
+                ak.contents.NumpyArray(np.array([1, 2], dtype=np.int64)),
+                ak.contents.ListOffsetArray(
+                    ak.index.Index64([0, 12]),
+                    ak.contents.NumpyArray(
+                        np.array(
+                            [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33],
+                            dtype=np.uint8,
+                        ),
+                        parameters={"__array__": "char"},
+                    ),
+                    parameters={"__array__": "string"},
+                ),
+            ],
+        )
+    )


### PR DESCRIPTION
This regression was introduced by #2763. This PR ensures that strings are treated as scalars in `fill_none`.