### PR TITLE
fix: `Array.__getitem__` should set `attrs` on result

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -621,7 +621,12 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         See also #ak.to_list.
         """
         for item in self._layout:
-            yield wrap_layout(prepare_layout(item), self._behavior, allow_other=True)
+            yield wrap_layout(
+                prepare_layout(item),
+                self._behavior,
+                allow_other=True,
+                attrs=self._attrs,
+            )
 
     def __getitem__(self, where):
         """
@@ -1054,7 +1059,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         """
         with ak._errors.SlicingErrorContext(self, where):
             return wrap_layout(
-                prepare_layout(self._layout[where]), self._behavior, allow_other=True
+                prepare_layout(self._layout[where]),
+                self._behavior,
+                allow_other=True,
+                attrs=self._attrs,
             )
 
     def __bytes__(self) -> bytes:
@@ -1969,7 +1977,10 @@ class Record(NDArrayOperatorsMixin):
         """
         with ak._errors.SlicingErrorContext(self, where):
             return wrap_layout(
-                prepare_layout(self._layout[where]), self._behavior, allow_other=True
+                prepare_layout(self._layout[where]),
+                self._behavior,
+                allow_other=True,
+                attrs=self._attrs,
             )
 
     def __setitem__(self, where, what):

--- a/tests/test_2866_getitem_attrs.py
+++ b/tests/test_2866_getitem_attrs.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+ATTRS = {"foo": "bar", "@foo": "baz"}
+
+
+def test_array_slice():
+    array = ak.Array([[0, 1, 2], [4]], attrs=ATTRS)
+    assert array.attrs is ATTRS
+
+    assert array[0].attrs is ATTRS
+    assert array[1:].attrs is ATTRS
+
+
+def test_array_field():
+    array = ak.Array([[{"x": 1}, {"x": 2}], [{"x": 10}]], attrs=ATTRS)
+    assert array.attrs is ATTRS
+
+    assert array.x.attrs is ATTRS
+    assert array.x[1:].attrs is ATTRS
+
+
+def test_record_field():
+    array = ak.Array([{"x": [1, 2, 3]}], attrs=ATTRS)
+    assert array.attrs is ATTRS
+
+    record = array[0]
+    assert record.attrs is ATTRS
+    assert record.x.attrs is ATTRS


### PR DESCRIPTION
The assignment of `attrs` to derived arrays was missing in highlevel. This fixes it, and adds more tests!