### PR TITLE
fix: include header-only files in sdist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,8 @@ repos:
       files: src
       additional_dependencies:
         - numpy>=1.24
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.15
+  hooks:
+    - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ include = [
     "/requirements-test-minimal.txt"
 ]
 artifacts = [
-    "/tests-cuda-kernels"
+    "/tests-cuda-kernels",
     "/src/awkward/_connect/header-only",
     "/src/awkward/_connect/cuda/_kernel_signatures.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,14 +62,12 @@ init = "awkward.numba:_register"
 "Releases" = "https://github.com/scikit-hep/awkward-1.0/releases"
 "Source Code" = "https://github.com/scikit-hep/awkward-1.0"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.wheel]
+packages = ["src/awkward"]
 artifacts = [
     "/src/awkward/_connect/header-only",
     "/src/awkward/_connect/cuda/_kernel_signatures.py"
 ]
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/awkward"]
 
 [tool.hatch.build.targets.wheel.hooks.version]
 path = "src/awkward/_version.py"
@@ -89,6 +87,8 @@ include = [
 ]
 artifacts = [
     "/tests-cuda-kernels"
+    "/src/awkward/_connect/header-only",
+    "/src/awkward/_connect/cuda/_kernel_signatures.py"
 ]
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]


### PR DESCRIPTION
Fixes #2897 by ensuring that our SDist includes the header-only files. This is necessary both because semantically the SDist should represent a snapshot of the repo (in our case a generated snapshot), and because it's possible to build wheels from SDists, which is not possible if files are missing.