### PR TITLE
docs: link to execute JupyterLite full screen

### DIFF
--- a/docs/getting-started/demo/what-is-an-awkward-array.ipynb
+++ b/docs/getting-started/demo/what-is-an-awkward-array.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "deletable": false,
+    "editable": false
+   },
+   "source": "<center>\n<button data-commandLinker-command=\"application:toggle-zen\" href=\"#\">Toggle fullscreen</i></button>\n</center>"
+  },
+  {
+   "cell_type": "markdown",
    "id": "53a4d322",
    "metadata": {
     "deletable": false,

--- a/docs/getting-started/demo/what-is-an-awkward-array.ipynb
+++ b/docs/getting-started/demo/what-is-an-awkward-array.ipynb
@@ -6,7 +6,7 @@
     "deletable": false,
     "editable": false
    },
-   "source": "<center>\n<button data-commandLinker-command=\"application:toggle-zen\" href=\"#\">Toggle fullscreen</i></button>\n</center>"
+   "source": "<center>\n<button data-commandLinker-command=\"application:toggle-zen\" href=\"#\">Toggle fullscreen</i> <i class=\"fa-solid fa-expand\"></button>\n</center>"
   },
   {
    "cell_type": "markdown",

--- a/docs/getting-started/try-awkward-array.md
+++ b/docs/getting-started/try-awkward-array.md
@@ -1,5 +1,7 @@
 # Try it
 
+[Execute the Notebook full-screen](../retro/notebooks/?path=what-is-an-awkward-array.ipynb)
+
 :::{retrolite} demo/what-is-an-awkward-array.ipynb
    :height: auto
 :::

--- a/docs/getting-started/try-awkward-array.md
+++ b/docs/getting-started/try-awkward-array.md
@@ -1,6 +1,6 @@
 # Try it
 
-<a href="../lite/retro/notebooks/?path=what-is-an-awkward-array.ipynb">Execute the Notebook full-screen</a>
+[Execute the Notebook full-screen](../retro/notebooks/?path=what-is-an-awkward-array.ipynb)
 
 :::{retrolite} demo/what-is-an-awkward-array.ipynb
    :height: auto

--- a/docs/getting-started/try-awkward-array.md
+++ b/docs/getting-started/try-awkward-array.md
@@ -1,6 +1,6 @@
 # Try it
 
-[Execute the Notebook full-screen](../retro/notebooks/?path=what-is-an-awkward-array.ipynb)
+<a href="../lite/retro/notebooks/?path=what-is-an-awkward-array.ipynb">Execute the Notebook full-screen</a>
 
 :::{retrolite} demo/what-is-an-awkward-array.ipynb
    :height: auto

--- a/docs/getting-started/try-awkward-array.md
+++ b/docs/getting-started/try-awkward-array.md
@@ -1,7 +1,5 @@
 # Try it
 
-[Execute the Notebook full-screen](../retro/notebooks/?path=what-is-an-awkward-array.ipynb)
-
 :::{retrolite} demo/what-is-an-awkward-array.ipynb
    :height: auto
 :::


### PR DESCRIPTION
I could not find a way to run JupyterLite at https://awkward-array.org/doc/main/getting-started/try-awkward-array.html#try-it full screen, if not it is too small to execute comfortably in my opinion.

Following https://jupyterlite-sphinx.readthedocs.io/en/latest/full.html, I think the easiest way is to provide a link to https://awkward-array.org/doc/main/lite/retro/notebooks/?path=what-is-an-awkward-array.ipynb