### PR TITLE
ci: fix path to header only tests

### DIFF
--- a/.github/workflows/header-only-test.yml
+++ b/.github/workflows/header-only-test.yml
@@ -32,7 +32,7 @@ jobs:
         import os
         import pathlib
         import subprocess
-        for path in pathlib.Path("build/bin").glob("test_*"):
+        for path in pathlib.Path("build/tests/bin").glob("test_*"):
             if path.is_file():
                 print(f"Running {path.name}", flush=True)
                 print("::group::Test output", flush=True)


### PR DESCRIPTION
I think the header only tests were not executing due to a change in the path