### PR TITLE
refactor: split "meta" into `Meta`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,10 +226,11 @@ module = [
     'awkward._nplikes.*',
     'awkward._behavior.*',
     'awkward._backends.*',
-    'awkward.forms.*',
-    'awkward.types.*',
+    'awkward._meta.*',
     'awkward._errors',
     'awkward._dispatch',
+    'awkward.forms.*',
+    'awkward.types.*',
     'awkward.index',
 ]
 ignore_errors = false

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Sized
+from functools import lru_cache
 from types import ModuleType
 
 from packaging.version import parse as parse_version
@@ -893,12 +894,21 @@ def to_awkwardarrow_type(
         return storage_type
 
 
+@lru_cache
+def find_first_content_subclass(cls):
+    for base_cls in reversed(cls.mro()):
+        if base_cls is not ak.contents.Content and issubclass(
+            base_cls, ak.contents.Content
+        ):
+            return base_cls
+    raise TypeError
+
+
 def direct_Content_subclass(node):
     if node is None:
         return None
     else:
-        mro = type(node).mro()
-        return mro[mro.index(ak.contents.Content) - 1]
+        return find_first_content_subclass(type(node))
 
 
 def direct_Content_subclass_name(node):

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class BitMaskedMeta(Meta):
-    _content: Meta
+class BitMaskedMeta(Meta, Generic[T]):
+    _content: T
     is_option = True
 
     @property
@@ -49,3 +51,8 @@ class BitMaskedMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return True
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -1,0 +1,51 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class BitMaskedMeta(Meta):
+    _content: Meta
+    is_option = True
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        return self._content.purelist_depth
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return self._content.minmax_depth
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return self._content.branch_depth
+
+    @property
+    def fields(self) -> list[str]:
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return True

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -55,4 +55,3 @@ class BitMaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -1,0 +1,51 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class ByteMaskedMeta(Meta):
+    _content: Meta
+    is_option = True
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        return self._content.purelist_depth
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return self._content.minmax_depth
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return self._content.branch_depth
+
+    @property
+    def fields(self) -> list[str]:
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return True

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class ByteMaskedMeta(Meta):
-    _content: Meta
+class ByteMaskedMeta(Meta, Generic[T]):
+    _content: T
     is_option = True
 
     @property
@@ -49,3 +51,8 @@ class ByteMaskedMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return True
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -55,4 +55,3 @@ class ByteMaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/emptymeta.py
+++ b/src/awkward/_meta/emptymeta.py
@@ -1,0 +1,46 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class EmptyMeta(Meta):
+    is_unknown = True
+    is_leaf = True
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        return None
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return True
+
+    @property
+    def purelist_depth(self) -> int:
+        return 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return True
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return (1, 1)
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return (False, 1)
+
+    @property
+    def fields(self) -> list[str]:
+        return []
+
+    @property
+    def is_tuple(self) -> bool:
+        return False
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class IndexedMeta(Meta):
+class IndexedMeta(Meta, Generic[T]):
     is_indexed = True
 
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -50,3 +52,8 @@ class IndexedMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -1,0 +1,52 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class IndexedMeta(Meta):
+    is_indexed = True
+
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        return self._content.purelist_depth
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return self._content.minmax_depth
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return self._content.branch_depth
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -56,4 +56,3 @@ class IndexedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class IndexedOptionMeta(Meta):
+class IndexedOptionMeta(Meta, Generic[T]):
     is_indexed = True
     is_option = True
 
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -51,3 +53,8 @@ class IndexedOptionMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return True
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -57,4 +57,3 @@ class IndexedOptionMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -1,0 +1,53 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class IndexedOptionMeta(Meta):
+    is_indexed = True
+    is_option = True
+
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        return self._content.purelist_depth
+
+    @property
+    def is_identity_like(self) -> bool:
+        return self._content.is_identity_like
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return self._content.minmax_depth
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return self._content.branch_depth
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return True

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class ListMeta(Meta):
+class ListMeta(Meta, Generic[T]):
     is_list = True
 
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -61,3 +63,8 @@ class ListMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -47,10 +47,10 @@ class ListMeta(Meta, Generic[T]):
     @property
     def branch_depth(self) -> tuple[bool, int]:
         if self.parameter("__array__") in ("string", "bytestring"):
-            return (False, 1)
+            return False, 1
         else:
             branch, depth = self._content.branch_depth
-            return (branch, depth + 1)
+            return branch, depth + 1
 
     @property
     def fields(self):

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -1,0 +1,63 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class ListMeta(Meta):
+    is_list = True
+
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return False
+
+    @property
+    def purelist_depth(self) -> int:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return 1
+        else:
+            return self._content.purelist_depth + 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (1, 1)
+        else:
+            mindepth, maxdepth = self._content.minmax_depth
+            return (mindepth + 1, maxdepth + 1)
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (False, 1)
+        else:
+            branch, depth = self._content.branch_depth
+            return (branch, depth + 1)
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -67,4 +67,3 @@ class ListMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/listoffsetmeta.py
+++ b/src/awkward/_meta/listoffsetmeta.py
@@ -1,0 +1,63 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class ListOffsetMeta(Meta):
+    is_list = True
+
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return False
+
+    @property
+    def purelist_depth(self) -> int:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return 1
+        else:
+            return self._content.purelist_depth + 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (1, 1)
+        else:
+            mindepth, maxdepth = self._content.minmax_depth
+            return (mindepth + 1, maxdepth + 1)
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (False, 1)
+        else:
+            branch, depth = self._content.branch_depth
+            return (branch, depth + 1)
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/listoffsetmeta.py
+++ b/src/awkward/_meta/listoffsetmeta.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class ListOffsetMeta(Meta):
+class ListOffsetMeta(Meta, Generic[T]):
     is_list = True
 
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -61,3 +63,8 @@ class ListOffsetMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/listoffsetmeta.py
+++ b/src/awkward/_meta/listoffsetmeta.py
@@ -67,4 +67,3 @@ class ListOffsetMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -1,0 +1,115 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._typing import ClassVar, JSONMapping, JSONSerializable, Self
+from awkward._util import UNSET
+
+
+class Meta:
+    is_numpy: ClassVar[bool] = False
+    is_unknown: ClassVar[bool] = False
+    is_list: ClassVar[bool] = False
+    is_regular: ClassVar[bool] = False
+    is_option: ClassVar[bool] = False
+    is_indexed: ClassVar[bool] = False
+    is_record: ClassVar[bool] = False
+    is_union: ClassVar[bool] = False
+    is_leaf: ClassVar[bool] = False
+
+    _parameters: JSONMapping | None
+
+    @property
+    def parameters(self) -> JSONMapping:
+        """
+        Free-form parameters associated with every array node as a dict from parameter
+        name to its JSON-like value. Some parameters are special and are used to assign
+        behaviors to the data.
+
+        Note that the dict returned by this property is a *view* of the array node's
+        parameters. *Changing the dict will change the array!*
+
+        See #ak.behavior.
+        """
+        if self._parameters is None:
+            self._parameters = {}
+        return self._parameters
+
+    def parameter(self, key: str) -> JSONSerializable:
+        """
+        Returns a parameter's value or None.
+
+        (No distinction is ever made between unset parameters and parameters set to None.)
+        """
+        if self._parameters is None:
+            return None
+        else:
+            return self._parameters.get(key)
+
+    def purelist_parameter(self, key: str) -> JSONSerializable:
+        """
+        Return the value of the outermost parameter matching `key` in a sequence
+        of nested lists, stopping at the first record or tuple layer.
+
+        If a layer has #ak.types.UnionType, the value is only returned if all
+        possibilities have the same value.
+        """
+        return self.purelist_parameters(key)
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        """
+        Return the value of the outermost parameter matching one of `keys` in a sequence
+        of nested lists, stopping at the first record or tuple layer.
+
+        If a layer has #ak.types.UnionType, the value is only returned if all
+        possibilities have the same value.
+        """
+        raise NotImplementedError
+
+    @property
+    def is_identity_like(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    def purelist_isregular(self) -> bool:
+        """
+        Returns True if all dimensions down to the first record or tuple layer have
+        #ak.types.RegularType; False otherwise.
+        """
+        raise NotImplementedError
+
+    @property
+    def purelist_depth(self) -> int:
+        """
+        Number of dimensions of nested lists, not counting anything deeper than the
+        first record or tuple layer, if any. The depth of a one-dimensional array is
+        `1`.
+
+        If the array contains #ak.types.UnionType data and its contents have
+        equal depths, the return value is that depth. If they do not have equal
+        depths, the return value is `-1`.
+        """
+        raise NotImplementedError
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        raise NotImplementedError
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        raise NotImplementedError
+
+    @property
+    def fields(self) -> list[str]:
+        raise NotImplementedError
+
+    @property
+    def is_tuple(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        raise NotImplementedError
+
+    def copy(self, *, parameters: JSONMapping | None = UNSET) -> Self:
+        raise NotImplementedError

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from awkward._typing import ClassVar, JSONMapping, JSONSerializable, Self
+from awkward._typing import (
+    ClassVar,
+    JSONMapping,
+    JSONSerializable,
+    Self,
+)
 from awkward._util import UNSET
 
 

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -8,7 +8,7 @@ from awkward._typing import (
     JSONSerializable,
     Self,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, Sentinel
 
 
 class Meta:
@@ -116,5 +116,5 @@ class Meta:
     def dimension_optiontype(self) -> bool:
         raise NotImplementedError
 
-    def copy(self, *, parameters: JSONMapping | None = UNSET) -> Self:
+    def copy(self, *, parameters: JSONMapping | None | Sentinel = UNSET) -> Self:
         raise NotImplementedError

--- a/src/awkward/_meta/numpymeta.py
+++ b/src/awkward/_meta/numpymeta.py
@@ -1,0 +1,53 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._nplikes.shape import ShapeItem
+from awkward._typing import JSONSerializable
+
+
+class NumpyMeta(Meta):
+    is_numpy = True
+    is_leaf = True
+    inner_shape: tuple[ShapeItem, ...]
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+        return None
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return True
+
+    @property
+    def purelist_depth(self) -> int:
+        return len(self.inner_shape) + 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        depth = len(self.inner_shape) + 1
+        return (depth, depth)
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return (False, len(self.inner_shape) + 1)
+
+    @property
+    def fields(self) -> list[str]:
+        return []
+
+    @property
+    def is_tuple(self) -> bool:
+        return False
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/recordmeta.py
+++ b/src/awkward/_meta/recordmeta.py
@@ -1,0 +1,141 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from awkward._meta.meta import Meta
+from awkward._regularize import is_integer
+from awkward._typing import JSONSerializable
+from awkward.errors import FieldNotFoundError
+
+
+class RecordMeta(Meta):
+    is_record = True
+
+    _contents: Sequence[Meta]
+    _fields: list[str] | None
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._fields is None
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+        return None
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return True
+
+    @property
+    def purelist_depth(self) -> int:
+        return 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        if len(self._contents) == 0:
+            return (1, 1)
+        mins, maxs = [], []
+        for content in self._contents:
+            mindepth, maxdepth = content.minmax_depth
+            mins.append(mindepth)
+            maxs.append(maxdepth)
+        return (min(mins), max(maxs))
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        if len(self._contents) == 0:
+            return (False, 1)
+        anybranch = False
+        mindepth = None
+        for content in self._contents:
+            branch, depth = content.branch_depth
+            if mindepth is None:
+                mindepth = depth
+            if branch or mindepth != depth:
+                anybranch = True
+            if mindepth > depth:
+                mindepth = depth
+        return (anybranch, mindepth)
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False
+
+    @property
+    def is_leaf(self):
+        return len(self._contents) == 0
+
+    @property
+    def contents(self):
+        return self._contents
+
+    @property
+    def fields(self) -> list[str]:
+        if self._fields is None:
+            return [str(i) for i in range(len(self._contents))]
+        else:
+            return self._fields
+
+    def index_to_field(self, index):
+        if 0 <= index < len(self._contents):
+            if self._fields is None:
+                return str(index)
+            else:
+                return self._fields[index]
+        else:
+            raise IndexError(
+                f"no index {index} in record with {len(self._contents)} fields"
+            )
+
+    def field_to_index(self, field):
+        if self._fields is None:
+            try:
+                i = int(field)
+            except ValueError:
+                pass
+            else:
+                if 0 <= i < len(self._contents):
+                    return i
+        else:
+            try:
+                i = self._fields.index(field)
+            except ValueError:
+                pass
+            else:
+                return i
+        raise FieldNotFoundError(
+            f"no field {field!r} in record with {len(self._contents)} fields"
+        )
+
+    def has_field(self, field):
+        if self._fields is None:
+            try:
+                i = int(field)
+            except ValueError:
+                return False
+            else:
+                return 0 <= i < len(self._contents)
+        else:
+            return field in self._fields
+
+    def content(self, index_or_field):
+        if is_integer(index_or_field):
+            index = index_or_field
+        elif isinstance(index_or_field, str):
+            index = self.field_to_index(index_or_field)
+        else:
+            raise TypeError(
+                "index_or_field must be an integer (index) or string (field), not {}".format(
+                    repr(index_or_field)
+                )
+            )
+        return self._contents[index]

--- a/src/awkward/_meta/recordmeta.py
+++ b/src/awkward/_meta/recordmeta.py
@@ -53,25 +53,27 @@ class RecordMeta(Meta, Generic[T]):
     @property
     def branch_depth(self) -> tuple[bool, int]:
         if len(self._contents) == 0:
-            return (False, 1)
-        anybranch = False
-        mindepth = None
+            return False, 1
+
+        any_branch = False
+        min_depth = None
         for content in self._contents:
             branch, depth = content.branch_depth
-            if mindepth is None:
-                mindepth = depth
-            if branch or mindepth != depth:
-                anybranch = True
-            if mindepth > depth:
-                mindepth = depth
-        return (anybranch, mindepth)
+            if min_depth is None:
+                min_depth = depth
+            if branch or min_depth != depth:
+                any_branch = True
+            if min_depth > depth:
+                min_depth = depth
+        assert min_depth is not None
+        return any_branch, min_depth
 
     @property
     def dimension_optiontype(self) -> bool:
         return False
 
     @property
-    def is_leaf(self) -> bool:
+    def is_leaf(self) -> bool:  # type: ignore[override]
         return len(self._contents) == 0
 
     @property
@@ -138,4 +140,4 @@ class RecordMeta(Meta, Generic[T]):
                     repr(index_or_field)
                 )
             )
-        return self._contents[index]
+        return self._contents[index]  # type: ignore[index]

--- a/src/awkward/_meta/recordmeta.py
+++ b/src/awkward/_meta/recordmeta.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 from awkward._meta.meta import Meta
 from awkward._regularize import is_integer
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
 from awkward.errors import FieldNotFoundError
 
+T = TypeVar("T", bound=Meta)
 
-class RecordMeta(Meta):
+
+class RecordMeta(Meta, Generic[T]):
     is_record = True
 
-    _contents: Sequence[Meta]
+    _contents: list[T]
     _fields: list[str] | None
 
     @property
@@ -71,11 +71,11 @@ class RecordMeta(Meta):
         return False
 
     @property
-    def is_leaf(self):
+    def is_leaf(self) -> bool:
         return len(self._contents) == 0
 
     @property
-    def contents(self):
+    def contents(self) -> list[T]:
         return self._contents
 
     @property
@@ -85,7 +85,7 @@ class RecordMeta(Meta):
         else:
             return self._fields
 
-    def index_to_field(self, index):
+    def index_to_field(self, index: int) -> str:
         if 0 <= index < len(self._contents):
             if self._fields is None:
                 return str(index)
@@ -96,7 +96,7 @@ class RecordMeta(Meta):
                 f"no index {index} in record with {len(self._contents)} fields"
             )
 
-    def field_to_index(self, field):
+    def field_to_index(self, field: str) -> int:
         if self._fields is None:
             try:
                 i = int(field)
@@ -116,7 +116,7 @@ class RecordMeta(Meta):
             f"no field {field!r} in record with {len(self._contents)} fields"
         )
 
-    def has_field(self, field):
+    def has_field(self, field: str) -> bool:
         if self._fields is None:
             try:
                 i = int(field)
@@ -127,7 +127,7 @@ class RecordMeta(Meta):
         else:
             return field in self._fields
 
-    def content(self, index_or_field):
+    def content(self, index_or_field: int | str) -> T:
         if is_integer(index_or_field):
             index = index_or_field
         elif isinstance(index_or_field, str):

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -70,4 +70,3 @@ class RegularMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from awkward._meta.meta import Meta
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class RegularMeta(Meta):
+class RegularMeta(Meta, Generic[T]):
     is_list = True
     is_regular = True
 
     size: ShapeItem
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -64,3 +66,8 @@ class RegularMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -1,0 +1,66 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._nplikes.shape import ShapeItem
+from awkward._typing import JSONSerializable
+
+
+class RegularMeta(Meta):
+    is_list = True
+    is_regular = True
+
+    size: ShapeItem
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return 1
+        else:
+            return self._content.purelist_depth + 1
+
+    @property
+    def is_identity_like(self) -> bool:
+        return False
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (1, 1)
+        else:
+            mindepth, maxdepth = self._content.minmax_depth
+            return (mindepth + 1, maxdepth + 1)
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        if self.parameter("__array__") in ("string", "bytestring"):
+            return (False, 1)
+        else:
+            branch, depth = self._content.branch_depth
+            return (branch, depth + 1)
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return False

--- a/src/awkward/_meta/unionmeta.py
+++ b/src/awkward/_meta/unionmeta.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Sequence
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class UnionMeta(Meta):
+class UnionMeta(Meta, Generic[T]):
     is_union = True
 
-    _contents: Sequence[Meta]
+    _contents: list[T]
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -93,3 +94,10 @@ class UnionMeta(Meta):
             if content.dimension_optiontype:
                 return True
         return False
+
+    def content(self, index: int) -> T:
+        return self._contents[index]
+
+    @property
+    def contents(self) -> list[T]:
+        return self._contents

--- a/src/awkward/_meta/unionmeta.py
+++ b/src/awkward/_meta/unionmeta.py
@@ -46,6 +46,7 @@ class UnionMeta(Meta, Generic[T]):
                 out = content.purelist_depth
             elif out != content.purelist_depth:
                 return -1
+        assert out is not None
         return out
 
     @property
@@ -66,18 +67,21 @@ class UnionMeta(Meta, Generic[T]):
     @property
     def branch_depth(self) -> tuple[bool, int]:
         if len(self._contents) == 0:
-            return (False, 1)
-        anybranch = False
-        mindepth = None
+            return False, 1
+
+        any_branch = False
+        min_depth = None
         for content in self._contents:
             branch, depth = content.branch_depth
-            if mindepth is None:
-                mindepth = depth
-            if branch or mindepth != depth:
-                anybranch = True
-            if mindepth > depth:
-                mindepth = depth
-        return (anybranch, mindepth)
+            if min_depth is None:
+                min_depth = depth
+            if branch or min_depth != depth:
+                any_branch = True
+            if min_depth > depth:
+                min_depth = depth
+
+        assert min_depth is not None
+        return any_branch, min_depth
 
     @property
     def fields(self) -> list[str]:

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -1,0 +1,51 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._meta.meta import Meta
+from awkward._typing import JSONSerializable
+
+
+class UnmaskedMeta(Meta):
+    is_option = True
+    _content: Meta
+
+    def purelist_parameters(self, *keys: str) -> JSONSerializable:
+        if self._parameters is not None:
+            for key in keys:
+                if key in self._parameters:
+                    return self._parameters[key]
+
+        return self._content.purelist_parameters(*keys)
+
+    @property
+    def purelist_isregular(self) -> bool:
+        return self._content.purelist_isregular
+
+    @property
+    def purelist_depth(self) -> int:
+        return self._content.purelist_depth
+
+    @property
+    def is_identity_like(self) -> bool:
+        return self._content.is_identity_like
+
+    @property
+    def minmax_depth(self) -> tuple[int, int]:
+        return self._content.minmax_depth
+
+    @property
+    def branch_depth(self) -> tuple[bool, int]:
+        return self._content.branch_depth
+
+    @property
+    def fields(self):
+        return self._content.fields
+
+    @property
+    def is_tuple(self) -> bool:
+        return self._content.is_tuple
+
+    @property
+    def dimension_optiontype(self) -> bool:
+        return True

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -55,4 +55,3 @@ class UnmaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
-

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
-from awkward._typing import JSONSerializable
+from awkward._typing import Generic, JSONSerializable, TypeVar
+
+T = TypeVar("T", bound=Meta)
 
 
-class UnmaskedMeta(Meta):
+class UnmaskedMeta(Meta, Generic[T]):
     is_option = True
-    _content: Meta
+    _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -49,3 +51,8 @@ class UnmaskedMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return True
+
+    @property
+    def content(self) -> T:
+        return self._content
+

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -135,8 +135,6 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(
         self, mask, content, valid_when, length, lsb_order, *, parameters=None
     ):

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._meta.bitmaskedmeta import BitMaskedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -50,7 +51,7 @@ numpy = Numpy.instance()
 
 
 @final
-class BitMaskedArray(Content):
+class BitMaskedArray(BitMaskedMeta, Content):
     """
     Like #ak.contents.ByteMaskedArray, BitMaskedArray implements an
     #ak.types.OptionType with two buffers, `mask` and `content`.
@@ -134,7 +135,7 @@ class BitMaskedArray(Content):
                     raise AssertionError(where)
     """
 
-    is_option = True
+    _content: Content
 
     def __init__(
         self, mask, content, valid_when, length, lsb_order, *, parameters=None

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -51,7 +51,7 @@ numpy = Numpy.instance()
 
 
 @final
-class BitMaskedArray(BitMaskedMeta, Content):
+class BitMaskedArray(BitMaskedMeta[Content], Content):
     """
     Like #ak.contents.ByteMaskedArray, BitMaskedArray implements an
     #ak.types.OptionType with two buffers, `mask` and `content`.
@@ -211,10 +211,6 @@ class BitMaskedArray(BitMaskedMeta, Content):
     @property
     def mask(self):
         return self._mask
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     @property
     def valid_when(self):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.bytemaskedmeta import ByteMaskedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -52,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ByteMaskedArray(Content):
+class ByteMaskedArray(ByteMaskedMeta, Content):
     """
     The ByteMaskedArray implements an #ak.types.OptionType with two aligned
     buffers, a boolean `mask` and `content`. At any element `i` where
@@ -109,7 +110,7 @@ class ByteMaskedArray(Content):
                     raise AssertionError(where)
     """
 
-    is_option = True
+    _content: Content
 
     def __init__(self, mask, content, valid_when, *, parameters=None):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.int8)):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -53,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ByteMaskedArray(ByteMaskedMeta, Content):
+class ByteMaskedArray(ByteMaskedMeta[Content], Content):
     """
     The ByteMaskedArray implements an #ak.types.OptionType with two aligned
     buffers, a boolean `mask` and `content`. At any element `i` where
@@ -159,10 +159,6 @@ class ByteMaskedArray(ByteMaskedMeta, Content):
     @property
     def mask(self):
         return self._mask
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     @property
     def valid_when(self):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -110,8 +110,6 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, mask, content, valid_when, *, parameters=None):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.int8)):
             raise TypeError(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -966,51 +966,6 @@ class Content(Meta):
     ):
         raise NotImplementedError
 
-    @property
-    def is_identity_like(self) -> bool:
-        return self.form_cls.is_identity_like.__get__(self)
-
-    @property
-    def purelist_isregular(self) -> bool:
-        """
-        Returns True if all dimensions down to the first record or tuple layer have
-        #ak.types.RegularType; False otherwise.
-        """
-        return self.form_cls.purelist_isregular.__get__(self)
-
-    @property
-    def purelist_depth(self) -> int:
-        """
-        Number of dimensions of nested lists, not counting anything deeper than the
-        first record or tuple layer, if any. The depth of a one-dimensional array is
-        `1`.
-
-        If the array contains #ak.types.UnionType data and its contents have
-        equal depths, the return value is that depth. If they do not have equal
-        depths, the return value is `-1`.
-        """
-        return self.form_cls.purelist_depth.__get__(self)
-
-    @property
-    def minmax_depth(self) -> tuple[int, int]:
-        return self.form_cls.minmax_depth.__get__(self)
-
-    @property
-    def branch_depth(self) -> tuple[bool, int]:
-        return self.form_cls.branch_depth.__get__(self)
-
-    @property
-    def fields(self) -> list[str]:
-        return self.form_cls.fields.__get__(self)
-
-    @property
-    def is_tuple(self) -> bool:
-        return self.form_cls.is_tuple.__get__(self)
-
-    @property
-    def dimension_optiontype(self) -> bool:
-        return self.form_cls.dimension_optiontype.__get__(self)
-
     def _pad_none_axis0(self, target: int, clip: bool) -> Content:
         if not clip and (self.length is unknown_length or (target < self.length)):
             index = Index64(

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -17,6 +17,7 @@ from awkward._backends.dispatch import (
 from awkward._behavior import get_array_class, get_record_class
 from awkward._kernels import KernelError
 from awkward._layout import wrap_layout
+from awkward._meta.meta import Meta
 from awkward._nplikes import to_nplike
 from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.numpy import Numpy
@@ -119,17 +120,7 @@ class ToArrowOptions(TypedDict):
     record_is_scalar: bool
 
 
-class Content:
-    is_numpy = False
-    is_unknown = False
-    is_list = False
-    is_regular = False
-    is_option = False
-    is_indexed = False
-    is_record = False
-    is_union = False
-    is_leaf = False
-
+class Content(Meta):
     def _init(self, parameters: dict[str, Any] | None, backend: Backend):
         if parameters is None:
             pass
@@ -194,33 +185,6 @@ class Content:
 
         self._parameters = parameters
         self._backend = backend
-
-    @property
-    def parameters(self) -> dict[str, JSONValueType]:
-        """
-        Free-form parameters associated with every array node as a dict from parameter
-        name to its JSON-like value. Some parameters are special and are used to assign
-        behaviors to the data.
-
-        Note that the dict returned by this property is a *view* of the array node's
-        parameters. *Changing the dict will change the array!*
-
-        See #ak.behavior.
-        """
-        if self._parameters is None:
-            self._parameters = {}
-        return self._parameters
-
-    def parameter(self, key: str) -> JSONValueType | None:
-        """
-        Returns a parameter's value or None.
-
-        (No distinction is ever made between unset parameters and parameters set to None.)
-        """
-        if self._parameters is None:
-            return None
-        else:
-            return self._parameters.get(key)
 
     @property
     def backend(self) -> Backend:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -10,6 +10,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
+from awkward._meta.emptymeta import EmptyMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -47,7 +48,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class EmptyArray(Content):
+class EmptyArray(EmptyMeta, Content):
     """
     An EmptyArray is used whenever an array's type is not known because it is empty
     (such as data from #ak.ArrayBuilder without enough sample points to resolve the
@@ -81,9 +82,6 @@ class EmptyArray(Content):
                 else:
                     raise AssertionError(where)
     """
-
-    is_unknown = True
-    is_leaf = True
 
     def __init__(self, *, parameters=None, backend=None):
         if not (parameters is None or len(parameters) == 0):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -52,7 +52,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedArray(IndexedMeta, Content):
+class IndexedArray(IndexedMeta[Content], Content):
     """
     IndexedArray is a general-purpose tool for *lazily* changing the order of
     and/or duplicating some `content` with a
@@ -142,10 +142,6 @@ class IndexedArray(IndexedMeta, Content):
     @property
     def index(self):
         return self._index
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     form_cls: Final = IndexedForm
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -103,8 +103,6 @@ class IndexedArray(IndexedMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, index, content, *, parameters=None):
         if not (
             isinstance(index, Index)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.indexedmeta import IndexedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -51,7 +52,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedArray(Content):
+class IndexedArray(IndexedMeta, Content):
     """
     IndexedArray is a general-purpose tool for *lazily* changing the order of
     and/or duplicating some `content` with a
@@ -102,7 +103,7 @@ class IndexedArray(Content):
                     raise AssertionError(where)
     """
 
-    is_indexed = True
+    _content: Content
 
     def __init__(self, index, content, *, parameters=None):
         if not (

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -50,7 +51,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedOptionArray(Content):
+class IndexedOptionArray(IndexedOptionMeta, Content):
     """
     IndexedOptionArray is an #ak.contents.IndexedArray for which
     negative values in the index are interpreted as missing. It represents
@@ -98,8 +99,7 @@ class IndexedOptionArray(Content):
                     raise AssertionError(where)
     """
 
-    is_option = True
-    is_indexed = True
+    _content: Content
 
     def __init__(self, index, content, *, parameters=None):
         if not (

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -51,7 +51,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedOptionArray(IndexedOptionMeta, Content):
+class IndexedOptionArray(IndexedOptionMeta[Content], Content):
     """
     IndexedOptionArray is an #ak.contents.IndexedArray for which
     negative values in the index are interpreted as missing. It represents
@@ -137,10 +137,6 @@ class IndexedOptionArray(IndexedOptionMeta, Content):
     @property
     def index(self):
         return self._index
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     form_cls: Final = IndexedOptionForm
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -99,8 +99,6 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, index, content, *, parameters=None):
         if not (
             isinstance(index, Index)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -120,8 +120,6 @@ class ListArray(ListMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, starts, stops, content, *, parameters=None):
         if not isinstance(starts, Index) and starts.dtype in (
             np.dtype(np.int32),

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.listmeta import ListMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
@@ -47,7 +48,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListArray(Content):
+class ListArray(ListMeta, Content):
     """
     ListArray generalizes #ak.contents.ListOffsetArray by not
     requiring its `content` to be in increasing order and by allowing it to
@@ -119,7 +120,7 @@ class ListArray(Content):
                     raise AssertionError(where)
     """
 
-    is_list = True
+    _content: Content
 
     def __init__(self, starts, stops, content, *, parameters=None):
         if not isinstance(starts, Index) and starts.dtype in (

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -48,7 +48,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListArray(ListMeta, Content):
+class ListArray(ListMeta[Content], Content):
     """
     ListArray generalizes #ak.contents.ListOffsetArray by not
     requiring its `content` to be in increasing order and by allowing it to
@@ -180,10 +180,6 @@ class ListArray(ListMeta, Content):
     @property
     def stops(self) -> Index:
         return self._stops
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     form_cls: Final = ListForm
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -113,8 +113,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, offsets, content, *, parameters=None):
         if not isinstance(offsets, Index) and offsets.dtype in (
             np.dtype(np.int32),

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.listoffsetmeta import ListOffsetMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -48,7 +49,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ListOffsetArray(Content):
+class ListOffsetArray(ListOffsetMeta, Content):
     """
     ListOffsetArray describes unequal-length lists (often called a
     "jagged" or "ragged" array). Like #ak.contents.RegularArray, the
@@ -112,7 +113,7 @@ class ListOffsetArray(Content):
                     raise AssertionError(where)
     """
 
-    is_list = True
+    _content: Content
 
     def __init__(self, offsets, content, *, parameters=None):
         if not isinstance(offsets, Index) and offsets.dtype in (

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -49,7 +49,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ListOffsetArray(ListOffsetMeta, Content):
+class ListOffsetArray(ListOffsetMeta[Content], Content):
     """
     ListOffsetArray describes unequal-length lists (often called a
     "jagged" or "ragged" array). Like #ak.contents.RegularArray, the
@@ -164,10 +164,6 @@ class ListOffsetArray(ListOffsetMeta, Content):
     @property
     def offsets(self) -> Index:
         return self._offsets
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     form_cls: Final = ListOffsetForm
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -12,6 +12,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
+from awkward._meta.numpymeta import NumpyMeta
 from awkward._nplikes import to_nplike
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.jax import Jax
@@ -56,7 +57,7 @@ numpy = Numpy.instance()
 
 
 @final
-class NumpyArray(Content):
+class NumpyArray(NumpyMeta, Content):
     """
     A NumpyArray describes 1-dimensional or rectilinear data using a NumPy
     `np.ndarray`, a CuPy `cp.ndarray`, etc., depending on the backend.
@@ -110,9 +111,6 @@ class NumpyArray(Content):
                 else:
                     return result
     """
-
-    is_numpy = True
-    is_leaf = True
 
     def __init__(self, data: ArrayLike, *, parameters=None, backend=None):
         if backend is None:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -60,7 +60,7 @@ def _apply_record_reducer(reducer, layout: Content, mask: bool, behavior) -> Con
 
 
 @final
-class RecordArray(RecordMeta, Content):
+class RecordArray(RecordMeta[Content], Content):
     """
     RecordArray represents an array of tuples or records, all with the
     same type. Its `contents` is an ordered list of arrays.
@@ -145,8 +145,6 @@ class RecordArray(RecordMeta, Content):
                 else:
                     raise AssertionError(where)
     """
-
-    _contents: Sequence[Content]
 
     def __init__(
         self,
@@ -271,10 +269,6 @@ class RecordArray(RecordMeta, Content):
         #       computed version (for typetracer conversions)
         self._length = length
         self._init(parameters, backend)
-
-    @property
-    def contents(self):
-        return self._contents
 
     @property
     def fields(self) -> list[str]:
@@ -419,7 +413,7 @@ class RecordArray(RecordMeta, Content):
         return "".join(out)
 
     def content(self, index_or_field: str | SupportsIndex) -> Content:
-        out = self.form_cls.content(self, index_or_field)
+        out = super().content(index_or_field)
         if (
             self._length is unknown_length
             or out.length is unknown_length

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -12,6 +12,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._behavior import find_record_reducer
 from awkward._layout import maybe_posaxis, wrap_layout
+from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -59,7 +60,7 @@ def _apply_record_reducer(reducer, layout: Content, mask: bool, behavior) -> Con
 
 
 @final
-class RecordArray(Content):
+class RecordArray(RecordMeta, Content):
     """
     RecordArray represents an array of tuples or records, all with the
     same type. Its `contents` is an ordered list of arrays.
@@ -145,11 +146,7 @@ class RecordArray(Content):
                     raise AssertionError(where)
     """
 
-    is_record = True
-
-    @property
-    def is_leaf(self):
-        return len(self._contents) == 0
+    _contents: Sequence[Content]
 
     def __init__(
         self,
@@ -280,7 +277,7 @@ class RecordArray(Content):
         return self._contents
 
     @property
-    def fields(self):
+    def fields(self) -> list[str]:
         if self._fields is None:
             return [str(i) for i in range(len(self._contents))]
         else:
@@ -328,7 +325,7 @@ class RecordArray(Content):
         return cls(contents, fields, length, parameters=parameters, backend=backend)
 
     @property
-    def is_tuple(self):
+    def is_tuple(self) -> bool:
         return self._fields is None
 
     def to_tuple(self) -> Self:
@@ -420,15 +417,6 @@ class RecordArray(Content):
         out.append(indent + "</RecordArray>")
         out.append(post)
         return "".join(out)
-
-    def index_to_field(self, index: SupportsIndex) -> str:
-        return self.form_cls.index_to_field(self, index)
-
-    def field_to_index(self, field: str) -> SupportsIndex:
-        return self.form_cls.field_to_index(self, field)
-
-    def has_field(self, field: str | SupportsIndex) -> bool:
-        return self.form_cls.has_field(self, field)
 
     def content(self, index_or_field: str | SupportsIndex) -> Content:
         out = self.form_cls.content(self, index_or_field)

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -50,7 +50,7 @@ numpy = Numpy.instance()
 
 
 @final
-class RegularArray(RegularMeta, Content):
+class RegularArray(RegularMeta[Content], Content):
     """
     RegularArray describes lists that all have the same length, the single
     integer `size`. Its underlying `content` is a flattened view of the data;
@@ -176,10 +176,6 @@ class RegularArray(RegularMeta, Content):
         else:
             self._length = zeros_length
         self._init(parameters, content.backend)
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     @property
     def size(self):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -120,8 +120,6 @@ class RegularArray(RegularMeta[Content], Content):
                     raise AssertionError(where)
     """
 
-    _content: Content
-
     def __init__(self, content, size, zeros_length=0, *, parameters=None):
         if not isinstance(content, Content):
             raise TypeError(

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.regularmeta import RegularMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -49,7 +50,7 @@ numpy = Numpy.instance()
 
 
 @final
-class RegularArray(Content):
+class RegularArray(RegularMeta, Content):
     """
     RegularArray describes lists that all have the same length, the single
     integer `size`. Its underlying `content` is a flattened view of the data;
@@ -119,8 +120,7 @@ class RegularArray(Content):
                     raise AssertionError(where)
     """
 
-    is_list = True
-    is_regular = True
+    _content: Content
 
     def __init__(self, content, size, zeros_length=0, *, parameters=None):
         if not isinstance(content, Content):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -49,7 +49,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnionArray(UnionMeta, Content):
+class UnionArray(UnionMeta[Content], Content):
     """
     UnionArray represents data drawn from an ordered list of `contents`,
     which can have different types, using
@@ -102,8 +102,6 @@ class UnionArray(UnionMeta, Content):
                 else:
                     raise AssertionError(where)
     """
-
-    _contents: Sequence[Content]
 
     def __init__(self, tags, index, contents, *, parameters=None):
         if not (isinstance(tags, Index) and tags.dtype == np.dtype(np.int8)):
@@ -205,10 +203,6 @@ class UnionArray(UnionMeta, Content):
     @property
     def index(self):
         return self._index
-
-    @property
-    def contents(self):
-        return self._contents
 
     form_cls: Final = UnionForm
 
@@ -463,9 +457,6 @@ class UnionArray(UnionMeta, Content):
                 contents,
                 parameters=parameters,
             )
-
-    def content(self, index):
-        return self._contents[index]
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> UnionForm:
         form_key = getkey(self)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.unionmeta import UnionMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -48,7 +49,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnionArray(Content):
+class UnionArray(UnionMeta, Content):
     """
     UnionArray represents data drawn from an ordered list of `contents`,
     which can have different types, using
@@ -102,7 +103,7 @@ class UnionArray(Content):
                     raise AssertionError(where)
     """
 
-    is_union = True
+    _contents: Sequence[Content]
 
     def __init__(self, tags, index, contents, *, parameters=None):
         if not (isinstance(tags, Index) and tags.dtype == np.dtype(np.int8)):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -53,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnmaskedArray(UnmaskedMeta, Content):
+class UnmaskedArray(UnmaskedMeta[Content], Content):
     """
     UnmaskedArray implements an #ak.types.OptionType for which the values are
     never, in fact, missing. It exists to satisfy systems that formally require this
@@ -103,10 +103,6 @@ class UnmaskedArray(UnmaskedMeta, Content):
         self._init(parameters, content.backend)
 
     _content: Content
-
-    @property
-    def content(self) -> Content:
-        return self._content
 
     form_cls: Final = UnmaskedForm
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -102,8 +102,6 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         self._content = content
         self._init(parameters, content.backend)
 
-    _content: Content
-
     form_cls: Final = UnmaskedForm
 
     def copy(self, content=UNSET, *, parameters=UNSET):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
+from awkward._meta.unmaskedmeta import UnmaskedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
@@ -52,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnmaskedArray(Content):
+class UnmaskedArray(UnmaskedMeta, Content):
     """
     UnmaskedArray implements an #ak.types.OptionType for which the values are
     never, in fact, missing. It exists to satisfy systems that formally require this
@@ -85,8 +86,6 @@ class UnmaskedArray(Content):
                     return UnmaskedArray(self.content[where])
     """
 
-    is_option = True
-
     def __init__(self, content, *, parameters=None):
         if not isinstance(content, Content):
             raise TypeError(
@@ -102,6 +101,8 @@ class UnmaskedArray(Content):
             )
         self._content = content
         self._init(parameters, content.backend)
+
+    _content: Content
 
     @property
     def content(self) -> Content:

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class BitMaskedForm(BitMaskedMeta, Form):
+class BitMaskedForm(BitMaskedMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.bitmaskedmeta import BitMaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class BitMaskedForm(Form):
-    is_option = True
+class BitMaskedForm(BitMaskedMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -121,10 +122,6 @@ class BitMaskedForm(Form):
                 form_key=form_key,
             )
 
-    @property
-    def is_identity_like(self):
-        return False
-
     def __repr__(self):
         args = [
             repr(self._mask),
@@ -165,42 +162,6 @@ class BitMaskedForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        return self._content.purelist_depth
-
-    @property
-    def minmax_depth(self):
-        return self._content.minmax_depth
-
-    @property
-    def branch_depth(self):
-        return self._content.branch_depth
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return True
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.bytemaskedmeta import ByteMaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ByteMaskedForm(Form):
-    is_option = True
+class ByteMaskedForm(ByteMaskedMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -104,7 +105,7 @@ class ByteMaskedForm(Form):
             )
 
     @property
-    def is_identity_like(self):
+    def is_identity_like(self) -> bool:
         return False
 
     def __repr__(self):
@@ -144,42 +145,6 @@ class ByteMaskedForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        return self._content.purelist_depth
-
-    @property
-    def minmax_depth(self):
-        return self._content.minmax_depth
-
-    @property
-    def branch_depth(self):
-        return self._content.branch_depth
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return True
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ByteMaskedForm(ByteMaskedMeta, Form):
+class ByteMaskedForm(ByteMaskedMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/emptyform.py
+++ b/src/awkward/forms/emptyform.py
@@ -7,9 +7,10 @@ from inspect import signature
 
 import awkward as ak
 from awkward._errors import deprecate
+from awkward._meta.emptymeta import EmptyMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET, Sentinel
 from awkward.forms.form import Form, JSONMapping, _SpecifierMatcher
 
@@ -19,10 +20,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class EmptyForm(Form):
-    is_numpy = True
-    is_unknown = True
-
+class EmptyForm(EmptyMeta, Form):
     def __init__(
         self, *, parameters: JSONMapping | None = None, form_key: str | None = None
     ):
@@ -92,41 +90,6 @@ class EmptyForm(Form):
             f"{type(self).__name__}.to_NumpyForm accepts either the new `primitive` argument as a keyword-only "
             f"argument, or the legacy `dtype` argument as positional or keyword"
         )
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        return None
-
-    @property
-    def purelist_isregular(self) -> bool:
-        return True
-
-    @property
-    def purelist_depth(self) -> int:
-        return 1
-
-    @property
-    def is_identity_like(self) -> bool:
-        return True
-
-    @property
-    def minmax_depth(self) -> tuple[int, int]:
-        return (1, 1)
-
-    @property
-    def branch_depth(self) -> tuple[bool, int]:
-        return (False, 1)
-
-    @property
-    def fields(self) -> list[str]:
-        return []
-
-    @property
-    def is_tuple(self) -> bool:
-        return False
-
-    @property
-    def dimension_optiontype(self) -> bool:
-        return False
 
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -13,11 +13,11 @@ from glob import escape as escape_glob
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._errors import deprecate
+from awkward._meta.meta import Meta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import parameters_union
 from awkward._typing import (
-    ClassVar,
     DType,
     Final,
     Iterator,
@@ -374,16 +374,7 @@ index_to_dtype: Final[dict[str, DType]] = {
 }
 
 
-class Form:
-    is_numpy: ClassVar = False
-    is_unknown: ClassVar = False
-    is_list: ClassVar = False
-    is_regular: ClassVar = False
-    is_option: ClassVar = False
-    is_indexed: ClassVar = False
-    is_record: ClassVar = False
-    is_union: ClassVar = False
-
+class Form(Meta):
     def _init(self, *, parameters: JSONMapping | None, form_key: str | None):
         if parameters is not None and not isinstance(parameters, dict):
             raise TypeError(
@@ -408,7 +399,7 @@ class Form:
         return self._parameters
 
     @property
-    def is_identity_like(self):
+    def is_identity_like(self) -> bool:
         """Return True if the content or its non-list descendents are an identity"""
         raise NotImplementedError
 
@@ -425,27 +416,27 @@ class Form:
         raise NotImplementedError
 
     @property
-    def purelist_isregular(self):
+    def purelist_isregular(self) -> bool:
         raise NotImplementedError
 
     @property
-    def purelist_depth(self):
+    def purelist_depth(self) -> int:
         raise NotImplementedError
 
     @property
-    def minmax_depth(self):
+    def minmax_depth(self) -> tuple[int, int]:
         raise NotImplementedError
 
     @property
-    def branch_depth(self):
+    def branch_depth(self) -> tuple[bool, int]:
         raise NotImplementedError
 
     @property
-    def fields(self):
+    def fields(self) -> list[str]:
         raise NotImplementedError
 
     @property
-    def is_tuple(self):
+    def is_tuple(self) -> bool:
         raise NotImplementedError
 
     @property

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -22,7 +22,6 @@ from awkward._typing import (
     Final,
     Iterator,
     JSONMapping,
-    JSONSerializable,
     Self,
 )
 
@@ -391,53 +390,6 @@ class Form(Meta):
 
         self._parameters = parameters
         self._form_key = form_key
-
-    @property
-    def parameters(self) -> JSONMapping:
-        if self._parameters is None:
-            self._parameters = {}
-        return self._parameters
-
-    @property
-    def is_identity_like(self) -> bool:
-        """Return True if the content or its non-list descendents are an identity"""
-        raise NotImplementedError
-
-    def parameter(self, key: str) -> JSONSerializable:
-        if self._parameters is None:
-            return None
-        else:
-            return self._parameters.get(key)
-
-    def purelist_parameter(self, key: str) -> JSONSerializable:
-        return self.purelist_parameters(key)
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        raise NotImplementedError
-
-    @property
-    def purelist_isregular(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def purelist_depth(self) -> int:
-        raise NotImplementedError
-
-    @property
-    def minmax_depth(self) -> tuple[int, int]:
-        raise NotImplementedError
-
-    @property
-    def branch_depth(self) -> tuple[bool, int]:
-        raise NotImplementedError
-
-    @property
-    def fields(self) -> list[str]:
-        raise NotImplementedError
-
-    @property
-    def is_tuple(self) -> bool:
-        raise NotImplementedError
 
     @property
     def form_key(self):

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedForm(IndexedMeta, Form):
+class IndexedForm(IndexedMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.indexedmeta import IndexedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedForm(Form):
-    is_indexed = True
+class IndexedForm(IndexedMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -147,46 +148,6 @@ class IndexedForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        return self._content.purelist_depth
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        return self._content.minmax_depth
-
-    @property
-    def branch_depth(self):
-        return self._content.branch_depth
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,9 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedOptionForm(Form):
-    is_option = True
-    is_indexed = True
+class IndexedOptionForm(IndexedOptionMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -129,46 +129,6 @@ class IndexedOptionForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        return self._content.purelist_depth
-
-    @property
-    def is_identity_like(self):
-        return self._content.is_identity_like
-
-    @property
-    def minmax_depth(self):
-        return self._content.minmax_depth
-
-    @property
-    def branch_depth(self):
-        return self._content.branch_depth
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return True
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedOptionForm(IndexedOptionMeta, Form):
+class IndexedOptionForm(IndexedOptionMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.listmeta import ListMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListForm(Form):
-    is_list = True
+class ListForm(ListMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -132,57 +133,6 @@ class ListForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return False
-
-    @property
-    def purelist_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return 1
-        else:
-            return self._content.purelist_depth + 1
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (1, 1)
-        else:
-            mindepth, maxdepth = self._content.minmax_depth
-            return (mindepth + 1, maxdepth + 1)
-
-    @property
-    def branch_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (False, 1)
-        else:
-            branch, depth = self._content.branch_depth
-            return (branch, depth + 1)
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListForm(ListMeta, Form):
+class ListForm(ListMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import awkward as ak
+from awkward._meta.listoffsetmeta import ListOffsetMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
 from awkward._typing import (
     DType,
     Iterator,
     JSONMapping,
-    JSONSerializable,
     Self,
     final,
 )
@@ -24,8 +24,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListOffsetForm(Form):
-    is_list = True
+class ListOffsetForm(ListOffsetMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -104,57 +104,6 @@ class ListOffsetForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return False
-
-    @property
-    def purelist_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return 1
-        else:
-            return self._content.purelist_depth + 1
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (1, 1)
-        else:
-            mindepth, maxdepth = self._content.minmax_depth
-            return (mindepth + 1, maxdepth + 1)
-
-    @property
-    def branch_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (False, 1)
-        else:
-            branch, depth = self._content.branch_depth
-            return (branch, depth + 1)
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -24,7 +24,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListOffsetForm(ListOffsetMeta, Form):
+class ListOffsetForm(ListOffsetMeta[Form], Form):
     _content: Form
 
     def __init__(

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -10,11 +10,14 @@ from awkward._meta.numpymeta import NumpyMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, JSONMapping, Self, final
+from awkward._typing import TYPE_CHECKING, DType, JSONMapping, Self, final
 from awkward._util import UNSET, Sentinel
 from awkward.forms.form import Form, _SpecifierMatcher
 
 __all__ = ("NumpyForm",)
+
+if TYPE_CHECKING:
+    from awkward.forms.regularform import RegularForm
 
 np = NumpyMetadata.instance()
 
@@ -176,7 +179,7 @@ class NumpyForm(NumpyMeta, Form):
         else:
             return False
 
-    def to_RegularForm(self):
+    def to_RegularForm(self) -> RegularForm:
         out = NumpyForm(self._primitive, (), parameters=None, form_key=None)
         for x in self._inner_shape[::-1]:
             out = ak.forms.RegularForm(out, x, parameters=None, form_key=None)

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -6,10 +6,11 @@ from collections.abc import Callable, Iterable, Iterator
 
 import awkward as ak
 from awkward._errors import deprecate
+from awkward._meta.numpymeta import NumpyMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, JSONMapping, JSONSerializable, Self, final
+from awkward._typing import DType, JSONMapping, Self, final
 from awkward._util import UNSET, Sentinel
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -61,9 +62,7 @@ def from_dtype(
 
 
 @final
-class NumpyForm(Form):
-    is_numpy = True
-
+class NumpyForm(NumpyMeta, Form):
     def __init__(
         self,
         primitive,
@@ -183,46 +182,6 @@ class NumpyForm(Form):
             out = ak.forms.RegularForm(out, x, parameters=None, form_key=None)
         out._parameters = self._parameters
         return out
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-        return None
-
-    @property
-    def purelist_isregular(self):
-        return True
-
-    @property
-    def purelist_depth(self):
-        return len(self.inner_shape) + 1
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        depth = len(self.inner_shape) + 1
-        return (depth, depth)
-
-    @property
-    def branch_depth(self):
-        return (False, len(self.inner_shape) + 1)
-
-    @property
-    def fields(self):
-        return []
-
-    @property
-    def is_tuple(self):
-        return False
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         output.append(".".join(path))

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -179,8 +179,10 @@ class NumpyForm(NumpyMeta, Form):
         else:
             return False
 
-    def to_RegularForm(self) -> RegularForm:
-        out = NumpyForm(self._primitive, (), parameters=None, form_key=None)
+    def to_RegularForm(self) -> RegularForm | NumpyForm:
+        out: RegularForm | NumpyForm = NumpyForm(
+            self._primitive, (), parameters=None, form_key=None
+        )
         for x in self._inner_shape[::-1]:
             out = ak.forms.RegularForm(out, x, parameters=None, form_key=None)
         out._parameters = self._parameters

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Sequence
 
 import awkward as ak
+from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._regularize import is_integer
-from awkward._typing import DType, JSONSerializable, Self, final
+from awkward._typing import DType, Self, final
 from awkward._util import UNSET
-from awkward.errors import FieldNotFoundError
 from awkward.forms.form import Form, _SpecifierMatcher
 
 __all__ = ("RecordForm",)
@@ -19,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RecordForm(Form):
-    is_record = True
+class RecordForm(RecordMeta, Form):
+    _contents: Sequence[Form]
 
     def __init__(
         self,
@@ -59,7 +58,7 @@ class RecordForm(Form):
         return self._contents
 
     @property
-    def fields(self):
+    def fields(self) -> list[str]:
         if self._fields is None:
             return [str(i) for i in range(len(self._contents))]
         else:
@@ -91,68 +90,9 @@ class RecordForm(Form):
     ):
         return cls(contents, fields, parameters=parameters, form_key=form_key)
 
-    @property
-    def is_tuple(self):
-        return self._fields is None
-
     def __repr__(self):
         args = [repr(self._contents), repr(self._fields), *self._repr_args()]
         return "{}({})".format(type(self).__name__, ", ".join(args))
-
-    def index_to_field(self, index):
-        if 0 <= index < len(self._contents):
-            if self._fields is None:
-                return str(index)
-            else:
-                return self._fields[index]
-        else:
-            raise IndexError(
-                f"no index {index} in record with {len(self._contents)} fields"
-            )
-
-    def field_to_index(self, field):
-        if self._fields is None:
-            try:
-                i = int(field)
-            except ValueError:
-                pass
-            else:
-                if 0 <= i < len(self._contents):
-                    return i
-        else:
-            try:
-                i = self._fields.index(field)
-            except ValueError:
-                pass
-            else:
-                return i
-        raise FieldNotFoundError(
-            f"no field {field!r} in record with {len(self._contents)} fields"
-        )
-
-    def has_field(self, field):
-        if self._fields is None:
-            try:
-                i = int(field)
-            except ValueError:
-                return False
-            else:
-                return 0 <= i < len(self._contents)
-        else:
-            return field in self._fields
-
-    def content(self, index_or_field):
-        if is_integer(index_or_field):
-            index = index_or_field
-        elif isinstance(index_or_field, str):
-            index = self.field_to_index(index_or_field)
-        else:
-            raise TypeError(
-                "index_or_field must be an integer (index) or string (field), not {}".format(
-                    repr(index_or_field)
-                )
-            )
-        return self._contents[index]
 
     def _to_dict_part(self, verbose, toplevel):
         out = {"class": "RecordArray"}
@@ -194,56 +134,6 @@ class RecordForm(Form):
                 return False
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-        return None
-
-    @property
-    def purelist_isregular(self):
-        return True
-
-    @property
-    def purelist_depth(self):
-        return 1
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        if len(self._contents) == 0:
-            return (1, 1)
-        mins, maxs = [], []
-        for content in self._contents:
-            mindepth, maxdepth = content.minmax_depth
-            mins.append(mindepth)
-            maxs.append(maxdepth)
-        return (min(mins), max(maxs))
-
-    @property
-    def branch_depth(self):
-        if len(self._contents) == 0:
-            return (False, 1)
-        anybranch = False
-        mindepth = None
-        for content in self._contents:
-            branch, depth = content.branch_depth
-            if mindepth is None:
-                mindepth = depth
-            if branch or mindepth != depth:
-                anybranch = True
-            if mindepth > depth:
-                mindepth = depth
-        return (anybranch, mindepth)
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         for content, field in zip(self._contents, self.fields):

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator
 
 import awkward as ak
 from awkward._meta.recordmeta import RecordMeta
@@ -18,9 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RecordForm(RecordMeta, Form):
-    _contents: Sequence[Form]
-
+class RecordForm(RecordMeta[Form], Form):
     def __init__(
         self,
         contents,

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -20,7 +20,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RegularForm(RegularMeta, Form):
+class RegularForm(RegularMeta[Form], Form):
     _content: Form
 
     def __init__(self, content, size, *, parameters=None, form_key=None):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 
 import awkward as ak
+from awkward._meta.regularmeta import RegularMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
-from awkward._typing import DType, JSONSerializable, Self, final
+from awkward._typing import DType, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -19,9 +20,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RegularForm(Form):
-    is_list = True
-    is_regular = True
+class RegularForm(RegularMeta, Form):
+    _content: Form
 
     def __init__(self, content, size, *, parameters=None, form_key=None):
         if not isinstance(content, Form):
@@ -93,57 +93,6 @@ class RegularForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return 1
-        else:
-            return self._content.purelist_depth + 1
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (1, 1)
-        else:
-            mindepth, maxdepth = self._content.minmax_depth
-            return (mindepth + 1, maxdepth + 1)
-
-    @property
-    def branch_depth(self):
-        if self.parameter("__array__") in ("string", "bytestring"):
-            return (False, 1)
-        else:
-            branch, depth = self._content.branch_depth
-            return (branch, depth + 1)
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return False
 
     def _columns(self, path, output, list_indicator):
         if (

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections import Counter
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 
 import awkward as ak
+from awkward._meta.unionmeta import UnionMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import type_parameters_equal
-from awkward._typing import DType, Iterator, JSONSerializable, Self, final
+from awkward._typing import DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -18,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnionForm(Form):
-    is_union = True
+class UnionForm(UnionMeta, Form):
+    _contents: Sequence[Form]
 
     def __init__(
         self,
@@ -154,86 +154,6 @@ class UnionForm(Form):
         ):
             return self._contents == other._contents
 
-        return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        for key in keys:
-            out = self._contents[0].purelist_parameter(key)
-            for content in self._contents[1:]:
-                tmp = content.purelist_parameter(key)
-                if out != tmp:
-                    return None
-            return out
-
-        return None
-
-    @property
-    def purelist_isregular(self):
-        for content in self._contents:
-            if not content.purelist_isregular:
-                return False
-        return True
-
-    @property
-    def purelist_depth(self):
-        out = None
-        for content in self._contents:
-            if out is None:
-                out = content.purelist_depth
-            elif out != content.purelist_depth:
-                return -1
-        return out
-
-    @property
-    def is_identity_like(self):
-        return False
-
-    @property
-    def minmax_depth(self):
-        if len(self._contents) == 0:
-            return (0, 0)
-        mins, maxs = [], []
-        for content in self._contents:
-            mindepth, maxdepth = content.minmax_depth
-            mins.append(mindepth)
-            maxs.append(maxdepth)
-        return (min(mins), max(maxs))
-
-    @property
-    def branch_depth(self):
-        if len(self._contents) == 0:
-            return (False, 1)
-        anybranch = False
-        mindepth = None
-        for content in self._contents:
-            branch, depth = content.branch_depth
-            if mindepth is None:
-                mindepth = depth
-            if branch or mindepth != depth:
-                anybranch = True
-            if mindepth > depth:
-                mindepth = depth
-        return (anybranch, mindepth)
-
-    @property
-    def fields(self):
-        field_counts = Counter([f for c in self._contents for f in c.fields])
-        return [f for f, n in field_counts.items() if n == len(self._contents)]
-
-    @property
-    def is_tuple(self):
-        return all(x.is_tuple for x in self._contents) and (len(self._contents) > 0)
-
-    @property
-    def dimension_optiontype(self):
-        for content in self._contents:
-            if content.dimension_optiontype:
-                return True
         return False
 
     def _columns(self, path, output, list_indicator):

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 
 import awkward as ak
 from awkward._meta.unionmeta import UnionMeta
@@ -18,9 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnionForm(UnionMeta, Form):
-    _contents: Sequence[Form]
-
+class UnionForm(UnionMeta[Form], Form):
     def __init__(
         self,
         tags,
@@ -109,9 +107,6 @@ class UnionForm(UnionMeta, Form):
             ._union_of_optionarrays(ak.index._form_to_zero_length(index), parameters)
             .form
         )
-
-    def content(self, index):
-        return self._contents[index]
 
     def __repr__(self):
         args = [

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 
 import awkward as ak
+from awkward._meta.unmaskedmeta import UnmaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import parameters_union, type_parameters_equal
-from awkward._typing import DType, JSONSerializable, Self, final
+from awkward._typing import DType, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -17,8 +18,8 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnmaskedForm(Form):
-    is_option = True
+class UnmaskedForm(UnmaskedMeta, Form):
+    _content: Form
 
     def __init__(
         self,
@@ -103,46 +104,6 @@ class UnmaskedForm(Form):
             )
         else:
             return False
-
-    def purelist_parameters(self, *keys: str) -> JSONSerializable:
-        if self._parameters is not None:
-            for key in keys:
-                if key in self._parameters:
-                    return self._parameters[key]
-
-        return self._content.purelist_parameters(*keys)
-
-    @property
-    def purelist_isregular(self):
-        return self._content.purelist_isregular
-
-    @property
-    def purelist_depth(self):
-        return self._content.purelist_depth
-
-    @property
-    def is_identity_like(self):
-        return self._content.is_identity_like
-
-    @property
-    def minmax_depth(self):
-        return self._content.minmax_depth
-
-    @property
-    def branch_depth(self):
-        return self._content.branch_depth
-
-    @property
-    def fields(self):
-        return self._content.fields
-
-    @property
-    def is_tuple(self):
-        return self._content.is_tuple
-
-    @property
-    def dimension_optiontype(self):
-        return True
 
     def _columns(self, path, output, list_indicator):
         self._content._columns(path, output, list_indicator)

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnmaskedForm(UnmaskedMeta, Form):
+class UnmaskedForm(UnmaskedMeta[Form], Form):
     _content: Form
 
     def __init__(


### PR DESCRIPTION
@jpivarski and I have discussed this on-and-off for over a year now.

Presently, `ak.contents.Content` subclasses re-use code from `ak.forms.Form` subclasses using explicit descriptor lookups. As such, `ak.forms.Form` serves as the implementation for many metadata methods. As we look to grow the set of metadata-only methods, it would be nice to formalise this hierarchy. Benefits include:
- easier type checking
- lower overhead (right now, e.g. `Content.parameter` involves an additional attribute lookup and function call)


As it now seems possible that we'll want an `enforce_form` function, I would like for the ability to implement the `_mergeable_next` protocol at the "meta" level, and doing this properly feels more readable (and easier to reason about) to me; we're not fighting the type system by implementing this via inheritance.
