### PR TITLE
fix: cartesian nested record

### DIFF
--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -312,7 +312,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
 
         result = ak.contents.RecordArray(outs, fields, parameters=parameters)
         for i in range(len(array_layouts))[::-1]:
-            if i in nested:
+            if i in nested_as_index:
                 result = ak.contents.RegularArray(result, layouts[i + 1].length, 0)
 
     else:

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -290,8 +290,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
 
     backend = next((layout.backend for layout in layouts), cpu)
     if posaxis == 0:
+        # Translate nested field names to nested field indices
         if fields is not None:
-            nested = [i for i, name in enumerate(fields) if name in nested]
+            nested_as_index = [i for i, name in enumerate(fields) if name in nested]
+        else:
+            nested_as_index = nested
 
         indexes = [
             ak.index.Index64(backend.index_nplike.reshape(x, (-1,)))
@@ -313,6 +316,11 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
                 result = ak.contents.RegularArray(result, layouts[i + 1].length, 0)
 
     else:
+        # Translate nested field names to nested field indices
+        if fields is not None:
+            nested_as_index = [i for i, name in enumerate(fields) if name in nested]
+        else:
+            nested_as_index = nested
 
         def add_outer_dimensions(
             layout: ak.contents.Content, n: int
@@ -369,7 +377,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
         axes_to_flatten = [
             posaxis + i + 1
             for i, _ in enumerate(array_layouts)
-            if i < len(array_layouts) - 1 and i not in nested
+            if i < len(array_layouts) - 1 and i not in nested_as_index
         ]
         # This list *must* be sorted in reverse order
         axes_to_flatten.reverse()

--- a/tests/test_2329_cartesian_broadcasting_fixes.py
+++ b/tests/test_2329_cartesian_broadcasting_fixes.py
@@ -8,7 +8,7 @@ import pytest  # noqa: F401
 import awkward as ak
 
 
-def test_nested_exis_0():
+def test_nested_axis_0():
     arrays = {"x": np.arange(4), "y": ["this", "that", "foo", "bar!"]}
 
     result = ak.cartesian(arrays, nested=True, axis=0)

--- a/tests/test_2928_nested_cartesian_record.py
+++ b/tests/test_2928_nested_cartesian_record.py
@@ -1,0 +1,94 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+pa = pytest.importorskip("pyarrow")
+
+
+def test():
+    one = ak.zip({"pt": [[1, 2], [1]], "eta": [[1.1, 2.1], [1]]})
+    two = ak.zip({"pt": [[2.1], [2.21, 2.22]], "eta": [[2.11], [2.221, 2.222]]})
+    assert ak.cartesian({"foo": one, "bar": two}, nested=False).layout.is_equal_to(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 2, 4]),
+            ak.contents.RecordArray(
+                [
+                    ak.contents.IndexedArray(
+                        ak.index.Index64([0, 1, 2, 2]),
+                        ak.contents.RecordArray(
+                            [
+                                ak.contents.NumpyArray(
+                                    np.array([1, 2, 1], dtype=np.int64)
+                                ),
+                                ak.contents.NumpyArray(
+                                    np.array([1.1, 2.1, 1.0], dtype=np.float64)
+                                ),
+                            ],
+                            ["pt", "eta"],
+                        ),
+                    ),
+                    ak.contents.IndexedArray(
+                        ak.index.Index64([0, 0, 1, 2]),
+                        ak.contents.RecordArray(
+                            [
+                                ak.contents.NumpyArray(
+                                    np.array([2.1, 2.21, 2.22], dtype=np.float64)
+                                ),
+                                ak.contents.NumpyArray(
+                                    np.array([2.11, 2.221, 2.222], dtype=np.float64)
+                                ),
+                            ],
+                            ["pt", "eta"],
+                        ),
+                    ),
+                ],
+                ["foo", "bar"],
+            ),
+        )
+    )
+    assert ak.cartesian({"foo": one, "bar": two}, nested=True).layout.is_equal_to(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64([0, 2, 3]),
+            ak.contents.ListOffsetArray(
+                ak.index.Index64([0, 1, 2, 4]),
+                ak.contents.RecordArray(
+                    [
+                        ak.contents.IndexedArray(
+                            ak.index.Index64([0, 1, 2, 2]),
+                            ak.contents.RecordArray(
+                                [
+                                    ak.contents.NumpyArray(
+                                        np.array([1, 2, 1], dtype=np.int64)
+                                    ),
+                                    ak.contents.NumpyArray(
+                                        np.array([1.1, 2.1, 1.0], dtype=np.float64)
+                                    ),
+                                ],
+                                ["pt", "eta"],
+                            ),
+                        ),
+                        ak.contents.IndexedArray(
+                            ak.index.Index64([0, 0, 1, 2]),
+                            ak.contents.RecordArray(
+                                [
+                                    ak.contents.NumpyArray(
+                                        np.array([2.1, 2.21, 2.22], dtype=np.float64)
+                                    ),
+                                    ak.contents.NumpyArray(
+                                        np.array([2.11, 2.221, 2.222], dtype=np.float64)
+                                    ),
+                                ],
+                                ["pt", "eta"],
+                            ),
+                        ),
+                    ],
+                    ["foo", "bar"],
+                ),
+            ),
+        )
+    )


### PR DESCRIPTION
Fixes #2928, by normalising string field names to integers.

This code could be further refactored; it's becoming clear that our `recursively_apply` abstraction would benefit from better support for smarter continuations (i.e. re-entrant with a different callable). That can be tackled later, though.