### PR TITLE
feat: Implement Indexed builder

### DIFF
--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1126,7 +1126,7 @@ namespace awkward {
       /// @brief Inserts the last valid index in the `index` buffer and
       /// returns the reference to the builder content.
       BUILDER&
-      append() noexcept {
+      append_index() noexcept {
         index_.append(content_.length());
         return content_;
       }
@@ -1136,7 +1136,7 @@ namespace awkward {
       ///
       /// Just an interface; not actually faster than calling append many times.
       BUILDER&
-      extend(size_t size) noexcept {
+      extend_index(size_t size) noexcept {
         size_t start = content_.length();
         size_t stop = start + size;
         for (size_t i = start; i < stop; i++) {

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1085,6 +1085,218 @@ namespace awkward {
     };
 
 
+    /// @class Indexed
+    ///
+    /// @brief Builds an IndexedArray which consists of an `index` buffer.
+    /// The negative values in the index are interpreted as missing.
+    ///
+    /// The index values can be 64-bit signed integers `int64`, 32-bit signed
+    /// integers `int32`.
+    ///
+    /// @tparam PRIMITIVE The type of `index` buffer.
+    /// @tparam BUILDER The type of builder content.
+    template <typename PRIMITIVE, typename BUILDER>
+    class Indexed {
+    public:
+      /// @brief Creates a new Indexed layout builder by allocating a new `index`
+      /// buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
+      Indexed()
+          : index_(
+                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      /// @brief Creates a new Indexed layout builder by allocating a new `index`
+      /// buffer, taking `options` from {@link BuilderOptions BuilderOptions}
+      /// for initializing the buffer.
+      ///
+      /// @param options Initial size configuration of a buffer.
+      Indexed(const awkward::BuilderOptions& options)
+          : index_(awkward::GrowableBuffer<PRIMITIVE>(options)),
+            last_valid_(-1) {
+        size_t id = 0;
+        set_id(id);
+      }
+
+      /// @brief Returns the reference to the builder content.
+      BUILDER&
+      content() noexcept {
+        return content_;
+      }
+
+      /// @brief Inserts the last valid index in the `index` buffer and
+      /// returns the reference to the builder content.
+      BUILDER&
+      append_valid() noexcept {
+        last_valid_ = content_.length();
+        index_.append(last_valid_);
+        return content_;
+      }
+
+      /// @brief Inserts `size` number of valid index in the `index` buffer
+      /// and returns the reference to the builder content.
+      ///
+      /// Just an interface; not actually faster than calling append many times.
+      BUILDER&
+      extend_valid(size_t size) noexcept {
+        size_t start = content_.length();
+        size_t stop = start + size;
+        last_valid_ = stop - 1;
+        for (size_t i = start; i < stop; i++) {
+          index_.append(i);
+        }
+        return content_;
+      }
+
+      /// @brief Inserts `-1` in the `index` buffer.
+      void
+      append_invalid() noexcept {
+        index_.append(-1);
+      }
+
+      /// @brief Inserts `-1` in the `index` buffer `size` number of times
+      ///
+      /// Just an interface; not actually faster than calling append many times.
+      void
+      extend_invalid(size_t size) noexcept {
+        for (size_t i = 0; i < size; i++) {
+          index_.append(-1);
+        }
+      }
+
+      /// @brief Parameters for the builder form.
+      const std::string&
+      parameters() const noexcept {
+        return parameters_;
+      }
+
+      /// @brief Sets the form parameters.
+      void
+      set_parameters(std::string parameter) noexcept {
+        parameters_ = parameter;
+      }
+
+      /// @brief Assigns a unique ID to each node.
+      void
+      set_id(size_t& id) noexcept {
+        id_ = id;
+        id++;
+        content_.set_id(id);
+      }
+
+      /// @brief Discards the accumulated index and clears the content
+      /// of the builder. Also, last valid returns to `-1`.
+      void
+      clear() noexcept {
+        last_valid_ = -1;
+        index_.clear();
+        content_.clear();
+      }
+
+      /// @brief Current length of the `index` buffer.
+      size_t
+      length() const noexcept {
+        return index_.length();
+      }
+
+      /// @brief Checks for validity and consistency.
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != last_valid_ + 1) {
+          std::stringstream out;
+          out << "Indexed node" << id_ << " has content length "
+              << content_.length() << " but last valid index is " << last_valid_
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
+      /// @brief Retrieves the names and sizes (in bytes) of the buffers used
+      /// in the builder and its contents.
+      void
+      buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const
+          noexcept {
+        names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
+        content_.buffer_nbytes(names_nbytes);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in each of the
+      /// buffers of the builder and its contents to user-defined pointers.
+      ///
+      /// Used to fill the buffers map by allocating it with user-defined pointers
+      /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
+      void
+      to_buffers(std::map<std::string, void*>& buffers) const noexcept {
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_buffers(buffers);
+      }
+
+      /// @brief Copies and concatenates the accumulated data in the builder buffer to
+      /// a user-defined pointer if the given node name matches with the node associated
+      /// with the builder; otherwise, it searches the builder contents to locate a
+      /// matching node.
+      void
+      to_buffer(void* buffer, const char* name) const noexcept {
+        if (std::string(name) == std::string("node" + std::to_string(id_) + "-index")) {
+          index_.concatenate(reinterpret_cast<PRIMITIVE*>(buffer));
+        }
+        content_.to_buffer(buffer, name);
+      }
+
+      /// @brief Copies and concatenates all the accumulated data in the builder
+      /// to a map of user-allocated buffers.
+      ///
+      /// The map keys and the buffer sizes are obtained from #buffer_nbytes
+      void
+      to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
+        index_.concatenate(reinterpret_cast<PRIMITIVE*>(
+            buffers["node" + std::to_string(id_) + "-index"]));
+        content_.to_char_buffers(buffers);
+      }
+
+      /// @brief Generates a unique description of the builder and its
+      /// contents in the form of a JSON-like string.
+      std::string
+      form() const noexcept {
+        std::stringstream form_key;
+        form_key << "node" << id_;
+        std::string params("");
+        if (parameters_ == "") {
+        } else {
+          params = std::string(", \"parameters\": { " + parameters_ + " }");
+        }
+        return "{ \"class\": \"IndexedOptionArray\", \"index\": \"" +
+               type_to_numpy_like<PRIMITIVE>() +
+               "\", \"content\": " + content_.form() + params +
+               ", \"form_key\": \"" + form_key.str() + "\" }";
+      }
+
+    private:
+      /// @brief Buffer of `PRIMITIVE` type.
+      ///
+      /// It specifies the index of each element.
+      GrowableBuffer<PRIMITIVE> index_;
+
+      /// @brief The content of the IndexedOptionArray.
+      BUILDER content_;
+
+      /// @brief Form parameters.
+      std::string parameters_;
+
+      /// @brief Unique form ID.
+      size_t id_;
+
+      /// @brief Last valid index.
+      size_t last_valid_;
+    };
+
     /// @class IndexedOption
     ///
     /// @brief Builds an IndexedOptionArray which consists of an `index` buffer.

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1188,6 +1188,22 @@ namespace awkward {
         content_.buffer_nbytes(names_nbytes);
       }
 
+      /// @brief Checks for validity and consistency.
+      bool
+      is_valid(std::string& error) const noexcept {
+        if (content_.length() != index_.length()) {
+          std::stringstream out;
+          out << "Indexed node" << id_ << " has content length "
+              << content_.length() << " but index has length " << index_.length()
+              << "\n";
+          error.append(out.str());
+
+          return false;
+        } else {
+          return content_.is_valid(error);
+        }
+      }
+
       /// @brief Copies and concatenates all the accumulated data in each of the
       /// buffers of the builder and its contents to user-defined pointers.
       ///

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1088,7 +1088,6 @@ namespace awkward {
     /// @class Indexed
     ///
     /// @brief Builds an IndexedArray which consists of an `index` buffer.
-    /// The negative values in the index are interpreted as missing.
     ///
     /// The index values can be 64-bit signed integers `int64`, 32-bit signed
     /// integers `int32`.
@@ -1102,8 +1101,7 @@ namespace awkward {
       /// buffer, using `AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS` for initializing the buffer.
       Indexed()
           : index_(
-                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
-            last_valid_(-1) {
+                awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
       }
@@ -1114,8 +1112,7 @@ namespace awkward {
       ///
       /// @param options Initial size configuration of a buffer.
       Indexed(const awkward::BuilderOptions& options)
-          : index_(awkward::GrowableBuffer<PRIMITIVE>(options)),
-            last_valid_(-1) {
+          : index_(awkward::GrowableBuffer<PRIMITIVE>(options)) {
         size_t id = 0;
         set_id(id);
       }
@@ -1129,41 +1126,23 @@ namespace awkward {
       /// @brief Inserts the last valid index in the `index` buffer and
       /// returns the reference to the builder content.
       BUILDER&
-      append_valid() noexcept {
-        last_valid_ = content_.length();
-        index_.append(last_valid_);
+      append() noexcept {
+        index_.append(content_.length());
         return content_;
       }
 
-      /// @brief Inserts `size` number of valid index in the `index` buffer
+      /// @brief Inserts `size` number indices in the `index` buffer
       /// and returns the reference to the builder content.
       ///
       /// Just an interface; not actually faster than calling append many times.
       BUILDER&
-      extend_valid(size_t size) noexcept {
+      extend(size_t size) noexcept {
         size_t start = content_.length();
         size_t stop = start + size;
-        last_valid_ = stop - 1;
         for (size_t i = start; i < stop; i++) {
           index_.append(i);
         }
         return content_;
-      }
-
-      /// @brief Inserts `-1` in the `index` buffer.
-      void
-      append_invalid() noexcept {
-        index_.append(-1);
-      }
-
-      /// @brief Inserts `-1` in the `index` buffer `size` number of times
-      ///
-      /// Just an interface; not actually faster than calling append many times.
-      void
-      extend_invalid(size_t size) noexcept {
-        for (size_t i = 0; i < size; i++) {
-          index_.append(-1);
-        }
       }
 
       /// @brief Parameters for the builder form.
@@ -1187,10 +1166,9 @@ namespace awkward {
       }
 
       /// @brief Discards the accumulated index and clears the content
-      /// of the builder. Also, last valid returns to `-1`.
+      /// of the builder.
       void
       clear() noexcept {
-        last_valid_ = -1;
         index_.clear();
         content_.clear();
       }
@@ -1199,22 +1177,6 @@ namespace awkward {
       size_t
       length() const noexcept {
         return index_.length();
-      }
-
-      /// @brief Checks for validity and consistency.
-      bool
-      is_valid(std::string& error) const noexcept {
-        if (content_.length() != last_valid_ + 1) {
-          std::stringstream out;
-          out << "Indexed node" << id_ << " has content length "
-              << content_.length() << " but last valid index is " << last_valid_
-              << "\n";
-          error.append(out.str());
-
-          return false;
-        } else {
-          return content_.is_valid(error);
-        }
       }
 
       /// @brief Retrieves the names and sizes (in bytes) of the buffers used
@@ -1272,7 +1234,7 @@ namespace awkward {
         } else {
           params = std::string(", \"parameters\": { " + parameters_ + " }");
         }
-        return "{ \"class\": \"IndexedOptionArray\", \"index\": \"" +
+        return "{ \"class\": \"IndexedArray\", \"index\": \"" +
                type_to_numpy_like<PRIMITIVE>() +
                "\", \"content\": " + content_.form() + params +
                ", \"form_key\": \"" + form_key.str() + "\" }";
@@ -1292,9 +1254,6 @@ namespace awkward {
 
       /// @brief Unique form ID.
       size_t id_;
-
-      /// @brief Last valid index.
-      size_t last_valid_;
     };
 
     /// @class IndexedOption

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1090,7 +1090,7 @@ namespace awkward {
     /// @brief Builds an IndexedArray which consists of an `index` buffer.
     ///
     /// The index values can be 64-bit signed integers `int64`, 32-bit signed
-    /// integers `int32`.
+    /// integers `int32` or 32-bit unsigned integers `uint32`.
     ///
     /// @tparam PRIMITIVE The type of `index` buffer.
     /// @tparam BUILDER The type of builder content.

--- a/header-only/tests/test_1494-layout-builder.cpp
+++ b/header-only/tests/test_1494-layout-builder.cpp
@@ -1217,8 +1217,6 @@ test_Indexed() {
   IndexedBuilder<uint32_t, NumpyBuilder<double>> builder;
   assert(builder.length() == 0);
 
-  std::cout << "Executing test_Indexed";
-
   auto& subbuilder = builder.append_index();
   subbuilder.append(1.1);
 

--- a/header-only/tests/test_1494-layout-builder.cpp
+++ b/header-only/tests/test_1494-layout-builder.cpp
@@ -1227,7 +1227,7 @@ test_Indexed() {
 
   double data[3] = {3.3, 4.4, 5.5};
 
-  builder.extend_index(1);
+  builder.extend_index(3);
   subbuilder.extend(data, 3);
 
   // [1.1, 2.2, 3.3, 4.4, 5.5]

--- a/header-only/tests/test_1494-layout-builder.cpp
+++ b/header-only/tests/test_1494-layout-builder.cpp
@@ -1267,60 +1267,6 @@ test_Indexed() {
 }
 
 void
-test_Indexed_as_IndexedOption() {
-  IndexedOptionBuilder<uint32_t, NumpyBuilder<double>> builder;
-  assert(builder.length() == 0);
-
-  auto& subbuilder = builder.append_valid();
-  subbuilder.append(1.1);
-
-  builder.append_valid();
-  subbuilder.append(2.2);
-
-  double data[3] = {3.3, 4.4, 5.5};
-
-  builder.extend_valid(3);
-  subbuilder.extend(data, 3);
-
-  // [1.1, 2.2, 3.3, 4.4, 5.5]
-
-  std::string error;
-  assert(builder.is_valid(error) == true);
-
-  std::map<std::string, size_t> names_nbytes = {};
-  builder.buffer_nbytes(names_nbytes);
-  assert(names_nbytes.size() == 2);
-
-  auto buffers = empty_buffers(names_nbytes);
-  builder.to_buffers(buffers);
-
-  std::ostringstream out;
-  dump(out,
-       "node0-index", (uint32_t*)buffers["node0-index"], names_nbytes["node0-index"]/sizeof(uint32_t),
-       "node1-data", (double*)buffers["node1-data"], names_nbytes["node1-data"]/sizeof(double));
-
-  std::string check{"node0-index: 0 1 2 3 4 \n"
-                    "node1-data: 1.1 2.2 3.3 4.4 5.5 \n"};
-  assert(out.str().compare(check) == 0);
-
-  assert(builder.form() ==
-  "{ "
-      "\"class\": \"IndexedOptionArray\", "
-      "\"index\": \"u32\", "
-      "\"content\": { "
-          "\"class\": \"NumpyArray\", "
-          "\"primitive\": \"float64\", "
-          "\"form_key\": \"node1\" "
-      "}, "
-      "\"form_key\": \"node0\" "
-  "}");
-
-  clear_buffers(buffers);
-  builder.clear();
-  assert(builder.length() == 0);
-}
-
-void
 test_IndexedOption() {
   IndexedOptionBuilder<int32_t, NumpyBuilder<double>> builder;
   assert(builder.length() == 0);
@@ -1931,7 +1877,6 @@ int main(int /* argc */, char ** /* argv */) {
   test_Tuple_Numpy_ListOffset();
   test_Regular();
   test_Regular_size0();
-  test_Indexed_as_IndexedOption();
   test_Indexed();
   test_IndexedOption();
   test_IndexedOption_Record();


### PR DESCRIPTION
As discussed with @jpivarski and @ManasviGoyal, here is the implementation of the Indexed layout builder.
The final objective is to use this for `EnumType` instead of using `NumpyBuilder`.