### PR TITLE
fix: lazily project union contents

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -708,7 +708,7 @@ class UnionArray(UnionMeta[Content], Content):
         nextcarry = ak.index.Index64(
             tmpcarry.data[: lenout[0]], nplike=self._backend.index_nplike
         )
-        return self._contents[index]._carry(nextcarry, False)
+        return self._contents[index]._carry(nextcarry, True)
 
     @staticmethod
     def regular_index(

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -947,7 +947,7 @@ def _recurse_union_non_union(
 
         # Index over them
         index = ak.index.Index64(index_data)
-        return ak.contents.IndexedArray(index, next_content)
+        return ak.contents.IndexedArray.simplified(index, next_content)
     else:
         # Find the first content whose type equals the given type
         for tag, content in enumerate(layout.contents):  # noqa: B007


### PR DESCRIPTION
This fixes #2911 by changing the projection policy of unions, as described in https://github.com/scikit-hep/awkward/issues/2911#issuecomment-1865440604

ping @lgray 