### PR TITLE
fix: ak.std and ak.var for axis != -1.

### DIFF
--- a/tests/test_0115_generic_reducer_operation.py
+++ b/tests/test_0115_generic_reducer_operation.py
@@ -2153,10 +2153,14 @@ def test_nonreducers():
     )
 
     assert ak.operations.mean(y) == np.mean(ak.operations.to_numpy(y))
-    assert ak.operations.var(y) == np.var(ak.operations.to_numpy(y))
-    assert ak.operations.var(y, ddof=1) == np.var(ak.operations.to_numpy(y), ddof=1)
-    assert ak.operations.std(y) == np.std(ak.operations.to_numpy(y))
-    assert ak.operations.std(y, ddof=1) == np.std(ak.operations.to_numpy(y), ddof=1)
+    assert ak.operations.var(y) == pytest.approx(np.var(ak.operations.to_numpy(y)))
+    assert ak.operations.var(y, ddof=1) == pytest.approx(
+        np.var(ak.operations.to_numpy(y), ddof=1)
+    )
+    assert ak.operations.std(y) == pytest.approx(np.std(ak.operations.to_numpy(y)))
+    assert ak.operations.std(y, ddof=1) == pytest.approx(
+        np.std(ak.operations.to_numpy(y), ddof=1)
+    )
 
     assert ak.operations.moment(y, 1) == np.mean(ak.operations.to_numpy(y))
     assert ak.operations.moment(y - ak.operations.mean(y), 2) == np.var(

--- a/tests/test_2754_highlevel_behavior_missing.py
+++ b/tests/test_2754_highlevel_behavior_missing.py
@@ -17,8 +17,8 @@ behavior = {**behavior_1, **behavior_2}
     ("func", "axis"),
     [
         pytest.param(ak.softmax, 0, marks=pytest.mark.xfail()),
-        pytest.param(ak.std, 0, marks=pytest.mark.xfail()),
-        pytest.param(ak.var, 0, marks=pytest.mark.xfail()),
+        (ak.std, 0),
+        (ak.var, 0),
         (ak.softmax, 1),
         (ak.std, 1),
         (ak.var, 1),

--- a/tests/test_2918_fix_var_axis_not_minus_one.py
+++ b/tests/test_2918_fix_var_axis_not_minus_one.py
@@ -1,0 +1,29 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test():
+    data = ak.Array(
+        [[[0, 1.1, 2.2], []], [], [[3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]]]
+    )
+    assert ak.var(data, axis=0).tolist() == [
+        pytest.approx([2.7225, 2.7225, 0]),
+        pytest.approx([0]),
+        pytest.approx([0, 0, 0, 0]),
+    ]
+    assert ak.var(data, axis=1).tolist() == [
+        pytest.approx([0, 0, 0]),
+        pytest.approx([]),
+        pytest.approx([1.88222222, 2.7225, 0, 0]),
+    ]
+    assert ak.var(data, axis=2).tolist() == [
+        pytest.approx([0.80666667, np.nan], nan_ok=True),
+        pytest.approx([]),
+        pytest.approx([0.3025, 0, 1.5125]),
+    ]


### PR DESCRIPTION
Although $\frac{1}{n}\sum_i (x_i - \mbox{mean}(x))^2$ is more precise than $(\frac{1}{n}\sum_i x_i^2) - \mbox{mean}(x)$, the latter can only be broadcasted when `axis=-1`. This had been failing without a useful error message; now it works (with less precision).