### PR TITLE
refactor: drop use of `behavior` in `recursively_apply`

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -35,7 +35,6 @@ def recursively_apply(
     if isinstance(layout, Content):
         return layout._recursively_apply(
             action,
-            behavior,
             1,
             copy.copy(depth_context),
             lateral_context,

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -33,8 +33,9 @@ from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.forms.bitmaskedform import BitMaskedForm
 from awkward.forms.form import Form
@@ -696,7 +697,7 @@ class BitMaskedArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         return self.to_ByteMaskedArray()._to_arrow(
             pyarrow, mask_node, validbytes, length, options
@@ -706,7 +707,7 @@ class BitMaskedArray(Content):
         return self.to_ByteMaskedArray()._to_backend_array(allow_missing, backend)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import math
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -31,6 +31,7 @@ from awkward._typing import (
 from awkward._util import UNSET
 from awkward.contents.bytemaskedarray import ByteMaskedArray
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -717,8 +718,13 @@ class BitMaskedArray(Content):
         return self.to_ByteMaskedArray()._drop_none()
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if self._backend.nplike.known_data:
             content = self._content[0 : self._length]
         else:
@@ -735,7 +741,6 @@ class BitMaskedArray(Content):
                     self._mask,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -752,7 +757,6 @@ class BitMaskedArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
@@ -765,7 +769,6 @@ class BitMaskedArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import math
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -32,6 +32,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1079,8 +1080,13 @@ class ByteMaskedArray(Content):
         return self.project()
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if self._backend.nplike.known_data:
             content = self._content[0 : self._mask.length]
         else:
@@ -1097,7 +1103,6 @@ class ByteMaskedArray(Content):
                     self._mask,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1112,7 +1117,6 @@ class ByteMaskedArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
@@ -1125,7 +1129,6 @@ class ByteMaskedArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -34,8 +34,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.bytemaskedform import ByteMaskedForm
@@ -1052,7 +1053,7 @@ class ByteMaskedArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         this_validbytes = self.mask_as_bool(valid_when=True)
 
@@ -1068,7 +1069,7 @@ class ByteMaskedArray(Content):
         return self.to_IndexedOptionArray64()._to_backend_array(allow_missing, backend)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -99,7 +99,7 @@ class ApplyActionOptions(TypedDict):
     function_name: str | None
 
 
-class RemoveStructureOptionsType(TypedDict):
+class RemoveStructureOptions(TypedDict):
     flatten_records: bool
     function_name: str
     drop_nones: bool
@@ -108,7 +108,7 @@ class RemoveStructureOptionsType(TypedDict):
     list_to_regular: bool
 
 
-class ToArrowOptionsType(TypedDict):
+class ToArrowOptions(TypedDict):
     list_to32: bool
     string_to32: bool
     bytestring_to32: bool
@@ -1107,7 +1107,7 @@ class Content:
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         raise NotImplementedError
 
@@ -1130,7 +1130,7 @@ class Content:
         raise NotImplementedError
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         raise NotImplementedError
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -34,6 +34,7 @@ from awkward._typing import (
     AxisMaybeNone,
     JSONMapping,
     Literal,
+    Protocol,
     Self,
     SupportsIndex,
     TypeAlias,
@@ -72,7 +73,23 @@ float | int | str | list[JSONValueType] | dict[str, JSONValueType]
 """
 
 
-class RecursivelyApplyOptionsType(TypedDict):
+class ImplementsApplyAction(Protocol):
+    def __call__(
+        self,
+        layout: Content,
+        *,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        continuation: Callable[[], Content],
+        behavior: Mapping | None,
+        backend: Backend,
+        options: ApplyActionOptions,
+    ) -> Content | None:
+        ...
+
+
+class ApplyActionOptions(TypedDict):
     allow_records: bool
     keep_parameters: bool
     numpy_to_regular: bool
@@ -1119,12 +1136,11 @@ class Content:
 
     def _recursively_apply(
         self,
-        action: ActionType,
-        behavior: dict | None,
+        action: ImplementsApplyAction,
         depth: int,
-        depth_context: dict[str, Any] | None,
-        lateral_context: dict[str, Any] | None,
-        options: RecursivelyApplyOptionsType,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
     ) -> Content | None:
         raise NotImplementedError
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -27,6 +27,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -400,8 +401,13 @@ class EmptyArray(Content):
         return [self]
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if options["return_array"]:
 
             def continuation():
@@ -421,7 +427,6 @@ class EmptyArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -29,8 +29,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.emptyform import EmptyForm
@@ -365,7 +366,7 @@ class EmptyArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         if options["emptyarray_to"] is None:
             return pyarrow.Array.from_buffers(
@@ -396,7 +397,7 @@ class EmptyArray(Content):
         return backend.nplike.empty(0, dtype=np.float64)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         return [self]
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -33,8 +33,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1005,7 +1006,7 @@ class IndexedArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         if (
             not options["categorical_as_dictionary"]
@@ -1059,7 +1060,7 @@ class IndexedArray(Content):
         return self.project()._to_backend_array(allow_missing, backend)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         return self.project()._remove_structure(backend, options)
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -31,6 +31,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1063,8 +1064,13 @@ class IndexedArray(Content):
         return self.project()._remove_structure(backend, options)
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if (
             self._backend.nplike.known_data
             and self._backend.nplike.known_data
@@ -1092,7 +1098,6 @@ class IndexedArray(Content):
                     index,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1106,7 +1111,6 @@ class IndexedArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
@@ -1119,7 +1123,6 @@ class IndexedArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -31,6 +31,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1634,8 +1635,13 @@ class IndexedOptionArray(Content):
         return self.project()
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if (
             self._backend.nplike.known_data
             and self._backend.nplike.known_data
@@ -1667,7 +1673,6 @@ class IndexedOptionArray(Content):
                     index,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1681,7 +1686,6 @@ class IndexedOptionArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
@@ -1694,7 +1698,6 @@ class IndexedOptionArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -33,8 +33,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1543,7 +1544,7 @@ class IndexedOptionArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         index = numpy.asarray(self._index.data, copy=True)
         this_validbytes = self.mask_as_bool(valid_when=True)
@@ -1623,7 +1624,7 @@ class IndexedOptionArray(Content):
                 return content
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -29,6 +29,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1525,8 +1526,13 @@ class ListArray(Content):
         )
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if (
             self._backend.nplike.known_data
             and self._backend.nplike.known_data
@@ -1554,7 +1560,6 @@ class ListArray(Content):
                     stops,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth + 1,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1568,7 +1573,6 @@ class ListArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth + 1,
                     copy.copy(depth_context),
                     lateral_context,
@@ -1581,7 +1585,6 @@ class ListArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -31,8 +31,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.contents.listoffsetarray import ListOffsetArray
 from awkward.forms.form import Form
@@ -1497,7 +1498,7 @@ class ListArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         return self.to_ListOffsetArray64(False)._to_arrow(
             pyarrow, mask_node, validbytes, length, options
@@ -1513,7 +1514,7 @@ class ListArray(Content):
             return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         return self.to_ListOffsetArray64(False)._remove_structure(backend, options)
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -29,6 +29,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -2157,8 +2158,13 @@ class ListOffsetArray(Content):
         return ak.contents.ListOffsetArray(new_offsets, new_content)
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if self._backend.nplike.known_data:
             offsetsmin = self._offsets[0]
             offsets = ak.index.Index(
@@ -2176,7 +2182,6 @@ class ListOffsetArray(Content):
                     offsets,
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth + 1,
                         copy.copy(depth_context),
                         lateral_context,
@@ -2190,7 +2195,6 @@ class ListOffsetArray(Content):
             def continuation():
                 content._recursively_apply(
                     action,
-                    behavior,
                     depth + 1,
                     copy.copy(depth_context),
                     lateral_context,
@@ -2203,7 +2207,6 @@ class ListOffsetArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -31,8 +31,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1899,7 +1900,7 @@ class ListOffsetArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         is_string = self.parameter("__array__") == "string"
         is_bytestring = self.parameter("__array__") == "bytestring"
@@ -2082,7 +2083,7 @@ class ListOffsetArray(Content):
             return self.to_RegularArray()._to_backend_array(allow_missing, backend)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         if (
             self.parameter("__array__") == "string"

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -36,6 +36,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1259,11 +1260,16 @@ class NumpyArray(Content):
         ]
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if self._data.ndim != 1 and options["numpy_to_regular"]:
             return self.to_RegularArray()._recursively_apply(
-                action, behavior, depth, depth_context, lateral_context, options
+                action, depth, depth_context, lateral_context, options
             )
 
         if options["return_array"]:
@@ -1287,7 +1293,6 @@ class NumpyArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,8 +38,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1211,7 +1212,7 @@ class NumpyArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         if self._data.ndim != 1:
             return self.to_RegularArray()._to_arrow(
@@ -1246,7 +1247,7 @@ class NumpyArray(Content):
         return to_nplike(self.data, backend.nplike, from_nplike=self._backend.nplike)
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         if options["keepdims"]:
             shape = (1,) * (self._data.ndim - 1) + (-1,)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -34,8 +34,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1106,7 +1107,7 @@ class RecordArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         values = [
             (x if x.length == length else x[:length])._to_arrow(
@@ -1171,7 +1172,7 @@ class RecordArray(Content):
         return out
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         if options["flatten_records"]:
             out = []

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
-from collections.abc import Iterable, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -32,6 +32,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1192,8 +1193,13 @@ class RecordArray(Content):
             )
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if self._backend.nplike.known_data:
             contents = [x[: self._length] for x in self._contents]
         else:
@@ -1211,7 +1217,6 @@ class RecordArray(Content):
                     [
                         content._recursively_apply(
                             action,
-                            behavior,
                             depth,
                             copy.copy(depth_context),
                             lateral_context,
@@ -1231,7 +1236,6 @@ class RecordArray(Content):
                 for content in contents:
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1244,7 +1248,6 @@ class RecordArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -32,8 +32,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.forms.form import Form
 from awkward.forms.regularform import RegularForm
@@ -1317,7 +1318,7 @@ class RegularArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         assert self._backend.nplike.known_data
 
@@ -1376,7 +1377,7 @@ class RegularArray(Content):
             )
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         if (
             self.parameter("__array__") == "string"

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -31,8 +31,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -1450,7 +1451,7 @@ class UnionArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         nptags = self._tags.raw(numpy)
         npindex = self._index.raw(numpy)
@@ -1535,7 +1536,7 @@ class UnionArray(Content):
         )
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         out = []
         for i in range(len(self._contents)):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import copy
 import ctypes
-from collections.abc import Iterable, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -29,6 +29,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -1547,8 +1548,13 @@ class UnionArray(Content):
         return out
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if options["return_array"]:
             if options["return_simplified"]:
                 make = UnionArray.simplified
@@ -1562,7 +1568,6 @@ class UnionArray(Content):
                     [
                         content._recursively_apply(
                             action,
-                            behavior,
                             depth,
                             copy.copy(depth_context),
                             lateral_context,
@@ -1579,7 +1584,6 @@ class UnionArray(Content):
                 for content in self._contents:
                     content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -1592,7 +1596,6 @@ class UnionArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import math
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
@@ -32,6 +32,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.contents.content import (
+    ApplyActionOptions,
     Content,
     RemoveStructureOptionsType,
     ToArrowOptionsType,
@@ -517,8 +518,13 @@ class UnmaskedArray(Content):
         return self.content
 
     def _recursively_apply(
-        self, action, behavior, depth, depth_context, lateral_context, options
-    ):
+        self,
+        action: ImplementsApplyAction,
+        depth: int,
+        depth_context: Mapping[str, Any] | None,
+        lateral_context: Mapping[str, Any] | None,
+        options: ApplyActionOptions,
+    ) -> Content | None:
         if options["return_array"]:
             if options["return_simplified"]:
                 make = UnmaskedArray.simplified
@@ -529,7 +535,6 @@ class UnmaskedArray(Content):
                 return make(
                     self._content._recursively_apply(
                         action,
-                        behavior,
                         depth,
                         copy.copy(depth_context),
                         lateral_context,
@@ -543,7 +548,6 @@ class UnmaskedArray(Content):
             def continuation():
                 self._content._recursively_apply(
                     action,
-                    behavior,
                     depth,
                     copy.copy(depth_context),
                     lateral_context,
@@ -556,7 +560,6 @@ class UnmaskedArray(Content):
             depth_context=depth_context,
             lateral_context=lateral_context,
             continuation=continuation,
-            behavior=behavior,
             backend=self._backend,
             options=options,
         )

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -34,8 +34,9 @@ from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
-    RemoveStructureOptionsType,
-    ToArrowOptionsType,
+    ImplementsApplyAction,
+    RemoveStructureOptions,
+    ToArrowOptions,
 )
 from awkward.errors import AxisError
 from awkward.forms.form import Form
@@ -494,7 +495,7 @@ class UnmaskedArray(Content):
         mask_node: Content | None,
         validbytes: Content | None,
         length: int,
-        options: ToArrowOptionsType,
+        options: ToArrowOptions,
     ):
         return self._content._to_arrow(pyarrow, self, None, length, options)
 
@@ -506,7 +507,7 @@ class UnmaskedArray(Content):
             return content
 
     def _remove_structure(
-        self, backend: Backend, options: RemoveStructureOptionsType
+        self, backend: Backend, options: RemoveStructureOptions
     ) -> list[Content]:
         branch, depth = self.branch_depth
         if branch or options["drop_nones"] or depth > 1:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -359,7 +359,6 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
                 nextlayout = ak._do.recursively_apply(
                     layout,
                     apply_pad_inner_list,
-                    behavior,
                     lateral_context={"n": n_inside},
                 )
                 return add_outer_dimensions(nextlayout, n_outside)
@@ -380,7 +379,6 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior):
             ak._do.recursively_apply(
                 layout,
                 apply_pad_inner_list_at_axis,
-                behavior,
                 lateral_context={"i": i},
             )
             for i, layout in enumerate(layouts)

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -46,6 +46,6 @@ def _impl(array, highlevel):
         array, allow_record=False, allow_unknown=False, primitive_policy="error"
     )
     behavior = behavior_of(array)
-    ak._do.recursively_apply(layout, action, behavior=behavior)
+    ak._do.recursively_apply(layout, action)
 
     return wrap_layout(output[0], behavior, highlevel)

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -113,9 +113,9 @@ def _impl(array, axis, highlevel, behavior):
                 return layout.drop_none()
 
     options = {"none_indexes": []}
-    out = ak._do.recursively_apply(layout, action, behavior, options)
+    out = ak._do.recursively_apply(layout, action, options)
 
     if len(options["none_indexes"]) > 0:
-        out = ak._do.recursively_apply(out, recompute_offsets, behavior, options)
+        out = ak._do.recursively_apply(out, recompute_offsets, options)
 
     return wrap_layout(out, behavior, highlevel, like=behavior)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -128,5 +128,5 @@ def _impl(array, value, axis, highlevel, behavior):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-    out = ak._do.recursively_apply(arraylayout, action, behavior)
+    out = ak._do.recursively_apply(arraylayout, action)
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -101,6 +101,6 @@ def _impl(array, axis, highlevel, behavior):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -51,7 +51,7 @@ def _impl(array, highlevel, behavior):
         array, allow_record=False, allow_unknown=False, primitive_policy="error"
     )
     behavior = behavior_of(array, behavior=behavior)
-    out = ak._do.recursively_apply(layout, action, behavior=behavior)
+    out = ak._do.recursively_apply(layout, action)
     if highlevel:
         return wrap_layout(out, behavior)
     else:

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -62,7 +62,7 @@ def _impl(array, axis, highlevel, behavior):
             if layout.is_regular:
                 return continuation().to_ListOffsetArray64(False)
 
-        out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     elif maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level is already regular (ArrayType)
@@ -80,6 +80,6 @@ def _impl(array, axis, highlevel, behavior):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -208,7 +208,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown):
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
     return wrap_layout(out, behavior, highlevel)
 
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -66,6 +66,6 @@ def _impl(array, axis, highlevel, behavior):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -59,5 +59,5 @@ def _impl(array, highlevel, behavior):
         array, allow_record=False, allow_unknown=False, primitive_policy="error"
     )
     behavior = behavior_of(array, behavior=behavior)
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -107,7 +107,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior):
             else:
                 return None
 
-        out = ak._do.recursively_apply(layout, action, behavior)
+        out = ak._do.recursively_apply(layout, action)
 
     else:
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -106,6 +106,6 @@ def _impl(array, axis, highlevel, behavior):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -228,5 +228,5 @@ def _impl(array, highlevel, behavior):
     )
     behavior = behavior_of(array, behavior=behavior)
 
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -89,6 +89,6 @@ def _impl(array, axis, highlevel, behavior):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, behavior, numpy_to_regular=True)
+    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -85,5 +85,5 @@ def _impl(array, to, highlevel, behavior):
         array, allow_record=False, allow_unknown=False, primitive_policy="error"
     )
     behavior = behavior_of(array, behavior=behavior)
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -75,7 +75,7 @@ def _impl(array, axis, highlevel, behavior):
             if layout.is_list:
                 return continuation().to_RegularArray()
 
-        out = ak._do.recursively_apply(layout, action, behavior)
+        out = ak._do.recursively_apply(layout, action)
 
     elif maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level can only be regular (ArrayType)
@@ -92,6 +92,6 @@ def _impl(array, axis, highlevel, behavior):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action, behavior)
+        out = ak._do.recursively_apply(layout, action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -511,7 +511,7 @@ def _impl(
 
         def action(layout, **kwargs):
             nonlocal transformer_did_terminate
-            out = transformation(layout, **kwargs)
+            out = transformation(layout, **kwargs, behavior=behavior)
 
             if out is None:
                 return out
@@ -529,7 +529,6 @@ def _impl(
         # ak._broadcasting.apply_step, below. ak_transform._impl knows implementation details.
         out = layout._recursively_apply(
             action,
-            behavior,
             1,
             copy.copy(depth_context),
             lateral_context,
@@ -550,7 +549,7 @@ def _impl(
 
         def action(inputs, **kwargs):
             nonlocal transformer_did_terminate
-            out = transformation(tuple(inputs), **kwargs)
+            out = transformation(tuple(inputs), **kwargs, behavior=behavior)
 
             if out is None:
                 if all(isinstance(x, ak.contents.NumpyArray) for x in inputs):

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -65,7 +65,7 @@ def _impl(array, highlevel, behavior):
                         "union of different sets of fields, cannot ak.unzip"
                     )
 
-    ak._do.recursively_apply(layout, check_for_union, behavior, return_array=False)
+    ak._do.recursively_apply(layout, check_for_union, return_array=False)
 
     if len(fields) == 0:
         return (wrap_layout(layout, behavior, highlevel, allow_other=True),)

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -59,7 +59,7 @@ def _impl(array, name, highlevel, behavior):
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
 
     def action2(layout, **ignore):
         if layout.is_union:
@@ -72,6 +72,6 @@ def _impl(array, name, highlevel, behavior):
         else:
             return None
 
-    out2 = ak._do.recursively_apply(out, action2, behavior)
+    out2 = ak._do.recursively_apply(out, action2)
 
     return wrap_layout(out2, behavior, highlevel)

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -72,7 +72,6 @@ def _impl(base, where, highlevel, behavior):
                         next_content = ak._do.recursively_apply(
                             content,
                             action,
-                            behavior,
                             depth_context={"where": next_where},
                         )
                         next_contents.append(next_content)
@@ -96,7 +95,5 @@ def _impl(base, where, highlevel, behavior):
         else:
             return None
 
-    out = ak._do.recursively_apply(
-        base, action, behavior, depth_context={"where": where}
-    )
+    out = ak._do.recursively_apply(base, action, depth_context={"where": where})
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -44,7 +44,7 @@ def _impl(array, highlevel, behavior):
 
     out = ak._do.recursively_apply(
         layout,
-        (lambda layout, behavior=behavior, **kwargs: None),
+        (lambda layout, **kwargs: None),
         keep_parameters=False,
     )
 

--- a/src/awkward/operations/str/akstr_capitalize.py
+++ b/src/awkward/operations/str/akstr_capitalize.py
@@ -54,7 +54,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_capitalize, pc.ascii_capitalize, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_center.py
+++ b/src/awkward/operations/str/akstr_center.py
@@ -60,7 +60,6 @@ def _impl(array, width, padding, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_center, pc.ascii_center, width, padding, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_count_substring.py
+++ b/src/awkward/operations/str/akstr_count_substring.py
@@ -58,6 +58,6 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_count_substring_regex.py
+++ b/src/awkward/operations/str/akstr_count_substring_regex.py
@@ -58,6 +58,6 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_ends_with.py
+++ b/src/awkward/operations/str/akstr_ends_with.py
@@ -54,5 +54,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -76,7 +76,6 @@ def _impl(array, pattern, highlevel, behavior):
             bytestring_to_string=False,
             expect_option_type=True,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_find_substring.py
+++ b/src/awkward/operations/str/akstr_find_substring.py
@@ -56,5 +56,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_find_substring_regex.py
+++ b/src/awkward/operations/str/akstr_find_substring_regex.py
@@ -58,5 +58,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -82,6 +82,6 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
                 generate_bitmasks=True,
             )
 
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_is_alnum.py
+++ b/src/awkward/operations/str/akstr_is_alnum.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_alnum, pc.ascii_is_alnum, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_alpha.py
+++ b/src/awkward/operations/str/akstr_is_alpha.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_alpha, pc.ascii_is_alpha, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_ascii.py
+++ b/src/awkward/operations/str/akstr_is_ascii.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.string_is_ascii, pc.string_is_ascii, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_decimal.py
+++ b/src/awkward/operations/str/akstr_is_decimal.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_decimal, pc.ascii_is_decimal, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_digit.py
+++ b/src/awkward/operations/str/akstr_is_digit.py
@@ -55,7 +55,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_digit, pc.utf8_is_digit, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -76,6 +76,6 @@ def _impl(array, value_set, skip_nones, highlevel, behavior):
                 pc.is_in, layout, value_set_layout, skip_nulls=skip_nones
             )
 
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
 
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_is_lower.py
+++ b/src/awkward/operations/str/akstr_is_lower.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_lower, pc.ascii_is_lower, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_numeric.py
+++ b/src/awkward/operations/str/akstr_is_numeric.py
@@ -55,7 +55,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_numeric, pc.utf8_is_numeric, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_printable.py
+++ b/src/awkward/operations/str/akstr_is_printable.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_printable, pc.ascii_is_printable, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_space.py
+++ b/src/awkward/operations/str/akstr_is_space.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_space, pc.ascii_is_space, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_title.py
+++ b/src/awkward/operations/str/akstr_is_title.py
@@ -57,7 +57,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_title, pc.ascii_is_title, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_is_upper.py
+++ b/src/awkward/operations/str/akstr_is_upper.py
@@ -56,7 +56,6 @@ def _impl(array, highlevel, behavior):
             # pc.ascii_is_upper is defined on binary, but for consistency with is_lower and is_title...
             bytestring_to_string=True,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -87,7 +87,7 @@ def _impl(array, separator, highlevel, behavior):
                 bytestring_to32=True,
             )
 
-        out = ak._do.recursively_apply(layout, apply_unary, behavior=behavior)
+        out = ak._do.recursively_apply(layout, apply_unary)
     else:
         separator_layout = ak.to_layout(separator, allow_record=False).to_backend(
             backend

--- a/src/awkward/operations/str/akstr_length.py
+++ b/src/awkward/operations/str/akstr_length.py
@@ -52,7 +52,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_length, pc.binary_length, bytestring_to_string=False
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_lower.py
+++ b/src/awkward/operations/str/akstr_lower.py
@@ -52,7 +52,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_lower, pc.ascii_lower, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_lpad.py
+++ b/src/awkward/operations/str/akstr_lpad.py
@@ -60,7 +60,6 @@ def _impl(array, width, padding, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_lpad, pc.ascii_lpad, width, padding, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_ltrim.py
+++ b/src/awkward/operations/str/akstr_ltrim.py
@@ -60,7 +60,6 @@ def _impl(array, characters, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_ltrim, pc.ascii_ltrim, characters, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_ltrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_ltrim_whitespace.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
             pc.ascii_ltrim_whitespace,
             bytestring_to_string=True,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_match_like.py
+++ b/src/awkward/operations/str/akstr_match_like.py
@@ -59,5 +59,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_match_substring.py
+++ b/src/awkward/operations/str/akstr_match_substring.py
@@ -56,5 +56,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_match_substring_regex.py
+++ b/src/awkward/operations/str/akstr_match_substring_regex.py
@@ -57,5 +57,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_replace_slice.py
+++ b/src/awkward/operations/str/akstr_replace_slice.py
@@ -60,7 +60,6 @@ def _impl(array, start, stop, replacement, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_replace_slice, pc.binary_replace_slice, start, stop, replacement
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_replace_substring.py
+++ b/src/awkward/operations/str/akstr_replace_substring.py
@@ -66,7 +66,6 @@ def _impl(array, pattern, replacement, max_replacements, highlevel, behavior):
             replacement,
             max_replacements=max_replacements,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_replace_substring_regex.py
+++ b/src/awkward/operations/str/akstr_replace_substring_regex.py
@@ -66,7 +66,6 @@ def _impl(array, pattern, replacement, max_replacements, highlevel, behavior):
             replacement,
             max_replacements=max_replacements,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_reverse.py
+++ b/src/awkward/operations/str/akstr_reverse.py
@@ -54,7 +54,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_reverse, pc.binary_reverse, bytestring_to_string=False
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_rpad.py
+++ b/src/awkward/operations/str/akstr_rpad.py
@@ -60,7 +60,6 @@ def _impl(array, width, padding, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_rpad, pc.ascii_rpad, width, padding, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_rtrim.py
+++ b/src/awkward/operations/str/akstr_rtrim.py
@@ -59,7 +59,6 @@ def _impl(array, characters, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_rtrim, pc.ascii_rtrim, characters, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_rtrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_rtrim_whitespace.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
             pc.ascii_rtrim_whitespace,
             bytestring_to_string=True,
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_slice.py
+++ b/src/awkward/operations/str/akstr_slice.py
@@ -65,6 +65,6 @@ def _impl(array, start, stop, step, highlevel, behavior):
         elif layout.is_list and layout.parameter("__array__") == "bytestring":
             return layout[:, start:stop:step]
 
-    out = ak._do.recursively_apply(ak.operations.to_layout(array), action, behavior)
+    out = ak._do.recursively_apply(ak.operations.to_layout(array), action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -61,6 +61,6 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior):
         reverse=reverse,
         bytestring_to_string=False,
     )
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern_regex.py
+++ b/src/awkward/operations/str/akstr_split_pattern_regex.py
@@ -65,6 +65,6 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior):
         reverse=reverse,
         bytestring_to_string=False,
     )
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -69,6 +69,6 @@ def _impl(array, max_splits, reverse, highlevel, behavior):
         reverse=reverse,
         bytestring_to_string=True,
     )
-    out = ak._do.recursively_apply(layout, action, behavior)
+    out = ak._do.recursively_apply(layout, action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_starts_with.py
+++ b/src/awkward/operations/str/akstr_starts_with.py
@@ -54,5 +54,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply, behavior=behavior)
+    out = ak._do.recursively_apply(layout, apply)
     return wrap_layout(out, highlevel=highlevel, behavior=behavior)

--- a/src/awkward/operations/str/akstr_swapcase.py
+++ b/src/awkward/operations/str/akstr_swapcase.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_swapcase, pc.ascii_swapcase, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_title.py
+++ b/src/awkward/operations/str/akstr_title.py
@@ -55,7 +55,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_title, pc.ascii_title, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -65,10 +65,6 @@ def _impl(array, highlevel, behavior):
                 pc.dictionary_encode, layout, expect_option_type=False
             )
 
-    out = ak._do.recursively_apply(
-        ak.operations.to_layout(array),
-        action,
-        behavior,
-    )
+    out = ak._do.recursively_apply(ak.operations.to_layout(array), action)
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_trim.py
+++ b/src/awkward/operations/str/akstr_trim.py
@@ -60,7 +60,6 @@ def _impl(array, characters, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_trim, pc.ascii_trim, characters, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_trim_whitespace.py
+++ b/src/awkward/operations/str/akstr_trim_whitespace.py
@@ -52,7 +52,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_trim_whitespace, pc.ascii_trim_whitespace, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)

--- a/src/awkward/operations/str/akstr_upper.py
+++ b/src/awkward/operations/str/akstr_upper.py
@@ -53,7 +53,6 @@ def _impl(array, highlevel, behavior):
         ak.operations.str._get_ufunc_action(
             pc.utf8_upper, pc.ascii_upper, bytestring_to_string=True
         ),
-        behavior,
     )
 
     return wrap_layout(out, behavior, highlevel)


### PR DESCRIPTION
This prepares the way to drop this argument in `recursively_apply`