### PR TITLE
fix: only compare scalars in full_like

### DIFF
--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -7,7 +7,7 @@ from awkward._connect.numpy import UNSUPPORTED
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._nplikes.typetracer import ensure_known_scalar
+from awkward._nplikes.typetracer import is_unknown_scalar
 from awkward.operations.ak_zeros_like import _ZEROS
 
 __all__ = ("full_like",)
@@ -125,12 +125,14 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
         if layout.is_numpy:
             original = nplike.asarray(layout.data)
 
-            if fill_value is _ZEROS or ensure_known_scalar(fill_value == 0, False):
+            if fill_value is _ZEROS or (
+                not is_unknown_scalar(fill_value) and fill_value == 0
+            ):
                 return ak.contents.NumpyArray(
                     nplike.zeros_like(original, dtype=dtype),
                     parameters=layout.parameters,
                 )
-            elif ensure_known_scalar(fill_value == 1, False):
+            elif not is_unknown_scalar(fill_value) and fill_value == 1:
                 return ak.contents.NumpyArray(
                     nplike.ones_like(original, dtype=dtype),
                     parameters=layout.parameters,

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -8,6 +8,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import is_unknown_scalar
+from awkward._regularize import is_integer_like
 from awkward.operations.ak_zeros_like import _ZEROS
 
 __all__ = ("full_like",)
@@ -126,13 +127,19 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
             original = nplike.asarray(layout.data)
 
             if fill_value is _ZEROS or (
-                not is_unknown_scalar(fill_value) and fill_value == 0
+                is_integer_like(fill_value)
+                and not is_unknown_scalar(fill_value)
+                and fill_value == 0
             ):
                 return ak.contents.NumpyArray(
                     nplike.zeros_like(original, dtype=dtype),
                     parameters=layout.parameters,
                 )
-            elif not is_unknown_scalar(fill_value) and fill_value == 1:
+            elif (
+                is_integer_like(fill_value)
+                and not is_unknown_scalar(fill_value)
+                and fill_value == 1
+            ):
                 return ak.contents.NumpyArray(
                     nplike.ones_like(original, dtype=dtype),
                     parameters=layout.parameters,

--- a/tests/test_2857_full_like_scalar.py
+++ b/tests/test_2857_full_like_scalar.py
@@ -1,0 +1,36 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    arr = ak.Array([{"x": 1}, {"x": 2}])
+    # Fill with
+    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="<M8[s]")
+    assert result.layout.is_equal_to(
+        ak.contents.RecordArray(
+            [
+                ak.contents.NumpyArray(
+                    np.array([20, 20], dtype=np.dtype("datetime64[s]"))
+                )
+            ],
+            ["x"],
+        )
+    )
+
+
+def test_typetracer():
+    arr = ak.Array([{"x": 1}, {"x": 2}], backend="typetracer")
+    # Fill with
+    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="<M8[s]")
+    assert result.layout.form == (
+        ak.forms.RecordForm(
+            [ak.forms.NumpyForm("datetime64[s]")],
+            ["x"],
+        )
+    )


### PR DESCRIPTION
Currently we follow a ufunc branch in `full_like`, which can be avoided. This branch may fail for non-castable fill-value dtypes e.g. datetime64.