### PR TITLE
fix: prepare for NumPy 2

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -504,8 +504,10 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
 def _scalar_type_of(obj) -> DType:
     if is_unknown_scalar(obj):
         return obj.dtype
+    elif isinstance(obj, numpy.generic):
+        return numpy.dtype(obj)
     else:
-        return numpy.obj2sctype(obj)
+        return numpy.array(obj).dtype
 
 
 def try_touch_data(array: Any):


### PR DESCRIPTION
To build this PR I ran the ruff linter, and found a case of a removal in 2.0. I would not be surprised if there are usages that the linter can't find, so we'll only be confident once the preview wheels are out.