### PR TITLE
refactor: split `ak._do` into `meta` and `content`

### DIFF
--- a/src/awkward/__init__.py
+++ b/src/awkward/__init__.py
@@ -16,7 +16,8 @@ import awkward.types
 import awkward.forms
 
 # internal
-import awkward._do
+import awkward._do.content
+import awkward._do.meta
 import awkward._slicing
 import awkward._broadcasting
 import awkward._reducers

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -9,6 +9,7 @@ from awkward import contents, highlevel, record
 from awkward._backends.backend import Backend
 from awkward._backends.jax import JaxBackend
 from awkward._behavior import behavior_of
+from awkward._do.content import recursively_apply
 from awkward._layout import wrap_layout
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -30,9 +31,7 @@ def find_all_buffers(
         if isinstance(node, ak.contents.NumpyArray):
             data_ptrs.append(node.data)
 
-    ak._do.recursively_apply(
-        layout, action=action, return_array=False, numpy_to_regular=False
-    )
+    recursively_apply(layout, action=action, return_array=False, numpy_to_regular=False)
 
     return data_ptrs
 
@@ -54,7 +53,7 @@ def replace_all_buffers(
                     buffer, parameters=node.parameters, backend=backend
                 )
 
-    return ak._do.recursively_apply(layout, action=action, numpy_to_regular=False)
+    return recursively_apply(layout, action=action, numpy_to_regular=False)
 
 
 T = TypeVar(

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -21,6 +21,7 @@ from awkward._behavior import (
     find_ufunc_generic,
 )
 from awkward._categorical import as_hashable
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
 from awkward._parameters import parameters_intersect
@@ -316,11 +317,9 @@ def _array_ufunc_string_likes(
     nplike = left.backend.nplike
 
     # first condition: string lengths must be the same
-    left_counts_layout = ak._do.reduce(left, ak._reducers.Count(), axis=-1, mask=False)
+    left_counts_layout = do_reduce(left, ak._reducers.Count(), axis=-1, mask=False)
     assert left_counts_layout.is_numpy
-    right_counts_layout = ak._do.reduce(
-        right, ak._reducers.Count(), axis=-1, mask=False
-    )
+    right_counts_layout = do_reduce(right, ak._reducers.Count(), axis=-1, mask=False)
     assert right_counts_layout.is_numpy
 
     counts1 = nplike.asarray(left_counts_layout.data)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import collections
 import functools
 import inspect
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator, Mapping
 from itertools import chain
 
 import numpy
@@ -26,7 +26,7 @@ from awkward._layout import wrap_layout
 from awkward._nplikes import to_nplike
 from awkward._parameters import parameters_intersect
 from awkward._regularize import is_non_string_like_iterable
-from awkward._typing import Any, Iterator, Mapping
+from awkward._typing import Any
 from awkward._util import Sentinel
 from awkward.contents.numpyarray import NumpyArray
 

--- a/src/awkward/_do/content.py
+++ b/src/awkward/_do/content.py
@@ -246,10 +246,6 @@ def num(layout, axis):
     return layout._num(axis, 0)
 
 
-def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
-    return one._mergeable_next(two, mergebool=mergebool)
-
-
 def mergemany(contents: list[Content]) -> Content:
     assert len(contents) != 0
     return contents[0]._mergemany(contents[1:])

--- a/src/awkward/_do/content.py
+++ b/src/awkward/_do/content.py
@@ -9,13 +9,15 @@ from numbers import Integral
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, AxisMaybeNone, Literal
-from awkward.contents.content import ActionType, Content
+from awkward._typing import TYPE_CHECKING, Any, AxisMaybeNone, Literal
 from awkward.errors import AxisError
 from awkward.forms import form
-from awkward.record import Record
 
 np = NumpyMetadata.instance()
+
+if TYPE_CHECKING:
+    from awkward.contents.content import ActionType, Content
+    from awkward.record import Record
 
 
 def recursively_apply(
@@ -32,6 +34,9 @@ def recursively_apply(
     function_name: str | None = None,
     regular_to_jagged=False,
 ) -> Content | Record | None:
+    from awkward.contents.content import Content
+    from awkward.record import Record
+
     if isinstance(layout, Content):
         return layout._recursively_apply(
             action,
@@ -201,6 +206,8 @@ def remove_structure(
     allow_records: bool = False,
     list_to_regular: bool = False,
 ):
+    from awkward.record import Record
+
     if isinstance(layout, Record):
         return remove_structure(
             layout._array[layout._at : layout._at + 1],

--- a/src/awkward/_do/meta.py
+++ b/src/awkward/_do/meta.py
@@ -3,66 +3,12 @@
 from __future__ import annotations
 
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import TYPE_CHECKING, TypeGuard, TypeVar
+from awkward._typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from awkward._meta.bitmaskedmeta import BitMaskedMeta
-    from awkward._meta.bytemaskedmeta import ByteMaskedMeta
-    from awkward._meta.indexedmeta import IndexedMeta
-    from awkward._meta.indexedoptionmeta import IndexedOptionMeta
-    from awkward._meta.listmeta import ListMeta
-    from awkward._meta.listoffsetmeta import ListOffsetMeta
     from awkward._meta.meta import Meta
-    from awkward._meta.numpymeta import NumpyMeta
-    from awkward._meta.recordmeta import RecordMeta
-    from awkward._meta.regularmeta import RegularMeta
-    from awkward._meta.unionmeta import UnionMeta
-    from awkward._meta.unmaskedmeta import UnmaskedMeta
 
 np = NumpyMetadata.instance()
-
-
-T = TypeVar("T", bound="Meta")
-
-
-def is_option(
-    meta: Meta
-) -> TypeGuard[IndexedOptionMeta | BitMaskedMeta | ByteMaskedMeta | UnmaskedMeta]:
-    return meta.is_option
-
-
-def is_list(meta: Meta) -> TypeGuard[RegularMeta | ListOffsetMeta | ListMeta]:
-    return meta.is_list
-
-
-def is_numpy(meta: Meta) -> TypeGuard[NumpyMeta]:
-    return meta.is_numpy
-
-
-def is_regular(meta: Meta) -> TypeGuard[RegularMeta]:
-    return meta.is_regular
-
-
-def is_union(meta: Meta) -> TypeGuard[UnionMeta]:
-    return meta.is_union
-
-
-def is_record(meta: Meta) -> TypeGuard[RecordMeta]:
-    return meta.is_record
-
-
-def is_indexed(meta: Meta) -> TypeGuard[IndexedOptionMeta, IndexedMeta]:
-    return meta.is_indexed
-
-
-# FIXME: narrow this to have `is_tuple` be a const True
-def is_record_tuple(meta: Meta) -> TypeGuard[RecordMeta]:
-    return meta.is_record and meta.is_tuple
-
-
-# FIXME: narrow this to have `is_tuple` be a const False
-def is_record_record(meta: Meta) -> TypeGuard[RecordMeta]:
-    return meta.is_record and not meta.is_tuple
 
 
 def mergeable(one: Meta, two: Meta, mergebool: bool = True) -> bool:

--- a/src/awkward/_do/meta.py
+++ b/src/awkward/_do/meta.py
@@ -3,10 +3,73 @@
 from __future__ import annotations
 
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward.contents.content import Content
+from awkward._typing import TYPE_CHECKING, TypeGuard, TypeVar
+
+if TYPE_CHECKING:
+    from awkward._meta.bitmaskedmeta import BitMaskedMeta
+    from awkward._meta.bytemaskedmeta import ByteMaskedMeta
+    from awkward._meta.indexedmeta import IndexedMeta
+    from awkward._meta.indexedoptionmeta import IndexedOptionMeta
+    from awkward._meta.listmeta import ListMeta
+    from awkward._meta.listoffsetmeta import ListOffsetMeta
+    from awkward._meta.meta import Meta
+    from awkward._meta.numpymeta import NumpyMeta
+    from awkward._meta.recordmeta import RecordMeta
+    from awkward._meta.regularmeta import RegularMeta
+    from awkward._meta.unionmeta import UnionMeta
+    from awkward._meta.unmaskedmeta import UnmaskedMeta
 
 np = NumpyMetadata.instance()
 
 
-def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
+T = TypeVar("T", bound="Meta")
+
+
+def is_option(
+    meta: Meta
+) -> TypeGuard[IndexedOptionMeta | BitMaskedMeta | ByteMaskedMeta | UnmaskedMeta]:
+    return meta.is_option
+
+
+def is_list(meta: Meta) -> TypeGuard[RegularMeta | ListOffsetMeta | ListMeta]:
+    return meta.is_list
+
+
+def is_numpy(meta: Meta) -> TypeGuard[NumpyMeta]:
+    return meta.is_numpy
+
+
+def is_regular(meta: Meta) -> TypeGuard[RegularMeta]:
+    return meta.is_regular
+
+
+def is_union(meta: Meta) -> TypeGuard[UnionMeta]:
+    return meta.is_union
+
+
+def is_record(meta: Meta) -> TypeGuard[RecordMeta]:
+    return meta.is_record
+
+
+def is_indexed(meta: Meta) -> TypeGuard[IndexedOptionMeta, IndexedMeta]:
+    return meta.is_indexed
+
+
+class ImplementsTuple(RecordMeta):  # Intersection
+    _fields: None
+
+
+def is_record_tuple(meta: Meta) -> TypeGuard[ImplementsTuple]:
+    return meta.is_record and meta.is_tuple
+
+
+class ImplementsRecord(RecordMeta):
+    _fields: list[str]
+
+
+def is_record_record(meta: Meta) -> TypeGuard[ImplementsRecord]:
+    return meta.is_record and not meta.is_tuple
+
+
+def mergeable(one: Meta, two: Meta, mergebool: bool = True) -> bool:
     return one._mergeable_next(two, mergebool=mergebool)

--- a/src/awkward/_do/meta.py
+++ b/src/awkward/_do/meta.py
@@ -55,19 +55,13 @@ def is_indexed(meta: Meta) -> TypeGuard[IndexedOptionMeta, IndexedMeta]:
     return meta.is_indexed
 
 
-class ImplementsTuple(RecordMeta):  # Intersection
-    _fields: None
-
-
-def is_record_tuple(meta: Meta) -> TypeGuard[ImplementsTuple]:
+# FIXME: narrow this to have `is_tuple` be a const True
+def is_record_tuple(meta: Meta) -> TypeGuard[RecordMeta]:
     return meta.is_record and meta.is_tuple
 
 
-class ImplementsRecord(RecordMeta):
-    _fields: list[str]
-
-
-def is_record_record(meta: Meta) -> TypeGuard[ImplementsRecord]:
+# FIXME: narrow this to have `is_tuple` be a const False
+def is_record_record(meta: Meta) -> TypeGuard[RecordMeta]:
     return meta.is_record and not meta.is_tuple
 
 

--- a/src/awkward/_do/meta.py
+++ b/src/awkward/_do/meta.py
@@ -1,0 +1,12 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward.contents.content import Content
+
+np = NumpyMetadata.instance()
+
+
+def mergeable(one: Content, two: Content, mergebool: bool = True) -> bool:
+    return one._mergeable_next(two, mergebool=mergebool)

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class BitMaskedMeta(Meta, Generic[T]):
-    _content: T
+class BitMaskedMeta(Meta):
+    _content: Meta
     is_option = True
 
     @property
@@ -54,15 +53,15 @@ class BitMaskedMeta(Meta, Generic[T]):
         return True
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif is_option(other) or is_indexed(other):
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and type_parameters_equal(self._parameters, other._parameters)

--- a/src/awkward/_meta/bitmaskedmeta.py
+++ b/src/awkward/_meta/bitmaskedmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -55,3 +56,15 @@ class BitMaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and type_parameters_equal(self._parameters, other._parameters)
+        else:
+            return self._content._mergeable_next(other, mergebool)

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class ByteMaskedMeta(Meta, Generic[T]):
-    _content: T
+class ByteMaskedMeta(Meta):
+    _content: Meta
     is_option = True
 
     @property
@@ -54,15 +53,15 @@ class ByteMaskedMeta(Meta, Generic[T]):
         return True
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif is_option(other) or is_indexed(other):
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and type_parameters_equal(self._parameters, other._parameters)

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/bytemaskedmeta.py
+++ b/src/awkward/_meta/bytemaskedmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -55,3 +56,15 @@ class ByteMaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and type_parameters_equal(self._parameters, other._parameters)
+        else:
+            return self._content._mergeable_next(other, mergebool)

--- a/src/awkward/_meta/emptymeta.py
+++ b/src/awkward/_meta/emptymeta.py
@@ -44,3 +44,6 @@ class EmptyMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        return True

--- a/src/awkward/_meta/emptymeta.py
+++ b/src/awkward/_meta/emptymeta.py
@@ -45,5 +45,5 @@ class EmptyMeta(Meta):
     def dimension_optiontype(self) -> bool:
         return False
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         return True

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class IndexedMeta(Meta, Generic[T]):
+class IndexedMeta(Meta):
     is_indexed = True
 
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -55,15 +54,15 @@ class IndexedMeta(Meta, Generic[T]):
         return False
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
         # We can only combine option/indexed types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
+        elif is_option(other) or is_indexed(other):
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and type_parameters_equal(self._parameters, other._parameters)

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/indexedmeta.py
+++ b/src/awkward/_meta/indexedmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -56,3 +57,15 @@ class IndexedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and type_parameters_equal(self._parameters, other._parameters)
+        else:
+            return self._content._mergeable_next(other, mergebool)

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class IndexedOptionMeta(Meta, Generic[T]):
+class IndexedOptionMeta(Meta):
     is_indexed = True
     is_option = True
 
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -56,15 +55,15 @@ class IndexedOptionMeta(Meta, Generic[T]):
         return True
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
         # We can only combine option/indexed types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
+        elif is_option(other) or is_indexed(other):
             return self._content._mergeable_next(
                 other.content, mergebool
             ) and type_parameters_equal(self._parameters, other._parameters)

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/indexedoptionmeta.py
+++ b/src/awkward/_meta/indexedoptionmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -57,3 +58,15 @@ class IndexedOptionMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._content._mergeable_next(
+                other.content, mergebool
+            ) and type_parameters_equal(self._parameters, other._parameters)
+        else:
+            return self._content._mergeable_next(other, mergebool)

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class ListMeta(Meta, Generic[T]):
+class ListMeta(Meta):
     is_list = True
 
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -66,24 +65,23 @@ class ListMeta(Meta, Generic[T]):
         return False
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
         # Check against option contents
-        elif other.is_option or other.is_indexed:
+        elif is_option(other) or is_indexed(other):
+            assert hasattr(other, "content")
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not type_parameters_equal(self._parameters, other._parameters):
             return False
-        elif other.is_list:
+        elif is_list(other):
             return self._content._mergeable_next(other.content, mergebool)
-        elif other.is_numpy and len(other.inner_shape) > 0:
-            return self._mergeable_next(
-                other._to_regular_primitive(), mergebool
-            )  # TODO
+        elif is_numpy(other) and len(other.inner_shape) > 0:
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
         else:
             return False

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_list, is_numpy, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/listmeta.py
+++ b/src/awkward/_meta/listmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -67,3 +68,22 @@ class ListMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not type_parameters_equal(self._parameters, other._parameters):
+            return False
+        elif other.is_list:
+            return self._content._mergeable_next(other.content, mergebool)
+        elif other.is_numpy and len(other.inner_shape) > 0:
+            return self._mergeable_next(
+                other._to_regular_primitive(), mergebool
+            )  # TODO
+        else:
+            return False

--- a/src/awkward/_meta/listoffsetmeta.py
+++ b/src/awkward/_meta/listoffsetmeta.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class ListOffsetMeta(Meta, Generic[T]):
+class ListOffsetMeta(Meta):
     is_list = True
 
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -66,24 +65,23 @@ class ListOffsetMeta(Meta, Generic[T]):
         return False
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
         # Check against option contents
-        elif other.is_option or other.is_indexed:
+        elif is_option(other) or is_indexed(other):
+            assert hasattr(other, "content")
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not type_parameters_equal(self._parameters, other._parameters):
             return False
-        elif other.is_list:
+        elif is_list(other):
             return self._content._mergeable_next(other.content, mergebool)
-        elif other.is_numpy and len(other.inner_shape) > 0:
-            return self._mergeable_next(
-                other._to_regular_primitive(), mergebool
-            )  # TODO
+        elif is_numpy(other) and len(other.inner_shape) > 0:
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
         else:
             return False

--- a/src/awkward/_meta/listoffsetmeta.py
+++ b/src/awkward/_meta/listoffsetmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_list, is_numpy, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -118,3 +118,6 @@ class Meta:
 
     def copy(self, *, parameters: JSONMapping | None | Sentinel = UNSET) -> Self:
         raise NotImplementedError
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        raise NotImplementedError

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -3,12 +3,67 @@
 from __future__ import annotations
 
 from awkward._typing import (
+    TYPE_CHECKING,
     ClassVar,
     JSONMapping,
     JSONSerializable,
     Self,
+    TypeGuard,
 )
 from awkward._util import UNSET, Sentinel
+
+if TYPE_CHECKING:
+    from awkward._meta.bitmaskedmeta import BitMaskedMeta
+    from awkward._meta.bytemaskedmeta import ByteMaskedMeta
+    from awkward._meta.indexedmeta import IndexedMeta
+    from awkward._meta.indexedoptionmeta import IndexedOptionMeta
+    from awkward._meta.listmeta import ListMeta
+    from awkward._meta.listoffsetmeta import ListOffsetMeta
+    from awkward._meta.numpymeta import NumpyMeta
+    from awkward._meta.recordmeta import RecordMeta
+    from awkward._meta.regularmeta import RegularMeta
+    from awkward._meta.unionmeta import UnionMeta
+    from awkward._meta.unmaskedmeta import UnmaskedMeta
+
+
+def is_option(
+    meta: Meta
+) -> TypeGuard[IndexedOptionMeta | BitMaskedMeta | ByteMaskedMeta | UnmaskedMeta]:
+    return meta.is_option
+
+
+def is_list(meta: Meta) -> TypeGuard[RegularMeta | ListOffsetMeta | ListMeta]:
+    return meta.is_list
+
+
+def is_numpy(meta: Meta) -> TypeGuard[NumpyMeta]:
+    return meta.is_numpy
+
+
+def is_regular(meta: Meta) -> TypeGuard[RegularMeta]:
+    return meta.is_regular
+
+
+def is_union(meta: Meta) -> TypeGuard[UnionMeta]:
+    return meta.is_union
+
+
+def is_record(meta: Meta) -> TypeGuard[RecordMeta]:
+    return meta.is_record
+
+
+def is_indexed(meta: Meta) -> TypeGuard[IndexedOptionMeta | IndexedMeta]:
+    return meta.is_indexed
+
+
+# FIXME: narrow this to have `is_tuple` be a const True
+def is_record_tuple(meta: Meta) -> TypeGuard[RecordMeta]:
+    return meta.is_record and meta.is_tuple
+
+
+# FIXME: narrow this to have `is_tuple` be a const False
+def is_record_record(meta: Meta) -> TypeGuard[RecordMeta]:
+    return meta.is_record and not meta.is_tuple
 
 
 class Meta:

--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -119,5 +119,5 @@ class Meta:
     def copy(self, *, parameters: JSONMapping | None | Sentinel = UNSET) -> Self:
         raise NotImplementedError
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         raise NotImplementedError

--- a/src/awkward/_meta/numpymeta.py
+++ b/src/awkward/_meta/numpymeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_numpy, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_numpy, is_option
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
 from awkward._parameters import type_parameters_equal

--- a/src/awkward/_meta/numpymeta.py
+++ b/src/awkward/_meta/numpymeta.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from awkward._meta.meta import Meta
 from awkward._nplikes.shape import ShapeItem
-from awkward._typing import JSONSerializable
+from awkward._parameters import type_parameters_equal
+from awkward._typing import TYPE_CHECKING, Generic, JSONSerializable, TypeVar
+
+if TYPE_CHECKING:
+    from awkward._meta.regularmeta import RegularMeta
+
+T = TypeVar("T", bound=Meta)
 
 
-class NumpyMeta(Meta):
+class NumpyMeta(Meta, Generic[T]):
     is_numpy = True
     is_leaf = True
     inner_shape: tuple[ShapeItem, ...]
@@ -51,3 +57,57 @@ class NumpyMeta(Meta):
     @property
     def dimension_optiontype(self) -> bool:
         return False
+
+    def _to_regular_primitive(self) -> RegularMeta[T]:
+        raise NotImplementedError
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not type_parameters_equal(self._parameters, other._parameters):
+            return False
+        # Simplify *this* branch to be 1D self
+        elif len(self.inner_shape) > 0:
+            return self._to_regular_primitive()._mergeable_next(
+                other, mergebool
+            )  # TODO
+
+        elif other.is_numpy:
+            if len(self.inner_shape) != len(other.inner_shape):
+                return False
+
+            # Obvious fast-path
+            if self.dtype == other.dtype:  # TODO
+                return True
+
+            # Special-case booleans i.e. {bool, number}
+            elif (
+                np.issubdtype(self.dtype, np.bool_)
+                and np.issubdtype(other.dtype, np.number)
+                or np.issubdtype(self.dtype, np.number)
+                and np.issubdtype(other.dtype, np.bool_)
+            ):
+                return mergebool
+
+            # Currently we're less permissive than NumPy on merging datetimes / timedeltas
+            elif (
+                np.issubdtype(self.dtype, np.datetime64)
+                or np.issubdtype(self.dtype, np.timedelta64)
+                or np.issubdtype(other.dtype, np.datetime64)
+                or np.issubdtype(other.dtype, np.timedelta64)
+            ):
+                return False
+
+            # Default merging (can we cast one to the other)
+            else:
+                return self.backend.nplike.can_cast(
+                    self.dtype, other.dtype
+                ) or self.backend.nplike.can_cast(other.dtype, self.dtype)
+
+        else:
+            return False

--- a/src/awkward/_meta/numpymeta.py
+++ b/src/awkward/_meta/numpymeta.py
@@ -78,16 +78,19 @@ class NumpyMeta(Meta):
             return False
         # Simplify *this* branch to be 1D self
         elif len(self.inner_shape) > 0:
-            return self._to_regular_primitive()._mergeable_next(
-                other, mergebool
-            )  # TODO
+            # TODO: `_to_regular_primitive` is a mechanism for re-using our merge
+            #       logic that already handles `RegularArray`. Rather than
+            #       converting the NumpyArray into a contiguous `RegularArray`,
+            #       we return something with arbitrary data (e.g. a broadcasted empty array!)
+            #       N.B. NumpyForm doesn't need to do this, only NumpyArray.
+            return self._to_regular_primitive()._mergeable_next(other, mergebool)
 
         elif is_numpy(other):
             if len(self.inner_shape) != len(other.inner_shape):
                 return False
 
             # Obvious fast-path
-            if self.dtype == other.dtype:  # TODO
+            if self.dtype == other.dtype:
                 return True
 
             # Special-case booleans i.e. {bool, number}

--- a/src/awkward/_meta/numpymeta.py
+++ b/src/awkward/_meta/numpymeta.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from awkward._do.meta import is_indexed, is_numpy, is_option
 from awkward._meta.meta import Meta
+from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
 from awkward._parameters import type_parameters_equal
-from awkward._typing import TYPE_CHECKING, JSONSerializable
+from awkward._typing import TYPE_CHECKING, DType, JSONSerializable
 
+np = NumpyMetadata.instance()
 if TYPE_CHECKING:
     from awkward._meta.regularmeta import RegularMeta
 
@@ -16,6 +18,10 @@ class NumpyMeta(Meta):
     is_numpy = True
     is_leaf = True
     inner_shape: tuple[ShapeItem, ...]
+
+    @property
+    def dtype(self) -> DType:
+        raise NotImplementedError
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -104,9 +110,9 @@ class NumpyMeta(Meta):
 
             # Default merging (can we cast one to the other)
             else:
-                return self.backend.nplike.can_cast(
-                    self.dtype, other.dtype
-                ) or self.backend.nplike.can_cast(other.dtype, self.dtype)
+                return np.can_cast(
+                    self.dtype, other.dtype, casting="same_kind"
+                ) or np.can_cast(other.dtype, self.dtype, casting="same_kind")
 
         else:
             return False

--- a/src/awkward/_meta/recordmeta.py
+++ b/src/awkward/_meta/recordmeta.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import (
+from awkward._meta.meta import (
+    Meta,
     is_indexed,
     is_option,
     is_record,
     is_record_record,
     is_record_tuple,
 )
-from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
 from awkward._regularize import is_integer
 from awkward._typing import JSONSerializable

--- a/src/awkward/_meta/recordmeta.py
+++ b/src/awkward/_meta/recordmeta.py
@@ -170,10 +170,10 @@ class RecordMeta(Meta):
                     return False
 
             elif is_record_record(self) and is_record_record(other):
-                if set(self._fields) != set(other._fields):
+                if set(self._fields) != set(other._fields):  # type: ignore[arg-type]
                     return False
 
-                for i, field in enumerate(self._fields):
+                for i, field in enumerate(self._fields):  # type: ignore[arg-type]
                     x = self._contents[i]
                     y = other.contents[other.field_to_index(field)]
                     if not x._mergeable_next(y, mergebool):

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_list, is_numpy, is_option
 from awkward._nplikes.shape import ShapeItem
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_list, is_numpy, is_option
 from awkward._meta.meta import Meta
 from awkward._nplikes.shape import ShapeItem
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class RegularMeta(Meta, Generic[T]):
+class RegularMeta(Meta):
     is_list = True
     is_regular = True
 
     size: ShapeItem
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -69,22 +68,23 @@ class RegularMeta(Meta, Generic[T]):
         return False
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
         # Check against option contents
-        elif other.is_option or other.is_indexed:
+        elif is_option(other) or is_indexed(other):
+            assert hasattr(other, "content")
             return self._mergeable_next(other.content, mergebool)
         # Otherwise, do the parameters match? If not, we can't merge.
         elif not type_parameters_equal(self._parameters, other._parameters):
             return False
-        elif other.is_list:
+        elif is_list(other):
             return self._content._mergeable_next(other.content, mergebool)
-        elif other.is_numpy and len(other.inner_shape) > 0:
+        elif is_numpy(other) and len(other.inner_shape) > 0:
             return self._mergeable_next(other._to_regular_primitive(), mergebool)
         else:
             return False

--- a/src/awkward/_meta/regularmeta.py
+++ b/src/awkward/_meta/regularmeta.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from awkward._meta.meta import Meta
 from awkward._nplikes.shape import ShapeItem
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -70,3 +71,20 @@ class RegularMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # Check against option contents
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(other.content, mergebool)
+        # Otherwise, do the parameters match? If not, we can't merge.
+        elif not type_parameters_equal(self._parameters, other._parameters):
+            return False
+        elif other.is_list:
+            return self._content._mergeable_next(other.content, mergebool)
+        elif other.is_numpy and len(other.inner_shape) > 0:
+            return self._mergeable_next(other._to_regular_primitive(), mergebool)
+        else:
+            return False

--- a/src/awkward/_meta/unionmeta.py
+++ b/src/awkward/_meta/unionmeta.py
@@ -105,3 +105,6 @@ class UnionMeta(Meta, Generic[T]):
     @property
     def contents(self) -> list[T]:
         return self._contents
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        return True

--- a/src/awkward/_meta/unionmeta.py
+++ b/src/awkward/_meta/unionmeta.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from collections import Counter
 
 from awkward._meta.meta import Meta
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class UnionMeta(Meta, Generic[T]):
+class UnionMeta(Meta):
     is_union = True
 
-    _contents: list[T]
+    _contents: list[Meta]
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -99,12 +97,12 @@ class UnionMeta(Meta, Generic[T]):
                 return True
         return False
 
-    def content(self, index: int) -> T:
+    def content(self, index: int) -> Meta:
         return self._contents[index]
 
     @property
-    def contents(self) -> list[T]:
+    def contents(self) -> list[Meta]:
         return self._contents
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         return True

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._do.meta import is_indexed, is_option
-from awkward._meta.meta import Meta
+from awkward._meta.meta import Meta, is_indexed, is_option
 from awkward._parameters import type_parameters_equal
 from awkward._typing import JSONSerializable
 

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from awkward._meta.meta import Meta
+from awkward._parameters import type_parameters_equal
 from awkward._typing import Generic, JSONSerializable, TypeVar
 
 T = TypeVar("T", bound=Meta)
@@ -55,3 +56,15 @@ class UnmaskedMeta(Meta, Generic[T]):
     @property
     def content(self) -> T:
         return self._content
+
+    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+        # Is the other content is an identity, or a union?
+        if other.is_identity_like or other.is_union:
+            return True
+        # We can only combine option types whose array-record parameters agree
+        elif other.is_option or other.is_indexed:
+            return self._mergeable_next(
+                other.content, mergebool
+            ) and type_parameters_equal(self._parameters, other._parameters)
+        else:
+            return self._content._mergeable_next(other, mergebool)

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
+from awkward._do.meta import is_indexed, is_option
 from awkward._meta.meta import Meta
 from awkward._parameters import type_parameters_equal
-from awkward._typing import Generic, JSONSerializable, TypeVar
-
-T = TypeVar("T", bound=Meta)
+from awkward._typing import JSONSerializable
 
 
-class UnmaskedMeta(Meta, Generic[T]):
+class UnmaskedMeta(Meta):
     is_option = True
-    _content: T
+    _content: Meta
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:
         if self._parameters is not None:
@@ -54,16 +53,16 @@ class UnmaskedMeta(Meta, Generic[T]):
         return True
 
     @property
-    def content(self) -> T:
+    def content(self) -> Meta:
         return self._content
 
-    def _mergeable_next(self, other: T, mergebool: bool) -> bool:
+    def _mergeable_next(self, other: Meta, mergebool: bool) -> bool:
         # Is the other content is an identity, or a union?
         if other.is_identity_like or other.is_union:
             return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(
+        # We can only combine option/indexed types whose array-record parameters agree
+        elif is_option(other) or is_indexed(other):
+            return self._content._mergeable_next(
                 other.content, mergebool
             ) and type_parameters_equal(self._parameters, other._parameters)
         else:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -653,11 +653,6 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         assert not isinstance(x, PlaceholderArray)
         return x.astype(dtype, copy=copy)  # type: ignore[attr-defined]
 
-    def can_cast(
-        self, from_: DTypeLike | ArrayLikeT, to: DTypeLike | ArrayLikeT
-    ) -> bool:
-        return self._module.can_cast(from_, to, casting="same_kind")
-
     @classmethod
     def is_own_array(cls, obj) -> bool:
         return cls.is_own_array_type(type(obj))

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -83,7 +83,8 @@ class NumpyMetadata(PublicSingleton):
     datetime_data = staticmethod(numpy.datetime_data)
     issubdtype = staticmethod(numpy.issubdtype)
 
-    AxisError = numpy.AxisError
+    AxisError = staticmethod(numpy.AxisError)
+    can_cast = staticmethod(numpy.can_cast)
 
 
 if hasattr(numpy, "float16"):
@@ -535,10 +536,6 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
     def astype(
         self, x: ArrayLikeT, dtype: DTypeLike, *, copy: bool | None = True
     ) -> ArrayLikeT:
-        ...
-
-    @abstractmethod
-    def can_cast(self, from_: DType | ArrayLikeT, to: DType | ArrayLikeT) -> bool:
         ...
 
     @abstractmethod

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1512,11 +1512,6 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         x.touch_data()
         return TypeTracerArray._new(np.dtype(dtype), x.shape)
 
-    def can_cast(
-        self, from_: DTypeLike | TypeTracerArray, to: DTypeLike | TypeTracerArray
-    ) -> bool:
-        return numpy.can_cast(from_, to, casting="same_kind")
-
     @classmethod
     def is_own_array_type(cls, type_: type) -> bool:
         return issubclass(type_, TypeTracerArray)

--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -90,7 +90,7 @@ def use_builtin_reducer():
 
 
 def custom_reduce(obj, protocol: int) -> tuple | NotImplemented:
-    if (plugin := get_custom_reducer()) is None or _DISABLE_CUSTOM_REDUCER:
+    if _DISABLE_CUSTOM_REDUCER or (plugin := get_custom_reducer()) is None:
         return NotImplemented
     else:
         return plugin(obj, protocol)

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -6,6 +6,7 @@ import operator
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._do.content import flatten, local_index
 from awkward._nplikes import to_nplike
 from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
@@ -506,10 +507,10 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
     ):
         if item_backend.nplike.known_data:
             item = item.to_ListOffsetArray64(True)
-            localindex = ak._do.local_index(item, axis=1)
+            localindex = local_index(item, axis=1)
 
-            flat_index = ak._do.flatten(localindex, axis=1)
-            flat_mask = ak._do.flatten(item, axis=1)
+            flat_index = flatten(localindex, axis=1)
+            flat_mask = flatten(item, axis=1)
 
             assert flat_index.is_numpy and flat_mask.is_numpy
             nextcontent = flat_index.data[flat_mask.data]
@@ -558,7 +559,7 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
                     safeindex.shape[0], dtype=np.bool_
                 )
 
-            localindex = ak._do.local_index(item, axis=1)
+            localindex = local_index(item, axis=1)
 
             # nextcontent does not include missing values
             expanded[isnegative] = False

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import sys
 import typing
 from typing import *  # noqa: F403
+from typing import TypeVar
 
 import numpy
 
@@ -70,7 +71,7 @@ JSONMapping: TypeAlias = "dict[str, JSONSerializable]"
 DType: TypeAlias = numpy.dtype
 
 
-AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)  # noqa: F405
+AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)
 
 
 T = TypeVar("T")

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -30,9 +30,6 @@ __all__ = list(
     }
 )
 
-
-AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)  # noqa: F405
-
 if sys.version_info < (3, 11):
     from typing import ClassVar, Final, SupportsIndex, runtime_checkable
 
@@ -71,3 +68,14 @@ JSONSerializable: TypeAlias = (
 JSONMapping: TypeAlias = "dict[str, JSONSerializable]"
 
 DType: TypeAlias = numpy.dtype
+
+
+AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)  # noqa: F405
+
+
+T = TypeVar("T")
+
+
+class ImplementsReadOnlyProperty(Protocol[T]):
+    def __get__(self, instance, owner=None) -> T:
+        ...

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -15,9 +15,6 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._parameters import (
-    type_parameters_equal,
-)
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import (
@@ -572,18 +569,6 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
 
     def _offsets_and_flattened(self, axis: int, depth: int) -> tuple[Index, Content]:
         return self.to_ByteMaskedArray._offsets_and_flattened(axis, depth)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._content._mergeable_next(
-                other.content, mergebool
-            ) and type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -22,6 +22,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -48,7 +49,7 @@ numpy = Numpy.instance()
 
 
 @final
-class BitMaskedArray(BitMaskedMeta[Content], Content):
+class BitMaskedArray(BitMaskedMeta, Content):
     """
     Like #ak.contents.ByteMaskedArray, BitMaskedArray implements an
     #ak.types.OptionType with two buffers, `mask` and `content`.
@@ -131,6 +132,9 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(
         self, mask, content, valid_when, length, lsb_order, *, parameters=None

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -18,7 +18,6 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._parameters import (
     parameters_intersect,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -716,18 +715,6 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                     )
                 )
                 return (outoffsets, flattened)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._content._mergeable_next(
-                other.content, mergebool
-            ) and type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -26,6 +26,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -52,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ByteMaskedArray(ByteMaskedMeta[Content], Content):
+class ByteMaskedArray(ByteMaskedMeta, Content):
     """
     The ByteMaskedArray implements an #ak.types.OptionType with two aligned
     buffers, a boolean `mask` and `content`. At any element `i` where
@@ -108,6 +109,9 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, mask, content, valid_when, *, parameters=None):
         if not (isinstance(mask, Index) and mask.dtype == np.dtype(np.int8)):

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -122,6 +122,8 @@ class ToArrowOptions(TypedDict):
 
 
 class Content(Meta):
+    _mergeable_next: Callable[[Content, bool], bool]
+
     def _init(self, parameters: dict[str, Any] | None, backend: Backend):
         if parameters is None:
             pass

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -269,9 +269,6 @@ class EmptyArray(EmptyMeta, Content):
                 EmptyArray(backend=self._backend),
             )
 
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        return True
-
     def _mergemany(self, others: Sequence[Content]) -> Content:
         if len(others) == 0:
             return self

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._do.content import is_unique
 from awkward._layout import maybe_posaxis
 from awkward._meta.indexedmeta import IndexedMeta
 from awkward._nplikes.array_like import ArrayLike
@@ -25,6 +26,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -51,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedArray(IndexedMeta[Content], Content):
+class IndexedArray(IndexedMeta, Content):
     """
     IndexedArray is a general-purpose tool for *lazily* changing the order of
     and/or duplicating some `content` with a
@@ -101,6 +103,9 @@ class IndexedArray(IndexedMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, index, content, *, parameters=None):
         if not (
@@ -946,7 +951,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
     def _validity_error(self, path):
         if self.parameter("__array__") == "categorical":
-            if not ak._do.is_unique(self._content):
+            if not is_unique(self._content):
                 return 'at {} ("{}"): __array__ = "categorical" requires contents to be unique'.format(
                     path, type(self)
                 )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -17,7 +17,6 @@ from awkward._nplikes.typetracer import TypeTracer
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -495,18 +494,6 @@ class IndexedArray(IndexedMeta[Content], Content):
 
         else:
             return self.project()._offsets_and_flattened(axis, depth)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # We can only combine option/indexed types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._content._mergeable_next(
-                other.content, mergebool
-            ) and type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return self._content._mergeable_next(other, mergebool)
 
     def _merging_strategy(self, others):
         if len(others) == 0:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -17,7 +17,6 @@ from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -628,18 +627,6 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                     )
                 )
                 return (outoffsets, flattened)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # We can only combine option/indexed types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._content._mergeable_next(
-                other.content, mergebool
-            ) and type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return self._content._mergeable_next(other, mergebool)
 
     def _merging_strategy(self, others):
         if len(others) == 0:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._do.content import is_unique
 from awkward._layout import maybe_posaxis
 from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.array_like import ArrayLike
@@ -25,6 +26,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -50,7 +52,7 @@ numpy = Numpy.instance()
 
 
 @final
-class IndexedOptionArray(IndexedOptionMeta[Content], Content):
+class IndexedOptionArray(IndexedOptionMeta, Content):
     """
     IndexedOptionArray is an #ak.contents.IndexedArray for which
     negative values in the index are interpreted as missing. It represents
@@ -97,6 +99,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, index, content, *, parameters=None):
         if not (
@@ -1465,7 +1470,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _validity_error(self, path):
         if self.parameter("__array__") == "categorical":
-            if not ak._do.is_unique(self._content):
+            if not is_unique(self._content):
                 return 'at {} ("{}"): __array__ = "categorical" requires contents to be unique'.format(
                     path, type(self)
                 )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -15,7 +15,6 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._parameters import (
     parameters_intersect,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -1071,30 +1070,6 @@ class ListArray(ListMeta[Content], Content):
 
     def _offsets_and_flattened(self, axis: int, depth: int) -> tuple[Index, Content]:
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # Check against option contents
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(other.content, mergebool)
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not type_parameters_equal(self._parameters, other._parameters):
-            return False
-        elif isinstance(
-            other,
-            (
-                ak.contents.RegularArray,
-                ak.contents.ListArray,
-                ak.contents.ListOffsetArray,
-            ),
-        ):
-            return self._content._mergeable_next(other.content, mergebool)
-        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable_next(other._to_regular_primitive(), mergebool)
-        else:
-            return False
 
     def _mergemany(self, others: Sequence[Content]) -> Content:
         if len(others) == 0:

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -23,6 +23,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -47,7 +48,7 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListArray(ListMeta[Content], Content):
+class ListArray(ListMeta, Content):
     """
     ListArray generalizes #ak.contents.ListOffsetArray by not
     requiring its `content` to be in increasing order and by allowing it to
@@ -118,6 +119,9 @@ class ListArray(ListMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, starts, stops, content, *, parameters=None):
         if not isinstance(starts, Index) and starts.dtype in (

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -21,6 +21,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -46,7 +47,7 @@ numpy = Numpy.instance()
 
 
 @final
-class ListOffsetArray(ListOffsetMeta[Content], Content):
+class ListOffsetArray(ListOffsetMeta, Content):
     """
     ListOffsetArray describes unequal-length lists (often called a
     "jagged" or "ragged" array). Like #ak.contents.RegularArray, the
@@ -109,6 +110,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, offsets, content, *, parameters=None):
         if not isinstance(offsets, Index) and offsets.dtype in (

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -14,9 +14,6 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
-from awkward._parameters import (
-    type_parameters_equal,
-)
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import (
@@ -780,30 +777,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     offsets,
                     ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # Check against option contents
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(other.content, mergebool)
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not type_parameters_equal(self._parameters, other._parameters):
-            return False
-        elif isinstance(
-            other,
-            (
-                ak.contents.RegularArray,
-                ak.contents.ListArray,
-                ak.contents.ListOffsetArray,
-            ),
-        ):
-            return self._content._mergeable_next(other.content, mergebool)
-        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable_next(other._to_regular_primitive(), mergebool)
-        else:
-            return False
 
     def _mergemany(self, others: Sequence[Content]) -> Content:
         if len(others) == 0:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -56,7 +56,7 @@ numpy = Numpy.instance()
 
 
 @final
-class NumpyArray(NumpyMeta[Content], Content):
+class NumpyArray(NumpyMeta, Content):
     """
     A NumpyArray describes 1-dimensional or rectilinear data using a NumPy
     `np.ndarray`, a CuPy `cp.ndarray`, etc., depending on the backend.

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -19,7 +19,6 @@ from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import (
     parameters_intersect,
-    type_parameters_equal,
 )
 from awkward._slicing import NO_HEAD
 from awkward._typing import (
@@ -645,42 +644,6 @@ class RecordArray(RecordMeta[Content], Content):
                     backend=self._backend,
                 ),
             )
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # Check against option contents
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(other.content, mergebool)
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not type_parameters_equal(self._parameters, other._parameters):
-            return False
-        elif isinstance(other, RecordArray):
-            if self.is_tuple and other.is_tuple:
-                if len(self._contents) == len(other._contents):
-                    for self_cont, other_cont in zip(self._contents, other._contents):
-                        if not self_cont._mergeable_next(other_cont, mergebool):
-                            return False
-
-                    return True
-
-            elif not self.is_tuple and not other.is_tuple:
-                if set(self._fields) != set(other._fields):
-                    return False
-
-                for i, field in enumerate(self._fields):
-                    x = self._contents[i]
-                    y = other._contents[other.field_to_index(field)]
-                    if not x._mergeable_next(y, mergebool):
-                        return False
-                return True
-
-            else:
-                return False
-
-        else:
-            return False
 
     def _mergemany(self, others: Sequence[Content]) -> Content:
         if len(others) == 0:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -26,6 +26,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -59,7 +60,7 @@ def _apply_record_reducer(reducer, layout: Content, mask: bool, behavior) -> Con
 
 
 @final
-class RecordArray(RecordMeta[Content], Content):
+class RecordArray(RecordMeta, Content):
     """
     RecordArray represents an array of tuples or records, all with the
     same type. Its `contents` is an ordered list of arrays.
@@ -144,6 +145,9 @@ class RecordArray(RecordMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _contents: list[Content]
+    contents: ImplementsReadOnlyProperty[list[Content]]
 
     def __init__(
         self,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -24,6 +24,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -49,7 +50,7 @@ numpy = Numpy.instance()
 
 
 @final
-class RegularArray(RegularMeta[Content], Content):
+class RegularArray(RegularMeta, Content):
     """
     RegularArray describes lists that all have the same length, the single
     integer `size`. Its underlying `content` is a flattened view of the data;
@@ -118,6 +119,9 @@ class RegularArray(RegularMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, content, size, zeros_length=0, *, parameters=None):
         if not isinstance(content, Content):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -16,7 +16,6 @@ from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
@@ -725,30 +724,6 @@ class RegularArray(RegularMeta[Content], Content):
 
     def _offsets_and_flattened(self, axis: int, depth: int) -> tuple[Index, Content]:
         return self.to_ListOffsetArray64(True)._offsets_and_flattened(axis, depth)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # Check against option contents
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(other.content, mergebool)
-        # Otherwise, do the parameters match? If not, we can't merge.
-        elif not type_parameters_equal(self._parameters, other._parameters):
-            return False
-        elif isinstance(
-            other,
-            (
-                ak.contents.RegularArray,
-                ak.contents.ListArray,
-                ak.contents.ListOffsetArray,
-            ),
-        ):
-            return self._content._mergeable_next(other.content, mergebool)
-        elif isinstance(other, ak.contents.NumpyArray) and len(other.shape) > 1:
-            return self._mergeable_next(other._to_regular_primitive(), mergebool)
-        else:
-            return False
 
     def _mergemany(self, others: Sequence[Content]) -> Content:
         if len(others) == 0:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
 import awkward as ak
 from awkward._backends.backend import Backend
+from awkward._do.meta import mergeable
 from awkward._layout import maybe_posaxis
 from awkward._meta.unionmeta import UnionMeta
 from awkward._nplikes.array_like import ArrayLike
@@ -24,6 +25,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -49,7 +51,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnionArray(UnionMeta[Content], Content):
+class UnionArray(UnionMeta, Content):
     """
     UnionArray represents data drawn from an ordered list of `contents`,
     which can have different types, using
@@ -102,6 +104,9 @@ class UnionArray(UnionMeta[Content], Content):
                 else:
                     raise AssertionError(where)
     """
+
+    _contents: list[Content]
+    contents: ImplementsReadOnlyProperty[list[Content]]
 
     def __init__(self, tags, index, contents, *, parameters=None):
         if not (isinstance(tags, Index) and tags.dtype == np.dtype(np.int8)):
@@ -1403,7 +1408,7 @@ class UnionArray(UnionMeta[Content], Content):
         for i, content_i in enumerate(self._contents):
             for j in range(i):
                 content_j = self._contents[j]
-                if ak._do.mergeable(content_i, content_j, mergebool=False):
+                if mergeable(content_i, content_j, mergebool=False):
                     return f"at {path}: content({i}) is mergeable with content({j})"
 
         for i, content in enumerate(self._contents):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -985,9 +985,6 @@ class UnionArray(UnionMeta[Content], Content):
                     ),
                 )
 
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        return True
-
     def _merging_strategy(self, others):
         if len(others) == 0:
             raise ValueError(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -26,6 +26,7 @@ from awkward._typing import (
     Any,
     Callable,
     Final,
+    ImplementsReadOnlyProperty,
     Self,
     SupportsIndex,
     final,
@@ -52,7 +53,7 @@ numpy = Numpy.instance()
 
 
 @final
-class UnmaskedArray(UnmaskedMeta[Content], Content):
+class UnmaskedArray(UnmaskedMeta, Content):
     """
     UnmaskedArray implements an #ak.types.OptionType for which the values are
     never, in fact, missing. It exists to satisfy systems that formally require this
@@ -84,6 +85,9 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
                 else:
                     return UnmaskedArray(self.content[where])
     """
+
+    _content: Content
+    content: ImplementsReadOnlyProperty[Content]
 
     def __init__(self, content, *, parameters=None):
         if not isinstance(content, Content):

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -18,7 +18,6 @@ from awkward._nplikes.typetracer import MaybeNone
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
-    type_parameters_equal,
 )
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -335,18 +334,6 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
             else:
                 return (offsets, flattened)
-
-    def _mergeable_next(self, other: Content, mergebool: bool) -> bool:
-        # Is the other content is an identity, or a union?
-        if other.is_identity_like or other.is_union:
-            return True
-        # We can only combine option types whose array-record parameters agree
-        elif other.is_option or other.is_indexed:
-            return self._mergeable_next(
-                other.content, mergebool
-            ) and type_parameters_equal(self._parameters, other._parameters)
-        else:
-            return self._content._mergeable_next(other, mergebool)
 
     def _reverse_merge(self, other):
         return self.to_IndexedOptionArray64()._reverse_merge(other)

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -7,7 +7,14 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._meta.bitmaskedmeta import BitMaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, DType, Iterator, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +24,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class BitMaskedForm(BitMaskedMeta[Form], Form):
-    _content: Form
+class BitMaskedForm(BitMaskedMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -60,10 +68,6 @@ class BitMaskedForm(BitMaskedMeta[Form], Form):
     @property
     def mask(self):
         return self._mask
-
-    @property
-    def content(self):
-        return self._content
 
     @property
     def valid_when(self):

--- a/src/awkward/forms/bitmaskedform.py
+++ b/src/awkward/forms/bitmaskedform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import awkward as ak
 from awkward._meta.bitmaskedmeta import BitMaskedMeta
@@ -11,7 +11,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import awkward as ak
 from awkward._meta.bytemaskedmeta import ByteMaskedMeta
@@ -11,7 +11,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/bytemaskedform.py
+++ b/src/awkward/forms/bytemaskedform.py
@@ -7,7 +7,14 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._meta.bytemaskedmeta import ByteMaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, DType, Iterator, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +24,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ByteMaskedForm(ByteMaskedMeta[Form], Form):
-    _content: Form
+class ByteMaskedForm(ByteMaskedMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -54,10 +62,6 @@ class ByteMaskedForm(ByteMaskedMeta[Form], Form):
     @property
     def mask(self):
         return self._mask
-
-    @property
-    def content(self):
-        return self._content
 
     @property
     def valid_when(self):

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -379,6 +379,8 @@ index_to_dtype: Final[dict[str, DType]] = {
 
 
 class Form(Meta):
+    _mergeable_next: Callable[[Form, bool], bool]  # type: ignore[assignment]
+
     def _init(self, *, parameters: JSONMapping | None, form_key: str | None):
         if parameters is not None and not isinstance(parameters, dict):
             raise TypeError(

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import awkward as ak
 from awkward._meta.indexedmeta import IndexedMeta
@@ -12,7 +12,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/indexedform.py
+++ b/src/awkward/forms/indexedform.py
@@ -7,10 +7,15 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._meta.indexedmeta import IndexedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._parameters import (
-    parameters_union,
+from awkward._parameters import parameters_union
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
 )
-from awkward._typing import Any, DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -20,8 +25,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedForm(IndexedMeta[Form], Form):
-    _content: Form
+class IndexedForm(IndexedMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -49,10 +55,6 @@ class IndexedForm(IndexedMeta[Form], Form):
     @property
     def index(self):
         return self._index
-
-    @property
-    def content(self):
-        return self._content
 
     def copy(
         self,

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import awkward as ak
 from awkward._meta.indexedoptionmeta import IndexedOptionMeta
@@ -12,7 +12,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/indexedoptionform.py
+++ b/src/awkward/forms/indexedoptionform.py
@@ -7,10 +7,15 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._parameters import (
-    parameters_union,
+from awkward._parameters import parameters_union
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
 )
-from awkward._typing import Any, DType, Iterator, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -20,8 +25,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class IndexedOptionForm(IndexedOptionMeta[Form], Form):
-    _content: Form
+class IndexedOptionForm(IndexedOptionMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -49,10 +55,6 @@ class IndexedOptionForm(IndexedOptionMeta[Form], Form):
     @property
     def index(self):
         return self._index
-
-    @property
-    def content(self):
-        return self._content
 
     def copy(
         self,

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import awkward as ak
 from awkward._meta.listmeta import ListMeta
@@ -11,7 +11,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/listform.py
+++ b/src/awkward/forms/listform.py
@@ -7,7 +7,14 @@ from collections.abc import Callable
 import awkward as ak
 from awkward._meta.listmeta import ListMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, DType, Iterator, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -17,8 +24,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListForm(ListMeta[Form], Form):
-    _content: Form
+class ListForm(ListMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -60,10 +68,6 @@ class ListForm(ListMeta[Form], Form):
     @property
     def stops(self):
         return self._stops
-
-    @property
-    def content(self):
-        return self._content
 
     def copy(
         self,

--- a/src/awkward/forms/listoffsetform.py
+++ b/src/awkward/forms/listoffsetform.py
@@ -10,6 +10,7 @@ from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._typing import (
     Any,
     DType,
+    ImplementsReadOnlyProperty,
     Iterator,
     JSONMapping,
     Self,
@@ -24,8 +25,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class ListOffsetForm(ListOffsetMeta[Form], Form):
-    _content: Form
+class ListOffsetForm(ListOffsetMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -49,10 +51,6 @@ class ListOffsetForm(ListOffsetMeta[Form], Form):
     @property
     def offsets(self):
         return self._offsets
-
-    @property
-    def content(self):
-        return self._content
 
     def copy(
         self,

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -64,7 +64,7 @@ def from_dtype(
 
 
 @final
-class NumpyForm(NumpyMeta, Form):
+class NumpyForm(NumpyMeta[Form], Form):
     def __init__(
         self,
         primitive,
@@ -258,6 +258,9 @@ class NumpyForm(NumpyMeta, Form):
         from awkward.types.numpytype import primitive_to_dtype
 
         yield (getkey(self, "data"), primitive_to_dtype(self.primitive))
+
+    def _to_regular_primitive(self) -> RegularForm:
+        return self.to_RegularForm()
 
     def _is_equal_to(self, other: Any, all_parameters: bool, form_key: bool) -> bool:
         return self._is_equal_to_generic(other, all_parameters, form_key) and (

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -262,6 +262,12 @@ class NumpyForm(NumpyMeta, Form):
     def _to_regular_primitive(self) -> RegularForm | NumpyForm:
         return self.to_RegularForm()
 
+    @property
+    def dtype(self) -> DType:
+        from awkward.types.numpytype import primitive_to_dtype
+
+        return primitive_to_dtype(self.primitive)
+
     def _is_equal_to(self, other: Any, all_parameters: bool, form_key: bool) -> bool:
         return self._is_equal_to_generic(other, all_parameters, form_key) and (
             self._primitive == other._primitive

--- a/src/awkward/forms/numpyform.py
+++ b/src/awkward/forms/numpyform.py
@@ -64,7 +64,7 @@ def from_dtype(
 
 
 @final
-class NumpyForm(NumpyMeta[Form], Form):
+class NumpyForm(NumpyMeta, Form):
     def __init__(
         self,
         primitive,
@@ -259,7 +259,7 @@ class NumpyForm(NumpyMeta[Form], Form):
 
         yield (getkey(self, "data"), primitive_to_dtype(self.primitive))
 
-    def _to_regular_primitive(self) -> RegularForm:
+    def _to_regular_primitive(self) -> RegularForm | NumpyForm:
         return self.to_RegularForm()
 
     def _is_equal_to(self, other: Any, all_parameters: bool, form_key: bool) -> bool:

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -11,7 +11,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -7,7 +7,14 @@ from collections.abc import Callable, Iterable, Iterator
 import awkward as ak
 from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, DType, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -17,7 +24,10 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RecordForm(RecordMeta[Form], Form):
+class RecordForm(RecordMeta, Form):
+    _contents: list[Form]  # type: ignore[assignment]
+    contents: ImplementsReadOnlyProperty[list[Form]]  # type: ignore[assignment]
+
     def __init__(
         self,
         contents,
@@ -49,17 +59,6 @@ class RecordForm(RecordMeta[Form], Form):
         if fields is not None:
             assert len(self._fields) == len(self._contents)
         self._init(parameters=parameters, form_key=form_key)
-
-    @property
-    def contents(self):
-        return self._contents
-
-    @property
-    def fields(self) -> list[str]:
-        if self._fields is None:
-            return [str(i) for i in range(len(self._contents))]
-        else:
-            return self._fields
 
     def copy(
         self,

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -9,7 +9,14 @@ from awkward._meta.regularmeta import RegularMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._regularize import is_integer
-from awkward._typing import Any, DType, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -19,8 +26,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class RegularForm(RegularMeta[Form], Form):
-    _content: Form
+class RegularForm(RegularMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(self, content, size, *, parameters=None, form_key=None):
         if not isinstance(content, Form):
@@ -39,10 +47,6 @@ class RegularForm(RegularMeta[Form], Form):
         self._content = content
         self._size = size
         self._init(parameters=parameters, form_key=form_key)
-
-    @property
-    def content(self):
-        return self._content
 
     @property
     def size(self):

--- a/src/awkward/forms/regularform.py
+++ b/src/awkward/forms/regularform.py
@@ -13,7 +13,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -8,7 +8,14 @@ from itertools import permutations
 import awkward as ak
 from awkward._meta.unionmeta import UnionMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Any, DType, Iterator, Self, final
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
+)
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher, index_to_dtype
 
@@ -18,7 +25,10 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnionForm(UnionMeta[Form], Form):
+class UnionForm(UnionMeta, Form):
+    _contents: list[Form]  # type: ignore[assignment]
+    contents: ImplementsReadOnlyProperty[list[Form]]  # type: ignore[assignment]
+
     def __init__(
         self,
         tags,
@@ -62,10 +72,6 @@ class UnionForm(UnionMeta[Form], Form):
     @property
     def index(self):
         return self._index
-
-    @property
-    def contents(self):
-        return self._contents
 
     def copy(
         self,

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from itertools import permutations
 
 import awkward as ak
@@ -12,7 +12,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -7,10 +7,15 @@ from collections.abc import Callable, Iterator
 import awkward as ak
 from awkward._meta.unmaskedmeta import UnmaskedMeta
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._parameters import (
-    parameters_union,
+from awkward._parameters import parameters_union
+from awkward._typing import (
+    Any,
+    DType,
+    ImplementsReadOnlyProperty,
+    Iterator,
+    Self,
+    final,
 )
-from awkward._typing import Any, DType, Self, final
 from awkward._util import UNSET
 from awkward.forms.form import Form, _SpecifierMatcher
 
@@ -20,8 +25,9 @@ np = NumpyMetadata.instance()
 
 
 @final
-class UnmaskedForm(UnmaskedMeta[Form], Form):
-    _content: Form
+class UnmaskedForm(UnmaskedMeta, Form):
+    _content: Form  # type: ignore[assignment]
+    content: ImplementsReadOnlyProperty[Form]  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -39,10 +45,6 @@ class UnmaskedForm(UnmaskedMeta[Form], Form):
 
         self._content = content
         self._init(parameters=parameters, form_key=form_key)
-
-    @property
-    def content(self):
-        return self._content
 
     def copy(
         self,

--- a/src/awkward/forms/unmaskedform.py
+++ b/src/awkward/forms/unmaskedform.py
@@ -12,7 +12,6 @@ from awkward._typing import (
     Any,
     DType,
     ImplementsReadOnlyProperty,
-    Iterator,
     Self,
     final,
 )

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -72,7 +73,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.All()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -72,7 +73,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Any()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import combinations, local_index
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -105,11 +105,11 @@ def _impl(
         raise ValueError("the 'axis' for argcombinations must be non-negative")
     else:
         with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
-            layout = ak._do.local_index(
+            layout = local_index(
                 ctx.unwrap(array, allow_record=False, primitive_policy="error"),
                 axis,
             )
-        out = ak._do.combinations(
+        out = combinations(
             layout,
             n,
             replacement=replacement,

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -137,7 +138,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.ArgMax()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -135,7 +136,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
 
     reducer = ak._reducers.ArgMin()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_argsort.py
+++ b/src/awkward/operations/ak_argsort.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import argsort as do_argsort
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -73,7 +74,7 @@ def _impl(array, axis, ascending, stable, highlevel, behavior, attrs):
     axis = regularize_axis(axis)
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.argsort(layout, axis, ascending, stable)
+    out = do_argsort(layout, axis, ascending, stable)
     return ctx.wrap(out, highlevel=highlevel)
 
 

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -355,7 +356,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
                         "ak.cartesian does not compute combinations of the "
                         "characters of a string; please split it into lists"
                     )
-                nextlayout = ak._do.recursively_apply(
+                nextlayout = recursively_apply(
                     layout,
                     apply_pad_inner_list,
                     lateral_context={"n": n_inside},
@@ -375,7 +376,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
         axes_to_flatten.reverse()
 
         new_layouts = [
-            ak._do.recursively_apply(
+            recursively_apply(
                 layout,
                 apply_pad_inner_list_at_axis,
                 lateral_context={"i": i},

--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("categories",)
@@ -49,6 +49,6 @@ def _impl(array, highlevel, behavior, attrs):
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    ak._do.recursively_apply(layout, action)
+    recursively_apply(layout, action)
 
     return ctx.wrap(output, highlevel=highlevel)

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import combinations as do_combinations
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -225,7 +225,7 @@ def _impl(
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.combinations(
+    out = do_combinations(
         layout,
         n,
         replacement=replacement,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -6,6 +6,8 @@ import awkward as ak
 from awkward._backends.dispatch import backend_of_obj
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import mergemany
+from awkward._do.meta import mergeable
 from awkward._layout import HighLevelContext, ensure_same_backend, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -149,12 +151,12 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
         batches = [[content_or_others[0]]]
         for x in content_or_others[1:]:
             batch = batches[-1]
-            if ak._do.mergeable(batch[-1], x, mergebool=mergebool):
+            if mergeable(batch[-1], x, mergebool=mergebool):
                 batch.append(x)
             else:
                 batches.append([x])
 
-        contents = [ak._do.mergemany(b) for b in batches]
+        contents = [mergemany(b) for b in batches]
         if len(contents) > 1:
             out = _merge_as_union(contents)
         else:

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -114,7 +115,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Count()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -73,7 +74,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.CountNonzero()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_drop_none.py
+++ b/src/awkward/operations/ak_drop_none.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -115,9 +115,9 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 return layout.drop_none()
 
     options = {"none_indexes": []}
-    out = ak._do.recursively_apply(layout, action, depth_context=options)
+    out = recursively_apply(layout, action, depth_context=options)
 
     if len(options["none_indexes"]) > 0:
-        out = ak._do.recursively_apply(out, recompute_offsets, depth_context=options)
+        out = recursively_apply(out, recompute_offsets, depth_context=options)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -7,6 +7,8 @@ from itertools import permutations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import mergemany
+from awkward._do.meta import mergeable
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -942,8 +944,8 @@ def _recurse_union_non_union(
 
         # Merge the results
         for content in next_contents[1:]:
-            assert ak._do.mergeable(next_contents[0], content, mergebool=False)
-        next_content = ak._do.mergemany(next_contents)
+            assert mergeable(next_contents[0], content, mergebool=False)
+        next_content = mergemany(next_contents)
 
         # Index over them
         index = ak.index.Index64(index_data)

--- a/src/awkward/operations/ak_fill_none.py
+++ b/src/awkward/operations/ak_fill_none.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import fill_none as do_fill_none
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -107,7 +109,7 @@ def _impl(array, value, axis, highlevel, behavior, attrs):
 
         def action(layout, continuation, **kwargs):
             if layout.is_option:
-                return ak._do.fill_none(continuation(), value_layout)
+                return do_fill_none(continuation(), value_layout)
 
     else:
 
@@ -115,7 +117,7 @@ def _impl(array, value, axis, highlevel, behavior, attrs):
             posaxis = maybe_posaxis(layout, axis, depth)
             if posaxis is not None and posaxis + 1 == depth:
                 if layout.is_option:
-                    return ak._do.fill_none(layout, value_layout)
+                    return do_fill_none(layout, value_layout)
                 elif layout.is_union or layout.is_record or layout.is_indexed:
                     return None
                 else:
@@ -126,5 +128,5 @@ def _impl(array, value, axis, highlevel, behavior, attrs):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-    out = ak._do.recursively_apply(array_layout, action)
+    out = recursively_apply(array_layout, action)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -100,6 +101,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+        out = recursively_apply(layout, action, numpy_to_regular=True)
 
     return ctx.wrap(out, highlevel=highlevel, allow_other=True)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import flatten as do_flatten
+from awkward._do.content import mergemany, remove_structure
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -178,12 +180,12 @@ def _impl(array, axis, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
 
     if axis is None:
-        out = ak._do.remove_structure(layout, function_name="ak.flatten")
+        out = remove_structure(layout, function_name="ak.flatten")
         assert isinstance(out, tuple) and all(
             isinstance(x, ak.contents.Content) for x in out
         )
 
-        out = ak._do.mergemany(out)
+        out = mergemany(out)
 
     elif axis == 0 or maybe_posaxis(layout, axis, 1) == 0:
 
@@ -233,5 +235,5 @@ def _impl(array, axis, highlevel, behavior, attrs):
 
         out = apply(layout)
     else:
-        out = ak._do.flatten(layout, axis)
+        out = do_flatten(layout, axis)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -76,6 +77,6 @@ def _impl(array, generate_bitmasks, highlevel, behavior, attrs):
         if hasattr(layout, "__pyarrow_original"):
             del layout.__pyarrow_original
 
-    ak._do.recursively_apply(out, remove_revertable)
+    recursively_apply(out, remove_revertable)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_from_categorical.py
+++ b/src/awkward/operations/ak_from_categorical.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("from_categorical",)
@@ -50,5 +51,5 @@ def _impl(array, highlevel, behavior, attrs):
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
     return ctx.wrap(out, highlevel=highlevel, allow_other=True)

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -13,6 +13,7 @@ from awkward_cpp.lib import _ext
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
@@ -419,7 +420,7 @@ def _record_to_complex(layout, complex_record_fields):
                             f"expected record with fields {complex_record_fields[0]!r} and {complex_record_fields[1]!r} to have integer or floating point types, not {str(real.form.type)!r} and {str(imag.form.type)!r}"
                         )
 
-        return ak._do.recursively_apply(layout, action)
+        return recursively_apply(layout, action)
 
     else:
         raise TypeError("complex_record_fields must be None or a pair of strings")

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -63,7 +63,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
             if layout.is_regular:
                 return continuation().to_ListOffsetArray64(False)
 
-        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+        out = recursively_apply(layout, action, numpy_to_regular=True)
 
     elif maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level is already regular (ArrayType)
@@ -81,6 +81,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+        out = recursively_apply(layout, action, numpy_to_regular=True)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import is_unknown_scalar
@@ -227,7 +228,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
     return ctx.wrap(out, highlevel=highlevel)
 
 

--- a/src/awkward/operations/ak_is_none.py
+++ b/src/awkward/operations/ak_is_none.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -66,6 +67,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+    out = recursively_apply(layout, action, numpy_to_regular=True)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_local_index.py
+++ b/src/awkward/operations/ak_local_index.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import local_index as do_local_index
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -91,5 +91,5 @@ def _impl(array, axis, highlevel, behavior, attrs):
     axis = regularize_axis(axis)
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.local_index(layout, axis)
+    out = do_local_index(layout, axis)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -147,7 +148,7 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior, at
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Max(initial)
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_merge_option_of_records.py
+++ b/src/awkward/operations/ak_merge_option_of_records.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -73,7 +74,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 backend=backend,
             )
 
-    layout = ak._do.recursively_apply(layout, apply_displace_index)
+    layout = recursively_apply(layout, apply_displace_index)
 
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
@@ -96,5 +97,5 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 backend=backend,
             )
 
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import ArrayLike, NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -265,5 +266,5 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     layout.tags.data, layout.index.data, layout.contents
                 )
 
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -147,7 +148,7 @@ def _impl(array, axis, keepdims, initial, mask_identity, highlevel, behavior, at
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Min(initial)
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -55,5 +56,5 @@ def _impl(array, highlevel, behavior, attrs):
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_nan_to_num.py
+++ b/src/awkward/operations/ak_nan_to_num.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -106,7 +107,7 @@ def _impl(array, copy, nan, posinf, neginf, highlevel, behavior, attrs):
             else:
                 return None
 
-        out = ak._do.recursively_apply(layout, action)
+        out = recursively_apply(layout, action)
 
     else:
 

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -107,6 +108,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+    out = recursively_apply(layout, action, numpy_to_regular=True)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import pad_none as do_pad_none
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -116,6 +116,6 @@ def _impl(array, target, axis, clip, highlevel, behavior, attrs):
     axis = regularize_axis(axis)
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.pad_none(layout, target, axis, clip=clip)
+    out = do_pad_none(layout, target, axis, clip=clip)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -124,7 +125,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Prod()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import mergemany, remove_structure
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -68,12 +69,12 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
 
-    out = ak._do.remove_structure(layout, function_name="ak.ravel", drop_nones=False)
+    out = remove_structure(layout, function_name="ak.ravel", drop_nones=False)
     assert isinstance(out, tuple) and all(
         isinstance(x, ak.contents.Content) for x in out
     )
 
-    result = ak._do.mergemany(out)
+    result = mergemany(out)
 
     return ctx.wrap(result, highlevel=highlevel)
 

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -225,5 +226,5 @@ def _impl(array, highlevel, behavior, attrs):
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_integer, regularize_axis
@@ -88,6 +89,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
         elif layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
 
-    out = ak._do.recursively_apply(layout, action, numpy_to_regular=True)
+    out = recursively_apply(layout, action, numpy_to_regular=True)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_sort.py
+++ b/src/awkward/operations/ak_sort.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import sort as do_sort
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -62,7 +63,7 @@ def _impl(array, axis, ascending, stable, highlevel, behavior, attrs):
     axis = regularize_axis(axis)
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.sort(layout, axis, ascending, stable)
+    out = do_sort(layout, axis, ascending, stable)
     return ctx.wrap(out, highlevel=highlevel)
 
 

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
@@ -82,5 +83,5 @@ def _impl(array, to, highlevel, behavior, attrs):
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_strings_astype.py
+++ b/src/awkward/operations/ak_strings_astype.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
-from awkward._do.content import recursively_apply
+from awkward._do.content import pad_none, recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
@@ -68,7 +68,7 @@ def _impl(array, to, highlevel, behavior, attrs):
                 layout, highlevel=False, behavior=behavior
             )
             max_length = ak.operations.max(ak.operations.num(layout, behavior=behavior))
-            regulararray = ak._do.pad_none(layout, max_length, 1)
+            regulararray = pad_none(layout, max_length, 1)
             maskedarray = ak.operations.to_numpy(regulararray, allow_missing=True)
             npstrings = maskedarray.data
             if maskedarray.mask is not False:

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
+from awkward._do.content import reduce as do_reduce
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -274,7 +275,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     reducer = ak._reducers.Sum()
 
-    out = ak._do.reduce(
+    out = do_reduce(
         layout,
         reducer,
         axis=axis,

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
 from awkward._dispatch import high_level_function
+from awkward._do.content import to_buffers as do_to_buffers
 from awkward._nplikes.numpy_like import NumpyMetadata
 
 __all__ = ("to_buffers",)
@@ -139,7 +140,7 @@ def _impl(array, container, buffer_key, form_key, id_start, backend, byteorder):
     if backend is not None:
         backend = regularize_backend(backend)
 
-    return ak._do.to_buffers(
+    return do_to_buffers(
         layout,
         container=container,
         buffer_key=buffer_key,

--- a/src/awkward/operations/ak_to_regular.py
+++ b/src/awkward/operations/ak_to_regular.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import regularize_axis
@@ -76,7 +76,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
             if layout.is_list:
                 return continuation().to_RegularArray()
 
-        out = ak._do.recursively_apply(layout, action)
+        out = recursively_apply(layout, action)
 
     elif maybe_posaxis(layout, axis, 1) == 0:
         out = layout  # the top-level can only be regular (ArrayType)
@@ -93,6 +93,6 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     f"axis={axis} exceeds the depth of this array ({depth})"
                 )
 
-        out = ak._do.recursively_apply(layout, action)
+        out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -529,7 +529,7 @@ def _impl(
                     f"transformation must return a Content or None, not {type(out)}\n\n{out!r}"
                 )
 
-        # An exception to the rule of ak._do.recursively_apply, for symmetry with
+        # An exception to the rule of recursively_apply, for symmetry with
         # ak._broadcasting.apply_step, below. ak_transform._impl knows implementation details.
         out = layouts[0]._recursively_apply(
             action,

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend, maybe_posaxis
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -245,7 +246,7 @@ def _impl(array, counts, axis, highlevel, behavior, attrs):
 
                 return ak.contents.ListOffsetArray(ak.index.Index64(positions), content)
 
-        out = ak._do.recursively_apply(layout, apply)
+        out = recursively_apply(layout, apply)
 
     if (
         current_offsets is not None

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -64,7 +65,7 @@ def _impl(array, highlevel, behavior, attrs):
                         "union of different sets of fields, cannot ak.unzip"
                     )
 
-    ak._do.recursively_apply(layout, check_for_union, return_array=False)
+    recursively_apply(layout, check_for_union, return_array=False)
 
     if len(fields) == 0:
         return (ctx.wrap(layout, highlevel=highlevel, allow_other=True),)

--- a/src/awkward/operations/ak_validity_error.py
+++ b/src/awkward/operations/ak_validity_error.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import validity_error as do_validity_error
 
 __all__ = ("validity_error",)
 
@@ -35,7 +36,7 @@ def _impl(array, exception):
     layout = ak.operations.to_layout(
         array, allow_record=False, primitive_policy="error"
     )
-    out = ak._do.validity_error(layout, path="highlevel")
+    out = do_validity_error(layout, path="highlevel")
 
     if out not in (None, "") and exception:
         raise ValueError(out)

--- a/src/awkward/operations/ak_values_astype.py
+++ b/src/awkward/operations/ak_values_astype.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import numbers_to_type
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -73,5 +74,5 @@ def _impl(array, to, including_unknown, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
     to_str = ak.types.numpytype.dtype_to_primitive(np.dtype(to))
-    out = ak._do.numbers_to_type(layout, to_str, including_unknown)
+    out = numbers_to_type(layout, to_str, including_unknown)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -7,6 +7,7 @@ import copy
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_non_string_like_sequence
@@ -110,7 +111,7 @@ def _impl(base, what, where, highlevel, behavior, attrs):
                 else:
                     return None
 
-            ak._do.recursively_apply(layout, action_is_record, return_array=False)
+            recursively_apply(layout, action_is_record, return_array=False)
             return result
 
         if not purelist_is_record(base):

--- a/src/awkward/operations/ak_with_name.py
+++ b/src/awkward/operations/ak_with_name.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -60,6 +61,6 @@ def _impl(array, name, highlevel, behavior, attrs):
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_without_field.py
+++ b/src/awkward/operations/ak_without_field.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -68,7 +69,7 @@ def _impl(base, where, highlevel, behavior, attrs):
                 for i, content in enumerate(layout.contents):
                     if i == i_field:
                         # Visit this content to remove the next item in `where`
-                        next_content = ak._do.recursively_apply(
+                        next_content = recursively_apply(
                             content,
                             action,
                             depth_context={"where": next_where},
@@ -94,5 +95,5 @@ def _impl(base, where, highlevel, behavior, attrs):
         else:
             return None
 
-    out = ak._do.recursively_apply(base, action, depth_context={"where": where})
+    out = recursively_apply(base, action, depth_context={"where": where})
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_without_parameters.py
+++ b/src/awkward/operations/ak_without_parameters.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -41,7 +41,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array, allow_record=False, primitive_policy="error")
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout, lambda layout, **kwargs: None, keep_parameters=False
     )
 

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -85,7 +85,7 @@ from awkward.operations.str.akstr_upper import *
 
 
 def _drop_option_preserving_form(layout, ensure_empty_mask: bool = False):
-    from awkward._do import recursively_apply
+    from awkward._do.content import recursively_apply
     from awkward.contents import UnmaskedArray, IndexedOptionArray, IndexedArray
 
     def action(_, continuation, **kwargs):

--- a/src/awkward/operations/str/akstr_capitalize.py
+++ b/src/awkward/operations/str/akstr_capitalize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("capitalize",)
@@ -52,7 +53,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_capitalize, pc.ascii_capitalize, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_center.py
+++ b/src/awkward/operations/str/akstr_center.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("center",)
@@ -58,7 +59,7 @@ def _impl(array, width, padding, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_center, pc.ascii_center, width, padding, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_count_substring.py
+++ b/src/awkward/operations/str/akstr_count_substring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("count_substring",)
@@ -66,6 +67,6 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_count_substring_regex.py
+++ b/src/awkward/operations/str/akstr_count_substring_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("count_substring_regex",)
@@ -66,6 +67,6 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_ends_with.py
+++ b/src/awkward/operations/str/akstr_ends_with.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("ends_with",)
@@ -64,5 +65,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("extract_regex",)
@@ -69,7 +70,7 @@ def _impl(array, pattern, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.extract_regex,

--- a/src/awkward/operations/str/akstr_find_substring.py
+++ b/src/awkward/operations/str/akstr_find_substring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("find_substring",)
@@ -66,5 +67,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_find_substring_regex.py
+++ b/src/awkward/operations/str/akstr_find_substring_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("find_substring_regex",)
@@ -66,5 +67,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 
 __all__ = ("index_in",)
@@ -82,6 +82,6 @@ def _impl(array, value_set, skip_nones, highlevel, behavior, attrs):
                 generate_bitmasks=True,
             )
 
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_is_alnum.py
+++ b/src/awkward/operations/str/akstr_is_alnum.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_alnum",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_alnum, pc.ascii_is_alnum, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_alpha.py
+++ b/src/awkward/operations/str/akstr_is_alpha.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_alpha",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_alpha, pc.ascii_is_alpha, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_ascii.py
+++ b/src/awkward/operations/str/akstr_is_ascii.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_ascii",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.string_is_ascii, pc.string_is_ascii, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_decimal.py
+++ b/src/awkward/operations/str/akstr_is_decimal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_decimal",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_decimal, pc.ascii_is_decimal, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_digit.py
+++ b/src/awkward/operations/str/akstr_is_digit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_digit",)
@@ -53,7 +54,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_digit, pc.utf8_is_digit, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 
 __all__ = ("is_in",)
@@ -76,6 +76,6 @@ def _impl(array, value_set, skip_nones, highlevel, behavior, attrs):
                 pc.is_in, layout, value_set_layout, skip_nulls=skip_nones
             )
 
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_is_lower.py
+++ b/src/awkward/operations/str/akstr_is_lower.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_lower",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_lower, pc.ascii_is_lower, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_numeric.py
+++ b/src/awkward/operations/str/akstr_is_numeric.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_numeric",)
@@ -53,7 +54,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_numeric, pc.utf8_is_numeric, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_printable.py
+++ b/src/awkward/operations/str/akstr_is_printable.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_printable",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_printable, pc.ascii_is_printable, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_space.py
+++ b/src/awkward/operations/str/akstr_is_space.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_space",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_space, pc.ascii_is_space, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_title.py
+++ b/src/awkward/operations/str/akstr_is_title.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_title",)
@@ -55,7 +56,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_title, pc.ascii_is_title, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_is_upper.py
+++ b/src/awkward/operations/str/akstr_is_upper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("is_upper",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_is_upper,

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 
 __all__ = ("join",)
@@ -94,7 +95,7 @@ def _impl(array, separator, highlevel, behavior, attrs):
                 bytestring_to32=True,
             )
 
-        out = ak._do.recursively_apply(layout, apply_unary)
+        out = recursively_apply(layout, apply_unary)
     else:
 
         def apply_binary(layouts, **kwargs):

--- a/src/awkward/operations/str/akstr_length.py
+++ b/src/awkward/operations/str/akstr_length.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("length",)
@@ -50,7 +51,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_length, pc.binary_length, bytestring_to_string=False

--- a/src/awkward/operations/str/akstr_lower.py
+++ b/src/awkward/operations/str/akstr_lower.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("lower",)
@@ -50,7 +51,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_lower, pc.ascii_lower, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_lpad.py
+++ b/src/awkward/operations/str/akstr_lpad.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("lpad",)
@@ -57,7 +58,7 @@ def _impl(array, width, padding, highlevel, behavior, attrs):
 
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_lpad, pc.ascii_lpad, width, padding, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_ltrim.py
+++ b/src/awkward/operations/str/akstr_ltrim.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("ltrim",)
@@ -58,7 +59,7 @@ def _impl(array, characters, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_ltrim, pc.ascii_ltrim, characters, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_ltrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_ltrim_whitespace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("ltrim_whitespace",)
@@ -49,7 +50,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_ltrim_whitespace,

--- a/src/awkward/operations/str/akstr_match_like.py
+++ b/src/awkward/operations/str/akstr_match_like.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("match_like",)
@@ -69,5 +70,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_match_substring.py
+++ b/src/awkward/operations/str/akstr_match_substring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("match_substring",)
@@ -64,5 +65,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_match_substring_regex.py
+++ b/src/awkward/operations/str/akstr_match_substring_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("match_substring_regex",)
@@ -64,5 +65,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -7,6 +7,7 @@ import numbers
 import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -96,6 +97,6 @@ def _impl(array, num_repeats, highlevel, behavior, attrs):
             ):
                 return _apply_through_arrow(pc.binary_repeat, layout, num_repeats)
 
-        out = ak._do.recursively_apply(layout, action)
+        out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_replace_slice.py
+++ b/src/awkward/operations/str/akstr_replace_slice.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("replace_slice",)
@@ -60,7 +61,7 @@ def _impl(array, start, stop, replacement, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_replace_slice, pc.binary_replace_slice, start, stop, replacement

--- a/src/awkward/operations/str/akstr_replace_substring.py
+++ b/src/awkward/operations/str/akstr_replace_substring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("replace_substring",)
@@ -69,7 +70,7 @@ def _impl(array, pattern, replacement, max_replacements, highlevel, behavior, at
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.replace_substring,

--- a/src/awkward/operations/str/akstr_replace_substring_regex.py
+++ b/src/awkward/operations/str/akstr_replace_substring_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("replace_substring_regex",)
@@ -69,7 +70,7 @@ def _impl(array, pattern, replacement, max_replacements, highlevel, behavior, at
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.replace_substring_regex,

--- a/src/awkward/operations/str/akstr_reverse.py
+++ b/src/awkward/operations/str/akstr_reverse.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("reverse",)
@@ -52,7 +53,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_reverse, pc.binary_reverse, bytestring_to_string=False

--- a/src/awkward/operations/str/akstr_rpad.py
+++ b/src/awkward/operations/str/akstr_rpad.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("rpad",)
@@ -58,7 +59,7 @@ def _impl(array, width, padding, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_rpad, pc.ascii_rpad, width, padding, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_rtrim.py
+++ b/src/awkward/operations/str/akstr_rtrim.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("rtrim",)
@@ -57,7 +58,7 @@ def _impl(array, characters, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_rtrim, pc.ascii_rtrim, characters, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_rtrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_rtrim_whitespace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("rtrim_whitespace",)
@@ -49,7 +50,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_rtrim_whitespace,

--- a/src/awkward/operations/str/akstr_slice.py
+++ b/src/awkward/operations/str/akstr_slice.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("slice",)
@@ -74,6 +74,6 @@ def _impl(array, start, stop, step, highlevel, behavior, attrs):
             primitive_policy="error",
             string_policy="as-characters",
         )
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("split_pattern",)
@@ -76,6 +77,6 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior, attrs):
         reverse=reverse,
         bytestring_to_string=False,
     )
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_split_pattern_regex.py
+++ b/src/awkward/operations/str/akstr_split_pattern_regex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("split_pattern_regex",)
@@ -80,6 +81,6 @@ def _impl(array, pattern, max_splits, reverse, highlevel, behavior, attrs):
         reverse=reverse,
         bytestring_to_string=False,
     )
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("split_whitespace",)
@@ -77,6 +78,6 @@ def _impl(array, max_splits, reverse, highlevel, behavior, attrs):
         reverse=reverse,
         bytestring_to_string=True,
     )
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_starts_with.py
+++ b/src/awkward/operations/str/akstr_starts_with.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("starts_with",)
@@ -64,5 +65,5 @@ def _impl(array, pattern, ignore_case, highlevel, behavior, attrs):
         ignore_case=ignore_case,
         pattern=pattern,
     )
-    out = ak._do.recursively_apply(layout, apply)
+    out = recursively_apply(layout, apply)
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_swapcase.py
+++ b/src/awkward/operations/str/akstr_swapcase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("swapcase",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_swapcase, pc.ascii_swapcase, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_title.py
+++ b/src/awkward/operations/str/akstr_title.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("title",)
@@ -53,7 +54,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_title, pc.ascii_title, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("to_categorical",)
@@ -68,6 +68,6 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(layout, action)
+    out = recursively_apply(layout, action)
 
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_trim.py
+++ b/src/awkward/operations/str/akstr_trim.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("trim",)
@@ -58,7 +59,7 @@ def _impl(array, characters, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_trim, pc.ascii_trim, characters, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_trim_whitespace.py
+++ b/src/awkward/operations/str/akstr_trim_whitespace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("trim_whitespace",)
@@ -50,7 +51,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_trim_whitespace, pc.ascii_trim_whitespace, bytestring_to_string=True

--- a/src/awkward/operations/str/akstr_upper.py
+++ b/src/awkward/operations/str/akstr_upper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._do.content import recursively_apply
 from awkward._layout import HighLevelContext
 
 __all__ = ("upper",)
@@ -51,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(array)
 
-    out = ak._do.recursively_apply(
+    out = recursively_apply(
         layout,
         ak.operations.str._get_ufunc_action(
             pc.utf8_upper, pc.ascii_upper, bytestring_to_string=True

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -12,6 +12,7 @@ from awkward._backends.dispatch import (
     regularize_backend,
 )
 from awkward._behavior import get_record_class
+from awkward._do.content import validity_error as do_validity_error
 from awkward._layout import wrap_layout
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
@@ -98,7 +99,7 @@ class Record:
         return "".join(out)
 
     def validity_error(self, path="layout.array"):
-        return ak._do.validity_error(self._array, path)
+        return do_validity_error(self._array, path)
 
     @property
     def parameters(self):

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 
 import awkward.forms
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._do import touch_data as _touch_data
+from awkward._do.content import touch_data as _touch_data
 from awkward._layout import HighLevelContext, wrap_layout
 from awkward._nplikes.numpy import NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+
+from awkward._pickle import use_builtin_reducer
+
+
+@pytest.fixture(autouse=True)
+def disable_external_pickler():
+    """Fixture to disable external pickler implementation for every test"""
+    with use_builtin_reducer():
+        yield

--- a/tests/test_0072_fillna_operation.py
+++ b/tests/test_0072_fillna_operation.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import fill_none, pad_none
 
 to_list = ak.operations.to_list
 
@@ -15,30 +15,30 @@ def test_fillna_empty_array():
     value = ak.contents.NumpyArray(np.array([10]))
 
     assert to_list(empty) == []
-    array = ak._do.pad_none(empty, 5, 0)
+    array = pad_none(empty, 5, 0)
     assert to_list(array) == [None, None, None, None, None]
-    assert to_list(ak._do.fill_none(array, value)) == [10, 10, 10, 10, 10]
+    assert to_list(fill_none(array, value)) == [10, 10, 10, 10, 10]
 
 
 def test_fillna_numpy_array():
     content = ak.contents.NumpyArray(np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
     value = ak.contents.NumpyArray(np.array([0]))
 
-    array = ak._do.pad_none(content, 3, 0)
+    array = pad_none(content, 3, 0)
     assert to_list(array) == [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], None]
-    assert to_list(ak._do.fill_none(array, value)) == [
+    assert to_list(fill_none(array, value)) == [
         [1.1, 2.2, 3.3],
         [4.4, 5.5, 6.6],
         0,
     ]
 
-    array = ak._do.pad_none(content, 5, 1)
+    array = pad_none(content, 5, 1)
     assert to_list(array) == [
         [1.1, 2.2, 3.3, None, None],
         [4.4, 5.5, 6.6, None, None],
     ]
 
-    assert to_list(ak._do.fill_none(array, value)) == [
+    assert to_list(fill_none(array, value)) == [
         [1.1, 2.2, 3.3, 0, 0],
         [4.4, 5.5, 6.6, 0, 0],
     ]
@@ -79,7 +79,7 @@ def test_fillna_regular_array():
 
     assert to_list(regarray) == [[6.9, 3.9, 6.9], [2.2, 1.5, 1.6], [3.6, None, 6.7]]
 
-    assert to_list(ak._do.fill_none(regarray, value)) == [
+    assert to_list(fill_none(regarray, value)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, 666, 6.7],
@@ -103,7 +103,7 @@ def test_fillna_listarray_array():
         [8.8],
     ]
 
-    assert to_list(ak._do.fill_none(listarray, value)) == [
+    assert to_list(fill_none(listarray, value)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -121,7 +121,7 @@ def test_fillna_unionarray():
 
     assert to_list(array) == [[], ["two", "two"], [1.1], ["one"], [2.2, 2.2], []]
 
-    padded_array = ak._do.pad_none(array, 2, 1)
+    padded_array = pad_none(array, 2, 1)
     assert to_list(padded_array) == [
         [None, None],
         ["two", "two"],
@@ -132,7 +132,7 @@ def test_fillna_unionarray():
     ]
 
     value = ak.contents.NumpyArray(np.array([777]))
-    assert to_list(ak._do.fill_none(padded_array, value)) == [
+    assert to_list(fill_none(padded_array, value)) == [
         [777, 777],
         ["two", "two"],
         [1.1, 777],

--- a/tests/test_0078_argcross_and_cross.py
+++ b/tests/test_0078_argcross_and_cross.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import local_index
 
 to_list = ak.operations.to_list
 
@@ -313,8 +313,8 @@ def test_localindex():
     array = ak.operations.from_iter(
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
     )
-    assert to_list(ak._do.local_index(array, 0)) == [0, 1, 2, 3, 4]
-    assert to_list(ak._do.local_index(array, 1)) == [
+    assert to_list(local_index(array, 0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(array, 1)) == [
         [0, 1, 2],
         [],
         [0, 1],
@@ -326,9 +326,9 @@ def test_localindex():
         [[[0.0, 1.1, 2.2], [], [3.3, 4.4]], [], [[5.5]], [[6.6, 7.7, 8.8, 9.9]]],
         highlevel=False,
     )
-    assert to_list(ak._do.local_index(array, 0)) == [0, 1, 2, 3]
-    assert to_list(ak._do.local_index(array, 1)) == [[0, 1, 2], [], [0], [0]]
-    assert to_list(ak._do.local_index(array, 2)) == [
+    assert to_list(local_index(array, 0)) == [0, 1, 2, 3]
+    assert to_list(local_index(array, 1)) == [[0, 1, 2], [], [0], [0]]
+    assert to_list(local_index(array, 2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
@@ -338,9 +338,9 @@ def test_localindex():
     array = ak.operations.from_numpy(
         np.arange(2 * 3 * 5).reshape(2, 3, 5), regulararray=True, highlevel=False
     )
-    assert to_list(ak._do.local_index(array, 0)) == [0, 1]
-    assert to_list(ak._do.local_index(array, 1)) == [[0, 1, 2], [0, 1, 2]]
-    assert to_list(ak._do.local_index(array, 2)) == [
+    assert to_list(local_index(array, 0)) == [0, 1]
+    assert to_list(local_index(array, 1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(array, 2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]

--- a/tests/test_0080_flatpandas_multiindex_rows_and_columns.py
+++ b/tests/test_0080_flatpandas_multiindex_rows_and_columns.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import json

--- a/tests/test_0093_simplify_uniontypes_and_optiontypes.py
+++ b/tests/test_0093_simplify_uniontypes_and_optiontypes.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.meta import mergeable
 
 to_list = ak.operations.to_list
 
@@ -419,25 +419,25 @@ def test_recordarray_merge():
     )
     arrayt7 = ak.operations.from_iter([(0,), (1,), (2,)], highlevel=False)
 
-    assert ak._do.mergeable(arrayr1, arrayr2)
-    assert ak._do.mergeable(arrayr2, arrayr1)
-    assert not ak._do.mergeable(arrayr1, arrayr3)
-    assert ak._do.mergeable(arrayr1, arrayr4)
-    assert ak._do.mergeable(arrayr4, arrayr1)
-    assert not ak._do.mergeable(arrayr1, arrayr5)
-    assert not ak._do.mergeable(arrayr1, arrayr6)
-    assert ak._do.mergeable(arrayr5, arrayr6)
-    assert ak._do.mergeable(arrayr6, arrayr5)
-    assert not ak._do.mergeable(arrayr1, arrayr7)
+    assert mergeable(arrayr1, arrayr2)
+    assert mergeable(arrayr2, arrayr1)
+    assert not mergeable(arrayr1, arrayr3)
+    assert mergeable(arrayr1, arrayr4)
+    assert mergeable(arrayr4, arrayr1)
+    assert not mergeable(arrayr1, arrayr5)
+    assert not mergeable(arrayr1, arrayr6)
+    assert mergeable(arrayr5, arrayr6)
+    assert mergeable(arrayr6, arrayr5)
+    assert not mergeable(arrayr1, arrayr7)
 
-    assert ak._do.mergeable(arrayt1, arrayt2)
-    assert ak._do.mergeable(arrayt2, arrayt1)
-    assert not ak._do.mergeable(arrayt1, arrayt3)
-    assert not ak._do.mergeable(arrayt1, arrayt4)
-    assert not ak._do.mergeable(arrayt1, arrayt5)
-    assert not ak._do.mergeable(arrayt1, arrayt6)
-    assert not ak._do.mergeable(arrayt5, arrayt6)
-    assert not ak._do.mergeable(arrayt1, arrayt7)
+    assert mergeable(arrayt1, arrayt2)
+    assert mergeable(arrayt2, arrayt1)
+    assert not mergeable(arrayt1, arrayt3)
+    assert not mergeable(arrayt1, arrayt4)
+    assert not mergeable(arrayt1, arrayt5)
+    assert not mergeable(arrayt1, arrayt6)
+    assert not mergeable(arrayt5, arrayt6)
+    assert not mergeable(arrayt1, arrayt7)
 
     assert to_list(arrayr1._mergemany([arrayr2])) == [
         {"x": 0.0, "y": []},

--- a/tests/test_0127_tomask_operation.py
+++ b/tests/test_0127_tomask_operation.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import local_index
 
 to_list = ak.operations.to_list
 
@@ -720,30 +720,30 @@ def test_ByteMaskedArray_localindex():
         None,
         [[], [10.0, 11.1, 12.2]],
     ]
-    assert to_list(ak._do.local_index(array, axis=0)) == [0, 1, 2, 3, 4]
-    assert to_list(ak._do.local_index(array, axis=-3)) == [0, 1, 2, 3, 4]
-    assert to_list(ak._do.local_index(array, axis=1)) == [
+    assert to_list(local_index(array, axis=0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(array, axis=-3)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(array, axis=1)) == [
         [0, 1, 2],
         [],
         None,
         None,
         [0, 1],
     ]
-    assert to_list(ak._do.local_index(array, axis=-2)) == [
+    assert to_list(local_index(array, axis=-2)) == [
         [0, 1, 2],
         [],
         None,
         None,
         [0, 1],
     ]
-    assert to_list(ak._do.local_index(array, axis=2)) == [
+    assert to_list(local_index(array, axis=2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
         None,
         [[], [0, 1, 2]],
     ]
-    assert to_list(ak._do.local_index(array, axis=-1)) == [
+    assert to_list(local_index(array, axis=-1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,

--- a/tests/test_0150_flatten.py
+++ b/tests/test_0150_flatten.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
 import awkward as ak
+from awkward._do.content import flatten
 
 to_list = ak.operations.to_list
 
@@ -446,7 +446,7 @@ def test_flatten2():
         [5.5],
         [6.6, 7.7, 8.8, 9.9],
     ]
-    assert to_list(ak._do.flatten(array, axis=1)) == [
+    assert to_list(flatten(array, axis=1)) == [
         0.0,
         1.1,
         2.2,
@@ -458,7 +458,7 @@ def test_flatten2():
         8.8,
         9.9,
     ]
-    assert to_list(ak._do.flatten(array, axis=-1)) == [
+    assert to_list(flatten(array, axis=-1)) == [
         0.0,
         1.1,
         2.2,
@@ -471,12 +471,12 @@ def test_flatten2():
         9.9,
     ]
     with pytest.raises(ValueError) as err:
-        assert to_list(ak._do.flatten(array, axis=-2))
+        assert to_list(flatten(array, axis=-2))
         assert str(err.value).startswith("axis=0 not allowed for flatten")
 
     array2 = array[2:-1]
-    assert to_list(ak._do.flatten(array2, axis=1)) == [3.3, 4.4, 5.5]
-    assert to_list(ak._do.flatten(array2, axis=-1)) == [3.3, 4.4, 5.5]
+    assert to_list(flatten(array2, axis=1)) == [3.3, 4.4, 5.5]
+    assert to_list(flatten(array2, axis=-1)) == [3.3, 4.4, 5.5]
 
 
 def test_ByteMaskedArray_flatten():

--- a/tests/test_0184_concatenate_operation.py
+++ b/tests/test_0184_concatenate_operation.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
 import awkward as ak
+from awkward._do.content import pad_none
 
 to_list = ak.operations.to_list
 
@@ -66,7 +66,7 @@ def test_list_offset_array_concatenate():
     three = ak.contents.ListOffsetArray(offsets_three, one)
     four = ak.contents.ListOffsetArray(offsets_four, two)
 
-    padded_one = ak._do.pad_none(one, 7, 0)
+    padded_one = pad_none(one, 7, 0)
     assert to_list(padded_one) == [
         [0.0, 1.1, 2.2],
         [],
@@ -117,7 +117,7 @@ def test_list_offset_array_concatenate():
         [],
     ]
 
-    padded = ak._do.pad_none(three, 6, 0)
+    padded = pad_none(three, 6, 0)
 
     assert to_list(ak.operations.concatenate([padded, four], 1)) == [
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [0.33], []],

--- a/tests/test_0397_arrays_as_constants_in_numba.py
+++ b/tests/test_0397_arrays_as_constants_in_numba.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import sys

--- a/tests/test_0404_array_validity_check.py
+++ b/tests/test_0404_array_validity_check.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/master/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
 import awkward as ak
+from awkward._do.content import is_unique, unique
 
 to_list = ak.operations.to_list
 
@@ -76,9 +76,9 @@ def test_BitMaskedArray():
         None,
         None,
     ]
-    assert ak._do.is_unique(array, axis=None) is True
-    assert to_list(ak._do.unique(array, axis=None)) == [0, 1, 5, 7, 8, 9, None]
-    assert to_list(ak._do.unique(array, axis=-1)) == [0, 1, 5, 7, 8, 9, None]
+    assert is_unique(array, axis=None) is True
+    assert to_list(unique(array, axis=None)) == [0, 1, 5, 7, 8, 9, None]
+    assert to_list(unique(array, axis=-1)) == [0, 1, 5, 7, 8, 9, None]
 
 
 def test_ByteMaskedArray_0():
@@ -88,8 +88,8 @@ def test_ByteMaskedArray_0():
     mask = ak.index.Index8(np.array([0, 0, 1, 1, 0], dtype=np.int8))
     array = ak.contents.ByteMaskedArray(mask, content, valid_when=False)
     assert to_list(array) == [[0.0, 1.1, 2.2], [], None, None, [6.6, 7.7, 8.8, 9.9]]
-    assert ak._do.is_unique(array, axis=None) is True
-    assert to_list(ak._do.unique(array, axis=None)) == [
+    assert is_unique(array, axis=None) is True
+    assert to_list(unique(array, axis=None)) == [
         0.0,
         1.1,
         2.2,
@@ -99,7 +99,7 @@ def test_ByteMaskedArray_0():
         9.9,
         None,
     ]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array, axis=-1)) == [
         [0.0, 1.1, 2.2],
         [],
         [6.6, 7.7, 8.8, 9.9],
@@ -116,8 +116,8 @@ def test_ByteMaskedArray_1():
     array = ak.contents.ByteMaskedArray(mask, content, valid_when=False)
 
     assert to_list(array) == [[0.0, 1.1, 2.2], [], None, None, [6.6, 7.7, 8.8, 9.9]]
-    assert ak._do.is_unique(array, axis=None) is True
-    assert to_list(ak._do.unique(array, axis=None)) == [
+    assert is_unique(array, axis=None) is True
+    assert to_list(unique(array, axis=None)) == [
         0.0,
         1.1,
         2.2,
@@ -127,7 +127,7 @@ def test_ByteMaskedArray_1():
         9.9,
         None,
     ]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array, axis=-1)) == [
         [0.0, 1.1, 2.2],
         [],
         [6.6, 7.7, 8.8, 9.9],
@@ -144,9 +144,9 @@ def test_ByteMaskedArray_2():
     array = ak.contents.ByteMaskedArray(mask, content, valid_when=False)
 
     assert to_list(array) == [[1.1, 1.1, 2.2], [], None, None, [1.1, 7.7, 8.8, 9.9]]
-    assert ak._do.is_unique(array, axis=None) is False
-    assert to_list(ak._do.unique(array, axis=None)) == [1.1, 2.2, 7.7, 8.8, 9.9, None]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert is_unique(array, axis=None) is False
+    assert to_list(unique(array, axis=None)) == [1.1, 2.2, 7.7, 8.8, 9.9, None]
+    assert to_list(unique(array, axis=-1)) == [
         [1.1, 2.2],
         [],
         [1.1, 7.7, 8.8, 9.9],
@@ -162,8 +162,8 @@ def test_UnmaskedArray():
     array = ak.contents.UnmaskedArray(content)
 
     assert to_list(array) == [1.1, 2.2, 3.3, 4.4, 5.5]
-    assert ak._do.is_unique(array, axis=None) is True
-    assert to_list(ak._do.unique(array, axis=None)) == [1.1, 2.2, 3.3, 4.4, 5.5]
+    assert is_unique(array, axis=None) is True
+    assert to_list(unique(array, axis=None)) == [1.1, 2.2, 3.3, 4.4, 5.5]
 
 
 def test_subranges_equal():
@@ -220,14 +220,14 @@ def test_categorical():
     categorical = ak.str.to_categorical(array)
 
     assert ak.operations.is_valid(categorical) is True
-    assert ak._do.is_unique(categorical.layout) is False
+    assert is_unique(categorical.layout) is False
 
 
 def test_NumpyArray():
     array = ak.contents.NumpyArray(np.array([5, 6, 1, 3, 4, 5]))
 
-    assert ak._do.is_unique(array) is False
-    assert to_list(ak._do.unique(array)) == [1, 3, 4, 5, 6]
+    assert is_unique(array) is False
+    assert to_list(unique(array)) == [1, 3, 4, 5, 6]
 
 
 def test_2d():
@@ -272,15 +272,15 @@ def test_2d():
     )
 
     assert (
-        ak._do.is_unique(
+        is_unique(
             array,
         )
         is False
     )
-    assert ak._do.is_unique(array, axis=-1) is True
+    assert is_unique(array, axis=-1) is True
 
-    assert to_list(ak._do.unique(array)) == [1.1, 2.2, 3.3, 4.4, 5.5]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array)) == [1.1, 2.2, 3.3, 4.4, 5.5]
+    assert to_list(unique(array, axis=-1)) == [
         [1.1, 2.2, 3.3, 4.4, 5.5],
         [1.1, 2.2, 3.3, 4.4, 5.5],
         [1.1, 2.2, 3.3, 4.4, 5.5],
@@ -297,15 +297,15 @@ def test_2d_in_axis():
             ]
         )
     )
-    assert ak._do.is_unique(array) is False
-    assert to_list(ak._do.unique(array)) == [1.1, 2.2, 3.3, 4.4, 5.5]
+    assert is_unique(array) is False
+    assert to_list(unique(array)) == [1.1, 2.2, 3.3, 4.4, 5.5]
 
     assert to_list(ak.sort(array, axis=-1, highlevel=False)) == [
         [1.1, 1.1, 2.2, 3.3, 4.4, 5.5],
         [1.1, 2.2, 3.3, 3.3, 4.4, 5.5],
         [1.1, 2.2, 2.2, 3.3, 4.4, 5.5],
     ]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array, axis=-1)) == [
         [1.1, 2.2, 3.3, 4.4, 5.5],
         [1.1, 2.2, 3.3, 4.4, 5.5],
         [1.1, 2.2, 3.3, 4.4, 5.5],
@@ -331,9 +331,9 @@ def test_3d():
         )
     )  # 5
 
-    assert ak._do.is_unique(array) is True
+    assert is_unique(array) is True
 
-    assert to_list(ak._do.unique(array)) == [
+    assert to_list(unique(array)) == [
         -15.15,
         -14.14,
         -13.13,
@@ -366,7 +366,7 @@ def test_3d():
         15.15,
     ]
 
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array, axis=-1)) == [
         [
             [1.1, 2.2, 3.3, 4.4, 5.5],
             [6.6, 7.7, 8.8, 9.9, 10.1],
@@ -398,8 +398,8 @@ def test_3d_non_unique():
 
     array = ak.contents.NumpyArray(np_array)
 
-    assert to_list(ak._do.unique(array)) == to_list(np.unique(np_array))
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert to_list(unique(array)) == to_list(np.unique(np_array))
+    assert to_list(unique(array, axis=-1)) == [
         [[1.1, 4.4, 5.5, 13.13], [7.7, 10.1, 13.13], [12.12, 13.13]],
         [
             [-5.5, -4.4, -2.2, -1.1, 13.13],
@@ -421,8 +421,8 @@ def test_ListOffsetArray():
         "three",
         "two",
     ]
-    assert ak._do.is_unique(array) is True
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert is_unique(array) is True
+    assert to_list(unique(array, axis=-1)) == [
         "five",
         "four",
         "one",
@@ -440,8 +440,8 @@ def test_ListOffsetArray():
         "two",
         "two",
     ]
-    assert ak._do.is_unique(array2) is False
-    assert to_list(ak._do.unique(array2, axis=-1)) == [
+    assert is_unique(array2) is False
+    assert to_list(unique(array2, axis=-1)) == [
         "four",
         "one",
         "two",
@@ -461,8 +461,8 @@ def test_ListOffsetArray():
         [6.6, 7.7, 8.8, 5.5],
         [],
     ]
-    assert ak._do.is_unique(listoffsetarray) is True
-    assert to_list(ak._do.unique(listoffsetarray, axis=-1)) == [
+    assert is_unique(listoffsetarray) is True
+    assert to_list(unique(listoffsetarray, axis=-1)) == [
         [1.1, 2.2, 3.3],
         [],
         [0.0, 4.4],
@@ -470,7 +470,7 @@ def test_ListOffsetArray():
         [5.5, 6.6, 7.7, 8.8],
         [],
     ]
-    assert to_list(ak._do.unique(listoffsetarray)) == [
+    assert to_list(unique(listoffsetarray)) == [
         0.0,
         1.1,
         2.2,
@@ -497,8 +497,8 @@ def test_ListOffsetArray():
         [2.2, 3.3, 1.1],
         [5.5],
     ]
-    assert ak._do.is_unique(listoffsetarray) is False
-    assert to_list(ak._do.unique(listoffsetarray, axis=-1)) == [
+    assert is_unique(listoffsetarray) is False
+    assert to_list(unique(listoffsetarray, axis=-1)) == [
         [1.1, 2.2, 3.3],
         [],
         [0.0, 4.4],
@@ -520,8 +520,8 @@ def test_ListOffsetArray():
         [9.9],
         [5.5],
     ]
-    assert ak._do.is_unique(listoffsetarray1) is False
-    assert to_list(ak._do.unique(listoffsetarray1, axis=-1)) == [
+    assert is_unique(listoffsetarray1) is False
+    assert to_list(unique(listoffsetarray1, axis=-1)) == [
         [1.1, 2.2, 3.3],
         [1.1, 2.2, 3.3],
         [],
@@ -544,8 +544,8 @@ def test_ListOffsetArray():
         [5.5],
         [5.5],
     ]
-    assert ak._do.is_unique(listoffsetarray2) is False
-    assert to_list(ak._do.unique(listoffsetarray2, axis=-1)) == [
+    assert is_unique(listoffsetarray2) is False
+    assert to_list(unique(listoffsetarray2, axis=-1)) == [
         [1.1, 2.2, 3.3],
         [1.1, 2.2, 3.3],
         [],
@@ -576,8 +576,8 @@ def test_ListOffsetArray():
         [2.2, 6.6, 7.7, 9.9],
         [],
     ]
-    assert ak._do.is_unique(listoffsetarray2, axis=-1) is True
-    assert to_list(ak._do.unique(listoffsetarray2, axis=-1)) == [
+    assert is_unique(listoffsetarray2, axis=-1) is True
+    assert to_list(unique(listoffsetarray2, axis=-1)) == [
         [0.0, 1.1, 2.2],
         [],
         [1.1, 3.3],
@@ -604,8 +604,8 @@ def test_ListOffsetArray():
         [],
         [],
     ]
-    assert ak._do.is_unique(listoffsetarray) is True
-    assert to_list(ak._do.unique(listoffsetarray, axis=-1)) == [
+    assert is_unique(listoffsetarray) is True
+    assert to_list(unique(listoffsetarray, axis=-1)) == [
         [],
         [],
         [],
@@ -657,14 +657,14 @@ def test_RegularArray():
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert ak._do.is_unique(regular_array) is False
-    assert to_list(ak._do.unique(regular_array, axis=-1)) == [
+    assert is_unique(regular_array) is False
+    assert to_list(unique(regular_array, axis=-1)) == [
         [3.9, 6.9],
         [1.5, 1.6, 2.2],
         [3.6, 6.7, None],
     ]
 
-    assert to_list(ak._do.unique(regular_array, axis=None)) == [
+    assert to_list(unique(regular_array, axis=None)) == [
         1.5,
         1.6,
         2.2,
@@ -685,8 +685,8 @@ def test_RegularArray():
         [3.9, 6.9, 6.9],
         [None, None, None],
     ]
-    assert ak._do.is_unique(regular_array2) is False
-    assert to_list(ak._do.unique(regular_array2, axis=None)) == [3.9, 6.9, None]
+    assert is_unique(regular_array2) is False
+    assert to_list(unique(regular_array2, axis=None)) == [3.9, 6.9, None]
 
 
 def test_IndexedArray():
@@ -696,7 +696,7 @@ def test_IndexedArray():
     index = ak.index.Index64(np.array([4, 3, 2, 1, 0], dtype=np.int64))
     indexedarray = ak.contents.IndexedArray(index, content)
 
-    assert ak._do.is_unique(indexedarray) is True
+    assert is_unique(indexedarray) is True
 
     listoffsetarray = ak.operations.from_iter(
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
@@ -711,10 +711,10 @@ def test_IndexedArray():
         [],
         [0.0, 1.1, 2.2],
     ]
-    assert ak._do.is_unique(indexedarray) is True
+    assert is_unique(indexedarray) is True
 
-    assert ak._do.is_unique(indexedarray) is True
-    assert to_list(ak._do.unique(indexedarray)) == [
+    assert is_unique(indexedarray) is True
+    assert to_list(unique(indexedarray)) == [
         0.0,
         1.1,
         2.2,
@@ -726,7 +726,7 @@ def test_IndexedArray():
         8.8,
         9.9,
     ]
-    assert to_list(ak._do.unique(indexedarray, axis=-1)) == [
+    assert to_list(unique(indexedarray, axis=-1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -744,9 +744,9 @@ def test_IndexedArray():
         None,
         [0.0, 1.1, 2.2],
     ]
-    assert ak._do.is_unique(indexedarray) is False
-    assert ak._do.is_unique(indexedarray, axis=-1) is True
-    assert to_list(ak._do.unique(indexedarray, axis=-1)) == [
+    assert is_unique(indexedarray) is False
+    assert is_unique(indexedarray, axis=-1) is True
+    assert to_list(unique(indexedarray, axis=-1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
@@ -771,9 +771,9 @@ def test_RecordArray():
         ]
     )
 
-    assert ak._do.is_unique(array.layout) is False
-    assert ak._do.is_unique(array["x"].layout) is True
-    assert ak._do.is_unique(array["y"].layout) is False
+    assert is_unique(array.layout) is False
+    assert is_unique(array["x"].layout) is True
+    assert is_unique(array["y"].layout) is False
 
 
 def test_same_categories():
@@ -799,9 +799,9 @@ def test_same_categories():
         "two",
         "two",
     ]
-    assert ak._do.is_unique(categorical1) is False
-    assert ak._do.is_unique(categorical1.content) is True
-    assert ak._do.is_unique(categorical2) is False
+    assert is_unique(categorical1) is False
+    assert is_unique(categorical1.content) is True
+    assert is_unique(categorical2) is False
 
     assert to_list(array1) == [
         "one",
@@ -856,9 +856,9 @@ def test_UnionArray():
         [3, 3, 3],
         [],
     ]
-    assert ak._do.is_unique(array) is False
-    assert to_list(ak._do.unique(array, axis=None)) == [1.0, 1.1, 2.0, 2.2, 3.0, 3.3]
-    assert to_list(ak._do.unique(array, axis=-1)) == [
+    assert is_unique(array) is False
+    assert to_list(unique(array, axis=None)) == [1.0, 1.1, 2.0, 2.2, 3.0, 3.3]
+    assert to_list(unique(array, axis=-1)) == [
         [],
         [3.3],
         [1.0],

--- a/tests/test_1059_localindex.py
+++ b/tests/test_1059_localindex.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
 import awkward as ak
+from awkward._do.content import local_index
 
 to_list = ak.operations.to_list
 
@@ -14,12 +14,11 @@ def test_listoffsetarray_localindex():
     v2_array = ak.operations.from_iter(
         [[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]], highlevel=False
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [
+    assert to_list(local_index(v2_array, 1)) == [
         [0, 1, 2],
         [],
         [0, 1],
@@ -27,10 +26,9 @@ def test_listoffsetarray_localindex():
         [0, 1, 2, 3],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         [0, 1, 2],
         [],
         [0, 1],
@@ -38,141 +36,124 @@ def test_listoffsetarray_localindex():
         [0, 1, 2, 3],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, -2)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -3)
+        local_index(v2_array, -3)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 2)
+        local_index(v2_array, 2)
 
     v2_array = ak.operations.from_iter(
         [[[0.0, 1.1, 2.2], [], [3.3, 4.4]], [], [[5.5]], [[6.6, 7.7, 8.8, 9.9]]],
         highlevel=False,
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [], [0], [0]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [], [0], [0]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, 2)) == [
+    assert to_list(local_index(v2_array, 2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
         [[0, 1, 2, 3]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 2).form
-        == ak._do.local_index(v2_array, 2).form
+        local_index(v2_array.to_typetracer(), 2).form == local_index(v2_array, 2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         [[0]],
         [[0, 1, 2, 3]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [[0, 1, 2], [], [0], [0]]
+    assert to_list(local_index(v2_array, -2)) == [[0, 1, 2], [], [0], [0]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -3)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, -3)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -3).form
-        == ak._do.local_index(v2_array, -3).form
+        local_index(v2_array.to_typetracer(), -3).form == local_index(v2_array, -3).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -4)
+        local_index(v2_array, -4)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 3)
+        local_index(v2_array, 3)
 
 
 def test_regulararray_localindex():
     v2_array = ak.operations.from_numpy(
         np.arange(2 * 3 * 5).reshape(2, 3, 5), regulararray=True, highlevel=False
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1]
+    assert to_list(local_index(v2_array, 0)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, 2)) == [
+    assert to_list(local_index(v2_array, 2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 2).form
-        == ak._do.local_index(v2_array, 2).form
+        local_index(v2_array.to_typetracer(), 2).form == local_index(v2_array, 2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, -2)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -3)) == [0, 1]
+    assert to_list(local_index(v2_array, -3)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -3).form
-        == ak._do.local_index(v2_array, -3).form
+        local_index(v2_array.to_typetracer(), -3).form == local_index(v2_array, -3).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -4)
+        local_index(v2_array, -4)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 3)
+        local_index(v2_array, 3)
 
     v2_array = ak.operations.from_numpy(
         np.arange(2 * 3 * 5 * 10).reshape(2, 3, 5, 10),
         regulararray=True,
         highlevel=False,
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1]
+    assert to_list(local_index(v2_array, 0)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, 2)) == [
+    assert to_list(local_index(v2_array, 2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 2).form
-        == ak._do.local_index(v2_array, 2).form
+        local_index(v2_array.to_typetracer(), 2).form == local_index(v2_array, 2).form
     )
-    assert to_list(ak._do.local_index(v2_array, 3)) == [
+    assert to_list(local_index(v2_array, 3)) == [
         [
             [
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -221,10 +202,9 @@ def test_regulararray_localindex():
         ],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 3).form
-        == ak._do.local_index(v2_array, 3).form
+        local_index(v2_array.to_typetracer(), 3).form == local_index(v2_array, 3).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         [
             [
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -273,32 +253,28 @@ def test_regulararray_localindex():
         ],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [
+    assert to_list(local_index(v2_array, -2)) == [
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
         [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -3)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, -3)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -3).form
-        == ak._do.local_index(v2_array, -3).form
+        local_index(v2_array.to_typetracer(), -3).form == local_index(v2_array, -3).form
     )
-    assert to_list(ak._do.local_index(v2_array, -4)) == [0, 1]
+    assert to_list(local_index(v2_array, -4)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -4).form
-        == ak._do.local_index(v2_array, -4).form
+        local_index(v2_array.to_typetracer(), -4).form == local_index(v2_array, -4).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -5)
+        local_index(v2_array, -5)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 4)
+        local_index(v2_array, 4)
 
     v2_array = ak.highlevel.Array(
         ak.contents.RegularArray(
@@ -306,41 +282,35 @@ def test_regulararray_localindex():
         )
     ).layout
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == []
+    assert to_list(local_index(v2_array, 0)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == []
+    assert to_list(local_index(v2_array, 1)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, 2)) == []
+    assert to_list(local_index(v2_array, 2)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 2).form
-        == ak._do.local_index(v2_array, 2).form
+        local_index(v2_array.to_typetracer(), 2).form == local_index(v2_array, 2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == []
+    assert to_list(local_index(v2_array, -1)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == []
+    assert to_list(local_index(v2_array, -2)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
-    assert to_list(ak._do.local_index(v2_array, -3)) == []
+    assert to_list(local_index(v2_array, -3)) == []
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -3).form
-        == ak._do.local_index(v2_array, -3).form
+        local_index(v2_array.to_typetracer(), -3).form == local_index(v2_array, -3).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -4)
+        local_index(v2_array, -4)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 3)
+        local_index(v2_array, 3)
 
 
 def test_bytemaskedarray_localindex():
@@ -364,17 +334,17 @@ def test_bytemaskedarray_localindex():
         None,
         [[], [10.0, 11.1, 12.2]],
     ]
-    assert to_list(ak._do.local_index(v2_array, axis=0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, axis=0)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=0).form
-        == ak._do.local_index(v2_array, axis=0).form
+        local_index(v2_array.to_typetracer(), axis=0).form
+        == local_index(v2_array, axis=0).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=-3)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, axis=-3)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=-3).form
-        == ak._do.local_index(v2_array, axis=-3).form
+        local_index(v2_array.to_typetracer(), axis=-3).form
+        == local_index(v2_array, axis=-3).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=1)) == [
+    assert to_list(local_index(v2_array, axis=1)) == [
         [0, 1, 2],
         [],
         None,
@@ -382,10 +352,10 @@ def test_bytemaskedarray_localindex():
         [0, 1],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=1).form
-        == ak._do.local_index(v2_array, axis=1).form
+        local_index(v2_array.to_typetracer(), axis=1).form
+        == local_index(v2_array, axis=1).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=-2)) == [
+    assert to_list(local_index(v2_array, axis=-2)) == [
         [0, 1, 2],
         [],
         None,
@@ -393,10 +363,10 @@ def test_bytemaskedarray_localindex():
         [0, 1],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=-2).form
-        == ak._do.local_index(v2_array, axis=-2).form
+        local_index(v2_array.to_typetracer(), axis=-2).form
+        == local_index(v2_array, axis=-2).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=2)) == [
+    assert to_list(local_index(v2_array, axis=2)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
@@ -404,10 +374,10 @@ def test_bytemaskedarray_localindex():
         [[], [0, 1, 2]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=2).form
-        == ak._do.local_index(v2_array, axis=2).form
+        local_index(v2_array.to_typetracer(), axis=2).form
+        == local_index(v2_array, axis=2).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=-1)) == [
+    assert to_list(local_index(v2_array, axis=-1)) == [
         [[0, 1, 2], [], [0, 1]],
         [],
         None,
@@ -415,37 +385,37 @@ def test_bytemaskedarray_localindex():
         [[], [0, 1, 2]],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=-1).form
-        == ak._do.local_index(v2_array, axis=-1).form
+        local_index(v2_array.to_typetracer(), axis=-1).form
+        == local_index(v2_array, axis=-1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, axis=4)
+        local_index(v2_array, axis=4)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, axis=-4)
+        local_index(v2_array, axis=-4)
 
 
 def test_numpyarray_localindex():
     v2_array = ak.contents.numpyarray.NumpyArray(
         np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
     )
-    assert to_list(ak._do.local_index(v2_array, axis=0)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, axis=0)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=0).form
-        == ak._do.local_index(v2_array, axis=0).form
+        local_index(v2_array.to_typetracer(), axis=0).form
+        == local_index(v2_array, axis=0).form
     )
-    assert to_list(ak._do.local_index(v2_array, axis=-1)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, axis=-1)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), axis=-1).form
-        == ak._do.local_index(v2_array, axis=-1).form
+        local_index(v2_array.to_typetracer(), axis=-1).form
+        == local_index(v2_array, axis=-1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, axis=1)
+        local_index(v2_array, axis=1)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, axis=2)
+        local_index(v2_array, axis=2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, axis=-2)
+        local_index(v2_array, axis=-2)
 
 
 def test_bitmaskedarray_localindex():
@@ -482,7 +452,7 @@ def test_bitmaskedarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -497,7 +467,7 @@ def test_bitmaskedarray_localindex():
         11,
         12,
     ]
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -513,14 +483,13 @@ def test_bitmaskedarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -555,7 +524,7 @@ def test_bitmaskedarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -571,10 +540,9 @@ def test_bitmaskedarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -590,14 +558,13 @@ def test_bitmaskedarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -634,7 +601,7 @@ def test_bitmaskedarray_localindex():
         length=13,
         lsb_order=True,
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -650,10 +617,9 @@ def test_bitmaskedarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -669,14 +635,13 @@ def test_bitmaskedarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
 
 def test_unmaskedarray_localindex():
@@ -685,21 +650,19 @@ def test_unmaskedarray_localindex():
             np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
         )
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
 
 def test_unionarray_localindex():
@@ -711,21 +674,19 @@ def test_unionarray_localindex():
             ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5])),
         ],
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
 
 def test_recordarray_localindex():
@@ -740,31 +701,27 @@ def test_recordarray_localindex():
         ),
         3,
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1]
+    assert to_list(local_index(v2_array, 0)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [[0, 1, 2], [0, 1, 2]]
+    assert to_list(local_index(v2_array, -1)) == [[0, 1, 2], [0, 1, 2]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [0, 1]
+    assert to_list(local_index(v2_array, -2)) == [0, 1]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -3)
+        local_index(v2_array, -3)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 2)
+        local_index(v2_array, 2)
 
     v2_array = ak.contents.regulararray.RegularArray(
         ak.contents.recordarray.RecordArray(
@@ -774,7 +731,7 @@ def test_recordarray_localindex():
         zeros_length=10,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -787,10 +744,9 @@ def test_recordarray_localindex():
         9,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [
+    assert to_list(local_index(v2_array, 1)) == [
         [],
         [],
         [],
@@ -803,10 +759,9 @@ def test_recordarray_localindex():
         [],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         [],
         [],
         [],
@@ -819,10 +774,9 @@ def test_recordarray_localindex():
         [],
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [
+    assert to_list(local_index(v2_array, -2)) == [
         0,
         1,
         2,
@@ -835,12 +789,11 @@ def test_recordarray_localindex():
         9,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -3)
+        local_index(v2_array, -3)
 
     v2_array = ak.contents.listarray.ListArray(
         ak.index.Index(np.array([4, 100, 1])),
@@ -855,31 +808,27 @@ def test_recordarray_localindex():
         ),
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [], [0, 1]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [], [0, 1]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [[0, 1, 2], [], [0, 1]]
+    assert to_list(local_index(v2_array, -1)) == [[0, 1, 2], [], [0, 1]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [0, 1, 2]
+    assert to_list(local_index(v2_array, -2)) == [0, 1, 2]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -3)
+        local_index(v2_array, -3)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 2)
+        local_index(v2_array, 2)
 
     v2_array = ak.contents.listoffsetarray.ListOffsetArray(
         ak.index.Index(np.array([1, 4, 4, 6])),
@@ -892,31 +841,27 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, 1)) == [[0, 1, 2], [], [0, 1]]
+    assert to_list(local_index(v2_array, 1)) == [[0, 1, 2], [], [0, 1]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 1).form
-        == ak._do.local_index(v2_array, 1).form
+        local_index(v2_array.to_typetracer(), 1).form == local_index(v2_array, 1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [[0, 1, 2], [], [0, 1]]
+    assert to_list(local_index(v2_array, -1)) == [[0, 1, 2], [], [0, 1]]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
-    assert to_list(ak._do.local_index(v2_array, -2)) == [0, 1, 2]
+    assert to_list(local_index(v2_array, -2)) == [0, 1, 2]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -2).form
-        == ak._do.local_index(v2_array, -2).form
+        local_index(v2_array.to_typetracer(), -2).form == local_index(v2_array, -2).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -3)
+        local_index(v2_array, -3)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 2)
+        local_index(v2_array, 2)
 
     v2_array = ak.contents.indexedarray.IndexedArray(
         ak.index.Index(np.array([2, 2, 0, 1, 4, 5, 4])),
@@ -929,21 +874,19 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.indexedoptionarray.IndexedOptionArray(
         ak.index.Index(np.array([2, 2, -1, 1, -1, 5, 4])),
@@ -956,21 +899,19 @@ def test_recordarray_localindex():
             ["nest"],
         ),
     )
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(
         ak.index.Index(np.array([1, 0, 1, 0, 1], dtype=np.int8)),
@@ -985,21 +926,19 @@ def test_recordarray_localindex():
         valid_when=True,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bytemaskedarray.ByteMaskedArray(
         ak.index.Index(np.array([0, 1, 0, 1, 0], dtype=np.int8)),
@@ -1014,21 +953,19 @@ def test_recordarray_localindex():
         valid_when=False,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -1082,7 +1019,7 @@ def test_recordarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -1098,10 +1035,9 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -1117,13 +1053,12 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -1178,7 +1113,7 @@ def test_recordarray_localindex():
         lsb_order=False,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -1194,10 +1129,9 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -1213,14 +1147,13 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -1278,7 +1211,7 @@ def test_recordarray_localindex():
         lsb_order=True,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -1294,10 +1227,9 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -1313,14 +1245,13 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.bitmaskedarray.BitMaskedArray(
         ak.index.Index(
@@ -1378,7 +1309,7 @@ def test_recordarray_localindex():
         lsb_order=True,
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [
+    assert to_list(local_index(v2_array, 0)) == [
         0,
         1,
         2,
@@ -1394,10 +1325,9 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [
+    assert to_list(local_index(v2_array, -1)) == [
         0,
         1,
         2,
@@ -1413,14 +1343,13 @@ def test_recordarray_localindex():
         12,
     ]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.unmaskedarray.UnmaskedArray(
         ak.contents.recordarray.RecordArray(
@@ -1433,21 +1362,19 @@ def test_recordarray_localindex():
         )
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)
 
     v2_array = ak.contents.unionarray.UnionArray(
         ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
@@ -1467,18 +1394,16 @@ def test_recordarray_localindex():
         ],
     )
 
-    assert to_list(ak._do.local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, 0)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), 0).form
-        == ak._do.local_index(v2_array, 0).form
+        local_index(v2_array.to_typetracer(), 0).form == local_index(v2_array, 0).form
     )
-    assert to_list(ak._do.local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
+    assert to_list(local_index(v2_array, -1)) == [0, 1, 2, 3, 4, 5, 6]
     assert (
-        ak._do.local_index(v2_array.to_typetracer(), -1).form
-        == ak._do.local_index(v2_array, -1).form
+        local_index(v2_array.to_typetracer(), -1).form == local_index(v2_array, -1).form
     )
 
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, -2)
+        local_index(v2_array, -2)
     with pytest.raises(IndexError):
-        ak._do.local_index(v2_array, 1)
+        local_index(v2_array, 1)

--- a/tests/test_1074_combinations.py
+++ b/tests/test_1074_combinations.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import combinations
 
 to_list = ak.operations.to_list
 
@@ -14,7 +14,7 @@ def test_ListOffsetArray():
     v2_array = ak.highlevel.Array(
         [[0.0, 1.1, 2.2, 3.3], [], [4.4, 5.5, 6.6], [7.7], [8.8, 9.9, 10.0, 11.1, 12.2]]
     ).layout
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=False)) == [
+    assert to_list(combinations(v2_array, 2, replacement=False)) == [
         [(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)],
         [],
         [(4.4, 5.5), (4.4, 6.6), (5.5, 6.6)],
@@ -33,12 +33,10 @@ def test_ListOffsetArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=False).form
-        == ak._do.combinations(v2_array, 2, replacement=False).form
+        combinations(v2_array.to_typetracer(), 2, replacement=False).form
+        == combinations(v2_array, 2, replacement=False).form
     )
-    assert to_list(
-        ak._do.combinations(v2_array, 2, replacement=False, fields=["x", "y"])
-    ) == [
+    assert to_list(combinations(v2_array, 2, replacement=False, fields=["x", "y"])) == [
         [
             {"x": 0.0, "y": 1.1},
             {"x": 0.0, "y": 2.2},
@@ -64,28 +62,28 @@ def test_ListOffsetArray():
         ],
     ]
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(), 2, replacement=False, fields=["x", "y"]
         ).form
-        == ak._do.combinations(v2_array, 2, replacement=False, fields=["x", "y"]).form
+        == combinations(v2_array, 2, replacement=False, fields=["x", "y"]).form
     )
 
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array, 2, replacement=False, parameters={"some": "param"}
         ).content.parameters["some"]
         == "param"
     )
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(), 2, replacement=False, parameters={"some": "param"}
         ).form
-        == ak._do.combinations(
+        == combinations(
             v2_array, 2, replacement=False, parameters={"some": "param"}
         ).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=True)) == [
+    assert to_list(combinations(v2_array, 2, replacement=True)) == [
         [
             (0.0, 0.0),
             (0.0, 1.1),
@@ -120,11 +118,11 @@ def test_ListOffsetArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=True).form
-        == ak._do.combinations(v2_array, 2, replacement=True).form
+        combinations(v2_array.to_typetracer(), 2, replacement=True).form
+        == combinations(v2_array, 2, replacement=True).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, replacement=False)) == [
+    assert to_list(combinations(v2_array, 3, replacement=False)) == [
         [(0.0, 1.1, 2.2), (0.0, 1.1, 3.3), (0.0, 2.2, 3.3), (1.1, 2.2, 3.3)],
         [],
         [(4.4, 5.5, 6.6)],
@@ -143,11 +141,11 @@ def test_ListOffsetArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, replacement=False).form
-        == ak._do.combinations(v2_array, 3, replacement=False).form
+        combinations(v2_array.to_typetracer(), 3, replacement=False).form
+        == combinations(v2_array, 3, replacement=False).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, replacement=True)) == [
+    assert to_list(combinations(v2_array, 3, replacement=True)) == [
         [
             (0.0, 0.0, 0.0),
             (0.0, 0.0, 1.1),
@@ -223,8 +221,8 @@ def test_ListOffsetArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, replacement=True).form
-        == ak._do.combinations(v2_array, 3, replacement=True).form
+        combinations(v2_array.to_typetracer(), 3, replacement=True).form
+        == combinations(v2_array, 3, replacement=True).form
     )
 
 
@@ -233,18 +231,16 @@ def test_RegularArray():
         np.array([[0.0, 1.1, 2.2, 3.3], [4.4, 5.5, 6.6, 7.7]])
     ).layout
 
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=False)) == [
+    assert to_list(combinations(v2_array, 2, replacement=False)) == [
         [(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)],
         [(4.4, 5.5), (4.4, 6.6), (4.4, 7.7), (5.5, 6.6), (5.5, 7.7), (6.6, 7.7)],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=False).form
-        == ak._do.combinations(v2_array, 2, replacement=False).form
+        combinations(v2_array.to_typetracer(), 2, replacement=False).form
+        == combinations(v2_array, 2, replacement=False).form
     )
 
-    assert to_list(
-        ak._do.combinations(v2_array, 2, replacement=False, fields=["x", "y"])
-    ) == [
+    assert to_list(combinations(v2_array, 2, replacement=False, fields=["x", "y"])) == [
         [
             {"x": 0.0, "y": 1.1},
             {"x": 0.0, "y": 2.2},
@@ -263,28 +259,28 @@ def test_RegularArray():
         ],
     ]
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(), 2, replacement=False, fields=["x", "y"]
         ).form
-        == ak._do.combinations(v2_array, 2, replacement=False, fields=["x", "y"]).form
+        == combinations(v2_array, 2, replacement=False, fields=["x", "y"]).form
     )
 
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array, 2, replacement=False, parameters={"some": "param"}
         ).content.parameters["some"]
         == "param"
     )
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(), 2, replacement=False, parameters={"some": "param"}
         ).form
-        == ak._do.combinations(
+        == combinations(
             v2_array, 2, replacement=False, parameters={"some": "param"}
         ).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=True)) == [
+    assert to_list(combinations(v2_array, 2, replacement=True)) == [
         [
             (0.0, 0.0),
             (0.0, 1.1),
@@ -311,20 +307,20 @@ def test_RegularArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=True).form
-        == ak._do.combinations(v2_array, 2, replacement=True).form
+        combinations(v2_array.to_typetracer(), 2, replacement=True).form
+        == combinations(v2_array, 2, replacement=True).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, replacement=False)) == [
+    assert to_list(combinations(v2_array, 3, replacement=False)) == [
         [(0.0, 1.1, 2.2), (0.0, 1.1, 3.3), (0.0, 2.2, 3.3), (1.1, 2.2, 3.3)],
         [(4.4, 5.5, 6.6), (4.4, 5.5, 7.7), (4.4, 6.6, 7.7), (5.5, 6.6, 7.7)],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, replacement=False).form
-        == ak._do.combinations(v2_array, 3, replacement=False).form
+        combinations(v2_array.to_typetracer(), 3, replacement=False).form
+        == combinations(v2_array, 3, replacement=False).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, replacement=True)) == [
+    assert to_list(combinations(v2_array, 3, replacement=True)) == [
         [
             (0.0, 0.0, 0.0),
             (0.0, 0.0, 1.1),
@@ -371,15 +367,15 @@ def test_RegularArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, replacement=True).form
-        == ak._do.combinations(v2_array, 3, replacement=True).form
+        combinations(v2_array.to_typetracer(), 3, replacement=True).form
+        == combinations(v2_array, 3, replacement=True).form
     )
 
 
 def test_axis0():
     v2_array = ak.highlevel.Array([0.0, 1.1, 2.2, 3.3]).layout
 
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=False, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, replacement=False, axis=0)) == [
         (0.0, 1.1),
         (0.0, 2.2),
         (0.0, 3.3),
@@ -388,12 +384,12 @@ def test_axis0():
         (2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=False, axis=0).form
-        == ak._do.combinations(v2_array, 2, replacement=False, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, replacement=False, axis=0).form
+        == combinations(v2_array, 2, replacement=False, axis=0).form
     )
 
     assert to_list(
-        ak._do.combinations(v2_array, 2, replacement=False, axis=0, fields=["x", "y"])
+        combinations(v2_array, 2, replacement=False, axis=0, fields=["x", "y"])
     ) == [
         {"x": 0.0, "y": 1.1},
         {"x": 0.0, "y": 2.2},
@@ -403,42 +399,40 @@ def test_axis0():
         {"x": 2.2, "y": 3.3},
     ]
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(), 2, replacement=False, axis=0, fields=["x", "y"]
         ).form
-        == ak._do.combinations(
-            v2_array, 2, replacement=False, axis=0, fields=["x", "y"]
-        ).form
+        == combinations(v2_array, 2, replacement=False, axis=0, fields=["x", "y"]).form
     )
 
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array, 2, replacement=False, axis=0, parameters={"some": "param"}
         ).parameters["some"]
         == "param"
     )
     assert (
-        ak._do.combinations(
+        combinations(
             v2_array.to_typetracer(),
             2,
             replacement=False,
             axis=0,
             parameters={"some": "param"},
         ).form
-        == ak._do.combinations(
+        == combinations(
             v2_array, 2, replacement=False, axis=0, parameters={"some": "param"}
         ).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, replacement=False, axis=0)) == [
+    assert to_list(combinations(v2_array, 3, replacement=False, axis=0)) == [
         (0.0, 1.1, 2.2),
         (0.0, 1.1, 3.3),
         (0.0, 2.2, 3.3),
         (1.1, 2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, replacement=False, axis=0).form
-        == ak._do.combinations(v2_array, 3, replacement=False, axis=0).form
+        combinations(v2_array.to_typetracer(), 3, replacement=False, axis=0).form
+        == combinations(v2_array, 3, replacement=False, axis=0).form
     )
 
 
@@ -455,7 +449,7 @@ def test_IndexedArray():
         ]
     ).layout
 
-    assert to_list(ak._do.combinations(v2_array, 2, replacement=False)) == [
+    assert to_list(combinations(v2_array, 2, replacement=False)) == [
         [(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)],
         [],
         [(4.4, 5.5), (4.4, 6.6), (5.5, 6.6)],
@@ -476,8 +470,8 @@ def test_IndexedArray():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, replacement=False).form
-        == ak._do.combinations(v2_array, 2, replacement=False).form
+        combinations(v2_array.to_typetracer(), 2, replacement=False).form
+        == combinations(v2_array, 2, replacement=False).form
     )
 
 
@@ -490,7 +484,7 @@ def test_axis2():
         ]
     ).layout
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=1, replacement=False)) == [
+    assert to_list(combinations(v2_array, 2, axis=1, replacement=False)) == [
         [
             ([0.0, 1.1, 2.2, 3.3], []),
             ([0.0, 1.1, 2.2, 3.3], [4.4, 5.5, 6.6]),
@@ -500,11 +494,11 @@ def test_axis2():
         [([7.7], [8.8, 9.9, 10.0, 11.1, 12.2])],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=1, replacement=False).form
-        == ak._do.combinations(v2_array, 2, axis=1, replacement=False).form
+        combinations(v2_array.to_typetracer(), 2, axis=1, replacement=False).form
+        == combinations(v2_array, 2, axis=1, replacement=False).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=2, replacement=False)) == [
+    assert to_list(combinations(v2_array, 2, axis=2, replacement=False)) == [
         [
             [(0.0, 1.1), (0.0, 2.2), (0.0, 3.3), (1.1, 2.2), (1.1, 3.3), (2.2, 3.3)],
             [],
@@ -528,8 +522,8 @@ def test_axis2():
         ],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=2, replacement=False).form
-        == ak._do.combinations(v2_array, 2, axis=2, replacement=False).form
+        combinations(v2_array.to_typetracer(), 2, axis=2, replacement=False).form
+        == combinations(v2_array, 2, axis=2, replacement=False).form
     )
 
 
@@ -541,7 +535,7 @@ def test_ByteMaskedArray():
     mask = ak.index.Index8(np.array([0, 0, 1, 1, 0], dtype=np.int8))
     v2_array = ak.contents.ByteMaskedArray(mask, content, valid_when=False)
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         ([[0, 1, 2], [], [3, 4]], []),
         ([[0, 1, 2], [], [3, 4]], None),
         ([[0, 1, 2], [], [3, 4]], None),
@@ -554,11 +548,11 @@ def test_ByteMaskedArray():
         (None, [[], [10, 11, 12]]),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-3)) == [
+    assert to_list(combinations(v2_array, 2, axis=-3)) == [
         ([[0, 1, 2], [], [3, 4]], []),
         ([[0, 1, 2], [], [3, 4]], None),
         ([[0, 1, 2], [], [3, 4]], None),
@@ -571,11 +565,11 @@ def test_ByteMaskedArray():
         (None, [[], [10, 11, 12]]),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-3).form
-        == ak._do.combinations(v2_array, 2, axis=-3).form
+        combinations(v2_array.to_typetracer(), 2, axis=-3).form
+        == combinations(v2_array, 2, axis=-3).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=1)) == [
+    assert to_list(combinations(v2_array, 2, axis=1)) == [
         [([0, 1, 2], []), ([0, 1, 2], [3, 4]), ([], [3, 4])],
         [],
         None,
@@ -583,11 +577,11 @@ def test_ByteMaskedArray():
         [([], [10, 11, 12])],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=1).form
-        == ak._do.combinations(v2_array, 2, axis=1).form
+        combinations(v2_array.to_typetracer(), 2, axis=1).form
+        == combinations(v2_array, 2, axis=1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-2)) == [
+    assert to_list(combinations(v2_array, 2, axis=-2)) == [
         [([0, 1, 2], []), ([0, 1, 2], [3, 4]), ([], [3, 4])],
         [],
         None,
@@ -595,11 +589,11 @@ def test_ByteMaskedArray():
         [([], [10, 11, 12])],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-2).form
-        == ak._do.combinations(v2_array, 2, axis=-2).form
+        combinations(v2_array.to_typetracer(), 2, axis=-2).form
+        == combinations(v2_array, 2, axis=-2).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=2)) == [
+    assert to_list(combinations(v2_array, 2, axis=2)) == [
         [[(0, 1), (0, 2), (1, 2)], [], [(3, 4)]],
         [],
         None,
@@ -607,11 +601,11 @@ def test_ByteMaskedArray():
         [[], [(10, 11), (10, 12), (11, 12)]],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=2).form
-        == ak._do.combinations(v2_array, 2, axis=2).form
+        combinations(v2_array.to_typetracer(), 2, axis=2).form
+        == combinations(v2_array, 2, axis=2).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-1)) == [
+    assert to_list(combinations(v2_array, 2, axis=-1)) == [
         [[(0, 1), (0, 2), (1, 2)], [], [(3, 4)]],
         [],
         None,
@@ -619,8 +613,8 @@ def test_ByteMaskedArray():
         [[], [(10, 11), (10, 12), (11, 12)]],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-1).form
-        == ak._do.combinations(v2_array, 2, axis=-1).form
+        combinations(v2_array.to_typetracer(), 2, axis=-1).form
+        == combinations(v2_array, 2, axis=-1).form
     )
 
 
@@ -632,7 +626,7 @@ def test_IndexedOptionArray():
     index = ak.index.Index64(np.array([0, 1, -1, -1, 4], dtype=np.int64))
     v2_array = ak.contents.IndexedOptionArray(index, content)
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         ([[0, 1, 2], [], [3, 4]], []),
         ([[0, 1, 2], [], [3, 4]], None),
         ([[0, 1, 2], [], [3, 4]], None),
@@ -645,11 +639,11 @@ def test_IndexedOptionArray():
         (None, [[], [10, 11, 12]]),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-3)) == [
+    assert to_list(combinations(v2_array, 2, axis=-3)) == [
         ([[0, 1, 2], [], [3, 4]], []),
         ([[0, 1, 2], [], [3, 4]], None),
         ([[0, 1, 2], [], [3, 4]], None),
@@ -662,11 +656,11 @@ def test_IndexedOptionArray():
         (None, [[], [10, 11, 12]]),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-3).form
-        == ak._do.combinations(v2_array, 2, axis=-3).form
+        combinations(v2_array.to_typetracer(), 2, axis=-3).form
+        == combinations(v2_array, 2, axis=-3).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=1)) == [
+    assert to_list(combinations(v2_array, 2, axis=1)) == [
         [([0, 1, 2], []), ([0, 1, 2], [3, 4]), ([], [3, 4])],
         [],
         None,
@@ -674,11 +668,11 @@ def test_IndexedOptionArray():
         [([], [10, 11, 12])],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=1).form
-        == ak._do.combinations(v2_array, 2, axis=1).form
+        combinations(v2_array.to_typetracer(), 2, axis=1).form
+        == combinations(v2_array, 2, axis=1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-2)) == [
+    assert to_list(combinations(v2_array, 2, axis=-2)) == [
         [([0, 1, 2], []), ([0, 1, 2], [3, 4]), ([], [3, 4])],
         [],
         None,
@@ -686,11 +680,11 @@ def test_IndexedOptionArray():
         [([], [10, 11, 12])],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-2).form
-        == ak._do.combinations(v2_array, 2, axis=-2).form
+        combinations(v2_array.to_typetracer(), 2, axis=-2).form
+        == combinations(v2_array, 2, axis=-2).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=2)) == [
+    assert to_list(combinations(v2_array, 2, axis=2)) == [
         [[(0, 1), (0, 2), (1, 2)], [], [(3, 4)]],
         [],
         None,
@@ -698,11 +692,11 @@ def test_IndexedOptionArray():
         [[], [(10, 11), (10, 12), (11, 12)]],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=2).form
-        == ak._do.combinations(v2_array, 2, axis=2).form
+        combinations(v2_array.to_typetracer(), 2, axis=2).form
+        == combinations(v2_array, 2, axis=2).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-1)) == [
+    assert to_list(combinations(v2_array, 2, axis=-1)) == [
         [[(0, 1), (0, 2), (1, 2)], [], [(3, 4)]],
         [],
         None,
@@ -710,8 +704,8 @@ def test_IndexedOptionArray():
         [[], [(10, 11), (10, 12), (11, 12)]],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-1).form
-        == ak._do.combinations(v2_array, 2, axis=-1).form
+        combinations(v2_array.to_typetracer(), 2, axis=-1).form
+        == combinations(v2_array, 2, axis=-1).form
     )
 
 
@@ -720,7 +714,7 @@ def test_NumpyArray():
         np.array([0.0, 1.1, 2.2, 3.3], dtype=np.float64)
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         (0.0, 1.1),
         (0.0, 2.2),
         (0.0, 3.3),
@@ -729,11 +723,11 @@ def test_NumpyArray():
         (2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-1)) == [
+    assert to_list(combinations(v2_array, 2, axis=-1)) == [
         (0.0, 1.1),
         (0.0, 2.2),
         (0.0, 3.3),
@@ -742,25 +736,25 @@ def test_NumpyArray():
         (2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-1).form
-        == ak._do.combinations(v2_array, 2, axis=-1).form
+        combinations(v2_array.to_typetracer(), 2, axis=-1).form
+        == combinations(v2_array, 2, axis=-1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, axis=-1)) == [
+    assert to_list(combinations(v2_array, 3, axis=-1)) == [
         (0.0, 1.1, 2.2),
         (0.0, 1.1, 3.3),
         (0.0, 2.2, 3.3),
         (1.1, 2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, axis=-1).form
-        == ak._do.combinations(v2_array, 3, axis=-1).form
+        combinations(v2_array.to_typetracer(), 3, axis=-1).form
+        == combinations(v2_array, 3, axis=-1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 4, axis=-1)) == [(0.0, 1.1, 2.2, 3.3)]
+    assert to_list(combinations(v2_array, 4, axis=-1)) == [(0.0, 1.1, 2.2, 3.3)]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 4, axis=-1).form
-        == ak._do.combinations(v2_array, 4, axis=-1).form
+        combinations(v2_array.to_typetracer(), 4, axis=-1).form
+        == combinations(v2_array, 4, axis=-1).form
     )
 
 
@@ -798,7 +792,7 @@ def test_BitMaskedArray():
         lsb_order=False,
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         (0.0, 1.0),
         (0.0, 2.0),
         (0.0, 3.0),
@@ -879,11 +873,11 @@ def test_BitMaskedArray():
         (None, 5.5),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, axis=0)) == [
+    assert to_list(combinations(v2_array, 3, axis=0)) == [
         (0.0, 1.0, 2.0),
         (0.0, 1.0, 3.0),
         (0.0, 1.0, None),
@@ -1172,18 +1166,18 @@ def test_BitMaskedArray():
         (3.3, None, 5.5),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, axis=0).form
-        == ak._do.combinations(v2_array, 3, axis=0).form
+        combinations(v2_array.to_typetracer(), 3, axis=0).form
+        == combinations(v2_array, 3, axis=0).form
     )
 
 
 def test_EmptyArray():
     v2_array = ak.contents.emptyarray.EmptyArray()
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == []
+    assert to_list(combinations(v2_array, 2, axis=0)) == []
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
 
@@ -1201,17 +1195,17 @@ def test_RecordArray():
         ),
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         ([{"nest": 1.1}, {"nest": 2.2}, {"nest": 3.3}], []),
         ([{"nest": 1.1}, {"nest": 2.2}, {"nest": 3.3}], [{"nest": 4.4}, {"nest": 5.5}]),
         ([], [{"nest": 4.4}, {"nest": 5.5}]),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=1)) == [
+    assert to_list(combinations(v2_array, 2, axis=1)) == [
         [
             ({"nest": 1.1}, {"nest": 2.2}),
             ({"nest": 1.1}, {"nest": 3.3}),
@@ -1221,24 +1215,24 @@ def test_RecordArray():
         [({"nest": 4.4}, {"nest": 5.5})],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=1).form
-        == ak._do.combinations(v2_array, 2, axis=1).form
+        combinations(v2_array.to_typetracer(), 2, axis=1).form
+        == combinations(v2_array, 2, axis=1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, axis=1)) == [
+    assert to_list(combinations(v2_array, 3, axis=1)) == [
         [({"nest": 1.1}, {"nest": 2.2}, {"nest": 3.3})],
         [],
         [],
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, axis=1).form
-        == ak._do.combinations(v2_array, 3, axis=1).form
+        combinations(v2_array.to_typetracer(), 3, axis=1).form
+        == combinations(v2_array, 3, axis=1).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 4, axis=1)) == [[], [], []]
+    assert to_list(combinations(v2_array, 4, axis=1)) == [[], [], []]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 4, axis=1).form
-        == ak._do.combinations(v2_array, 4, axis=1).form
+        combinations(v2_array.to_typetracer(), 4, axis=1).form
+        == combinations(v2_array, 4, axis=1).form
     )
 
 
@@ -1261,7 +1255,7 @@ def test_UnionArray():
         ],
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         ({"nest": 5.5}, {"nest": 4.4}),
         ({"nest": 5.5}, {"nest": "1"}),
         ({"nest": 5.5}, {"nest": "2"}),
@@ -1285,11 +1279,11 @@ def test_UnionArray():
         ({"nest": "3"}, {"nest": 5.5}),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, axis=0)) == [
+    assert to_list(combinations(v2_array, 3, axis=0)) == [
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": "1"}),
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": "2"}),
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": 3.3}),
@@ -1327,11 +1321,11 @@ def test_UnionArray():
         ({"nest": 3.3}, {"nest": "3"}, {"nest": 5.5}),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, axis=0).form
-        == ak._do.combinations(v2_array, 3, axis=0).form
+        combinations(v2_array.to_typetracer(), 3, axis=0).form
+        == combinations(v2_array, 3, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 4, axis=0)) == [
+    assert to_list(combinations(v2_array, 4, axis=0)) == [
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": "1"}, {"nest": "2"}),
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": "1"}, {"nest": 3.3}),
         ({"nest": 5.5}, {"nest": 4.4}, {"nest": "1"}, {"nest": "3"}),
@@ -1369,11 +1363,11 @@ def test_UnionArray():
         ({"nest": "2"}, {"nest": 3.3}, {"nest": "3"}, {"nest": 5.5}),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 4, axis=0).form
-        == ak._do.combinations(v2_array, 4, axis=0).form
+        combinations(v2_array.to_typetracer(), 4, axis=0).form
+        == combinations(v2_array, 4, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-1)) == [
+    assert to_list(combinations(v2_array, 2, axis=-1)) == [
         ({"nest": 5.5}, {"nest": 4.4}),
         ({"nest": 5.5}, {"nest": "1"}),
         ({"nest": 5.5}, {"nest": "2"}),
@@ -1397,8 +1391,8 @@ def test_UnionArray():
         ({"nest": "3"}, {"nest": 5.5}),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-1).form
-        == ak._do.combinations(v2_array, 2, axis=-1).form
+        combinations(v2_array.to_typetracer(), 2, axis=-1).form
+        == combinations(v2_array, 2, axis=-1).form
     )
 
 
@@ -1409,7 +1403,7 @@ def test_UnmaskedArray():
         )
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=0)) == [
+    assert to_list(combinations(v2_array, 2, axis=0)) == [
         (0.0, 1.1),
         (0.0, 2.2),
         (0.0, 3.3),
@@ -1418,28 +1412,28 @@ def test_UnmaskedArray():
         (2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=0).form
-        == ak._do.combinations(v2_array, 2, axis=0).form
+        combinations(v2_array.to_typetracer(), 2, axis=0).form
+        == combinations(v2_array, 2, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 3, axis=0)) == [
+    assert to_list(combinations(v2_array, 3, axis=0)) == [
         (0.0, 1.1, 2.2),
         (0.0, 1.1, 3.3),
         (0.0, 2.2, 3.3),
         (1.1, 2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 3, axis=0).form
-        == ak._do.combinations(v2_array, 3, axis=0).form
+        combinations(v2_array.to_typetracer(), 3, axis=0).form
+        == combinations(v2_array, 3, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 4, axis=0)) == [(0.0, 1.1, 2.2, 3.3)]
+    assert to_list(combinations(v2_array, 4, axis=0)) == [(0.0, 1.1, 2.2, 3.3)]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 4, axis=0).form
-        == ak._do.combinations(v2_array, 4, axis=0).form
+        combinations(v2_array.to_typetracer(), 4, axis=0).form
+        == combinations(v2_array, 4, axis=0).form
     )
 
-    assert to_list(ak._do.combinations(v2_array, 2, axis=-1)) == [
+    assert to_list(combinations(v2_array, 2, axis=-1)) == [
         (0.0, 1.1),
         (0.0, 2.2),
         (0.0, 3.3),
@@ -1448,6 +1442,6 @@ def test_UnmaskedArray():
         (2.2, 3.3),
     ]
     assert (
-        ak._do.combinations(v2_array.to_typetracer(), 2, axis=-1).form
-        == ak._do.combinations(v2_array, 2, axis=-1).form
+        combinations(v2_array.to_typetracer(), 2, axis=-1).form
+        == combinations(v2_array, 2, axis=-1).form
     )

--- a/tests/test_1135_rpad_operation.py
+++ b/tests/test_1135_rpad_operation.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import pad_none
 
 to_list = ak.operations.to_list
 
@@ -13,12 +13,9 @@ to_list = ak.operations.to_list
 def test_rpad_and_clip_empty_array():
     empty = ak.contents.emptyarray.EmptyArray()
     assert to_list(empty) == []
-    assert to_list(ak._do.pad_none(empty, 5, 0)) == [None, None, None, None, None]
-    assert (
-        ak._do.pad_none(empty.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(empty, 5, 0).form
-    )
-    assert to_list(ak._do.pad_none(empty, 5, 0, clip=True)) == [
+    assert to_list(pad_none(empty, 5, 0)) == [None, None, None, None, None]
+    assert pad_none(empty.to_typetracer(), 5, 0).form == pad_none(empty, 5, 0).form
+    assert to_list(pad_none(empty, 5, 0, clip=True)) == [
         None,
         None,
         None,
@@ -26,8 +23,8 @@ def test_rpad_and_clip_empty_array():
         None,
     ]
     assert (
-        ak._do.pad_none(empty.to_typetracer(), 5, 0, clip=True).form
-        == ak._do.pad_none(empty, 5, 0, clip=True).form
+        pad_none(empty.to_typetracer(), 5, 0, clip=True).form
+        == pad_none(empty, 5, 0, clip=True).form
     )
 
 
@@ -40,7 +37,7 @@ def test_rpad_and_clip_numpy_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(ak._do.pad_none(array, 5, 0, clip=True)) == [
+    assert to_list(pad_none(array, 5, 0, clip=True)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
@@ -48,20 +45,20 @@ def test_rpad_and_clip_numpy_array():
         None,
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0, clip=True).form
-        == ak._do.pad_none(array, 5, 0, clip=True).form
+        pad_none(array.to_typetracer(), 5, 0, clip=True).form
+        == pad_none(array, 5, 0, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(array, 5, 1, clip=True)) == [
+    assert to_list(pad_none(array, 5, 1, clip=True)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None, None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None, None],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 1, clip=True).form
-        == ak._do.pad_none(array, 5, 1, clip=True).form
+        pad_none(array.to_typetracer(), 5, 1, clip=True).form
+        == pad_none(array, 5, 1, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(array, 7, 2, clip=True)) == [
+    assert to_list(pad_none(array, 7, 2, clip=True)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -74,23 +71,23 @@ def test_rpad_and_clip_numpy_array():
         ],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 7, 2, clip=True).form
-        == ak._do.pad_none(array, 7, 2, clip=True).form
+        pad_none(array.to_typetracer(), 7, 2, clip=True).form
+        == pad_none(array, 7, 2, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(array, 2, 2, clip=True)) == [
+    assert to_list(pad_none(array, 2, 2, clip=True)) == [
         [[0, 1], [5, 6], [10, 11]],
         [[15, 16], [20, 21], [25, 26]],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 2, clip=True).form
-        == ak._do.pad_none(array, 2, 2, clip=True).form
+        pad_none(array.to_typetracer(), 2, 2, clip=True).form
+        == pad_none(array, 2, 2, clip=True).form
     )
 
 
 def test_rpad_numpy_array():
     array = ak.contents.numpyarray.NumpyArray(np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
-    assert to_list(ak._do.pad_none(array, 10, 0)) == [
+    assert to_list(pad_none(array, 10, 0)) == [
         1.1,
         2.2,
         3.3,
@@ -102,33 +99,24 @@ def test_rpad_numpy_array():
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 10, 0).form
-        == ak._do.pad_none(array, 10, 0).form
-    )
+    assert pad_none(array.to_typetracer(), 10, 0).form == pad_none(array, 10, 0).form
 
     array = ak.contents.numpyarray.NumpyArray(
         np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
     )
-    assert to_list(ak._do.pad_none(array, 5, 0)) == [
+    assert to_list(pad_none(array, 5, 0)) == [
         [1.1, 2.2, 3.3],
         [4.4, 5.5, 6.6],
         None,
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(array, 5, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 5, 1)) == [
+    assert pad_none(array.to_typetracer(), 5, 0).form == pad_none(array, 5, 0).form
+    assert to_list(pad_none(array, 5, 1)) == [
         [1.1, 2.2, 3.3, None, None],
         [4.4, 5.5, 6.6, None, None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 1).form
-        == ak._do.pad_none(array, 5, 1).form
-    )
+    assert pad_none(array.to_typetracer(), 5, 1).form == pad_none(array, 5, 1).form
 
     array = ak.contents.numpyarray.NumpyArray(
         np.arange(2 * 3 * 5, dtype=np.int64).reshape(2, 3, 5)
@@ -138,93 +126,66 @@ def test_rpad_numpy_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(ak._do.pad_none(array, 1, 0)) == [
+    assert to_list(pad_none(array, 1, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 0).form
-        == ak._do.pad_none(array, 1, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 2, 0)) == [
+    assert pad_none(array.to_typetracer(), 1, 0).form == pad_none(array, 1, 0).form
+    assert to_list(pad_none(array, 2, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 0).form
-        == ak._do.pad_none(array, 2, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 3, 0)) == [
+    assert pad_none(array.to_typetracer(), 2, 0).form == pad_none(array, 2, 0).form
+    assert to_list(pad_none(array, 3, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 0).form
-        == ak._do.pad_none(array, 3, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 4, 0)) == [
+    assert pad_none(array.to_typetracer(), 3, 0).form == pad_none(array, 3, 0).form
+    assert to_list(pad_none(array, 4, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 0).form
-        == ak._do.pad_none(array, 4, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 5, 0)) == [
+    assert pad_none(array.to_typetracer(), 4, 0).form == pad_none(array, 4, 0).form
+    assert to_list(pad_none(array, 5, 0)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
         None,
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(array, 5, 0).form
-    )
+    assert pad_none(array.to_typetracer(), 5, 0).form == pad_none(array, 5, 0).form
 
-    assert to_list(ak._do.pad_none(array, 2, 1)) == [
+    assert to_list(pad_none(array, 2, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert to_list(ak._do.pad_none(array, 3, 1)) == [
+    assert to_list(pad_none(array, 3, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 1).form
-        == ak._do.pad_none(array, 3, 1).form
-    )
-    assert to_list(ak._do.pad_none(array, 4, 1)) == [
+    assert pad_none(array.to_typetracer(), 3, 1).form == pad_none(array, 3, 1).form
+    assert to_list(pad_none(array, 4, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 1).form
-        == ak._do.pad_none(array, 4, 1).form
-    )
-    assert to_list(ak._do.pad_none(array, 5, 1)) == [
+    assert pad_none(array.to_typetracer(), 4, 1).form == pad_none(array, 4, 1).form
+    assert to_list(pad_none(array, 5, 1)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], None, None],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29], None, None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 1).form
-        == ak._do.pad_none(array, 5, 1).form
-    )
+    assert pad_none(array.to_typetracer(), 5, 1).form == pad_none(array, 5, 1).form
 
-    assert to_list(ak._do.pad_none(array, 3, 2)) == [
+    assert to_list(pad_none(array, 3, 2)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 2).form
-        == ak._do.pad_none(array, 3, 2).form
-    )
+    assert pad_none(array.to_typetracer(), 3, 2).form == pad_none(array, 3, 2).form
 
-    assert to_list(ak._do.pad_none(array, 7, 2)) == [
+    assert to_list(pad_none(array, 7, 2)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -236,19 +197,13 @@ def test_rpad_numpy_array():
             [25, 26, 27, 28, 29, None, None],
         ],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 7, 2).form
-        == ak._do.pad_none(array, 7, 2).form
-    )
+    assert pad_none(array.to_typetracer(), 7, 2).form == pad_none(array, 7, 2).form
 
-    assert to_list(ak._do.pad_none(array, 2, 2)) == [
+    assert to_list(pad_none(array, 2, 2)) == [
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]],
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 2).form
-        == ak._do.pad_none(array, 2, 2).form
-    )
+    assert pad_none(array.to_typetracer(), 2, 2).form == pad_none(array, 2, 2).form
 
 
 def test_rpad_and_clip_regular_array():
@@ -283,7 +238,7 @@ def test_rpad_and_clip_regular_array():
     indexedarray = ak.contents.indexedoptionarray.IndexedOptionArray(index, content)
     array = ak.contents.regulararray.RegularArray(indexedarray, 3, zeros_length=0)
 
-    assert to_list(ak._do.pad_none(array, 5, 0, clip=True)) == [
+    assert to_list(pad_none(array, 5, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
@@ -291,81 +246,81 @@ def test_rpad_and_clip_regular_array():
         None,
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0, clip=True).form
-        == ak._do.pad_none(array, 5, 0, clip=True).form
+        pad_none(array.to_typetracer(), 5, 0, clip=True).form
+        == pad_none(array, 5, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 4, 0, clip=True)) == [
+    assert to_list(pad_none(array, 4, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 0, clip=True).form
-        == ak._do.pad_none(array, 4, 0, clip=True).form
+        pad_none(array.to_typetracer(), 4, 0, clip=True).form
+        == pad_none(array, 4, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 3, 0, clip=True)) == [
+    assert to_list(pad_none(array, 3, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 0, clip=True).form
-        == ak._do.pad_none(array, 3, 0, clip=True).form
+        pad_none(array.to_typetracer(), 3, 0, clip=True).form
+        == pad_none(array, 3, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 2, 0, clip=True)) == [
+    assert to_list(pad_none(array, 2, 0, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 0, clip=True).form
-        == ak._do.pad_none(array, 2, 0, clip=True).form
+        pad_none(array.to_typetracer(), 2, 0, clip=True).form
+        == pad_none(array, 2, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 1, 0, clip=True)) == [[6.9, 3.9, 6.9]]
+    assert to_list(pad_none(array, 1, 0, clip=True)) == [[6.9, 3.9, 6.9]]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(array, 1, 0, clip=True).form
+        pad_none(array.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(array, 1, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 5, 1, clip=True)) == [
+    assert to_list(pad_none(array, 5, 1, clip=True)) == [
         [6.9, 3.9, 6.9, None, None],
         [2.2, 1.5, 1.6, None, None],
         [3.6, None, 6.7, None, None],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 1, clip=True).form
-        == ak._do.pad_none(array, 5, 1, clip=True).form
+        pad_none(array.to_typetracer(), 5, 1, clip=True).form
+        == pad_none(array, 5, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 4, 1, clip=True)) == [
+    assert to_list(pad_none(array, 4, 1, clip=True)) == [
         [6.9, 3.9, 6.9, None],
         [2.2, 1.5, 1.6, None],
         [3.6, None, 6.7, None],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 1, clip=True).form
-        == ak._do.pad_none(array, 4, 1, clip=True).form
+        pad_none(array.to_typetracer(), 4, 1, clip=True).form
+        == pad_none(array, 4, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 3, 1, clip=True)) == [
+    assert to_list(pad_none(array, 3, 1, clip=True)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 1, clip=True).form
-        == ak._do.pad_none(array, 3, 1, clip=True).form
+        pad_none(array.to_typetracer(), 3, 1, clip=True).form
+        == pad_none(array, 3, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 2, 1, clip=True)) == [
+    assert to_list(pad_none(array, 2, 1, clip=True)) == [
         [6.9, 3.9],
         [2.2, 1.5],
         [3.6, None],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 1, clip=True).form
-        == ak._do.pad_none(array, 2, 1, clip=True).form
+        pad_none(array.to_typetracer(), 2, 1, clip=True).form
+        == pad_none(array, 2, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(array, 1, 1, clip=True)) == [[6.9], [2.2], [3.6]]
+    assert to_list(pad_none(array, 1, 1, clip=True)) == [[6.9], [2.2], [3.6]]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(array, 1, 1, clip=True).form
+        pad_none(array.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(array, 1, 1, clip=True).form
     )
 
     array = ak.contents.numpyarray.NumpyArray(np.arange(2 * 3 * 5).reshape(2, 3, 5))
@@ -374,7 +329,7 @@ def test_rpad_and_clip_regular_array():
         [[15, 16, 17, 18, 19], [20, 21, 22, 23, 24], [25, 26, 27, 28, 29]],
     ]
 
-    assert to_list(ak._do.pad_none(array, 7, 2, clip=True)) == [
+    assert to_list(pad_none(array, 7, 2, clip=True)) == [
         [
             [0, 1, 2, 3, 4, None, None],
             [5, 6, 7, 8, 9, None, None],
@@ -387,8 +342,8 @@ def test_rpad_and_clip_regular_array():
         ],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 7, 2, clip=True).form
-        == ak._do.pad_none(array, 7, 2, clip=True).form
+        pad_none(array.to_typetracer(), 7, 2, clip=True).form
+        == pad_none(array, 7, 2, clip=True).form
     )
 
     content = ak.contents.numpyarray.NumpyArray(
@@ -400,41 +355,39 @@ def test_rpad_and_clip_regular_array():
         listoffsetarray, 2, zeros_length=0
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 0, clip=True)) == [
-        [[0.0, 1.1, 2.2], []]
-    ]
+    assert to_list(pad_none(regulararray, 1, 0, clip=True)) == [[[0.0, 1.1, 2.2], []]]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(regulararray, 1, 0, clip=True).form
+        pad_none(regulararray.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(regulararray, 1, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 2, 0, clip=True)) == [
+    assert to_list(pad_none(regulararray, 2, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 2, 0, clip=True).form
-        == ak._do.pad_none(regulararray, 2, 0, clip=True).form
+        pad_none(regulararray.to_typetracer(), 2, 0, clip=True).form
+        == pad_none(regulararray, 2, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 0, clip=True)) == [
+    assert to_list(pad_none(regulararray, 3, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 0, clip=True).form
-        == ak._do.pad_none(regulararray, 3, 0, clip=True).form
+        pad_none(regulararray.to_typetracer(), 3, 0, clip=True).form
+        == pad_none(regulararray, 3, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 4, 0, clip=True)) == [
+    assert to_list(pad_none(regulararray, 4, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
         None,
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 4, 0, clip=True).form
-        == ak._do.pad_none(regulararray, 4, 0, clip=True).form
+        pad_none(regulararray.to_typetracer(), 4, 0, clip=True).form
+        == pad_none(regulararray, 4, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 5, 0, clip=True)) == [
+    assert to_list(pad_none(regulararray, 5, 0, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
@@ -442,91 +395,91 @@ def test_rpad_and_clip_regular_array():
         None,
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 5, 0, clip=True).form
-        == ak._do.pad_none(regulararray, 5, 0, clip=True).form
+        pad_none(regulararray.to_typetracer(), 5, 0, clip=True).form
+        == pad_none(regulararray, 5, 0, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 1, clip=True)) == [
+    assert to_list(pad_none(regulararray, 1, 1, clip=True)) == [
         [[0.0, 1.1, 2.2]],
         [[3.3, 4.4]],
         [[6.6, 7.7, 8.8, 9.9]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(regulararray, 1, 1, clip=True).form
+        pad_none(regulararray.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(regulararray, 1, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 2, 1, clip=True)) == [
+    assert to_list(pad_none(regulararray, 2, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 2, 1, clip=True).form
-        == ak._do.pad_none(regulararray, 2, 1, clip=True).form
+        pad_none(regulararray.to_typetracer(), 2, 1, clip=True).form
+        == pad_none(regulararray, 2, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 1, clip=True)) == [
+    assert to_list(pad_none(regulararray, 3, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], [], None],
         [[3.3, 4.4], [5.5], None],
         [[6.6, 7.7, 8.8, 9.9], [], None],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 1, clip=True).form
-        == ak._do.pad_none(regulararray, 3, 1, clip=True).form
+        pad_none(regulararray.to_typetracer(), 3, 1, clip=True).form
+        == pad_none(regulararray, 3, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 7, 1, clip=True)) == [
+    assert to_list(pad_none(regulararray, 7, 1, clip=True)) == [
         [[0.0, 1.1, 2.2], [], None, None, None, None, None],
         [[3.3, 4.4], [5.5], None, None, None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None, None, None],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 7, 1, clip=True).form
-        == ak._do.pad_none(regulararray, 7, 1, clip=True).form
+        pad_none(regulararray.to_typetracer(), 7, 1, clip=True).form
+        == pad_none(regulararray, 7, 1, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 2, clip=True)) == [
+    assert to_list(pad_none(regulararray, 1, 2, clip=True)) == [
         [[0.0], [None]],
         [[3.3], [5.5]],
         [[6.6], [None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 2, clip=True).form
-        == ak._do.pad_none(regulararray, 1, 2, clip=True).form
+        pad_none(regulararray.to_typetracer(), 1, 2, clip=True).form
+        == pad_none(regulararray, 1, 2, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 2, 2, clip=True)) == [
+    assert to_list(pad_none(regulararray, 2, 2, clip=True)) == [
         [[0.0, 1.1], [None, None]],
         [[3.3, 4.4], [5.5, None]],
         [[6.6, 7.7], [None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 2, 2, clip=True).form
-        == ak._do.pad_none(regulararray, 2, 2, clip=True).form
+        pad_none(regulararray.to_typetracer(), 2, 2, clip=True).form
+        == pad_none(regulararray, 2, 2, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 2, clip=True)) == [
+    assert to_list(pad_none(regulararray, 3, 2, clip=True)) == [
         [[0.0, 1.1, 2.2], [None, None, None]],
         [[3.3, 4.4, None], [5.5, None, None]],
         [[6.6, 7.7, 8.8], [None, None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 2, clip=True).form
-        == ak._do.pad_none(regulararray, 3, 2, clip=True).form
+        pad_none(regulararray.to_typetracer(), 3, 2, clip=True).form
+        == pad_none(regulararray, 3, 2, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 4, 2, clip=True)) == [
+    assert to_list(pad_none(regulararray, 4, 2, clip=True)) == [
         [[0.0, 1.1, 2.2, None], [None, None, None, None]],
         [[3.3, 4.4, None, None], [5.5, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 4, 2, clip=True).form
-        == ak._do.pad_none(regulararray, 4, 2, clip=True).form
+        pad_none(regulararray.to_typetracer(), 4, 2, clip=True).form
+        == pad_none(regulararray, 4, 2, clip=True).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 5, 2, clip=True)) == [
+    assert to_list(pad_none(regulararray, 5, 2, clip=True)) == [
         [[0.0, 1.1, 2.2, None, None], [None, None, None, None, None]],
         [[3.3, 4.4, None, None, None], [5.5, None, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9, None], [None, None, None, None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 5, 2, clip=True).form
-        == ak._do.pad_none(regulararray, 5, 2, clip=True).form
+        pad_none(regulararray.to_typetracer(), 5, 2, clip=True).form
+        == pad_none(regulararray, 5, 2, clip=True).form
     )
 
 
@@ -562,81 +515,57 @@ def test_rpad_regular_array():
     indexedarray = ak.contents.indexedoptionarray.IndexedOptionArray(index, content)
     array = ak.contents.regulararray.RegularArray(indexedarray, 3, zeros_length=0)
 
-    assert to_list(ak._do.pad_none(array, 5, 0)) == [
+    assert to_list(pad_none(array, 5, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(array, 5, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 4, 0)) == [
+    assert pad_none(array.to_typetracer(), 5, 0).form == pad_none(array, 5, 0).form
+    assert to_list(pad_none(array, 4, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 0).form
-        == ak._do.pad_none(array, 4, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 3, 0)) == [
+    assert pad_none(array.to_typetracer(), 4, 0).form == pad_none(array, 4, 0).form
+    assert to_list(pad_none(array, 3, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 0).form
-        == ak._do.pad_none(array, 3, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 1, 0)) == [
+    assert pad_none(array.to_typetracer(), 3, 0).form == pad_none(array, 3, 0).form
+    assert to_list(pad_none(array, 1, 0)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 0).form
-        == ak._do.pad_none(array, 1, 0).form
-    )
-    assert to_list(ak._do.pad_none(array, 5, 1)) == [
+    assert pad_none(array.to_typetracer(), 1, 0).form == pad_none(array, 1, 0).form
+    assert to_list(pad_none(array, 5, 1)) == [
         [6.9, 3.9, 6.9, None, None],
         [2.2, 1.5, 1.6, None, None],
         [3.6, None, 6.7, None, None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 1).form
-        == ak._do.pad_none(array, 5, 1).form
-    )
-    assert to_list(ak._do.pad_none(array, 4, 1)) == [
+    assert pad_none(array.to_typetracer(), 5, 1).form == pad_none(array, 5, 1).form
+    assert to_list(pad_none(array, 4, 1)) == [
         [6.9, 3.9, 6.9, None],
         [2.2, 1.5, 1.6, None],
         [3.6, None, 6.7, None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 4, 1).form
-        == ak._do.pad_none(array, 4, 1).form
-    )
-    assert to_list(ak._do.pad_none(array, 3, 1)) == [
+    assert pad_none(array.to_typetracer(), 4, 1).form == pad_none(array, 4, 1).form
+    assert to_list(pad_none(array, 3, 1)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 3, 1).form
-        == ak._do.pad_none(array, 3, 1).form
-    )
-    assert to_list(ak._do.pad_none(array, 1, 1)) == [
+    assert pad_none(array.to_typetracer(), 3, 1).form == pad_none(array, 3, 1).form
+    assert to_list(pad_none(array, 1, 1)) == [
         [6.9, 3.9, 6.9],
         [2.2, 1.5, 1.6],
         [3.6, None, 6.7],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 1).form
-        == ak._do.pad_none(array, 1, 1).form
-    )
+    assert pad_none(array.to_typetracer(), 1, 1).form == pad_none(array, 1, 1).form
 
     content = ak.contents.numpyarray.NumpyArray(
         np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
@@ -647,35 +576,35 @@ def test_rpad_regular_array():
         listoffsetarray, 2, zeros_length=0
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 0)) == [
+    assert to_list(pad_none(regulararray, 1, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 0).form
-        == ak._do.pad_none(regulararray, 1, 0).form
+        pad_none(regulararray.to_typetracer(), 1, 0).form
+        == pad_none(regulararray, 1, 0).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 0)) == [
+    assert to_list(pad_none(regulararray, 3, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 0).form
-        == ak._do.pad_none(regulararray, 3, 0).form
+        pad_none(regulararray.to_typetracer(), 3, 0).form
+        == pad_none(regulararray, 3, 0).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 4, 0)) == [
+    assert to_list(pad_none(regulararray, 4, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
         None,
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 4, 0).form
-        == ak._do.pad_none(regulararray, 4, 0).form
+        pad_none(regulararray.to_typetracer(), 4, 0).form
+        == pad_none(regulararray, 4, 0).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 7, 0)) == [
+    assert to_list(pad_none(regulararray, 7, 0)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
@@ -685,91 +614,91 @@ def test_rpad_regular_array():
         None,
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(regulararray, 7, 0).form
+        pad_none(regulararray.to_typetracer(), 7, 0).form
+        == pad_none(regulararray, 7, 0).form
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 1)) == [
+    assert to_list(pad_none(regulararray, 1, 1)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 1).form
-        == ak._do.pad_none(regulararray, 1, 1).form
+        pad_none(regulararray.to_typetracer(), 1, 1).form
+        == pad_none(regulararray, 1, 1).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 2, 1)) == [
+    assert to_list(pad_none(regulararray, 2, 1)) == [
         [[0.0, 1.1, 2.2], []],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], []],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 2, 1).form
-        == ak._do.pad_none(regulararray, 2, 1).form
+        pad_none(regulararray.to_typetracer(), 2, 1).form
+        == pad_none(regulararray, 2, 1).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 1)) == [
+    assert to_list(pad_none(regulararray, 3, 1)) == [
         [[0.0, 1.1, 2.2], [], None],
         [[3.3, 4.4], [5.5], None],
         [[6.6, 7.7, 8.8, 9.9], [], None],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 1).form
-        == ak._do.pad_none(regulararray, 3, 1).form
+        pad_none(regulararray.to_typetracer(), 3, 1).form
+        == pad_none(regulararray, 3, 1).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 5, 1)) == [
+    assert to_list(pad_none(regulararray, 5, 1)) == [
         [[0.0, 1.1, 2.2], [], None, None, None],
         [[3.3, 4.4], [5.5], None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 5, 1).form
-        == ak._do.pad_none(regulararray, 5, 1).form
+        pad_none(regulararray.to_typetracer(), 5, 1).form
+        == pad_none(regulararray, 5, 1).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 7, 1)) == [
+    assert to_list(pad_none(regulararray, 7, 1)) == [
         [[0.0, 1.1, 2.2], [], None, None, None, None, None],
         [[3.3, 4.4], [5.5], None, None, None, None, None],
         [[6.6, 7.7, 8.8, 9.9], [], None, None, None, None, None],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 7, 1).form
-        == ak._do.pad_none(regulararray, 7, 1).form
+        pad_none(regulararray.to_typetracer(), 7, 1).form
+        == pad_none(regulararray, 7, 1).form
     )
 
-    assert to_list(ak._do.pad_none(regulararray, 1, 2)) == [
+    assert to_list(pad_none(regulararray, 1, 2)) == [
         [[0.0, 1.1, 2.2], [None]],
         [[3.3, 4.4], [5.5]],
         [[6.6, 7.7, 8.8, 9.9], [None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 1, 2).form
-        == ak._do.pad_none(regulararray, 1, 2).form
+        pad_none(regulararray.to_typetracer(), 1, 2).form
+        == pad_none(regulararray, 1, 2).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 2, 2)) == [
+    assert to_list(pad_none(regulararray, 2, 2)) == [
         [[0.0, 1.1, 2.2], [None, None]],
         [[3.3, 4.4], [5.5, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 2, 2).form
-        == ak._do.pad_none(regulararray, 2, 2).form
+        pad_none(regulararray.to_typetracer(), 2, 2).form
+        == pad_none(regulararray, 2, 2).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 3, 2)) == [
+    assert to_list(pad_none(regulararray, 3, 2)) == [
         [[0.0, 1.1, 2.2], [None, None, None]],
         [[3.3, 4.4, None], [5.5, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 3, 2).form
-        == ak._do.pad_none(regulararray, 3, 2).form
+        pad_none(regulararray.to_typetracer(), 3, 2).form
+        == pad_none(regulararray, 3, 2).form
     )
-    assert to_list(ak._do.pad_none(regulararray, 4, 2)) == [
+    assert to_list(pad_none(regulararray, 4, 2)) == [
         [[0.0, 1.1, 2.2, None], [None, None, None, None]],
         [[3.3, 4.4, None, None], [5.5, None, None, None]],
         [[6.6, 7.7, 8.8, 9.9], [None, None, None, None]],
     ]
     assert (
-        ak._do.pad_none(regulararray.to_typetracer(), 4, 2).form
-        == ak._do.pad_none(regulararray, 4, 2).form
+        pad_none(regulararray.to_typetracer(), 4, 2).form
+        == pad_none(regulararray, 4, 2).form
     )
 
 
@@ -788,20 +717,20 @@ def test_rpad_and_clip_listoffset_array():
         [],
     ]
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 3, 0, clip=True)) == [
+    assert to_list(pad_none(listoffsetarray, 3, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 3, 0, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 3, 0, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 3, 0, clip=True).form
+        == pad_none(listoffsetarray, 3, 0, clip=True).form
     )
     assert "option[" + str(listoffsetarray.form.type) + "]" == str(
-        ak._do.pad_none(listoffsetarray, 3, 0, clip=True).form.type
+        pad_none(listoffsetarray, 3, 0, clip=True).form.type
     )
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 7, 0, clip=True)) == [
+    assert to_list(pad_none(listoffsetarray, 7, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -811,14 +740,14 @@ def test_rpad_and_clip_listoffset_array():
         None,
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 7, 0, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 7, 0, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 7, 0, clip=True).form
+        == pad_none(listoffsetarray, 7, 0, clip=True).form
     )
     assert "option[" + str(listoffsetarray.form.type) + "]" == str(
-        ak._do.pad_none(listoffsetarray, 7, 0, clip=True).form.type
+        pad_none(listoffsetarray, 7, 0, clip=True).form.type
     )
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 5, 1, clip=True)) == [
+    assert to_list(pad_none(listoffsetarray, 5, 1, clip=True)) == [
         [0.0, 1.1, 2.2, None, None],
         [None, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -827,17 +756,14 @@ def test_rpad_and_clip_listoffset_array():
         [None, None, None, None, None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 5, 1, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 5, 1, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 5, 1, clip=True).form
+        == pad_none(listoffsetarray, 5, 1, clip=True).form
     )
 
-    assert str(ak._do.pad_none(listoffsetarray, 5, 1).form.type) == "var * ?float64"
-    assert (
-        str(ak._do.pad_none(listoffsetarray, 5, 1, clip=True).form.type)
-        == "5 * ?float64"
-    )
+    assert str(pad_none(listoffsetarray, 5, 1).form.type) == "var * ?float64"
+    assert str(pad_none(listoffsetarray, 5, 1, clip=True).form.type) == "5 * ?float64"
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 1, clip=True)) == [
+    assert to_list(pad_none(listoffsetarray, 1, 1, clip=True)) == [
         [0.0],
         [None],
         [3.3],
@@ -846,8 +772,8 @@ def test_rpad_and_clip_listoffset_array():
         [None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 1, 1, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(listoffsetarray, 1, 1, clip=True).form
     )
 
     content = ak.contents.numpyarray.NumpyArray(np.array([1.5, 3.3]))
@@ -896,12 +822,12 @@ def test_rpad_and_clip_listoffset_array():
         [],
         [],
     ]
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 0, clip=True)) == [[3.3]]
+    assert to_list(pad_none(listoffsetarray, 1, 0, clip=True)) == [[3.3]]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 1, 0, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(listoffsetarray, 1, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 1, clip=True)) == [
+    assert to_list(pad_none(listoffsetarray, 1, 1, clip=True)) == [
         [3.3],
         [None],
         [None],
@@ -910,8 +836,8 @@ def test_rpad_and_clip_listoffset_array():
         [None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(listoffsetarray, 1, 1, clip=True).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(listoffsetarray, 1, 1, clip=True).form
     )
 
 
@@ -931,7 +857,7 @@ def test_rpad_listoffset_array():
         [],
     ]
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 3, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 3, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -940,15 +866,15 @@ def test_rpad_listoffset_array():
         [],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 3, 0).form
-        == ak._do.pad_none(listoffsetarray, 3, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 3, 0).form
+        == pad_none(listoffsetarray, 3, 0).form
     )
 
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 6
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 3, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 3, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 7, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 7, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [3.3, 4.4],
@@ -958,15 +884,15 @@ def test_rpad_listoffset_array():
         None,
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(listoffsetarray, 7, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 7, 0).form
+        == pad_none(listoffsetarray, 7, 0).form
     )
 
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 7, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 5, 1)) == [
+    assert to_list(pad_none(listoffsetarray, 5, 1)) == [
         [0.0, 1.1, 2.2, None, None],
         [None, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -975,16 +901,14 @@ def test_rpad_listoffset_array():
         [None, None, None, None, None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 5, 1).form
-        == ak._do.pad_none(listoffsetarray, 5, 1).form
+        pad_none(listoffsetarray.to_typetracer(), 5, 1).form
+        == pad_none(listoffsetarray, 5, 1).form
     )
-    assert ak.operations.type(
-        ak._do.pad_none(listoffsetarray, 5, 1)
-    ) == ak.types.ArrayType(
+    assert ak.operations.type(pad_none(listoffsetarray, 5, 1)) == ak.types.ArrayType(
         ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64"))), 6
     )
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 1)) == [
+    assert to_list(pad_none(listoffsetarray, 1, 1)) == [
         [0.0, 1.1, 2.2],
         [None],
         [3.3, 4.4],
@@ -993,8 +917,8 @@ def test_rpad_listoffset_array():
         [None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 1).form
-        == ak._do.pad_none(listoffsetarray, 1, 1).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 1).form
+        == pad_none(listoffsetarray, 1, 1).form
     )
 
     content = ak.contents.numpyarray.NumpyArray(np.array([1.5, 3.3]))
@@ -1044,7 +968,7 @@ def test_rpad_listoffset_array():
         [],
     ]
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 1, 0)) == [
         [3.3],
         [],
         [],
@@ -1053,17 +977,17 @@ def test_rpad_listoffset_array():
         [],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 0).form
-        == ak._do.pad_none(listoffsetarray, 1, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 0).form
+        == pad_none(listoffsetarray, 1, 0).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(
             ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64")))
         ),
         6,
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 1, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 6, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 6, 0)) == [
         [3.3],
         [],
         [],
@@ -1072,17 +996,17 @@ def test_rpad_listoffset_array():
         [],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 6, 0).form
-        == ak._do.pad_none(listoffsetarray, 6, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 6, 0).form
+        == pad_none(listoffsetarray, 6, 0).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(
             ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64")))
         ),
         6,
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 6, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 6, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 7, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 7, 0)) == [
         [3.3],
         [],
         [],
@@ -1092,14 +1016,14 @@ def test_rpad_listoffset_array():
         None,
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(listoffsetarray, 7, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 7, 0).form
+        == pad_none(listoffsetarray, 7, 0).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.operations.type(listoffsetarray).content), 7
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 7, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 7, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 9, 0)) == [
+    assert to_list(pad_none(listoffsetarray, 9, 0)) == [
         [3.3],
         [],
         [],
@@ -1111,14 +1035,14 @@ def test_rpad_listoffset_array():
         None,
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 9, 0).form
-        == ak._do.pad_none(listoffsetarray, 9, 0).form
+        pad_none(listoffsetarray.to_typetracer(), 9, 0).form
+        == pad_none(listoffsetarray, 9, 0).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.operations.type(listoffsetarray).content), 9
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 9, 0))
+    ) == ak.operations.type(pad_none(listoffsetarray, 9, 0))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 1, 1)) == [
+    assert to_list(pad_none(listoffsetarray, 1, 1)) == [
         [3.3],
         [None],
         [None],
@@ -1127,14 +1051,14 @@ def test_rpad_listoffset_array():
         [None],
     ]
     assert (
-        ak._do.pad_none(listoffsetarray.to_typetracer(), 1, 1).form
-        == ak._do.pad_none(listoffsetarray, 1, 1).form
+        pad_none(listoffsetarray.to_typetracer(), 1, 1).form
+        == pad_none(listoffsetarray, 1, 1).form
     )
     assert ak.types.ArrayType(
         ak.types.ListType(ak.types.OptionType(ak.types.NumpyType("float64"))), 6
-    ) == ak.operations.type(ak._do.pad_none(listoffsetarray, 1, 1))
+    ) == ak.operations.type(pad_none(listoffsetarray, 1, 1))
 
-    assert to_list(ak._do.pad_none(listoffsetarray, 4, 1)) == [
+    assert to_list(pad_none(listoffsetarray, 4, 1)) == [
         [3.3, None, None, None],
         [None, None, None, None],
         [None, None, None, None],
@@ -1143,7 +1067,7 @@ def test_rpad_listoffset_array():
         [None, None, None, None],
     ]
     assert ak.operations.type(listoffsetarray) == ak.operations.type(
-        ak._do.pad_none(listoffsetarray, 4, 1)
+        pad_none(listoffsetarray, 4, 1)
     )
 
 
@@ -1162,7 +1086,7 @@ def test_rpad_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert to_list(ak._do.pad_none(array, 1, 0)) == [
+    assert to_list(pad_none(array, 1, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1171,9 +1095,9 @@ def test_rpad_list_array():
     ]
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 5
-    ) == ak.operations.type(ak._do.pad_none(array, 1, 0))
+    ) == ak.operations.type(pad_none(array, 1, 0))
 
-    assert to_list(ak._do.pad_none(array, 2, 0)) == [
+    assert to_list(pad_none(array, 2, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1182,9 +1106,9 @@ def test_rpad_list_array():
     ]
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 5
-    ) == ak.operations.type(ak._do.pad_none(array, 2, 0))
+    ) == ak.operations.type(pad_none(array, 2, 0))
 
-    assert to_list(ak._do.pad_none(array, 7, 0)) == [
+    assert to_list(pad_none(array, 7, 0)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1195,9 +1119,9 @@ def test_rpad_list_array():
     ]
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
-    ) == ak.operations.type(ak._do.pad_none(array, 7, 0))
+    ) == ak.operations.type(pad_none(array, 7, 0))
 
-    assert to_list(ak._do.pad_none(array, 1, 1)) == [
+    assert to_list(pad_none(array, 1, 1)) == [
         [0.0, 1.1, 2.2],
         [None],
         [4.4, 5.5],
@@ -1205,7 +1129,7 @@ def test_rpad_list_array():
         [8.8],
     ]
 
-    assert to_list(ak._do.pad_none(array, 2, 1)) == [
+    assert to_list(pad_none(array, 2, 1)) == [
         [0.0, 1.1, 2.2],
         [None, None],
         [4.4, 5.5],
@@ -1213,7 +1137,7 @@ def test_rpad_list_array():
         [8.8, None],
     ]
 
-    assert to_list(ak._do.pad_none(array, 3, 1)) == [
+    assert to_list(pad_none(array, 3, 1)) == [
         [0.0, 1.1, 2.2],
         [None, None, None],
         [4.4, 5.5, None],
@@ -1221,7 +1145,7 @@ def test_rpad_list_array():
         [8.8, None, None],
     ]
 
-    assert to_list(ak._do.pad_none(array, 4, 1)) == [
+    assert to_list(pad_none(array, 4, 1)) == [
         [0.0, 1.1, 2.2, None],
         [None, None, None, None],
         [4.4, 5.5, None, None],
@@ -1245,25 +1169,25 @@ def test_rpad_and_clip_list_array():
         [5.5, 6.6, 7.7],
         [8.8],
     ]
-    assert to_list(ak._do.pad_none(array, 1, 0, clip=True)) == [[0.0, 1.1, 2.2]]
+    assert to_list(pad_none(array, 1, 0, clip=True)) == [[0.0, 1.1, 2.2]]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(array, 1, 0, clip=True).form
+        pad_none(array.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(array, 1, 0, clip=True).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 1
-    ) == ak.operations.type(ak._do.pad_none(array, 1, 0, clip=True))
+    ) == ak.operations.type(pad_none(array, 1, 0, clip=True))
 
-    assert to_list(ak._do.pad_none(array, 2, 0, clip=True)) == [[0.0, 1.1, 2.2], []]
+    assert to_list(pad_none(array, 2, 0, clip=True)) == [[0.0, 1.1, 2.2], []]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 0, clip=True).form
-        == ak._do.pad_none(array, 2, 0, clip=True).form
+        pad_none(array.to_typetracer(), 2, 0, clip=True).form
+        == pad_none(array, 2, 0, clip=True).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 2
-    ) == ak.operations.type(ak._do.pad_none(array, 2, 0, clip=True))
+    ) == ak.operations.type(pad_none(array, 2, 0, clip=True))
 
-    assert to_list(ak._do.pad_none(array, 7, 0, clip=True)) == [
+    assert to_list(pad_none(array, 7, 0, clip=True)) == [
         [0.0, 1.1, 2.2],
         [],
         [4.4, 5.5],
@@ -1273,14 +1197,14 @@ def test_rpad_and_clip_list_array():
         None,
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 7, 0, clip=True).form
-        == ak._do.pad_none(array, 7, 0, clip=True).form
+        pad_none(array.to_typetracer(), 7, 0, clip=True).form
+        == pad_none(array, 7, 0, clip=True).form
     )
     assert ak.types.ArrayType(
         ak.types.OptionType(ak.types.ListType(ak.types.NumpyType("float64"))), 7
-    ) == ak.operations.type(ak._do.pad_none(array, 7, 0, clip=True))
+    ) == ak.operations.type(pad_none(array, 7, 0, clip=True))
 
-    assert to_list(ak._do.pad_none(array, 1, 1, clip=True)) == [
+    assert to_list(pad_none(array, 1, 1, clip=True)) == [
         [0.0],
         [None],
         [4.4],
@@ -1288,11 +1212,11 @@ def test_rpad_and_clip_list_array():
         [8.8],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(array, 1, 1, clip=True).form
+        pad_none(array.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(array, 1, 1, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(array, 2, 1, clip=True)) == [
+    assert to_list(pad_none(array, 2, 1, clip=True)) == [
         [0.0, 1.1],
         [None, None],
         [4.4, 5.5],
@@ -1300,8 +1224,8 @@ def test_rpad_and_clip_list_array():
         [8.8, None],
     ]
     assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 1, clip=True).form
-        == ak._do.pad_none(array, 2, 1, clip=True).form
+        pad_none(array.to_typetracer(), 2, 1, clip=True).form
+        == pad_none(array, 2, 1, clip=True).form
     )
 
 
@@ -1328,17 +1252,15 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
 
-    assert to_list(ak._do.pad_none(backward, 4, 1)) == to_list(
-        ak._do.pad_none(indexedarray, 4, 1)
-    )
-    assert to_list(ak._do.pad_none(indexedarray, 1, 0)) == [
+    assert to_list(pad_none(backward, 4, 1)) == to_list(pad_none(indexedarray, 4, 1))
+    assert to_list(pad_none(indexedarray, 1, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
     ]
-    assert to_list(ak._do.pad_none(indexedarray, 2, 1)) == [
+    assert to_list(pad_none(indexedarray, 2, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None],
         [3.3, 4.4],
@@ -1346,10 +1268,10 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 2, 1).form
-        == ak._do.pad_none(indexedarray, 2, 1).form
+        pad_none(indexedarray.to_typetracer(), 2, 1).form
+        == pad_none(indexedarray, 2, 1).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 3, 1)) == [
+    assert to_list(pad_none(indexedarray, 3, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None],
         [3.3, 4.4, None],
@@ -1357,10 +1279,10 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 3, 1).form
-        == ak._do.pad_none(indexedarray, 3, 1).form
+        pad_none(indexedarray.to_typetracer(), 3, 1).form
+        == pad_none(indexedarray, 3, 1).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 4, 0)) == [
+    assert to_list(pad_none(indexedarray, 4, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1368,10 +1290,10 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 4, 0).form
-        == ak._do.pad_none(indexedarray, 4, 0).form
+        pad_none(indexedarray.to_typetracer(), 4, 0).form
+        == pad_none(indexedarray, 4, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 5, 0)) == [
+    assert to_list(pad_none(indexedarray, 5, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1379,33 +1301,33 @@ def test_rpad_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(indexedarray, 5, 0).form
+        pad_none(indexedarray.to_typetracer(), 5, 0).form
+        == pad_none(indexedarray, 5, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 6, 0)) == [
-        [6.6, 7.7, 8.8, 9.9],
-        [5.5],
-        [3.3, 4.4],
-        [],
-        [0.0, 1.1, 2.2],
-        None,
-    ]
-    assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 6, 0).form
-        == ak._do.pad_none(indexedarray, 6, 0).form
-    )
-    assert to_list(ak._do.pad_none(indexedarray, 7, 0)) == [
+    assert to_list(pad_none(indexedarray, 6, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
         [0.0, 1.1, 2.2],
         None,
+    ]
+    assert (
+        pad_none(indexedarray.to_typetracer(), 6, 0).form
+        == pad_none(indexedarray, 6, 0).form
+    )
+    assert to_list(pad_none(indexedarray, 7, 0)) == [
+        [6.6, 7.7, 8.8, 9.9],
+        [5.5],
+        [3.3, 4.4],
+        [],
+        [0.0, 1.1, 2.2],
+        None,
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(indexedarray, 7, 0).form
+        pad_none(indexedarray.to_typetracer(), 7, 0).form
+        == pad_none(indexedarray, 7, 0).form
     )
 
 
@@ -1431,44 +1353,42 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
     ]
 
-    assert to_list(ak._do.pad_none(backward, 4, 1, clip=True)) == to_list(
-        ak._do.pad_none(indexedarray, 4, 1, clip=True)
+    assert to_list(pad_none(backward, 4, 1, clip=True)) == to_list(
+        pad_none(indexedarray, 4, 1, clip=True)
     )
-    assert to_list(ak._do.pad_none(indexedarray, 1, 0, clip=True)) == [
-        [6.6, 7.7, 8.8, 9.9]
-    ]
+    assert to_list(pad_none(indexedarray, 1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 1, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(indexedarray, 1, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 2, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 2, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 2, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 2, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 2, 0, clip=True).form
+        == pad_none(indexedarray, 2, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 3, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 3, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 3, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 3, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 3, 0, clip=True).form
+        == pad_none(indexedarray, 3, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 4, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 4, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
         [],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 4, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 4, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 4, 0, clip=True).form
+        == pad_none(indexedarray, 4, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 5, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 5, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1476,10 +1396,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 5, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 5, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 5, 0, clip=True).form
+        == pad_none(indexedarray, 5, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 6, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 6, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1488,10 +1408,10 @@ def test_rpad_and_clip_indexed_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 6, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 6, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 6, 0, clip=True).form
+        == pad_none(indexedarray, 6, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 7, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 7, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1501,10 +1421,10 @@ def test_rpad_and_clip_indexed_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 7, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 7, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 7, 0, clip=True).form
+        == pad_none(indexedarray, 7, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 8, 0, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 8, 0, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1515,11 +1435,11 @@ def test_rpad_and_clip_indexed_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 8, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 8, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 8, 0, clip=True).form
+        == pad_none(indexedarray, 8, 0, clip=True).form
     )
 
-    assert to_list(ak._do.pad_none(indexedarray, 1, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 1, 1, clip=True)) == [
         [6.6],
         [5.5],
         [3.3],
@@ -1527,10 +1447,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 1, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(indexedarray, 1, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 2, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 2, 1, clip=True)) == [
         [6.6, 7.7],
         [5.5, None],
         [3.3, 4.4],
@@ -1538,10 +1458,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 2, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 2, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 2, 1, clip=True).form
+        == pad_none(indexedarray, 2, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 3, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 3, 1, clip=True)) == [
         [6.6, 7.7, 8.8],
         [5.5, None, None],
         [3.3, 4.4, None],
@@ -1549,10 +1469,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 3, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 3, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 3, 1, clip=True).form
+        == pad_none(indexedarray, 3, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 4, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 4, 1, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None, None],
         [3.3, 4.4, None, None],
@@ -1560,10 +1480,10 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 4, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 4, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 4, 1, clip=True).form
+        == pad_none(indexedarray, 4, 1, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 5, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 5, 1, clip=True)) == [
         [6.6, 7.7, 8.8, 9.9, None],
         [5.5, None, None, None, None],
         [3.3, 4.4, None, None, None],
@@ -1571,8 +1491,8 @@ def test_rpad_and_clip_indexed_array():
         [0.0, 1.1, 2.2, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 5, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 5, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 5, 1, clip=True).form
+        == pad_none(indexedarray, 5, 1, clip=True).form
     )
 
 
@@ -1630,10 +1550,8 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
 
-    assert to_list(ak._do.pad_none(backward, 4, 1)) == to_list(
-        ak._do.pad_none(indexedarray, 4, 1)
-    )
-    assert to_list(ak._do.pad_none(indexedarray, 1, 0)) == [
+    assert to_list(pad_none(backward, 4, 1)) == to_list(pad_none(indexedarray, 4, 1))
+    assert to_list(pad_none(indexedarray, 1, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1641,10 +1559,10 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 0).form
-        == ak._do.pad_none(indexedarray, 1, 0).form
+        pad_none(indexedarray.to_typetracer(), 1, 0).form
+        == pad_none(indexedarray, 1, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 1, 1)) == [
+    assert to_list(pad_none(indexedarray, 1, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1652,10 +1570,10 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 1).form
-        == ak._do.pad_none(indexedarray, 1, 1).form
+        pad_none(indexedarray.to_typetracer(), 1, 1).form
+        == pad_none(indexedarray, 1, 1).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 3, 1)) == [
+    assert to_list(pad_none(indexedarray, 3, 1)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5, None, None],
         [3.3, 4.4, None],
@@ -1663,10 +1581,10 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 3, 1).form
-        == ak._do.pad_none(indexedarray, 3, 1).form
+        pad_none(indexedarray.to_typetracer(), 3, 1).form
+        == pad_none(indexedarray, 3, 1).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 4, 0)) == [
+    assert to_list(pad_none(indexedarray, 4, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1674,10 +1592,10 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 4, 0).form
-        == ak._do.pad_none(indexedarray, 4, 0).form
+        pad_none(indexedarray.to_typetracer(), 4, 0).form
+        == pad_none(indexedarray, 4, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 5, 0)) == [
+    assert to_list(pad_none(indexedarray, 5, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1685,10 +1603,10 @@ def test_rpad_indexed_option_array():
         [0.0, None, None],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(indexedarray, 5, 0).form
+        pad_none(indexedarray.to_typetracer(), 5, 0).form
+        == pad_none(indexedarray, 5, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 6, 0)) == [
+    assert to_list(pad_none(indexedarray, 6, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1697,10 +1615,10 @@ def test_rpad_indexed_option_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 6, 0).form
-        == ak._do.pad_none(indexedarray, 6, 0).form
+        pad_none(indexedarray.to_typetracer(), 6, 0).form
+        == pad_none(indexedarray, 6, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 7, 0)) == [
+    assert to_list(pad_none(indexedarray, 7, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1710,10 +1628,10 @@ def test_rpad_indexed_option_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(indexedarray, 7, 0).form
+        pad_none(indexedarray.to_typetracer(), 7, 0).form
+        == pad_none(indexedarray, 7, 0).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 8, 0)) == [
+    assert to_list(pad_none(indexedarray, 8, 0)) == [
         [6.6, 7.7, 8.8, 9.9],
         [5.5],
         [3.3, 4.4],
@@ -1724,18 +1642,16 @@ def test_rpad_indexed_option_array():
         None,
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 8, 0).form
-        == ak._do.pad_none(indexedarray, 8, 0).form
+        pad_none(indexedarray.to_typetracer(), 8, 0).form
+        == pad_none(indexedarray, 8, 0).form
     )
 
-    assert to_list(ak._do.pad_none(indexedarray, 1, 0, clip=True)) == [
-        [6.6, 7.7, 8.8, 9.9]
-    ]
+    assert to_list(pad_none(indexedarray, 1, 0, clip=True)) == [[6.6, 7.7, 8.8, 9.9]]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 0, clip=True).form
-        == ak._do.pad_none(indexedarray, 1, 0, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 1, 0, clip=True).form
+        == pad_none(indexedarray, 1, 0, clip=True).form
     )
-    assert to_list(ak._do.pad_none(indexedarray, 1, 1, clip=True)) == [
+    assert to_list(pad_none(indexedarray, 1, 1, clip=True)) == [
         [6.6],
         [5.5],
         [3.3],
@@ -1743,8 +1659,8 @@ def test_rpad_indexed_option_array():
         [0.0],
     ]
     assert (
-        ak._do.pad_none(indexedarray.to_typetracer(), 1, 1, clip=True).form
-        == ak._do.pad_none(indexedarray, 1, 1, clip=True).form
+        pad_none(indexedarray.to_typetracer(), 1, 1, clip=True).form
+        == pad_none(indexedarray, 1, 1, clip=True).form
     )
 
 
@@ -1759,27 +1675,21 @@ def test_rpad_recordarray():
     contents = [content1, content2]
     array = ak.contents.recordarray.RecordArray(contents, keys)
 
-    assert to_list(ak._do.pad_none(array, 5, 0)) == [
+    assert to_list(pad_none(array, 5, 0)) == [
         {"x": [], "y": [2, 2]},
         {"x": [1.1], "y": [1]},
         {"x": [2.2, 2.2], "y": []},
         None,
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 5, 0).form
-        == ak._do.pad_none(array, 5, 0).form
-    )
+    assert pad_none(array.to_typetracer(), 5, 0).form == pad_none(array, 5, 0).form
 
-    assert to_list(ak._do.pad_none(array, 2, 1)) == [
+    assert to_list(pad_none(array, 2, 1)) == [
         {"x": [None, None], "y": [2, 2]},
         {"x": [1.1, None], "y": [1, None]},
         {"x": [2.2, 2.2], "y": [None, None]},
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 1).form
-        == ak._do.pad_none(array, 2, 1).form
-    )
+    assert pad_none(array.to_typetracer(), 2, 1).form == pad_none(array, 2, 1).form
 
 
 def test_rpad_unionarray():
@@ -1794,7 +1704,7 @@ def test_rpad_unionarray():
     array = ak.contents.unionarray.UnionArray(tags, index, [content1, content2])
     assert to_list(array) == [[], ["2", "2"], [1.1], ["1"], [2.2, 2.2], []]
 
-    assert to_list(ak._do.pad_none(array, 7, 0)) == [
+    assert to_list(pad_none(array, 7, 0)) == [
         [],
         ["2", "2"],
         [1.1],
@@ -1803,12 +1713,9 @@ def test_rpad_unionarray():
         [],
         None,
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 7, 0).form
-        == ak._do.pad_none(array, 7, 0).form
-    )
+    assert pad_none(array.to_typetracer(), 7, 0).form == pad_none(array, 7, 0).form
 
-    assert to_list(ak._do.pad_none(array, 2, 1)) == [
+    assert to_list(pad_none(array, 2, 1)) == [
         [None, None],
         ["2", "2"],
         [1.1, None],
@@ -1816,7 +1723,4 @@ def test_rpad_unionarray():
         [2.2, 2.2],
         [None, None],
     ]
-    assert (
-        ak._do.pad_none(array.to_typetracer(), 2, 1).form
-        == ak._do.pad_none(array, 2, 1).form
-    )
+    assert pad_none(array.to_typetracer(), 2, 1).form == pad_none(array, 2, 1).form

--- a/tests/test_1142_numbers_to_type.py
+++ b/tests/test_1142_numbers_to_type.py
@@ -1,11 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import numbers_to_type
 
 
 def test_numbers_to_type():
@@ -14,250 +14,226 @@ def test_numbers_to_type():
         ak.highlevel.Array([4, 5]).layout,
     )
 
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "bool", False)).dtype == np.dtype(
-        np.bool_
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "int8", False)).dtype == np.dtype(
-        np.int8
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint8", False)).dtype == np.dtype(
-        np.uint8
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "int16", False)).dtype == np.dtype(
-        np.int16
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint16", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(one, "bool", False)).dtype == np.dtype(np.bool_)
+    assert ak.to_numpy(numbers_to_type(one, "int8", False)).dtype == np.dtype(np.int8)
+    assert ak.to_numpy(numbers_to_type(one, "uint8", False)).dtype == np.dtype(np.uint8)
+    assert ak.to_numpy(numbers_to_type(one, "int16", False)).dtype == np.dtype(np.int16)
+    assert ak.to_numpy(numbers_to_type(one, "uint16", False)).dtype == np.dtype(
         np.uint16
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "int32", False)).dtype == np.dtype(
-        np.int32
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint32", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(one, "int32", False)).dtype == np.dtype(np.int32)
+    assert ak.to_numpy(numbers_to_type(one, "uint32", False)).dtype == np.dtype(
         np.uint32
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "int64", False)).dtype == np.dtype(
-        np.int64
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "uint64", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(one, "int64", False)).dtype == np.dtype(np.int64)
+    assert ak.to_numpy(numbers_to_type(one, "uint64", False)).dtype == np.dtype(
         np.uint64
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "float32", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(one, "float32", False)).dtype == np.dtype(
         np.float32
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(one, "float64", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(one, "float64", False)).dtype == np.dtype(
         np.float64
     )
+    assert np.asarray(numbers_to_type(one, "complex64", False).data).dtype == np.dtype(
+        np.complex64
+    )
+    assert np.asarray(numbers_to_type(one, "complex128", False).data).dtype == np.dtype(
+        np.complex128
+    )
+    assert np.asarray(numbers_to_type(one, "datetime64", False).data).dtype == np.dtype(
+        np.datetime64
+    )
     assert np.asarray(
-        ak._do.numbers_to_type(one, "complex64", False).data
-    ).dtype == np.dtype(np.complex64)
-    assert np.asarray(
-        ak._do.numbers_to_type(one, "complex128", False).data
-    ).dtype == np.dtype(np.complex128)
-    assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64", False).data
-    ).dtype == np.dtype(np.datetime64)
-    assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[Y]", False).data
+        numbers_to_type(one, "datetime64[Y]", False).data
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[M]", False).data
+        numbers_to_type(one, "datetime64[M]", False).data
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[W]", False).data
+        numbers_to_type(one, "datetime64[W]", False).data
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[D]", False).data
+        numbers_to_type(one, "datetime64[D]", False).data
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[h]", False).data
+        numbers_to_type(one, "datetime64[h]", False).data
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[m]", False).data
+        numbers_to_type(one, "datetime64[m]", False).data
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[s]", False).data
+        numbers_to_type(one, "datetime64[s]", False).data
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ms]", False).data
+        numbers_to_type(one, "datetime64[ms]", False).data
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[us]", False).data
+        numbers_to_type(one, "datetime64[us]", False).data
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ns]", False).data
+        numbers_to_type(one, "datetime64[ns]", False).data
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[ps]", False).data
+        numbers_to_type(one, "datetime64[ps]", False).data
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[fs]", False).data
+        numbers_to_type(one, "datetime64[fs]", False).data
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "datetime64[as]", False).data
+        numbers_to_type(one, "datetime64[as]", False).data
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64", False).data
+        numbers_to_type(one, "timedelta64", False).data
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[Y]", False).data
+        numbers_to_type(one, "timedelta64[Y]", False).data
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[M]", False).data
+        numbers_to_type(one, "timedelta64[M]", False).data
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[W]", False).data
+        numbers_to_type(one, "timedelta64[W]", False).data
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[D]", False).data
+        numbers_to_type(one, "timedelta64[D]", False).data
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[h]", False).data
+        numbers_to_type(one, "timedelta64[h]", False).data
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[m]", False).data
+        numbers_to_type(one, "timedelta64[m]", False).data
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[s]", False).data
+        numbers_to_type(one, "timedelta64[s]", False).data
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ms]", False).data
+        numbers_to_type(one, "timedelta64[ms]", False).data
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[us]", False).data
+        numbers_to_type(one, "timedelta64[us]", False).data
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ns]", False).data
+        numbers_to_type(one, "timedelta64[ns]", False).data
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[ps]", False).data
+        numbers_to_type(one, "timedelta64[ps]", False).data
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[fs]", False).data
+        numbers_to_type(one, "timedelta64[fs]", False).data
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(one, "timedelta64[as]", False).data
+        numbers_to_type(one, "timedelta64[as]", False).data
     ).dtype == np.dtype("timedelta64[as]")
 
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "bool", False)).dtype == np.dtype(
-        np.bool_
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "int8", False)).dtype == np.dtype(
-        np.int8
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint8", False)).dtype == np.dtype(
-        np.uint8
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "int16", False)).dtype == np.dtype(
-        np.int16
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint16", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(two, "bool", False)).dtype == np.dtype(np.bool_)
+    assert ak.to_numpy(numbers_to_type(two, "int8", False)).dtype == np.dtype(np.int8)
+    assert ak.to_numpy(numbers_to_type(two, "uint8", False)).dtype == np.dtype(np.uint8)
+    assert ak.to_numpy(numbers_to_type(two, "int16", False)).dtype == np.dtype(np.int16)
+    assert ak.to_numpy(numbers_to_type(two, "uint16", False)).dtype == np.dtype(
         np.uint16
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "int32", False)).dtype == np.dtype(
-        np.int32
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint32", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(two, "int32", False)).dtype == np.dtype(np.int32)
+    assert ak.to_numpy(numbers_to_type(two, "uint32", False)).dtype == np.dtype(
         np.uint32
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "int64", False)).dtype == np.dtype(
-        np.int64
-    )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "uint64", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(two, "int64", False)).dtype == np.dtype(np.int64)
+    assert ak.to_numpy(numbers_to_type(two, "uint64", False)).dtype == np.dtype(
         np.uint64
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "float32", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(two, "float32", False)).dtype == np.dtype(
         np.float32
     )
-    assert ak.to_numpy(ak._do.numbers_to_type(two, "float64", False)).dtype == np.dtype(
+    assert ak.to_numpy(numbers_to_type(two, "float64", False)).dtype == np.dtype(
         np.float64
     )
+    assert np.asarray(numbers_to_type(two, "complex64", False).data).dtype == np.dtype(
+        np.complex64
+    )
+    assert np.asarray(numbers_to_type(two, "complex128", False).data).dtype == np.dtype(
+        np.complex128
+    )
+    assert np.asarray(numbers_to_type(two, "datetime64", False).data).dtype == np.dtype(
+        np.datetime64
+    )
     assert np.asarray(
-        ak._do.numbers_to_type(two, "complex64", False).data
-    ).dtype == np.dtype(np.complex64)
-    assert np.asarray(
-        ak._do.numbers_to_type(two, "complex128", False).data
-    ).dtype == np.dtype(np.complex128)
-    assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64", False).data
-    ).dtype == np.dtype(np.datetime64)
-    assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[Y]", False).data
+        numbers_to_type(two, "datetime64[Y]", False).data
     ).dtype == np.dtype("datetime64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[M]", False).data
+        numbers_to_type(two, "datetime64[M]", False).data
     ).dtype == np.dtype("datetime64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[W]", False).data
+        numbers_to_type(two, "datetime64[W]", False).data
     ).dtype == np.dtype("datetime64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[D]", False).data
+        numbers_to_type(two, "datetime64[D]", False).data
     ).dtype == np.dtype("datetime64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[h]", False).data
+        numbers_to_type(two, "datetime64[h]", False).data
     ).dtype == np.dtype("datetime64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[m]", False).data
+        numbers_to_type(two, "datetime64[m]", False).data
     ).dtype == np.dtype("datetime64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[s]", False).data
+        numbers_to_type(two, "datetime64[s]", False).data
     ).dtype == np.dtype("datetime64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ms]", False).data
+        numbers_to_type(two, "datetime64[ms]", False).data
     ).dtype == np.dtype("datetime64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[us]", False).data
+        numbers_to_type(two, "datetime64[us]", False).data
     ).dtype == np.dtype("datetime64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ns]", False).data
+        numbers_to_type(two, "datetime64[ns]", False).data
     ).dtype == np.dtype("datetime64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[ps]", False).data
+        numbers_to_type(two, "datetime64[ps]", False).data
     ).dtype == np.dtype("datetime64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[fs]", False).data
+        numbers_to_type(two, "datetime64[fs]", False).data
     ).dtype == np.dtype("datetime64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "datetime64[as]", False).data
+        numbers_to_type(two, "datetime64[as]", False).data
     ).dtype == np.dtype("datetime64[as]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64", False).data
+        numbers_to_type(two, "timedelta64", False).data
     ).dtype == np.dtype(np.timedelta64)
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[Y]", False).data
+        numbers_to_type(two, "timedelta64[Y]", False).data
     ).dtype == np.dtype("timedelta64[Y]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[M]", False).data
+        numbers_to_type(two, "timedelta64[M]", False).data
     ).dtype == np.dtype("timedelta64[M]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[W]", False).data
+        numbers_to_type(two, "timedelta64[W]", False).data
     ).dtype == np.dtype("timedelta64[W]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[D]", False).data
+        numbers_to_type(two, "timedelta64[D]", False).data
     ).dtype == np.dtype("timedelta64[D]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[h]", False).data
+        numbers_to_type(two, "timedelta64[h]", False).data
     ).dtype == np.dtype("timedelta64[h]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[m]", False).data
+        numbers_to_type(two, "timedelta64[m]", False).data
     ).dtype == np.dtype("timedelta64[m]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[s]", False).data
+        numbers_to_type(two, "timedelta64[s]", False).data
     ).dtype == np.dtype("timedelta64[s]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ms]", False).data
+        numbers_to_type(two, "timedelta64[ms]", False).data
     ).dtype == np.dtype("timedelta64[ms]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[us]", False).data
+        numbers_to_type(two, "timedelta64[us]", False).data
     ).dtype == np.dtype("timedelta64[us]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ns]", False).data
+        numbers_to_type(two, "timedelta64[ns]", False).data
     ).dtype == np.dtype("timedelta64[ns]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[ps]", False).data
+        numbers_to_type(two, "timedelta64[ps]", False).data
     ).dtype == np.dtype("timedelta64[ps]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[fs]", False).data
+        numbers_to_type(two, "timedelta64[fs]", False).data
     ).dtype == np.dtype("timedelta64[fs]")
     assert np.asarray(
-        ak._do.numbers_to_type(two, "timedelta64[as]", False).data
+        numbers_to_type(two, "timedelta64[as]", False).data
     ).dtype == np.dtype("timedelta64[as]")

--- a/tests/test_1149_datetime_sort.py
+++ b/tests/test_1149_datetime_sort.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import datetime
@@ -8,6 +7,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 import awkward as ak
+from awkward._do.content import is_unique, unique
 
 to_list = ak.operations.to_list
 
@@ -49,8 +49,8 @@ def test_date_time_sort_argsort_unique():
         datetime.datetime(2020, 7, 27, 10, 41, 11),
     ]
     assert to_list(ak.argsort(array, highlevel=False)) == [1, 2, 0]
-    assert ak._do.is_unique(array) is True
-    assert to_list(ak._do.unique(array)) == [
+    assert is_unique(array) is True
+    assert to_list(unique(array)) == [
         datetime.datetime(2019, 1, 1, 0, 0),
         datetime.datetime(2020, 1, 1, 0, 0),
         datetime.datetime(2020, 7, 27, 10, 41, 11),
@@ -73,8 +73,8 @@ def test_time_delta_sort_argsort_unique():
         datetime.timedelta(days=41),
     ]
     assert to_list(ak.argsort(array, highlevel=False)) == [1, 2, 0]
-    assert ak._do.is_unique(array) is True
-    assert to_list(ak._do.unique(array)) == [
+    assert is_unique(array) is True
+    assert to_list(unique(array)) == [
         datetime.timedelta(days=1),
         datetime.timedelta(days=20),
         datetime.timedelta(days=41),

--- a/tests/test_1240_v2_implementation_of_numba_1.py
+++ b/tests/test_1240_v2_implementation_of_numba_1.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import sys

--- a/tests/test_2408_layoutbuilder_in_numba.py
+++ b/tests/test_2408_layoutbuilder_in_numba.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import pytest

--- a/tests/test_2682_custom_pickler.py
+++ b/tests/test_2682_custom_pickler.py
@@ -44,6 +44,8 @@ def _pickle_complex_array_and_return_form_impl():
     return pickle.loads(pickle.dumps(array)).layout.form
 
 
+# NOTE: custom picklers are disabled in our tests, but the subprocess that is
+#       spawned here doesn't pick up that configuration, thus it can be tested!
 def pickle_complex_array_and_return_form(pickler_source, tmp_path):
     """Create a new (spawned) process, and register the given pickler source
     via entrypoints"""

--- a/tests/test_2757_attrs_metadata.py
+++ b/tests/test_2757_attrs_metadata.py
@@ -1,20 +1,12 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
+import pickle
+
 import packaging.version
 import pytest
 
 import awkward as ak
-from awkward._pickle import use_builtin_reducer
-
-
-@pytest.fixture
-def array_pickler():
-    import pickle
-
-    with use_builtin_reducer():
-        yield pickle
-
 
 SOME_ATTRS = {"foo": "!SOME"}
 OTHER_ATTRS = {"bar": "!OTHER", "foo": "!OTHER"}
@@ -31,18 +23,18 @@ def test_set_attrs():
         array.attrs = "Hello world!"
 
 
-def test_serialise_with_transient_attrs(array_pickler):
+def test_serialise_with_transient_attrs():
     attrs = {**SOME_ATTRS, "@transient_key": lambda: None}
     array = ak.Array([1, 2, 3], attrs=attrs)
-    result = array_pickler.loads(array_pickler.dumps(array))
+    result = pickle.loads(pickle.dumps(array))
     assert result.attrs == SOME_ATTRS
 
 
-def test_serialise_with_nonserialisable_attrs(array_pickler):
+def test_serialise_with_nonserialisable_attrs():
     attrs = {**SOME_ATTRS, "non_transient_key": lambda: None}
     array = ak.Array([1, 2, 3], attrs=attrs)
     with pytest.raises(AttributeError, match=r"Can't pickle local object"):
-        array_pickler.loads(array_pickler.dumps(array))
+        pickle.loads(pickle.dumps(array))
 
 
 def test_transient_metadata_persists():

--- a/tests/test_2808_dtype_ufunc_bool.py
+++ b/tests/test_2808_dtype_ufunc_bool.py
@@ -1,5 +1,4 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
-
 from __future__ import annotations
 
 import numpy as np


### PR DESCRIPTION
This PR:
1. Splits `Content._mergeable_next` and `ak._do.mergeable` into `Meta._mergeable_next` and `ak._do.meta.mergeable`.
2. Adds `dtype` to `NumpyMeta`
3. Drops use of `Generic` in type hints for `Meta` classes

(3) is required because of the lack of higher-kinded types. This means that our type hints will only let us prove that `NumpyArray` is a `NumpyMeta` in some contexts, e.g. via `ak._meta.meta.is_numpy()`