### PR TITLE
fix: support arbitrary ufuncs with respect to NEP-50

### DIFF
--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -43,4 +43,4 @@ def test_numba_ufunc_legacy():
 
     flattened = ak.to_numpy(ak.flatten(result))
     # Seems like Numba chooses int64 here, on all platforms
-    assert flattened.dtype == np.dtype(np.int64)
+    assert flattened.dtype == np.iinfo(int).dtype

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -1,0 +1,45 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+import numpy as np
+import packaging.version
+import pytest
+
+import awkward as ak
+
+numba = pytest.importorskip("numba")
+
+NUMBA_HAS_NEP_50 = packaging.version.parse(
+    numba.__version__
+) >= packaging.version.Version("0.59.0")
+
+
+@pytest.mark.skipif(not NUMBA_HAS_NEP_50, reason="Numba does not have NEP-50 support")
+def test_numba_ufunc_nep_50():
+    raise NotImplementedError
+
+    @numba.vectorize
+    def add(x, y):
+        return x + y
+
+    array = ak.values_astype([[1, 2, 3], [4]], np.int8)
+
+    # FIXME: what error will Numba throw here for an out-of-bounds integer?
+    with pytest.warns(FutureWarning, match=r"not create a writeable array"):
+        result = add(array, 2**63 - 1)
+
+    flattened = ak.to_numpy(ak.flatten(result))
+    assert flattened.dtype == np.dtype(np.int8)
+
+
+@pytest.mark.skipif(NUMBA_HAS_NEP_50, reason="Numba has NEP-50 support")
+def test_numba_ufunc_legacy():
+    @numba.vectorize
+    def add(x, y):
+        return x + y
+
+    array = ak.values_astype([[1, 2, 3], [4]], np.int8)
+    with pytest.warns(FutureWarning, match=r"not create a writeable array"):
+        result = add(array, 2**63 - 1)
+
+    flattened = ak.to_numpy(ak.flatten(result))
+    assert flattened.dtype == np.dtype(np.int64)

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -42,5 +42,5 @@ def test_numba_ufunc_legacy():
         result = add(array, np.int16(np.iinfo(np.int8).max + 1))
 
     flattened = ak.to_numpy(ak.flatten(result))
-    # Seems like Numba chooses int64 here, on all platforms
-    assert flattened.dtype == np.dtype(np.int_)
+    # Seems like Numba chooses int64 here unless a 32-bit platform
+    assert flattened.dtype == np.dtype(np.int32 if ak._util.bits32 else np.int64)

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -25,7 +25,7 @@ def test_numba_ufunc_nep_50():
 
     # FIXME: what error will Numba throw here for an out-of-bounds integer?
     with pytest.warns(FutureWarning, match=r"not create a writeable array"):
-        result = add(array, 2**63 - 1)
+        result = add(array, np.int16(np.iinfo(np.int8).max + 1))
 
     flattened = ak.to_numpy(ak.flatten(result))
     assert flattened.dtype == np.dtype(np.int8)
@@ -39,7 +39,7 @@ def test_numba_ufunc_legacy():
 
     array = ak.values_astype([[1, 2, 3], [4]], np.int8)
     with pytest.warns(FutureWarning, match=r"not create a writeable array"):
-        result = add(array, 2**63 - 1)
+        result = add(array, np.int16(np.iinfo(np.int8).max + 1))
 
     flattened = ak.to_numpy(ak.flatten(result))
-    assert flattened.dtype == np.dtype(np.int64)
+    assert flattened.dtype == np.dtype(np.int16)

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -42,4 +42,5 @@ def test_numba_ufunc_legacy():
         result = add(array, np.int16(np.iinfo(np.int8).max + 1))
 
     flattened = ak.to_numpy(ak.flatten(result))
-    assert flattened.dtype == np.dtype(np.int16)
+    # Seems like Numba chooses int64 here, on all platforms
+    assert flattened.dtype == np.dtype(np.int64)

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -43,4 +43,4 @@ def test_numba_ufunc_legacy():
 
     flattened = ak.to_numpy(ak.flatten(result))
     # Seems like Numba chooses int64 here, on all platforms
-    assert flattened.dtype == np.iinfo(int).dtype
+    assert flattened.dtype == np.dtype(np.int_)


### PR DESCRIPTION
This PR takes into consideration the failure of Numba ufuncs in our NEP-50 aware machinery. It's unfortunate that this has taken a subsequent PR, but in retrospect we should have duck-typed this from the beginning.

Now, we just ask the ufunc object if it supports NEP-50 via `resolve_dtypes`. In future, we should gracefully support Numba's implementation, assuming that it implements this in a similar way to NumPy, which it ought to.

Our test suite will fail once Numba >=0.59.0 is available, because we can't know for certain what kind of exception it will throw. Thus, we'll catch that at the time and implement the correct exception handler in pytest.