### PR TITLE
fix: failing tests after #2877

### DIFF
--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_ByteMaskedArray_getitem_nextcarry.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_ByteMaskedArray_getitem_nextcarry.cu
@@ -15,8 +15,8 @@ template <typename T, typename C>
 __global__ void
 awkward_ByteMaskedArray_getitem_nextcarry_a(T* tocarry,
                                             const C* mask,
-                                            bool validwhen,
                                             int64_t length,
+                                            bool validwhen,
                                             int64_t* scan_in_array,
                                             uint64_t invocation_index,
                                             uint64_t* err_code) {
@@ -37,8 +37,8 @@ template <typename T, typename C>
 __global__ void
 awkward_ByteMaskedArray_getitem_nextcarry_b(T* tocarry,
                                             const C* mask,
-                                            bool validwhen,
                                             int64_t length,
+                                            bool validwhen,
                                             int64_t* scan_in_array,
                                             uint64_t invocation_index,
                                             uint64_t* err_code) {

--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_getitem_jagged_expand.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_getitem_jagged_expand.cu
@@ -18,7 +18,7 @@ awkward_ListArray_getitem_jagged_expand(T* multistarts,
                                         uint64_t invocation_index,
                                         uint64_t* err_code) {
   if (err_code[0] == NO_ERROR) {
-    int64_t thread_id = (blockIdx.x * blockDim.x + threadIdx.x) / jaggedsize;
+    int64_t thread_id = (blockIdx.x * blockDim.x + threadIdx.x) % length;
     int64_t thready_id = (blockIdx.x * blockDim.x + threadIdx.x) % jaggedsize;
     W start = fromstarts[thread_id];
     X stop = fromstops[thread_id];


### PR DESCRIPTION
Just noticed that a few changes in #2877 are making the cuda tests fail. So I have fixed them.