### PR TITLE
ci: compile header only tests in Debug mode

### DIFF
--- a/.github/workflows/header-only-test.yml
+++ b/.github/workflows/header-only-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Run CMake
       run: |
-        cmake -B build -S header-only -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+        cmake -B build -S header-only -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=bin -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
         cmake --build build/
 
     - name: Run tests


### PR DESCRIPTION
The header only tests were compiled in `Release` mode,
therefore making all `assert` statements ineffective.

See for example https://github.com/zonca/awkward/pull/4
where I add an error in the unit test but tests pass anyway
