### PR TITLE
fix: ufunc handling of attrs

### DIFF
--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -11,6 +11,7 @@ from itertools import chain
 import numpy
 
 import awkward as ak
+from awkward._attrs import attrs_of
 from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of, backend_of_obj, common_backend
 from awkward._behavior import (
@@ -353,6 +354,7 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
         return NotImplemented
 
     behavior = behavior_of(*inputs)
+    attrs = attrs_of(*inputs)
     backend = backend_of(*inputs, coerce_to_common=True)
 
     inputs = _array_ufunc_custom_cast(inputs, behavior, backend)
@@ -458,9 +460,9 @@ def array_ufunc(ufunc, method: str, inputs, kwargs: dict[str, Any]):
     )
 
     if len(out) == 1:
-        return wrap_layout(out[0], behavior)
+        return wrap_layout(out[0], behavior=behavior, attrs=attrs)
     else:
-        return tuple(wrap_layout(o, behavior) for o in out)
+        return tuple(wrap_layout(o, behavior=behavior, attrs=attrs) for o in out)
 
 
 def action_for_matmul(inputs):

--- a/tests/test_2837_ufunc_attrs_behavior.py
+++ b/tests/test_2837_ufunc_attrs_behavior.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test():
+    x = ak.Array([1, 2, 3], behavior={"foo": "BAR"}, attrs={"hello": "world"})
+    y = ak.Array([8, 0, 9], behavior={"do": "re"}, attrs={"mi": "fa"})
+    z = x + y
+    assert z.attrs == {"hello": "world", "mi": "fa"}
+    assert z.behavior == {"foo": "BAR", "do": "re"}
+
+
+def test_unary():
+    x = ak.Array([1, 2, 3], behavior={"foo": "BAR"}, attrs={"hello": "world"})
+    y = -x
+    assert y.attrs is x.attrs
+    assert x.behavior is y.behavior
+
+
+def test_two_return():
+    x = ak.Array([1, 2, 3], behavior={"foo": "BAR"}, attrs={"hello": "world"})
+    y, y_ret = divmod(x, 2)
+    assert y.attrs is y_ret.attrs
+    assert y.attrs is x.attrs
+
+    assert y.behavior is y_ret.behavior
+    assert y.behavior is x.behavior


### PR DESCRIPTION
I noticed that ufuncs in dask-awkward were not propagating attrs. It turns out that the bug originates here — odd that our tests didn't catch this, but perhaps it was a trivial oversight.