### PR TITLE
feat: add `with_field_attr`

### DIFF
--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -23,6 +23,7 @@ from awkward.operations.ak_count_nonzero import *
 from awkward.operations.ak_covar import *
 from awkward.operations.ak_drop_none import *
 from awkward.operations.ak_enforce_type import *
+from awkward.operations.ak_field_attrs import *
 from awkward.operations.ak_fields import *
 from awkward.operations.ak_fill_none import *
 from awkward.operations.ak_firsts import *
@@ -100,6 +101,7 @@ from awkward.operations.ak_values_astype import *
 from awkward.operations.ak_var import *
 from awkward.operations.ak_where import *
 from awkward.operations.ak_with_field import *
+from awkward.operations.ak_with_field_attr import *
 from awkward.operations.ak_with_name import *
 from awkward.operations.ak_with_parameter import *
 from awkward.operations.ak_without_field import *

--- a/src/awkward/operations/ak_field_attrs.py
+++ b/src/awkward/operations/ak_field_attrs.py
@@ -1,0 +1,81 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+__all__ = ("field_attrs",)
+
+import awkward as ak
+from awkward._dispatch import high_level_function
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._regularize import is_non_string_like_sequence
+
+np = NumpyMetadata.instance()
+
+
+@high_level_function()
+def field_attrs(array, field):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        field (str or tuple of str): Field name, or series of field names
+            to resolve.
+
+    This function returns a new array with a parameter set on the outermost
+    node of its #ak.Array.layout.
+
+    Note that a "new array" is a lightweight shallow copy, not a duplication
+    of large data buffers.
+
+    You can also remove a single parameter with this function, since setting
+    a parameter to None is equivalent to removing it.
+    """
+    # Dispatch
+    yield (array,)
+
+    # Implementation
+    return _impl(array, field)
+
+
+def _impl(array, field):
+    layout = ak.operations.to_layout(
+        array, allow_record=True, allow_unknown=False, primitive_policy="error"
+    )
+    if not (
+        isinstance(field, str)
+        or (
+            is_non_string_like_sequence(field)
+            and all(isinstance(x, str) for x in field)
+        )
+    ):
+        raise TypeError("Field attributes may only be assigned by field name(s) ")
+
+    result_entries = []
+
+    def apply(layout, depth_context, **kwargs):
+        path = depth_context["path"]
+        if path:
+            if layout.is_record:
+                head, *tail = path
+                ak._do.recursively_apply(
+                    layout.content(head),
+                    apply,
+                    depth_context={"path": tail},
+                    return_array=False,
+                )
+                return layout
+
+        else:
+            if layout._parameters is not None:
+                result_entries.append(layout._parameters)
+
+            if layout.is_list or layout.is_numpy or layout.is_record:
+                return layout
+            elif layout.is_unknown:
+                raise ValueError
+            else:
+                return None
+
+    ak._do.recursively_apply(
+        layout, apply, depth_context={"path": field}, return_array=False
+    )
+
+    from collections import ChainMap
+
+    return ChainMap(*reversed(result_entries))

--- a/src/awkward/operations/ak_with_field_attr.py
+++ b/src/awkward/operations/ak_with_field_attr.py
@@ -1,0 +1,84 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+__all__ = ("with_field_attr",)
+
+import awkward as ak
+from awkward._behavior import behavior_of
+from awkward._dispatch import high_level_function
+from awkward._layout import wrap_layout
+from awkward._nplikes.numpylike import NumpyMetadata
+from awkward._regularize import is_non_string_like_sequence
+
+np = NumpyMetadata.instance()
+
+
+@high_level_function()
+def with_field_attr(array, field, parameter, value, *, highlevel=True, behavior=None):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        field (str or tuple of str): Field name, or series of field names
+            to resolve.
+        parameter (str): Name of the parameter to set on that array.
+        value (JSON): Value of the parameter to set on that array.
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+
+    This function returns a new array with a parameter set on the deepest
+    node with the given field name in the #ak.Array.layout.
+
+    Note that a "new array" is a lightweight shallow copy, not a duplication
+    of large data buffers.
+
+    You can also remove a single parameter with this function, since setting
+    a parameter to None is equivalent to removing it.
+    """
+    # Dispatch
+    yield (array,)
+
+    # Implementation
+    return _impl(array, field, parameter, value, highlevel, behavior)
+
+
+def _impl(array, field, parameter, value, highlevel, behavior):
+    behavior = behavior_of(array, behavior=behavior)
+    layout = ak.operations.to_layout(
+        array, allow_record=True, allow_unknown=False, primitive_policy="error"
+    )
+    if not (
+        isinstance(field, str)
+        or (
+            is_non_string_like_sequence(field)
+            and all(isinstance(x, str) for x in field)
+        )
+    ):
+        raise TypeError("Field attributes may only be assigned by field name(s) ")
+
+    def apply(layout, depth_context, continuation, **kwargs):
+        path = depth_context["path"]
+        if path:
+            if layout.is_record:
+                head, *tail = path
+                return layout.copy(
+                    contents=[
+                        ak._do.recursively_apply(
+                            content, apply, depth_context={"path": tail}
+                        )
+                        if field == head
+                        else content
+                        for field, content in zip(layout.fields, layout.contents)
+                    ]
+                )
+        elif not path:
+            if layout.is_list or layout.is_numpy or layout.is_record:
+                return layout.with_parameter(parameter, value)
+            if layout.is_unknown:
+                raise ValueError
+
+            if layout.parameter(parameter) is not None:
+                return continuation().with_parameter(parameter, None)
+
+    out = ak._do.recursively_apply(layout, apply, depth_context={"path": field})
+
+    return wrap_layout(out, behavior_of(array, behavior=behavior), highlevel)


### PR DESCRIPTION
This PR is intended to serve as a conversation topic relating to #1391. I'm not intending to merge this PR as-is.

@jpivarski and I discussed the needs of the XArray issue, and it seems that we want a mechanism that can set the deepest node's parameters, while following a path. The names here aren't final; it's just a talking point.

Here's an example of the semantics.

```python
import awkward as ak


layout = ak.contents.ListOffsetArray(
    ak.index.Index64([0, 2, 4, 6]),
    ak.contents.RecordArray(
        [
            ak.contents.IndexedOptionArray(
                ak.index.Index64([0, 1, 2, 3, 4, 5, 6]),
                ak.contents.NumpyArray([1, 2, 3, 1, 2, 3]),
            )
        ],
        ["x"],
    ),
)

result = ak.with_field_attr(layout, "x", "foo", "bar", highlevel=False)
mapping = ak.field_attrs(result, "x")
assert mapping.get("foo") == "bar"


layout = ak.contents.ListOffsetArray(
    ak.index.Index64([0, 2, 4, 6]),
    ak.contents.RecordArray(
        [
            ak.contents.IndexedOptionArray(
                ak.index.Index64([0, 1, 2, 3, 4, 5, 6]),
                ak.contents.NumpyArray([1, 2, 3, 1, 2, 3], parameters={"foo": "bar"}),
            )
        ],
        ["x"],
    ),
)

mapping = ak.field_attrs(layout, "x")
assert mapping.get("foo") == "bar"


layout = ak.contents.ListOffsetArray(
    ak.index.Index64([0, 2, 4, 6]),
    ak.contents.RecordArray(
        [
            ak.contents.IndexedOptionArray(
                ak.index.Index64([0, 1, 2, 3, 4, 5, 6]),
                ak.contents.NumpyArray([1, 2, 3, 1, 2, 3], parameters={"foo": "baz"}),
                parameters={"foo": "baz"},
            )
        ],
        ["x"],
    ),
)

mapping = ak.field_attrs(layout, "x")
assert mapping.get("foo") == "baz"
```