### PR TITLE
feat: add `recursive` flag to `Content.to_packed`

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -771,13 +771,15 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         if self._content.is_record:
             next = self.to_IndexedOptionArray64()
 
-            content = next._content.to_packed()
-            if content.length > self._length:
-                content = content[: self._length]
+            content = (
+                next._content[: self._length].to_packed(True)
+                if recursive
+                else next._content[: self._length]
+            )
 
             return ak.contents.IndexedOptionArray(
                 next._index, content, parameters=next._parameters
@@ -790,9 +792,11 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             else:
                 mask = self._mask[:excess_length]
 
-            content = self._content.to_packed()
-            if content.length > self._length:
-                content = content[: self._length]
+            content = (
+                self._content[: self._length].to_packed(True)
+                if recursive
+                else self._content[: self._length]
+            )
 
             return BitMaskedArray(
                 mask,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1133,21 +1133,26 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         if self._content.is_record:
             next = self.to_IndexedOptionArray64()
-            content = next._content.to_packed()
-            if content.length > self._mask.length:
-                content = content[: self._mask.length]
+
+            content = (
+                next._content[: self._mask.length].to_packed(True)
+                if recursive
+                else next._content[: self._mask.length]
+            )
 
             return ak.contents.IndexedOptionArray(
                 next._index, content, parameters=next._parameters
             )
 
         else:
-            content = self._content.to_packed()
-            if content.length > self._mask.length:
-                content = content[: self._mask.length]
+            content = (
+                self._content[: self._mask.length].to_packed(True)
+                if recursive
+                else self._content[: self._mask.length]
+            )
 
             return ByteMaskedArray(
                 self._mask, content, self._valid_when, parameters=self._parameters

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1079,7 +1079,7 @@ class Content(Meta):
             },
         )
 
-    def to_packed(self) -> Content:
+    def to_packed(self, recursive: bool = True) -> Content:
         raise NotImplementedError
 
     def to_list(self, behavior: dict | None = None) -> list:

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -437,7 +437,7 @@ class EmptyArray(EmptyMeta, Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         return self
 
     def _to_list(self, behavior, json_conversions):

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1148,13 +1148,13 @@ class IndexedArray(IndexedMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         if self.parameter("__array__") == "categorical":
-            return IndexedArray(
-                self._index, self._content.to_packed(), parameters=self._parameters
-            )
+            content = self._content.to_packed(True) if recursive else self._content
+            return IndexedArray(self._index, content, parameters=self._parameters)
         else:
-            return self.project().to_packed()
+            projected = self.project()
+            return projected.to_packed(True) if recursive else projected
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1717,28 +1717,28 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
-        index_nplike = self._backend.index_nplike
-        is_none = self._index.data < 0
-        num_none = index_nplike.index_as_shape_item(index_nplike.count_nonzero(is_none))
-        if self.parameter("__array__") == "categorical" or (
-            self._backend.index_nplike.known_data
-            and self._content.length <= (self._index.length - num_none)
-        ):
+    def to_packed(self, recursive: bool = True) -> Self:
+        if self.parameter("__array__") == "categorical":
+            content = self._content.to_packed(True) if recursive else self._content
             return ak.contents.IndexedOptionArray(
-                self._index, self._content.to_packed(), parameters=self._parameters
+                self._index, content, parameters=self._parameters
             )
 
         else:
+            index_nplike = self._backend.index_nplike
+            original_index = self._index.data
+            is_none = original_index < 0
+            num_none = index_nplike.count_nonzero(is_none)
             new_index = index_nplike.empty(self._index.length, dtype=self._index.dtype)
             new_index[is_none] = -1
             new_index[~is_none] = index_nplike.arange(
                 index_nplike.shape_item_as_index(new_index.size - num_none),
                 dtype=self._index.dtype,
             )
+            projected = self.project()
             return ak.contents.IndexedOptionArray(
-                ak.index.Index(new_index, nplike=index_nplike),
-                self.project().to_packed(),
+                ak.index.Index(new_index, nplike=self._backend.index_nplike),
+                projected.to_packed(True) if recursive else projected,
                 parameters=self._parameters,
             )
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1602,8 +1602,8 @@ class ListArray(ListMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
-        return self.to_ListOffsetArray64(True).to_packed()
+    def to_packed(self, recursive: bool = True) -> Self:
+        return self.to_ListOffsetArray64(True).to_packed(recursive)
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2214,10 +2214,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         next = self.to_ListOffsetArray64(True)
-        next_content = next._content[: next._offsets[-1]].to_packed()
-        return ListOffsetArray(next._offsets, next_content, parameters=next._parameters)
+        next_content = next._content[: next._offsets[-1]]
+        return ListOffsetArray(
+            next._offsets,
+            next_content.to_packed(True) if recursive else next_content,
+            parameters=next._parameters,
+        )
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1303,7 +1303,7 @@ class NumpyArray(NumpyMeta, Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         return self.to_contiguous().to_RegularArray()
 
     def _to_list(self, behavior, json_conversions):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1242,12 +1242,10 @@ class RecordArray(RecordMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x.to_packed()
-                if x.length == self._length
-                else x[: self._length].to_packed()
+                x[: self._length].to_packed(True) if recursive else x[: self._length]
                 for x in self._contents
             ],
             self._fields,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -1458,18 +1458,16 @@ class RegularArray(RegularMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         index_nplike = self._backend.index_nplike
         length = self._length * self._size
-        if self._content.length == length:
-            content = self._content.to_packed()
-        else:
-            content = self._content[
-                : index_nplike.shape_item_as_index(length)
-            ].to_packed()
+        content = self._content[: index_nplike.shape_item_as_index(length)]
 
         return RegularArray(
-            content, self._size, self._length, parameters=self._parameters
+            content.to_packed(True) if recursive else content,
+            self._size,
+            self._length,
+            parameters=self._parameters,
         )
 
     def _to_list(self, behavior, json_conversions):

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1592,15 +1592,18 @@ class UnionArray(UnionMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
-        tags = self._tags.raw(self._backend.nplike)
-        original_index = index = self._index.raw(self._backend.nplike)[: tags.shape[0]]
+    def to_packed(self, recursive: bool = True) -> Self:
+        index_nplike = self._backend.index_nplike
+        tags = self._tags.data
+        original_index = index = self._index.data[: tags.shape[0]]
 
         contents = list(self._contents)
 
         for tag in range(len(self._contents)):
             is_tag = tags == tag
-            num_tag = self._backend.index_nplike.count_nonzero(is_tag)
+            num_tag = index_nplike.index_as_shape_item(
+                index_nplike.count_nonzero(is_tag)
+            )
 
             if len(contents[tag]) > num_tag:
                 if original_index is index:
@@ -1610,7 +1613,9 @@ class UnionArray(UnionMeta[Content], Content):
                 )
                 contents[tag] = self.project(tag)
 
-            contents[tag] = contents[tag].to_packed()
+            contents[tag] = (
+                contents[tag].to_packed(True) if recursive else contents[tag]
+            )
 
         return UnionArray(
             ak.index.Index8(tags, nplike=self._backend.index_nplike),

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -564,8 +564,11 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         else:
             raise AssertionError(result)
 
-    def to_packed(self) -> Self:
-        return UnmaskedArray(self._content.to_packed(), parameters=self._parameters)
+    def to_packed(self, recursive: bool = True) -> Self:
+        return UnmaskedArray(
+            self._content.to_packed(True) if recursive else self._content,
+            parameters=self._parameters,
+        )
 
     def _to_list(self, behavior, json_conversions):
         if not self._backend.nplike.known_data:

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -193,11 +193,11 @@ class Record:
     def _getitem_fields(self, where, only_fields: tuple[str, ...] = ()):
         return self._array._getitem_fields(where)._getitem_at(self._at)
 
-    def to_packed(self) -> Self:
+    def to_packed(self, recursive: bool = True) -> Self:
         if self._array.length == 1:
-            return Record(self._array.to_packed(), self._at)
+            return Record(self._array.to_packed(recursive), self._at)
         else:
-            return Record(self._array[self._at : self._at + 1].to_packed(), 0)
+            return Record(self._array[self._at : self._at + 1].to_packed(recursive), 0)
 
     def to_list(self, behavior=None):
         return self._to_list(behavior, None)


### PR DESCRIPTION
This should fix #2916, which was caused by eager recursive packing of the array layout before unflattening.

This was first discussed in https://github.com/scikit-hep/awkward/issues/910#issuecomment-860494445, where we understood that _not_ packing the layout can lead to invalid unflatten operations.

This PR fixes #2916 by introducing a `recursive: bool = True` argument to `Content.to_packed()`. This allows us to perform a single-layout packing, which ensures that nodes below the current node are left untouched, reducing the numbers of buffers required at runtime.

I'm not 100% sure if this is the _right_ API to go with. I _think_ talking about packing non-recursively makes sense, rather than as a shoehorned bugfix. But, @jpivarski if you think otherwise let me know!