### PR TITLE
ci: fix name of artifacts in deploy-cpp

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check awkward-cpp/dist/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: awkward-cpp/dist/*.tar.gz
 
@@ -109,7 +109,7 @@ jobs:
         )
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 
@@ -158,7 +158,7 @@ jobs:
         )
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
 
@@ -172,7 +172,7 @@ jobs:
       name: "pypi"
       url: "https://pypi.org/project/awkward-cpp/"
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -50,6 +50,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: awkward-sdist
         path: awkward-cpp/dist/*.tar.gz
 
   build_wheels:
@@ -111,6 +112,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
+        name: awkward-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build }}
         path: wheelhouse/*.whl
 
 
@@ -160,6 +162,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
+        name: awkward-wheels-${{ matrix.arch }}-py${{ matrix.python }}
         path: wheelhouse/*.whl
 
   upload_all:
@@ -174,7 +177,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        pattern: "awkward*"
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: distributions
         path: dist/*
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: header-only
         path: header-only
@@ -108,7 +108,7 @@ jobs:
       name: "pypi"
       url: "https://pypi.org/project/awkward/"
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: distributions
         path: dist
@@ -121,7 +121,7 @@ jobs:
     needs: [bundle-headers]
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: header-only
         path: header-only


### PR DESCRIPTION
This was done on-the-fly, so it might have mistakes. I'll give it another look before merging.

The changes to upload-artifact include breaking merging of same-name artifacts (the default behaviour if artifacts are unnamed). This PR adds explicit names, and downloads artifacts by a pattern.