### PR TITLE
chore: only copy non-test headers

### DIFF
--- a/dev/copy-cpp-headers.py
+++ b/dev/copy-cpp-headers.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     if connect_path.exists():
         shutil.rmtree(connect_path)
     connect_path.mkdir(parents=True)
-    for path in header_only_path.rglob("*.h"):
+    for path in header_only_path.rglob("*/awkward/*.h"):
         dest_path = connect_path / path.name
         shutil.copy(path, dest_path)
 


### PR DESCRIPTION
Whilst checking our wheel to ensure that the necessary headers are included (c.f. #2892), I noticed that an extra header file has snuck into the archive.

This PR ensures we only flatten the `header-only/*/awkward/*` heirarchy.