### PR TITLE
fix: support bool types in `resolve_dtypes`

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy_like import (
 )
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast
+from awkward._typing import TYPE_CHECKING, Any, DType, Final, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
@@ -208,6 +208,17 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         else:
             return self._apply_ufunc_legacy(ufunc, method, args, kwargs)
 
+    def _get_nep_50_dtype(
+        self, obj: Any
+    ) -> DType | type[int] | type[complex] | type[float]:
+        if hasattr(obj, "dtype"):
+            return obj.dtype
+        elif isinstance(obj, bool):
+            return np.dtype(np.bool_)
+        else:
+            assert isinstance(obj, (int, complex, float))
+            return type(obj)
+
     # Does NumPy support value-less ufunc resolution?
     def _apply_ufunc_nep_50(
         self,
@@ -217,7 +228,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         kwargs: dict[str, Any] | None = None,
     ) -> ArrayLikeT | tuple[ArrayLikeT]:
         # Determine input argument dtypes
-        input_arg_dtypes = [getattr(obj, "dtype", type(obj)) for obj in args]
+        input_arg_dtypes = [self._get_nep_50_dtype(obj) for obj in args]
         # Resolve these for the given ufunc
         arg_dtypes = tuple(input_arg_dtypes + [None] * ufunc.nout)
         resolved_dtypes = ufunc.resolve_dtypes(arg_dtypes)

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -105,8 +105,8 @@ class UfuncLike(Protocol):
     nout: int
 
     def resolve_dtypes(
-        self, dtypes: tuple[numpy.dtype | type, ...]
-    ) -> tuple[numpy.dtype, ...]:
+        self, dtypes: tuple[DType | type[int] | type[complex] | type[float] | None, ...]
+    ) -> tuple[DType, ...]:
         ...
 
     def __call__(self, *args: ArrayLikeT, **kwargs) -> ArrayLikeT:

--- a/tests/test_2808_dtype_ufunc_bool.py
+++ b/tests/test_2808_dtype_ufunc_bool.py
@@ -1,0 +1,37 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import packaging.version
+import pytest
+
+import awkward as ak
+
+if packaging.version.Version(np.__version__) < packaging.version.Version("1.24.0"):
+    pytest.skip("Only NumPy>=1.24 supports `resolve_dtypes`", allow_module_level=True)
+
+
+def test_bool():
+    array = ak.Array([[True, False], [True, False, False]])
+    assert (array == False).to_list() == [[False, True], [False, True, True]]  # noqa: E712
+
+
+def test_int():
+    array = ak.Array([[1, 2], [3, 4, 5]])
+    assert (array == 2).to_list() == [[False, True], [False, False, False]]
+
+
+def test_float():
+    array = ak.Array([[1.0, 2.7], [2.0, 7.0, 8.8]])
+    assert (array == 1.0).to_list() == [[True, False], [False, False, False]]
+
+
+def test_complex():
+    array = ak.Array([[1.0j, 2.7], [2.0 + 1j, 7.0, 8.8]])
+    assert (array == 1.0j).to_list() == [[True, False], [False, False, False]]
+
+
+def test_datetime64():
+    array = ak.Array([[np.datetime64(1, "D"), np.datetime64(10, "D")]])
+    assert (array == np.datetime64(10, "D")).to_list() == [[False, True]]


### PR DESCRIPTION
NumPy's `ufunc.resolve_dtypes` function does not accept bare Python `bool` types, despite upholding that pattern for the `int`, `float`, and `complex` types. This PR converts `bool` to `np.dtype("bool")`.