### PR TITLE
test: generate unit tests for cpu and cuda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Test CPU kernels
         run: python -m pytest -vv -rs awkward-cpp/tests-cpu-kernels
 
+      - name: Test CPU kernels with explicitly defined values
+        run: python -m pytest -vv -rs awkward-cpp/tests-cpu-kernels-explicit
+
       - name: Test non-kernels
         run: >-
           python -m pytest -vv -rs tests --cov=awkward --cov-report=term

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,12 @@ src/awkward/_connect/header-only
 src/awkward/_version.py
 
 # Kernel tests
+awkward-cpp/tests-cpu-kernels
+awkward-cpp/tests-cpu-kernels-explicit
+awkward-cpp/tests-spec
+awkward-cpp/tests-spec-explicit
 tests-cuda-kernels
+tests-cuda-kernels-explicit
 
 # to use all-contributors-cli without adding it to the project
 node_modules

--- a/awkward-cpp/.gitignore
+++ b/awkward-cpp/.gitignore
@@ -11,5 +11,6 @@ src/awkward_cpp/_kernel_signatures.py
 tests-spec
 tests-spec-explicit
 tests-cpu-kernels
+tests-cpu-kernels-explicit
 
 dist

--- a/awkward-cpp/.gitignore
+++ b/awkward-cpp/.gitignore
@@ -7,10 +7,4 @@ header-only
 include/awkward/kernels.h
 src/awkward_cpp/_kernel_signatures.py
 
-# Kernel tests
-tests-spec
-tests-spec-explicit
-tests-cpu-kernels
-tests-cpu-kernels-explicit
-
 dist

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -68,5 +68,6 @@ sdist.include = [
     "src/awkward_cpp/_kernel_signatures.py",
     "tests-spec",
     "tests-spec-explicit",
-    "tests-cpu-kernels"
+    "tests-cpu-kernels",
+    "tests-cpu-kernels-explicit"
 ]

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -3,6 +3,7 @@ test-requires = ["pytest>=6", "."]
 test-command = """
 pytest {project}/tests \
        {package}/tests-cpu-kernels \
+       {package}/tests-cpu-kernels-explicit \
        {package}/tests-spec \
        {package}/tests-spec-explicit
 """

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -211,6 +211,8 @@ def getdtypes(args):
         if "List" in typename:
             count = typename.count("List")
             typename = gettypename(typename)
+            if typename == "bool" or typename == "float":
+                typename = typename + "_"
             if count == 1:
                 dtypes.append("cupy." + typename)
     return dtypes

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -526,13 +526,13 @@ def gencpuunittests(specdict):
     print("Generating Unit Tests for CPU kernels")
 
     unit_test_map = unittestmap()
-    unit_tests_cuda_kernels = os.path.join(
+    unit_tests_cpu_kernels = os.path.join(
         CURRENT_DIR, "..", "awkward-cpp", "tests-cpu-kernels-explicit"
     )
-    if os.path.exists(unit_tests_cuda_kernels):
-        shutil.rmtree(unit_tests_cuda_kernels)
-    os.mkdir(unit_tests_cuda_kernels)
-    with open(os.path.join(unit_tests_cuda_kernels, "__init__.py"), "w") as f:
+    if os.path.exists(unit_tests_cpu_kernels):
+        shutil.rmtree(unit_tests_cpu_kernels)
+    os.mkdir(unit_tests_cpu_kernels)
+    with open(os.path.join(unit_tests_cpu_kernels, "__init__.py"), "w") as f:
         f.write(
             f"""# AUTO GENERATED ON {reproducible_datetime()}
 # DO NOT EDIT BY HAND!
@@ -551,7 +551,7 @@ def gencpuunittests(specdict):
         if spec.templatized_kernel_name in list(unit_test_map.keys()):
             func = "test_unit_cpu" + spec.name + ".py"
             num = 1
-            with open(os.path.join(unit_tests_cuda_kernels, func), "w") as f:
+            with open(os.path.join(unit_tests_cpu_kernels, func), "w") as f:
                 f.write(
                     f"""# AUTO GENERATED ON {reproducible_datetime()}
 # DO NOT EDIT BY HAND!

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -658,6 +658,37 @@ def gencudakerneltests(specdict):
                                 f.write(" " * 4 + f"assert {arg} == pytest_{arg}\n")
                     f.write("\n")
 
+def gencudaunittests():
+    print("Generating Unit Tests for CUDA kernels")
+
+    unit_tests_cuda_kernels = os.path.join(CURRENT_DIR, "..", "tests-cuda-kernels-explicit")
+    if os.path.exists(unit_tests_cuda_kernels):
+        shutil.rmtree(unit_tests_cuda_kernels)
+    os.mkdir(unit_tests_cuda_kernels)
+    with open(os.path.join(unit_tests_cuda_kernels, "__init__.py"), "w") as f:
+        f.write(
+            f"""# AUTO GENERATED ON {reproducible_datetime()}
+# DO NOT EDIT BY HAND!
+#
+# To regenerate file, run
+#
+#     python dev/generate-tests.py
+#
+
+# fmt: off
+
+"""
+        )
+    with open(os.path.join(CURRENT_DIR, "..", "kernel-test-data.json")) as f:
+        data = json.load(f)["unit-tests"]
+    for function in data:
+            num = 0
+            func = "test_cuda" + function["name"] + ".py"
+            with open(
+                os.path.join(CURRENT_DIR, "..", "tests-cuda-kernels-explicit", func),        
+                "w",
+            ) as file:
+                file.write("import pytest\nimport cupy\n\n")
 
 def genunittests():
     print("Generating Unit Tests")
@@ -715,3 +746,4 @@ if __name__ == "__main__":
     gencpukerneltests(specdict)
     genunittests()
     gencudakerneltests(specdict)
+    gencudaunittests()

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -221,11 +221,7 @@ def checkuint(inputs, args):
     flag = True
     for arg, val in inputs:
         typename = remove_const(
-        next(
-            argument
-            for argument in args
-                if argument.name == arg
-            ).typename
+            next(argument for argument in args if argument.name == arg).typename
         )
         if "List[uint" in typename and (any(n < 0 for n in val)):
             flag = False
@@ -515,15 +511,10 @@ def gencpuunittests(specdict):
         )
 
     for spec in specdict.values():
-        if (
-            spec.templatized_kernel_name in list(unit_tests.keys())
-        ):
+        if spec.templatized_kernel_name in list(unit_tests.keys()):
             func = "test_cpu" + spec.name + ".py"
             num = 0
-            with open(
-                os.path.join(unit_tests_cuda_kernels, func),
-                "w"
-            ) as f:
+            with open(os.path.join(unit_tests_cuda_kernels, func), "w") as f:
                 f.write(
                     f"""# AUTO GENERATED ON {reproducible_datetime()}
 # DO NOT EDIT BY HAND!
@@ -608,12 +599,10 @@ def gencpuunittests(specdict):
                                 args += arg.name
                                 count += 1
                             else:
-                                args += ", " + arg.name               
+                                args += ", " + arg.name
                         f.write(" " * 4 + "ret_pass = funcC(" + args + ")\n")
                         for arg, val in test["outputs"].items():
-                            f.write(
-                                " " * 4 + "pytest_" + arg + " = " + str(val) + "\n"
-                            )
+                            f.write(" " * 4 + "pytest_" + arg + " = " + str(val) + "\n")
                             if isinstance(val, list):
                                 f.write(
                                     " " * 4
@@ -896,7 +885,7 @@ def gencudaunittests(specdict):
                 unit_test_values = unit_tests[spec.templatized_kernel_name]
                 tests = unit_test_values["tests"]
                 status = unit_test_values["status"]
-                for test in tests:                    
+                for test in tests:
                     num += 1
                     funcName = "def test_" + spec.name + "_" + str(num) + "():\n"
                     dtypes = getdtypes(spec.args)
@@ -982,9 +971,7 @@ def gencudaunittests(specdict):
 """
                         )
                         for arg, val in test["outputs"].items():
-                            f.write(
-                                " " * 4 + "pytest_" + arg + " = " + str(val) + "\n"
-                            )
+                            f.write(" " * 4 + "pytest_" + arg + " = " + str(val) + "\n")
                             if isinstance(val, list):
                                 f.write(
                                     " " * 4

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -688,8 +688,6 @@ def gencudaunittests(specdict):
 
 """
         )
-    with open(os.path.join(CURRENT_DIR, "..", "kernel-test-data.json")) as f:
-        data = json.load(f)["unit-tests"]
 
     for spec in specdict.values():
         if spec.templatized_kernel_name in cuda_kernels_tests and spec.templatized_kernel_name in list(cuda_unit_tests.keys()):

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -658,6 +658,7 @@ def gencudakerneltests(specdict):
                                 f.write(" " * 4 + f"assert {arg} == pytest_{arg}\n")
                     f.write("\n")
 
+
 def cudaunittestmap():
     with open(os.path.join(CURRENT_DIR, "..", "kernel-test-data.json")) as f:
         data = json.load(f)["unit-tests"]
@@ -666,11 +667,14 @@ def cudaunittestmap():
         cuda_unit_tests_map[function["name"]] = function["tests"]
     return cuda_unit_tests_map
 
+
 def gencudaunittests(specdict):
     print("Generating Unit Tests for CUDA kernels")
 
     cuda_unit_tests = cudaunittestmap()
-    unit_tests_cuda_kernels = os.path.join(CURRENT_DIR, "..", "tests-cuda-kernels-explicit")
+    unit_tests_cuda_kernels = os.path.join(
+        CURRENT_DIR, "..", "tests-cuda-kernels-explicit"
+    )
     if os.path.exists(unit_tests_cuda_kernels):
         shutil.rmtree(unit_tests_cuda_kernels)
     os.mkdir(unit_tests_cuda_kernels)
@@ -690,7 +694,10 @@ def gencudaunittests(specdict):
         )
 
     for spec in specdict.values():
-        if spec.templatized_kernel_name in cuda_kernels_tests and spec.templatized_kernel_name in list(cuda_unit_tests.keys()):
+        if (
+            spec.templatized_kernel_name in cuda_kernels_tests
+            and spec.templatized_kernel_name in list(cuda_unit_tests.keys())
+        ):
             func = "test_cuda" + spec.templatized_kernel_name + ".py"
             num = 0
             with open(
@@ -698,7 +705,7 @@ def gencudaunittests(specdict):
                 "w",
             ) as file:
                 file.write(
-                        f"""# AUTO GENERATED ON {reproducible_datetime()}
+                    f"""# AUTO GENERATED ON {reproducible_datetime()}
 # DO NOT EDIT BY HAND!
 #
 # To regenerate file, run
@@ -721,7 +728,13 @@ def gencudaunittests(specdict):
                 )
                 for test in cuda_unit_tests[spec.templatized_kernel_name]:
                     num += 1
-                    funcName = "def test_" + spec.templatized_kernel_name + "_" + str(num) + "():\n"
+                    funcName = (
+                        "def test_"
+                        + spec.templatized_kernel_name
+                        + "_"
+                        + str(num)
+                        + "():\n"
+                    )
                     file.write(funcName)
                     dtypes = []
                     for arg, val in test["outputs"].items():
@@ -733,7 +746,9 @@ def gencudaunittests(specdict):
                             ).typename
                         )
                         if "List" not in typename:
-                            file.write(" " * 4 + arg + " = " + str([123] * len(val)) + "\n")
+                            file.write(
+                                " " * 4 + arg + " = " + str([123] * len(val)) + "\n"
+                            )
                         if "List" in typename:
                             count = typename.count("List")
                             typename = gettypename(typename)

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -547,7 +547,7 @@ def gencpuunittests(specdict):
 
     for spec in specdict.values():
         if spec.templatized_kernel_name in list(unit_test_map.keys()):
-            func = "test_cpu" + spec.name + ".py"
+            func = "test_unit_cpu" + spec.name + ".py"
             num = 1
             with open(os.path.join(unit_tests_cuda_kernels, func), "w") as f:
                 f.write(
@@ -572,7 +572,9 @@ def gencpuunittests(specdict):
                 unit_test_values = unit_test_map[spec.templatized_kernel_name]
                 tests = unit_test_values["tests"]
                 for test in tests:
-                    funcName = "def test_" + spec.name + "_" + str(num) + "():\n"
+                    funcName = (
+                        "def test_unit_cpu" + spec.name + "_" + str(num) + "():\n"
+                    )
                     unit_tests, num_outputs = getunittests(
                         test["inputs"], test["outputs"]
                     )
@@ -867,7 +869,7 @@ def gencudaunittests(specdict):
             spec.templatized_kernel_name in cuda_kernels_tests
             and spec.templatized_kernel_name in list(unit_test_map.keys())
         ):
-            func = "test_cuda" + spec.name + ".py"
+            func = "test_unit_cuda" + spec.name + ".py"
             num = 1
             with open(
                 os.path.join(unit_tests_cuda_kernels, func),
@@ -899,7 +901,9 @@ def gencudaunittests(specdict):
                 tests = unit_test_values["tests"]
                 status = unit_test_values["status"]
                 for test in tests:
-                    funcName = "def test_" + spec.name + "_" + str(num) + "():\n"
+                    funcName = (
+                        "def test_unit_cuda" + spec.name + "_" + str(num) + "():\n"
+                    )
                     dtypes = getdtypes(spec.args)
                     unit_tests, num_outputs = getunittests(
                         test["inputs"], test["outputs"]

--- a/kernel-test-data.json
+++ b/kernel-test-data.json
@@ -289,6 +289,7 @@
     "unit-tests": [
         {
             "name": "awkward_missing_repeat",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -800,6 +801,7 @@
         },
         {
             "name": "awkward_index_rpad_and_clip_axis0",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -913,6 +915,7 @@
         },
         {
             "name": "awkward_BitMaskedArray_to_ByteMaskedArray",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -951,6 +954,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_getitem_nextcarry",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -976,6 +980,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_getitem_nextcarry_outindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1010,6 +1015,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_numnull",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1185,6 +1191,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_toIndexedOptionArray",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1210,6 +1217,7 @@
         },
         {
             "name": "awkward_IndexedArray_flatten_nextcarry",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1225,6 +1233,7 @@
         },
         {
             "name": "awkward_IndexedArray_getitem_nextcarry",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1500,6 +1509,7 @@
         },
         {
             "name": "awkward_IndexedArray_getitem_nextcarry_outindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1527,6 +1537,7 @@
         },
         {
             "name": "awkward_IndexedArray_numnull",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -1649,6 +1660,7 @@
         },
         {
             "name": "awkward_ListArray_broadcast_tooffsets",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -2782,6 +2794,7 @@
         },
         {
             "name": "awkward_ListArray_compact_offsets",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -3577,6 +3590,7 @@
         },
         {
             "name": "awkward_RegularArray_localindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -3600,6 +3614,7 @@
         },
         {
             "name": "awkward_RegularArray_rpad_and_clip_axis1",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -3675,6 +3690,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_carry",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -4120,6 +4136,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_jagged_expand",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -4415,6 +4432,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_array",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -5452,6 +5470,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_array_advanced",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -5639,6 +5658,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_array_regularize",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -6434,6 +6454,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_at",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -6649,6 +6670,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_range",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -7266,6 +7288,7 @@
         },
         {
             "name": "awkward_RegularArray_getitem_next_range_spreadadvanced",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -7291,6 +7314,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_flatten_offsets",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -7604,6 +7628,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_toRegularArray",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -7654,6 +7679,7 @@
         },
         {
             "name": "awkward_MaskedArray_getitem_next_jagged_project",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -7703,6 +7729,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8005,6 +8032,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_overlay_mask",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8021,6 +8049,7 @@
         },
         {
             "name": "awkward_IndexedArray_flatten_none2empty",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8103,6 +8132,7 @@
         },
         {
             "name": "awkward_IndexedArray_reduce_next_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8229,6 +8259,7 @@
         },
         {
             "name": "awkward_IndexedArray_simplify",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8608,6 +8639,7 @@
         },
         {
             "name": "awkward_IndexedArray_validity",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -8993,6 +9025,7 @@
         },
         {
             "name": "awkward_IndexedOptionArray_rpad_and_clip_mask_axis1",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9007,6 +9040,7 @@
         },
         {
             "name": "awkward_index_rpad_and_clip_axis1",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9142,6 +9176,7 @@
         },
         {
             "name": "awkward_ListArray_combinations_length",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9231,6 +9266,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_jagged_carrylen",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9551,6 +9587,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_jagged_descend",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9600,6 +9637,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_jagged_expand",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9631,6 +9669,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_next_array",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9706,6 +9745,7 @@
         },
         {
             "name": "awkward_ListArray_min_range",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9751,6 +9791,7 @@
         },
         {
             "name": "awkward_ListArray_rpad_and_clip_length_axis1",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -9877,6 +9918,7 @@
         },
         {
             "name": "awkward_ListArray_validity",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -10440,6 +10482,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_jagged_apply",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -10805,6 +10848,7 @@
         },
         {
             "name": "awkward_UnionArray_regular_index",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -10843,6 +10887,7 @@
         },
         {
             "name": "awkward_UnionArray_regular_index_getsize",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -10875,6 +10920,7 @@
         },
         {
             "name": "awkward_IndexedArray_fill",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -10950,6 +10996,7 @@
         },
         {
             "name": "awkward_ListArray_fill",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11095,6 +11142,7 @@
         },
         {
             "name": "awkward_UnionArray_fillindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11120,6 +11168,7 @@
         },
         {
             "name": "awkward_UnionArray_validity",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11185,6 +11234,7 @@
         },
         {
             "name": "awkward_ByteMaskedArray_reduce_next_nonlocal_nextshifts_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11200,6 +11250,7 @@
         },
         {
             "name": "awkward_IndexedArray_index_of_nulls",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11347,6 +11398,7 @@
         },
         {
             "name": "awkward_IndexedArray_reduce_next_fix_offsets_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11422,6 +11474,7 @@
         },
         {
             "name": "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11541,6 +11594,7 @@
         },
         {
             "name": "awkward_IndexedArray_reduce_next_nonlocal_nextshifts_fromshifts_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -11609,6 +11663,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_next_array_advanced",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -12340,6 +12395,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_next_at",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -12907,6 +12963,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_next_range_counts",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -12930,6 +12987,7 @@
         },
         {
             "name": "awkward_ListArray_localindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -13023,6 +13081,7 @@
         },
         {
             "name": "awkward_ListArray_rpad_axis1",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -13171,6 +13230,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_reduce_local_outoffsets_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -13365,6 +13425,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_reduce_nonlocal_nextshifts_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -13835,6 +13896,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14104,6 +14166,7 @@
         },
         {
             "name": "awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14362,6 +14425,7 @@
         },
         {
             "name": "awkward_NumpyArray_reduce_mask_ByteMaskedArray_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14682,6 +14746,7 @@
         },
         {
             "name": "awkward_UnionArray_fillna",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14828,6 +14893,7 @@
         },
         {
             "name": "awkward_UnionArray_filltags",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14844,6 +14910,7 @@
         },
         {
             "name": "awkward_UnionArray_project",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -14995,6 +15062,7 @@
         },
         {
             "name": "awkward_UnionArray_simplify_one",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15101,6 +15169,7 @@
         },
         {
             "name": "awkward_localindex",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15139,6 +15208,7 @@
         },
         {
             "name": "awkward_BitMaskedArray_to_IndexedOptionArray",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15166,6 +15236,7 @@
         },
         {
             "name": "awkward_ListArray_getitem_jagged_shrink",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15231,6 +15302,7 @@
         },
         {
             "name": "awkward_Content_getitem_next_missing_jagged_getmaskstartstop",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15500,6 +15572,7 @@
         },
         {
             "name": "awkward_reduce_sum_bool",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15585,6 +15658,7 @@
         },
         {
             "name": "awkward_reduce_prod_bool",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15800,6 +15874,7 @@
         },
         {
             "name": "awkward_reduce_argmax",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -15915,6 +15990,7 @@
         },
         {
             "name": "awkward_reduce_max",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -16052,6 +16128,7 @@
         },
         {
             "name": "awkward_reduce_countnonzero",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -16117,6 +16194,7 @@
         },
         {
             "name": "awkward_reduce_count_64",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -16392,6 +16470,7 @@
         },
         {
             "name": "awkward_reduce_sum",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -16687,6 +16766,7 @@
         },
         {
             "name": "awkward_reduce_prod",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -17272,6 +17352,7 @@
         },
         {
             "name": "awkward_reduce_min",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -17420,6 +17501,7 @@
         },
         {
             "name": "awkward_reduce_argmin",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -17676,6 +17758,7 @@
         },
         {
             "name": "awkward_UnionArray_fillindex_count",
+            "status": false,
             "tests": [
                 {
                     "error": false,
@@ -17753,6 +17836,7 @@
         },
         {
             "name": "awkward_UnionArray_simplify",
+            "status": false,
             "tests": [
                 {
                     "error": false,

--- a/noxfile.py
+++ b/noxfile.py
@@ -132,6 +132,7 @@ def clean(session):
             pathlib.Path("awkward-cpp", "tests-spec"),
             pathlib.Path("awkward-cpp", "tests-spec-explicit"),
             pathlib.Path("awkward-cpp", "tests-cpu-kernels"),
+            pathlib.Path("awkward-cpp", "tests-cpu-kernels-explicit"),
             pathlib.Path("tests-cuda-kernels"),
         )
     if args.docs or clean_all:


### PR DESCRIPTION
Generated `unit-tests` for `cpu-kernels` (4978 tests which run in the CI too) and `cuda-kernels`. For now, I have added a `status` in the `kernel-test-data.json` to turn off the cuda tests. As I will fix/add the kernels, I will turn the tests for the kernels on.
