### PR TITLE
fix: support scalar returns from `firsts`

### DIFF
--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -102,4 +102,4 @@ def _impl(array, axis, highlevel, behavior, attrs):
 
         out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
 
-    return ctx.wrap(out, highlevel=highlevel)
+    return ctx.wrap(out, highlevel=highlevel, allow_other=True)

--- a/tests/test_2815_return_scalar_firsts.py
+++ b/tests/test_2815_return_scalar_firsts.py
@@ -1,0 +1,20 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array([1, 2, 3, 4])
+    first = ak.firsts(array, axis=0)
+    assert isinstance(first, np.int64) and first == 1
+
+
+def test_non_scalar():
+    array = ak.Array([[1, 2, 3], [4]])
+    first = ak.firsts(array, axis=0)
+    assert first.to_list() == [1, 2, 3]


### PR DESCRIPTION
I noticed that we expect `ak.firsts` to return scalar values, which was broken in a recent refactoring PR.