### PR TITLE
test: add PyPy to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,10 @@ jobs:
             python-architecture: x64
             runs-on: ubuntu-latest
             dependencies-kind: minimal
+          - python-version: 'pypy3.9'
+            python-architecture: x64
+            runs-on: ubuntu-latest
+            dependencies-kind: pypy
 
     runs-on: ${{ matrix.runs-on }}
 

--- a/requirements-test-pypy.txt
+++ b/requirements-test-pypy.txt
@@ -1,0 +1,3 @@
+pytest>=6
+pytest-cov
+pytest-xdist

--- a/tests/test_2757_attrs_metadata.py
+++ b/tests/test_2757_attrs_metadata.py
@@ -41,7 +41,9 @@ def test_serialise_with_transient_attrs(array_pickler):
 def test_serialise_with_nonserialisable_attrs(array_pickler):
     attrs = {**SOME_ATTRS, "non_transient_key": lambda: None}
     array = ak.Array([1, 2, 3], attrs=attrs)
-    with pytest.raises(AttributeError, match=r"Can't pickle local object"):
+    with pytest.raises(
+        (AttributeError, array_pickler.PicklingError), match=r"Can't pickle"
+    ):
         array_pickler.loads(array_pickler.dumps(array))
 
 


### PR DESCRIPTION
I saw a segfault in Ragged with PyPy (https://github.com/jpivarski/ragged/actions/runs/7465258504/job/20314035307) and although there were no indications that the segfault was due to Awkward, we should probably be testing Awkward with PyPy just to be aware of how often, if ever, this happens.

Since GitHub deletes these after some time, here's a copy of the segfault output from that test:

<details>
<pre>
2024-01-09T18:21:22.9683857Z Requested labels: ubuntu-latest
2024-01-09T18:21:22.9684049Z Job defined at: jpivarski/ragged/.github/workflows/ci.yml@refs/pull/9/merge
2024-01-09T18:21:22.9684151Z Waiting for a runner to pick up this job...
2024-01-09T18:21:24.6245679Z Job is waiting for a hosted runner to come online.
2024-01-09T18:21:26.7282134Z Job is about to start running on the hosted runner: GitHub Actions 9 (hosted)
2024-01-09T18:21:28.7953688Z Current runner version: '2.311.0'
2024-01-09T18:21:28.7976694Z ##[group]Operating System
2024-01-09T18:21:28.7977293Z Ubuntu
2024-01-09T18:21:28.7977743Z 22.04.3
2024-01-09T18:21:28.7978085Z LTS
2024-01-09T18:21:28.7978386Z ##[endgroup]
2024-01-09T18:21:28.7978839Z ##[group]Runner Image
2024-01-09T18:21:28.7979285Z Image: ubuntu-22.04
2024-01-09T18:21:28.7979649Z Version: 20231217.2.0
2024-01-09T18:21:28.7980705Z Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20231217.2/images/ubuntu/Ubuntu2204-Readme.md
2024-01-09T18:21:28.7982170Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20231217.2
2024-01-09T18:21:28.7983004Z ##[endgroup]
2024-01-09T18:21:28.7983481Z ##[group]Runner Image Provisioner
2024-01-09T18:21:28.7983982Z 2.0.321.1
2024-01-09T18:21:28.7984278Z ##[endgroup]
2024-01-09T18:21:28.7985319Z ##[group]GITHUB_TOKEN Permissions
2024-01-09T18:21:28.7986845Z Contents: read
2024-01-09T18:21:28.7987387Z Metadata: read
2024-01-09T18:21:28.7987925Z Packages: read
2024-01-09T18:21:28.7988462Z ##[endgroup]
2024-01-09T18:21:28.7991761Z Secret source: Actions
2024-01-09T18:21:28.7992349Z Prepare workflow directory
2024-01-09T18:21:28.8724045Z Prepare all required actions
2024-01-09T18:21:28.8881428Z Getting action download info
2024-01-09T18:21:29.1097823Z Download action repository 'actions/checkout@v4' (SHA:b4ffde65f46336ab88eb53be808477a3936bae11)
2024-01-09T18:21:29.2324043Z Download action repository 'actions/setup-python@v5' (SHA:0a5c61591373683505ea898e09a3ea4f39ef2b9c)
2024-01-09T18:21:29.7226639Z Download action repository 'codecov/codecov-action@v3.1.4' (SHA:eaaf4bedf32dbdc6b720b63067d99c4d77d6047d)
2024-01-09T18:21:30.2565561Z Complete job name: Check Python pypy-3.10 on ubuntu-latest
2024-01-09T18:21:30.3496377Z ##[group]Run actions/checkout@v4
2024-01-09T18:21:30.3497085Z with:
2024-01-09T18:21:30.3497455Z   fetch-depth: 0
2024-01-09T18:21:30.3497860Z   repository: jpivarski/ragged
2024-01-09T18:21:30.3498626Z   token: ***
2024-01-09T18:21:30.3499039Z   ssh-strict: true
2024-01-09T18:21:30.3499425Z   persist-credentials: true
2024-01-09T18:21:30.3499928Z   clean: true
2024-01-09T18:21:30.3500316Z   sparse-checkout-cone-mode: true
2024-01-09T18:21:30.3500777Z   fetch-tags: false
2024-01-09T18:21:30.3501237Z   show-progress: true
2024-01-09T18:21:30.3501640Z   lfs: false
2024-01-09T18:21:30.3501956Z   submodules: false
2024-01-09T18:21:30.3502433Z   set-safe-directory: true
2024-01-09T18:21:30.3502859Z env:
2024-01-09T18:21:30.3503152Z   FORCE_COLOR: 3
2024-01-09T18:21:30.3503595Z ##[endgroup]
2024-01-09T18:21:30.5653285Z Syncing repository: jpivarski/ragged
2024-01-09T18:21:30.5656315Z ##[group]Getting Git version info
2024-01-09T18:21:30.5657974Z Working directory is '/home/runner/work/ragged/ragged'
2024-01-09T18:21:30.5659789Z [command]/usr/bin/git version
2024-01-09T18:21:30.5660779Z git version 2.43.0
2024-01-09T18:21:30.5687873Z ##[endgroup]
2024-01-09T18:21:30.5707364Z Temporarily overriding HOME='/home/runner/work/_temp/97ca100c-9896-49a2-8e0d-8dbc3caeb0e1' before making global git config changes
2024-01-09T18:21:30.5709684Z Adding repository directory to the temporary git global config as a safe directory
2024-01-09T18:21:30.5711951Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/ragged/ragged
2024-01-09T18:21:30.5745603Z Deleting the contents of '/home/runner/work/ragged/ragged'
2024-01-09T18:21:30.5751871Z ##[group]Initializing the repository
2024-01-09T18:21:30.5755442Z [command]/usr/bin/git init /home/runner/work/ragged/ragged
2024-01-09T18:21:30.5824103Z hint: Using 'master' as the name for the initial branch. This default branch name
2024-01-09T18:21:30.5825785Z hint: is subject to change. To configure the initial branch name to use in all
2024-01-09T18:21:30.5827594Z hint: of your new repositories, which will suppress this warning, call:
2024-01-09T18:21:30.5828769Z hint: 
2024-01-09T18:21:30.5829702Z hint: 	git config --global init.defaultBranch <name>
2024-01-09T18:21:30.5830851Z hint: 
2024-01-09T18:21:30.5832516Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2024-01-09T18:21:30.5834165Z hint: 'development'. The just-created branch can be renamed via this command:
2024-01-09T18:21:30.5835478Z hint: 
2024-01-09T18:21:30.5836123Z hint: 	git branch -m <name>
2024-01-09T18:21:30.5837311Z Initialized empty Git repository in /home/runner/work/ragged/ragged/.git/
2024-01-09T18:21:30.5844996Z [command]/usr/bin/git remote add origin https://github.com/jpivarski/ragged
2024-01-09T18:21:30.5879891Z ##[endgroup]
2024-01-09T18:21:30.5880840Z ##[group]Disabling automatic garbage collection
2024-01-09T18:21:30.5882134Z [command]/usr/bin/git config --local gc.auto 0
2024-01-09T18:21:30.5909811Z ##[endgroup]
2024-01-09T18:21:30.5910512Z ##[group]Setting up auth
2024-01-09T18:21:30.5915226Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2024-01-09T18:21:30.5943033Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2024-01-09T18:21:30.6544072Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2024-01-09T18:21:30.6574165Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2024-01-09T18:21:30.6807726Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2024-01-09T18:21:30.6843051Z ##[endgroup]
2024-01-09T18:21:30.6844523Z ##[group]Fetching the repository
2024-01-09T18:21:30.6855864Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +637ba6d5f0a2d02eb72bb4183136c0139eb2caea:refs/remotes/pull/9/merge
2024-01-09T18:21:31.1194051Z From https://github.com/jpivarski/ragged
2024-01-09T18:21:31.1195922Z  * [new branch]      jpivarski/use-NotImplementedError        -> origin/jpivarski/use-NotImplementedError
2024-01-09T18:21:31.1197593Z  * [new branch]      main                                     -> origin/main
2024-01-09T18:21:31.1198384Z  * [new tag]         v0.0.1                                   -> v0.0.1
2024-01-09T18:21:31.1201028Z  * [new ref]         637ba6d5f0a2d02eb72bb4183136c0139eb2caea -> pull/9/merge
2024-01-09T18:21:31.1230223Z ##[endgroup]
2024-01-09T18:21:31.1231485Z ##[group]Determining the checkout info
2024-01-09T18:21:31.1232504Z ##[endgroup]
2024-01-09T18:21:31.1233459Z ##[group]Checking out the ref
2024-01-09T18:21:31.1236390Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/9/merge
2024-01-09T18:21:31.1295964Z Note: switching to 'refs/remotes/pull/9/merge'.
2024-01-09T18:21:31.1296877Z 
2024-01-09T18:21:31.1298773Z You are in 'detached HEAD' state. You can look around, make experimental
2024-01-09T18:21:31.1301955Z changes and commit them, and you can discard any commits you make in this
2024-01-09T18:21:31.1305641Z state without impacting any branches by switching back to a branch.
2024-01-09T18:21:31.1306394Z 
2024-01-09T18:21:31.1306913Z If you want to create a new branch to retain commits you create, you may
2024-01-09T18:21:31.1308276Z do so (now or later) by using -c with the switch command. Example:
2024-01-09T18:21:31.1309085Z 
2024-01-09T18:21:31.1309378Z   git switch -c <new-branch-name>
2024-01-09T18:21:31.1309787Z 
2024-01-09T18:21:31.1310040Z Or undo this operation with:
2024-01-09T18:21:31.1310433Z 
2024-01-09T18:21:31.1310615Z   git switch -
2024-01-09T18:21:31.1311011Z 
2024-01-09T18:21:31.1311728Z Turn off this advice by setting config variable advice.detachedHead to false
2024-01-09T18:21:31.1312486Z 
2024-01-09T18:21:31.1313327Z HEAD is now at 637ba6d Merge d78bbb728116cdf0ad61728f3fdce17ce96bc38d into dda1f9d44253024a6de8a6bc070bc7e671bedb49
2024-01-09T18:21:31.1318580Z ##[endgroup]
2024-01-09T18:21:31.1353051Z [command]/usr/bin/git log -1 --format='%H'
2024-01-09T18:21:31.1376341Z '637ba6d5f0a2d02eb72bb4183136c0139eb2caea'
2024-01-09T18:21:31.1689819Z ##[group]Run actions/setup-python@v5
2024-01-09T18:21:31.1690418Z with:
2024-01-09T18:21:31.1690743Z   python-version: pypy-3.10
2024-01-09T18:21:31.1691117Z   allow-prereleases: true
2024-01-09T18:21:31.1691563Z   check-latest: false
2024-01-09T18:21:31.1692053Z   token: ***
2024-01-09T18:21:31.1692379Z   update-environment: true
2024-01-09T18:21:31.1692810Z env:
2024-01-09T18:21:31.1693101Z   FORCE_COLOR: 3
2024-01-09T18:21:31.1693418Z ##[endgroup]
2024-01-09T18:21:31.3430434Z ##[group]Installed versions
2024-01-09T18:21:31.3713189Z Successfully set up PyPy 7.3.13 with Python (3.10.13)
2024-01-09T18:21:31.3715016Z ##[endgroup]
2024-01-09T18:21:31.3885942Z ##[group]Run python -m pip install .[test]
2024-01-09T18:21:31.3886555Z [36;1mpython -m pip install .[test][0m
2024-01-09T18:21:31.3953226Z shell: /usr/bin/bash -e {0}
2024-01-09T18:21:31.3953654Z env:
2024-01-09T18:21:31.3954076Z   FORCE_COLOR: 3
2024-01-09T18:21:31.3954520Z   pythonLocation: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:21:31.3955101Z   Python_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:21:31.3955733Z   Python2_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:21:31.3956323Z   Python3_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:21:31.3956960Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/PyPy/3.10.13/x64/bin/lib/pkgconfig
2024-01-09T18:21:31.3957597Z ##[endgroup]
2024-01-09T18:21:38.0570653Z Processing /home/runner/work/ragged/ragged
2024-01-09T18:21:38.0656919Z   Installing build dependencies: started
2024-01-09T18:21:42.8846695Z   Installing build dependencies: finished with status 'done'
2024-01-09T18:21:42.8865346Z   Getting requirements to build wheel: started
2024-01-09T18:21:43.1219572Z   Getting requirements to build wheel: finished with status 'done'
2024-01-09T18:21:43.1237549Z   Preparing metadata (pyproject.toml): started
2024-01-09T18:21:43.7467352Z   Preparing metadata (pyproject.toml): finished with status 'done'
2024-01-09T18:21:44.0902278Z /opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pip/_vendor/certifi/cacert.pem None
2024-01-09T18:21:44.0903628Z Collecting awkward (from ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.1647058Z /opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pip/_vendor/certifi/cacert.pem None
2024-01-09T18:21:44.1648541Z   Downloading awkward-2.5.1-py3-none-any.whl.metadata (6.9 kB)
2024-01-09T18:21:44.2334016Z Collecting pytest-cov>=3 (from ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.2641763Z   Downloading pytest_cov-4.1.0-py3-none-any.whl.metadata (26 kB)
2024-01-09T18:21:44.4169430Z Collecting pytest>=6 (from ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.4401631Z   Downloading pytest-7.4.4-py3-none-any.whl.metadata (7.9 kB)
2024-01-09T18:21:44.5187883Z Collecting iniconfig (from pytest>=6->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.5481412Z   Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
2024-01-09T18:21:44.6444996Z Collecting packaging (from pytest>=6->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.6487304Z   Using cached packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
2024-01-09T18:21:44.6913926Z Collecting pluggy<2.0,>=0.12 (from pytest>=6->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.6947835Z   Using cached pluggy-1.3.0-py3-none-any.whl.metadata (4.3 kB)
2024-01-09T18:21:44.7302572Z Collecting exceptiongroup>=1.0.0rc8 (from pytest>=6->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.7553618Z   Downloading exceptiongroup-1.2.0-py3-none-any.whl.metadata (6.6 kB)
2024-01-09T18:21:44.7917307Z Collecting tomli>=1.0.0 (from pytest>=6->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:44.7949219Z   Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
2024-01-09T18:21:45.1450250Z Collecting coverage>=5.2.1 (from coverage[toml]>=5.2.1->pytest-cov>=3->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:45.1720433Z   Downloading coverage-7.4.0-pp38.pp39.pp310-none-any.whl.metadata (8.1 kB)
2024-01-09T18:21:45.2684210Z Collecting awkward-cpp==27 (from awkward->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:45.2909499Z   Downloading awkward_cpp-27-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.2 kB)
2024-01-09T18:21:45.4043614Z Collecting importlib-metadata>=4.13.0 (from awkward->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:45.4271730Z   Downloading importlib_metadata-7.0.1-py3-none-any.whl.metadata (4.9 kB)
2024-01-09T18:21:45.5566647Z Collecting numpy>=1.18.0 (from awkward->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:21:45.5803172Z   Downloading numpy-1.26.3.tar.gz (15.7 MB)
2024-01-09T18:21:45.6276895Z [?25l     [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.0/15.7 MB[0m [31m?[0m eta [36m-:--:--[0m
2024-01-09T18:21:45.6686926Z [2K     [91m╸[0m[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.3/15.7 MB[0m [31m8.2 MB/s[0m eta [36m0:00:02[0m
2024-01-09T18:21:45.7201795Z [2K     [91m━━━[0m[91m╸[0m[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m1.6/15.7 MB[0m [31m20.9 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:45.7633982Z [2K     [91m━━━━━━━━━━━[0m[90m╺[0m[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m4.4/15.7 MB[0m [31m38.1 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:45.8094468Z [2K     [91m━━━━━━━━━━━━━━━━[0m[91m╸[0m[90m━━━━━━━━━━━━━━━━━━━━━━━[0m [32m6.5/15.7 MB[0m [31m38.9 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:45.8579237Z [2K     [91m━━━━━━━━━━━━━━━━━━━━━━━━[0m[91m╸[0m[90m━━━━━━━━━━━━━━━[0m [32m9.8/15.7 MB[0m [31m46.4 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:45.9026246Z [2K     [91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m[91m╸[0m[90m━━━━━━━[0m [32m12.9/15.7 MB[0m [31m60.6 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:45.9716912Z [2K     [91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m[90m╺[0m [32m15.4/15.7 MB[0m [31m64.0 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:46.0128844Z [2K     [91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m[91m╸[0m [32m15.7/15.7 MB[0m [31m61.4 MB/s[0m eta [36m0:00:01[0m
2024-01-09T18:21:46.0131044Z [2K     [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m15.7/15.7 MB[0m [31m38.3 MB/s[0m eta [36m0:00:00[0m
2024-01-09T18:21:49.0474714Z [?25h  Installing build dependencies: started
2024-01-09T18:21:52.2795766Z   Installing build dependencies: finished with status 'done'
2024-01-09T18:21:52.2813757Z   Getting requirements to build wheel: started
2024-01-09T18:21:52.5616751Z   Getting requirements to build wheel: finished with status 'done'
2024-01-09T18:21:52.5668476Z   Installing backend dependencies: started
2024-01-09T18:21:54.1203479Z   Installing backend dependencies: finished with status 'done'
2024-01-09T18:21:54.1217246Z   Preparing metadata (pyproject.toml): started
2024-01-09T18:22:56.7665170Z   Preparing metadata (pyproject.toml): still running...
2024-01-09T18:23:57.0330212Z   Preparing metadata (pyproject.toml): still running...
2024-01-09T18:24:25.4646759Z   Preparing metadata (pyproject.toml): finished with status 'done'
2024-01-09T18:24:25.5087641Z Collecting typing-extensions>=4.1.0 (from awkward->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:24:25.5117369Z   Using cached typing_extensions-4.9.0-py3-none-any.whl.metadata (3.0 kB)
2024-01-09T18:24:25.6366676Z Collecting zipp>=0.5 (from importlib-metadata>=4.13.0->awkward->ragged==0.0.2.dev8+g637ba6d)
2024-01-09T18:24:25.6601815Z   Downloading zipp-3.17.0-py3-none-any.whl.metadata (3.7 kB)
2024-01-09T18:24:25.7736310Z Downloading pytest-7.4.4-py3-none-any.whl (325 kB)
2024-01-09T18:24:25.7958590Z [?25l   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.0/325.3 kB[0m [31m?[0m eta [36m-:--:--[0m
2024-01-09T18:24:25.7960392Z [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m325.3/325.3 kB[0m [31m49.9 MB/s[0m eta [36m0:00:00[0m
2024-01-09T18:24:25.8193333Z [?25hDownloading pytest_cov-4.1.0-py3-none-any.whl (21 kB)
2024-01-09T18:24:25.8458937Z Downloading awkward-2.5.1-py3-none-any.whl (733 kB)
2024-01-09T18:24:25.8662281Z [?25l   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.0/733.1 kB[0m [31m?[0m eta [36m-:--:--[0m
2024-01-09T18:24:25.8664374Z [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m733.1/733.1 kB[0m [31m71.4 MB/s[0m eta [36m0:00:00[0m
2024-01-09T18:24:25.8949965Z [?25hDownloading awkward_cpp-27-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (706 kB)
2024-01-09T18:24:25.9192803Z [?25l   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.0/706.5 kB[0m [31m?[0m eta [36m-:--:--[0m
2024-01-09T18:24:25.9194779Z [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m706.5/706.5 kB[0m [31m67.8 MB/s[0m eta [36m0:00:00[0m
2024-01-09T18:24:25.9432706Z [?25hDownloading coverage-7.4.0-pp38.pp39.pp310-none-any.whl (198 kB)
2024-01-09T18:24:25.9607456Z [?25l   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m0.0/198.1 kB[0m [31m?[0m eta [36m-:--:--[0m
2024-01-09T18:24:25.9609428Z [2K   [90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m [32m198.1/198.1 kB[0m [31m34.0 MB/s[0m eta [36m0:00:00[0m
2024-01-09T18:24:25.9851699Z [?25hDownloading exceptiongroup-1.2.0-py3-none-any.whl (16 kB)
2024-01-09T18:24:26.0124094Z Downloading importlib_metadata-7.0.1-py3-none-any.whl (23 kB)
2024-01-09T18:24:26.0192715Z Using cached pluggy-1.3.0-py3-none-any.whl (18 kB)
2024-01-09T18:24:26.0225071Z Using cached typing_extensions-4.9.0-py3-none-any.whl (32 kB)
2024-01-09T18:24:26.0285629Z Using cached packaging-23.2-py3-none-any.whl (53 kB)
2024-01-09T18:24:26.0526766Z Downloading zipp-3.17.0-py3-none-any.whl (7.4 kB)
2024-01-09T18:24:26.0938995Z Building wheels for collected packages: ragged, numpy
2024-01-09T18:24:26.0957571Z   Building wheel for ragged (pyproject.toml): started
2024-01-09T18:24:26.1666319Z   Building wheel for ragged (pyproject.toml): finished with status 'done'
2024-01-09T18:24:26.1686634Z   Created wheel for ragged: filename=ragged-0.0.2.dev8+g637ba6d-py3-none-any.whl size=39236 sha256=64ebf256b51ed39506818c94a091d0391de2ca92e431e736bf5c3a92e4ef7da0
2024-01-09T18:24:26.1692471Z   Stored in directory: /tmp/pip-ephem-wheel-cache-t1zqxqac/wheels/e4/cd/fa/792c0758271a2668e05ac9c1c362d7ce1c357e71711aa56d7f
2024-01-09T18:24:26.1756287Z   Building wheel for numpy (pyproject.toml): started
2024-01-09T18:24:26.2744292Z   Building wheel for numpy (pyproject.toml): finished with status 'done'
2024-01-09T18:24:26.3085223Z   Created wheel for numpy: filename=numpy-1.26.3-pp310-pypy310_pp73-linux_x86_64.whl size=26260318 sha256=21a2716e132ceda03cd23351b4f152f006400cf219db0351da2e0ffec4e88aa4
2024-01-09T18:24:26.3089796Z   Stored in directory: /home/runner/.cache/pip/wheels/d1/e8/89/7de6c44b202bdcf4de8a26b3bcfaaba7998a9244880c794839
2024-01-09T18:24:26.3300941Z Successfully built ragged numpy
2024-01-09T18:24:26.6073174Z Installing collected packages: zipp, typing-extensions, tomli, pluggy, packaging, numpy, iniconfig, exceptiongroup, coverage, pytest, importlib-metadata, awkward-cpp, pytest-cov, awkward, ragged
2024-01-09T18:24:30.5324307Z Successfully installed awkward-2.5.1 awkward-cpp-27 coverage-7.4.0 exceptiongroup-1.2.0 importlib-metadata-7.0.1 iniconfig-2.0.0 numpy-1.26.3 packaging-23.2 pluggy-1.3.0 pytest-7.4.4 pytest-cov-4.1.0 ragged-0.0.2.dev8+g637ba6d tomli-2.0.1 typing-extensions-4.9.0 zipp-3.17.0
2024-01-09T18:24:30.5951447Z 
2024-01-09T18:24:30.5953933Z [1m[[0m[34;49mnotice[0m[1;39;49m][0m[39;49m A new release of pip is available: [0m[31;49m23.0.1[0m[39;49m -> [0m[32;49m23.3.2[0m
2024-01-09T18:24:30.5958113Z [1m[[0m[34;49mnotice[0m[1;39;49m][0m[39;49m To update, run: [0m[32;49mpip install --upgrade pip[0m
2024-01-09T18:24:31.0055140Z ##[group]Run python -m pytest -ra --cov --cov-report=xml --cov-report=term --durations=20
2024-01-09T18:24:31.0056146Z [36;1mpython -m pytest -ra --cov --cov-report=xml --cov-report=term --durations=20[0m
2024-01-09T18:24:31.0107418Z shell: /usr/bin/bash -e {0}
2024-01-09T18:24:31.0107803Z env:
2024-01-09T18:24:31.0108076Z   FORCE_COLOR: 3
2024-01-09T18:24:31.0108576Z   pythonLocation: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:24:31.0109186Z   Python_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:24:31.0109759Z   Python2_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:24:31.0110386Z   Python3_ROOT_DIR: /opt/hostedtoolcache/PyPy/3.10.13/x64
2024-01-09T18:24:31.0111020Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/PyPy/3.10.13/x64/bin/lib/pkgconfig
2024-01-09T18:24:31.0111854Z ##[endgroup]
2024-01-09T18:24:37.0924270Z Fatal Python error: Segmentation fault
2024-01-09T18:24:37.0925180Z 
2024-01-09T18:24:37.0925938Z Stack (most recent call first, approximate line numbers):
2024-01-09T18:24:37.0930871Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/assertion/rewrite.py", line 354 in _rewrite_test
2024-01-09T18:24:37.0933238Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/assertion/rewrite.py", line 146 in exec_module
2024-01-09T18:24:37.0935029Z   File "<frozen importlib._bootstrap>", line 664 in _load_unlocked
2024-01-09T18:24:37.0936294Z   File "<frozen importlib._bootstrap>", line 987 in _find_and_load_unlocked
2024-01-09T18:24:37.0937509Z   File "<frozen importlib._bootstrap>", line 1022 in _find_and_load
2024-01-09T18:24:37.0938729Z   File "<frozen importlib._bootstrap>", line 1038 in _gcd_import
2024-01-09T18:24:37.0940325Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/importlib/__init__.py", line 108 in import_module
2024-01-09T18:24:37.0942557Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/pathlib.py", line 486 in import_path
2024-01-09T18:24:37.0945000Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/python.py", line 613 in _importtestmodule
2024-01-09T18:24:37.0947234Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/python.py", line 527 in _getobj
2024-01-09T18:24:37.0949310Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/python.py", line 305 in obj
2024-01-09T18:24:37.0951963Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/python.py", line 536 in _inject_setup_module_fixture
2024-01-09T18:24:37.0954209Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/python.py", line 530 in collect
2024-01-09T18:24:37.0956365Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/runner.py", line 372 in <lambda>
2024-01-09T18:24:37.0958632Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/runner.py", line 318 in from_call
2024-01-09T18:24:37.0960098Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/runner.py", line 371 in pytest_make_collect_report
2024-01-09T18:24:37.0961352Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_callers.py", line 27 in _multicall
2024-01-09T18:24:37.0962692Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_manager.py", line 106 in _hookexec
2024-01-09T18:24:37.0964323Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_hooks.py", line 479 in __call__
2024-01-09T18:24:37.0965632Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/runner.py", line 544 in collect_one_node
2024-01-09T18:24:37.0966806Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 833 in genitems
2024-01-09T18:24:37.0968254Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 616 in perform_collect
2024-01-09T18:24:37.0969620Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 334 in pytest_collection
2024-01-09T18:24:37.0970848Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_callers.py", line 27 in _multicall
2024-01-09T18:24:37.0972010Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_manager.py", line 106 in _hookexec
2024-01-09T18:24:37.0973282Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_hooks.py", line 479 in __call__
2024-01-09T18:24:37.0974440Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 321 in _main
2024-01-09T18:24:37.0975614Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 258 in wrap_session
2024-01-09T18:24:37.0976897Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/main.py", line 317 in pytest_cmdline_main
2024-01-09T18:24:37.0978128Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_callers.py", line 27 in _multicall
2024-01-09T18:24:37.0979342Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_manager.py", line 106 in _hookexec
2024-01-09T18:24:37.0980540Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pluggy/_hooks.py", line 479 in __call__
2024-01-09T18:24:37.0981749Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/config/__init__.py", line 135 in main
2024-01-09T18:24:37.0983030Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/_pytest/config/__init__.py", line 185 in console_main
2024-01-09T18:24:37.0984312Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/site-packages/pytest/__main__.py", line 1 in <module>
2024-01-09T18:24:37.0985256Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/runpy.py", line 63 in _run_code
2024-01-09T18:24:37.0986213Z   File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/runpy.py", line 174 in _run_module_as_main
2024-01-09T18:24:37.0987052Z   File "<builtin>/app_main.py", line 133 in run_toplevel
2024-01-09T18:24:37.0987619Z   File "<builtin>/app_main.py", line 748 in run_command_line
2024-01-09T18:24:37.0988207Z   File "<builtin>/app_main.py", line 1149 in entry_point
2024-01-09T18:24:41.3182158Z /home/runner/work/_temp/be0d65a0-dd21-47ab-a9a8-14d26f566a27.sh: line 1:  4652 Segmentation fault      (core dumped) python -m pytest -ra --cov --cov-report=xml --cov-report=term --durations=20
2024-01-09T18:24:41.3197738Z ##[error]Process completed with exit code 139.
2024-01-09T18:24:41.3298530Z Post job cleanup.
2024-01-09T18:24:41.4040054Z [command]/usr/bin/git version
2024-01-09T18:24:41.4079674Z git version 2.43.0
2024-01-09T18:24:41.4121547Z Temporarily overriding HOME='/home/runner/work/_temp/98fef141-08d1-4736-8a53-e5d9a9afa270' before making global git config changes
2024-01-09T18:24:41.4123577Z Adding repository directory to the temporary git global config as a safe directory
2024-01-09T18:24:41.4127345Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/ragged/ragged
2024-01-09T18:24:41.4162735Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2024-01-09T18:24:41.4200663Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2024-01-09T18:24:41.4449371Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2024-01-09T18:24:41.4468964Z http.https://github.com/.extraheader
2024-01-09T18:24:41.4481633Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2024-01-09T18:24:41.4509478Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2024-01-09T18:24:41.5025650Z Cleaning up orphan processes
</pre>
</details>