### PR TITLE
chore: only build _ext and kernels

### DIFF
--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -25,15 +25,11 @@ Please check https://github.com/scikit-hep/awkward#installation-for-developers t
 endif()
 
 # Setup the RPATH for built libraries
-if(CMAKE_SYSTEM_NAME STREQUAL Emscripten)
-  message(STATUS "Using Emscripten")
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-  set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
-elseif(APPLE)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+if(APPLE)
   set(CMAKE_INSTALL_RPATH "@loader_path")
 else()
-  set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+  set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 endif()
 
 # Three tiers: [cpu-kernels (extern "C" interface), cuda-kernels (extern "C" interface)],

--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -54,31 +54,21 @@ target_include_directories(awkward-parent INTERFACE rapidjson/include)
 add_subdirectory(header-only EXCLUDE_FROM_ALL)
 target_link_libraries(awkward-parent INTERFACE awkward::growable-buffer)
 
-# First tier: cpu-kernels (object files, static library, and dynamic library).
-add_library(awkward-cpu-kernels-objects OBJECT ${CPU_KERNEL_SOURCES})
-set_target_properties(awkward-cpu-kernels-objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(awkward-cpu-kernels-objects PUBLIC awkward-parent)
+# First tier: cpu-kernels
+add_library(awkward-cpu-kernels SHARED ${CPU_KERNEL_SOURCES})
+target_link_libraries(awkward-cpu-kernels PUBLIC awkward-parent)
 set_target_properties(
-  awkward-cpu-kernels-objects
+  awkward-cpu-kernels
   PROPERTIES CXX_VISIBILITY_PRESET hidden
              VISIBILITY_INLINES_HIDDEN ON
              CXX_EXTENSIONS NO)
 
-add_library(awkward-cpu-kernels-static STATIC $<TARGET_OBJECTS:awkward-cpu-kernels-objects>)
-set_property(TARGET awkward-cpu-kernels-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(awkward-cpu-kernels-static PUBLIC awkward-parent)
-
-add_library(awkward-cpu-kernels SHARED $<TARGET_OBJECTS:awkward-cpu-kernels-objects>)
-target_link_libraries(awkward-cpu-kernels PUBLIC awkward-parent)
-
-# Second tier: libawkward (object files, static library, and dynamic library).
-add_library(awkward-objects OBJECT ${LIBAWKWARD_SOURCES})
-set_target_properties(awkward-objects PROPERTIES POSITION_INDEPENDENT_CODE 1)
-target_compile_definitions(awkward-objects PRIVATE LIBAWKWARD_EXPORT_SYMBOL=EXPORT_SYMBOL)
+# Second tier: libawkward
+add_library(awkward SHARED ${LIBAWKWARD_SOURCES})
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   # Avoid emitting vtables in the dependent libraries
   target_compile_options(
-    awkward-objects
+    awkward
     PRIVATE -Werror=weak-vtables
             -Wweak-vtables
             -Wshorten-64-to-32
@@ -90,21 +80,12 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
             -Wconversion
             -Wunused)
 endif()
-target_link_libraries(awkward-objects PUBLIC awkward-parent)
+target_link_libraries(awkward PUBLIC awkward-parent)
 set_target_properties(
-  awkward-objects
+  awkward
   PROPERTIES CXX_VISIBILITY_PRESET hidden
              VISIBILITY_INLINES_HIDDEN ON
              CXX_EXTENSIONS NO)
-
-add_library(awkward-static STATIC $<TARGET_OBJECTS:awkward-objects>)
-set_property(TARGET awkward-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(awkward-static PRIVATE awkward-cpu-kernels-static ${CMAKE_DL_LIBS})
-target_link_libraries(awkward-static PUBLIC awkward-parent)
-
-add_library(awkward SHARED $<TARGET_OBJECTS:awkward-objects>)
-target_link_libraries(awkward PRIVATE awkward-cpu-kernels-static ${CMAKE_DL_LIBS})
-target_link_libraries(awkward PUBLIC awkward-parent)
 
 # Third tier: Python modules.
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
@@ -112,8 +93,8 @@ find_package(pybind11 CONFIG REQUIRED)
 
 # Install python bindings
 file(GLOB LAYOUT_SOURCES "src/python/*.cpp")
-pybind11_add_module(_ext ${LAYOUT_SOURCES})
-target_link_libraries(_ext PRIVATE awkward-static)
+pybind11_add_module(_ext MODULE ${LAYOUT_SOURCES})
+target_link_libraries(_ext PRIVATE awkward)
 set_target_properties(
   _ext
   PROPERTIES CXX_VISIBILITY_PRESET hidden

--- a/awkward-cpp/include/awkward/builder/ArrayBuilder.h
+++ b/awkward-cpp/include/awkward/builder/ArrayBuilder.h
@@ -20,7 +20,7 @@ namespace awkward {
   /// @brief User interface to the Builder system: the ArrayBuilder is a
   /// fixed reference while the Builder subclass instances change in
   /// response to accumulating data.
-  class LIBAWKWARD_EXPORT_SYMBOL ArrayBuilder {
+  class EXPORT_SYMBOL ArrayBuilder {
   public:
     /// @brief Creates an ArrayBuilder from a full set of parameters.
     ///
@@ -244,131 +244,131 @@ private:
 
 extern "C" {
   /// @brief C interface to {@link awkward::ArrayBuilder#length ArrayBuilder::length}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_length(void* arraybuilder,
                                 int64_t* result);
   /// @brief C interface to {@link awkward::ArrayBuilder#clear ArrayBuilder::clear}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_clear(void* arraybuilder);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#null ArrayBuilder::null}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_null(void* arraybuilder);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#boolean ArrayBuilder::boolean}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_boolean(void* arraybuilder,
                                  bool x);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#integer ArrayBuilder::integer}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_integer(void* arraybuilder,
                                  int64_t x);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#real ArrayBuilder::real}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_real(void* arraybuilder,
                               double x);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#complex ArrayBuilder::complex}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_complex(void* arraybuilder,
                                  double real,
                                  double imag);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#datetime ArrayBuilder::datetime}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_datetime(void* arraybuilder,
                                   int64_t x,
                                   const char* unit);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#timedelta ArrayBuilder::timedelta}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_timedelta(void* arraybuilder,
                                    int64_t x,
                                    const char* unit);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_bytestring(void* arraybuilder,
                                     const char* x);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#bytestring ArrayBuilder::bytestring}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_bytestring_length(void* arraybuilder,
                                            const char* x,
                                            int64_t length);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_string(void* arraybuilder,
                                 const char* x);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#string ArrayBuilder::string}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_string_length(void* arraybuilder,
                                        const char* x,
                                        int64_t length);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#beginlist ArrayBuilder::beginlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_beginlist(void* arraybuilder);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#endlist ArrayBuilder::endlist}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_endlist(void* arraybuilder);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#begintuple ArrayBuilder::begintuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_begintuple(void* arraybuilder,
                                     int64_t numfields);
 
   /// @brief C interface to {@link awkward::ArrayBuilder#index ArrayBuilder::index}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_index(void* arraybuilder,
                                int64_t index);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#endtuple ArrayBuilder::endtuple}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_endtuple(void* arraybuilder);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#beginrecord ArrayBuilder::beginrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_beginrecord(void* arraybuilder);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#beginrecord_fast ArrayBuilder::beginrecord_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_beginrecord_fast(void* arraybuilder,
                                           const char* name);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#beginrecord_check ArrayBuilder::beginrecord_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_beginrecord_check(void* arraybuilder,
                                            const char* name);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#field_fast ArrayBuilder::field_fast}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_field_fast(void* arraybuilder,
                                     const char* key);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#field_check ArrayBuilder::field_check}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_field_check(void* arraybuilder,
                                      const char* key);
 
   /// @brief C interface to
   /// {@link awkward::ArrayBuilder#endrecord ArrayBuilder::endrecord}.
-  LIBAWKWARD_EXPORT_SYMBOL uint8_t
+  EXPORT_SYMBOL uint8_t
     awkward_ArrayBuilder_endrecord(void* arraybuilder);
 }
 

--- a/awkward-cpp/include/awkward/builder/BoolBuilder.h
+++ b/awkward-cpp/include/awkward/builder/BoolBuilder.h
@@ -16,7 +16,7 @@ namespace awkward {
   /// @class BoolBuilder
   ///
   /// @brief Builder node that accumulates boolean values.
-  class LIBAWKWARD_EXPORT_SYMBOL BoolBuilder: public Builder {
+  class EXPORT_SYMBOL BoolBuilder: public Builder {
   public:
     /// @brief Create an empty BoolBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/Builder.h
+++ b/awkward-cpp/include/awkward/builder/Builder.h
@@ -38,7 +38,7 @@ namespace awkward {
   ///
   /// @brief Abstract base class for nodes within an ArrayBuilder that
   /// cumulatively discover an array's type and fill it.
-  class LIBAWKWARD_EXPORT_SYMBOL Builder: public std::enable_shared_from_this<Builder> {
+  class EXPORT_SYMBOL Builder: public std::enable_shared_from_this<Builder> {
   public:
     /// @brief Virtual destructor acts as a first non-inline virtual function
     /// that determines a specific translation unit in which vtable shall be

--- a/awkward-cpp/include/awkward/builder/Complex128Builder.h
+++ b/awkward-cpp/include/awkward/builder/Complex128Builder.h
@@ -14,7 +14,7 @@ namespace awkward {
   /// @class Complex128Builder
   ///
   /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Complex128Builder: public Builder {
+  class EXPORT_SYMBOL Complex128Builder: public Builder {
   public:
     /// @brief Create an empty Complex128Builder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/DatetimeBuilder.h
+++ b/awkward-cpp/include/awkward/builder/DatetimeBuilder.h
@@ -13,7 +13,7 @@ namespace awkward {
   /// @class DatetimeBuilder
   ///
   /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL DatetimeBuilder: public Builder {
+  class EXPORT_SYMBOL DatetimeBuilder: public Builder {
   public:
     /// @brief Create an empty DatetimeBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/Float64Builder.h
+++ b/awkward-cpp/include/awkward/builder/Float64Builder.h
@@ -15,7 +15,7 @@ namespace awkward {
   /// @class Float64Builder
   ///
   /// @brief Builder node that accumulates real numbers (`double`).
-  class LIBAWKWARD_EXPORT_SYMBOL Float64Builder: public Builder {
+  class EXPORT_SYMBOL Float64Builder: public Builder {
   public:
     /// @brief Create an empty Float64Builder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/Int64Builder.h
+++ b/awkward-cpp/include/awkward/builder/Int64Builder.h
@@ -13,7 +13,7 @@ namespace awkward {
   /// @class Int64Builder
   ///
   /// @brief Builder node that accumulates integers (`int64_t`).
-  class LIBAWKWARD_EXPORT_SYMBOL Int64Builder: public Builder {
+  class EXPORT_SYMBOL Int64Builder: public Builder {
   public:
     /// @brief Create an empty Int64Builder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/ListBuilder.h
+++ b/awkward-cpp/include/awkward/builder/ListBuilder.h
@@ -15,7 +15,7 @@ namespace awkward {
   /// @class ListBuilder
   ///
   /// @brief Builder node that accumulates lists.
-  class LIBAWKWARD_EXPORT_SYMBOL ListBuilder: public Builder {
+  class EXPORT_SYMBOL ListBuilder: public Builder {
   public:
     /// @brief Create an empty ListBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/OptionBuilder.h
+++ b/awkward-cpp/include/awkward/builder/OptionBuilder.h
@@ -15,7 +15,7 @@ namespace awkward {
   /// @class OptionBuilder
   ///
   /// @brief Builder node that accumulates data with missing values (`None`).
-  class LIBAWKWARD_EXPORT_SYMBOL OptionBuilder: public Builder {
+  class EXPORT_SYMBOL OptionBuilder: public Builder {
   public:
     /// @brief Create an OptionBuilder from a number of nulls (all missing).
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/RecordBuilder.h
+++ b/awkward-cpp/include/awkward/builder/RecordBuilder.h
@@ -15,7 +15,7 @@ namespace awkward {
   /// @class RecordBuilder
   ///
   /// @brief Builder node for accumulated records.
-  class LIBAWKWARD_EXPORT_SYMBOL RecordBuilder: public Builder {
+  class EXPORT_SYMBOL RecordBuilder: public Builder {
   public:
     /// @brief Create an empty RecordBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/StringBuilder.h
+++ b/awkward-cpp/include/awkward/builder/StringBuilder.h
@@ -13,7 +13,7 @@ namespace awkward {
   /// @class StringBuilder
   ///
   /// @brief Builder node that accumulates strings.
-  class LIBAWKWARD_EXPORT_SYMBOL StringBuilder: public Builder {
+  class EXPORT_SYMBOL StringBuilder: public Builder {
   public:
     /// @brief Create an empty StringBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/TupleBuilder.h
+++ b/awkward-cpp/include/awkward/builder/TupleBuilder.h
@@ -15,7 +15,7 @@ namespace awkward {
   /// @class TupleBuilder
   ///
   /// @brief Builder node for accumulated tuples.
-  class LIBAWKWARD_EXPORT_SYMBOL TupleBuilder: public Builder {
+  class EXPORT_SYMBOL TupleBuilder: public Builder {
   public:
     /// @brief Create an empty TupleBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/builder/UnionBuilder.h
+++ b/awkward-cpp/include/awkward/builder/UnionBuilder.h
@@ -17,7 +17,7 @@ namespace awkward {
   /// @class UnionBuilder
   ///
   /// @brief Builder node for accumulated heterogeneous data.
-  class LIBAWKWARD_EXPORT_SYMBOL UnionBuilder: public Builder {
+  class EXPORT_SYMBOL UnionBuilder: public Builder {
   public:
     static const BuilderPtr
       fromsingle(const BuilderOptions& options,

--- a/awkward-cpp/include/awkward/builder/UnknownBuilder.h
+++ b/awkward-cpp/include/awkward/builder/UnknownBuilder.h
@@ -14,7 +14,7 @@ namespace awkward {
   /// @class UnknownBuilder
   ///
   /// @brief Builder node for accumulated data whose type is not yet known.
-  class LIBAWKWARD_EXPORT_SYMBOL UnknownBuilder: public Builder {
+  class EXPORT_SYMBOL UnknownBuilder: public Builder {
   public:
     /// @brief Create an empty UnknownBuilder.
     /// @param options Configuration options for building an array;

--- a/awkward-cpp/include/awkward/common.h
+++ b/awkward-cpp/include/awkward/common.h
@@ -40,10 +40,6 @@
   #define EXPORT_TEMPLATE_INST EXPORT_SYMBOL
 #endif
 
-#ifndef LIBAWKWARD_EXPORT_SYMBOL
-  #define LIBAWKWARD_EXPORT_SYMBOL
-#endif
-
 #include <iostream>
 #include <algorithm>
 #include <map>
@@ -53,7 +49,7 @@
 #include <cstring>
 
 extern "C" {
-  struct LIBAWKWARD_EXPORT_SYMBOL Error {
+  struct EXPORT_SYMBOL Error {
     const char* str;
     const char* filename;
     int64_t identity;

--- a/awkward-cpp/include/awkward/forth/ForthInputBuffer.h
+++ b/awkward-cpp/include/awkward/forth/ForthInputBuffer.h
@@ -14,7 +14,7 @@ namespace awkward {
   /// @brief HERE
   ///
   /// THERE
-  class LIBAWKWARD_EXPORT_SYMBOL ForthInputBuffer {
+  class EXPORT_SYMBOL ForthInputBuffer {
   public:
     /// @brief HERE
     ForthInputBuffer(const std::shared_ptr<void> ptr,

--- a/awkward-cpp/include/awkward/forth/ForthMachine.h
+++ b/awkward-cpp/include/awkward/forth/ForthMachine.h
@@ -19,7 +19,7 @@ namespace awkward {
   ///
   /// THERE
   template <typename T, typename I>
-  class LIBAWKWARD_EXPORT_SYMBOL ForthMachineOf {
+  class EXPORT_SYMBOL ForthMachineOf {
 
     template <typename TYPE> using IndexTypeOf = typename std::vector<TYPE>::size_type;
 

--- a/awkward-cpp/include/awkward/forth/ForthOutputBuffer.h
+++ b/awkward-cpp/include/awkward/forth/ForthOutputBuffer.h
@@ -31,7 +31,7 @@ namespace awkward {
   /// @brief HERE
   ///
   /// THERE
-  class LIBAWKWARD_EXPORT_SYMBOL ForthOutputBuffer {
+  class EXPORT_SYMBOL ForthOutputBuffer {
   public:
     ForthOutputBuffer(int64_t initial, double resize);
 
@@ -193,7 +193,7 @@ namespace awkward {
   };
 
   template <typename OUT>
-  class LIBAWKWARD_EXPORT_SYMBOL ForthOutputBufferOf : public ForthOutputBuffer {
+  class EXPORT_SYMBOL ForthOutputBufferOf : public ForthOutputBuffer {
   public:
     ForthOutputBufferOf(int64_t initial, double resize);
 

--- a/awkward-cpp/include/awkward/io/json.h
+++ b/awkward-cpp/include/awkward/io/json.h
@@ -61,6 +61,9 @@ namespace awkward {
              int64_t initial,
              double resize);
 
+    // Delete copy constructor
+    FromJsonObjectSchema(const FromJsonObjectSchema&) = delete;
+
     /// @brief HERE
     inline int64_t current_stack_depth() const noexcept {
       return current_stack_depth_;

--- a/awkward-cpp/include/awkward/io/json.h
+++ b/awkward-cpp/include/awkward/io/json.h
@@ -64,6 +64,9 @@ namespace awkward {
     // Delete copy constructor
     FromJsonObjectSchema(const FromJsonObjectSchema&) = delete;
 
+    // Delete copy-assignment constructor
+    FromJsonObjectSchema& operator=(FromJsonObjectSchema&) = delete;
+
     /// @brief HERE
     inline int64_t current_stack_depth() const noexcept {
       return current_stack_depth_;

--- a/awkward-cpp/include/awkward/io/json.h
+++ b/awkward-cpp/include/awkward/io/json.h
@@ -40,7 +40,7 @@ namespace awkward {
   /// representation in JSON format.
   /// @param minus_infinity_string User-defined string for a negative
   /// infinity representation in JSON format.
-  LIBAWKWARD_EXPORT_SYMBOL void
+  EXPORT_SYMBOL void
     fromjsonobject(FileLikeObject* source,
                    ArrayBuilder& builder,
                    int64_t buffersize,
@@ -49,7 +49,7 @@ namespace awkward {
                    const char* posinf_string = nullptr,
                    const char* neginf_string = nullptr);
 
-  class FromJsonObjectSchema {
+  class EXPORT_SYMBOL FromJsonObjectSchema {
   public:
     FromJsonObjectSchema(FileLikeObject* source,
              int64_t buffersize,

--- a/awkward-cpp/include/awkward/util.h
+++ b/awkward-cpp/include/awkward/util.h
@@ -47,7 +47,7 @@ namespace awkward {
     dtype_to_name(dtype dt);
 
     /// @brief Convert a dtype enum into a NumPy format string.
-    const std::string
+    EXPORT_SYMBOL const std::string
     dtype_to_format(dtype dt, const std::string& format = "");
 
     /// @brief Puts quotation marks around a string and escapes the appropriate

--- a/awkward-cpp/include/awkward/util.h
+++ b/awkward-cpp/include/awkward/util.h
@@ -19,7 +19,7 @@ namespace awkward {
     /// @brief NumPy dtypes that can be interpreted within Awkward C++
     /// (only the primitive, fixed-width types). Non-native-endian types
     /// are considered NOT_PRIMITIVE.
-    enum class dtype {
+    enum class EXPORT_SYMBOL dtype {
         NOT_PRIMITIVE,
         boolean,
         int8,
@@ -43,7 +43,7 @@ namespace awkward {
     };
 
     /// @brief Returns the name associated with a given dtype.
-    const std::string
+    EXPORT_SYMBOL const std::string
     dtype_to_name(dtype dt);
 
     /// @brief Convert a dtype enum into a NumPy format string.
@@ -100,7 +100,7 @@ namespace awkward {
     ///     Python object when there are no more C++ shared pointers
     ///     referencing it.
     template <typename T>
-    class LIBAWKWARD_EXPORT_SYMBOL array_deleter {
+    class EXPORT_SYMBOL array_deleter {
     public:
       /// @brief Called by `std::shared_ptr` when its reference count reaches
       /// zero.


### PR DESCRIPTION
Right now, we install three libraries: `_ext`, `libawkward`, `libawkward-cpu-kernels`, and build some additional static variants.

We didn't change this when splitting out awkward-cpp, because I didn't want to rock the boat any more. Since becoming more well versed with CMake's nuances, I'm confident that we can remove the leftover baggage. 

This PR keeps the separate `libawkward` and `_ext` libraries (because it doesn't appear trivial to merge them), but drops the static libraries.
