### PR TITLE
feat: decorator to validate and annotate dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ run_cuda_notebooks = os.environ.get("DOCS_RUN_CUDA", False)
 extensions = [
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_togglebutton",
     "sphinx_external_toc",
     "sphinx.ext.intersphinx",
     "myst_nb",

--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -395,55 +395,55 @@ for filename in glob.glob("../src/awkward/**/*.py", recursive=True):
         if isinstance(toplevel, ast.FunctionDef):
             dofunction(link, linelink, shortname, toplevel.name, toplevel)
 
-#
-# def test_signature_pos_or_kw():
-#     mod = ast.parse(
-#         """
-# def func(x, z):
-#     ...
-# """
-#     )
-#     node = mod.body[0]
-#     assert dosig(node) == "x, z"
-#
-#
-# def test_signature_kwarg():
-#     mod = ast.parse(
-#         """
-# def func(x, z=None):
-#     ...
-# """
-#     )
-#     node = mod.body[0]
-#     assert dosig(node) == "x, z=None"
-#
-#
-# def test_signature_vararg():
-#     mod = ast.parse(
-#         """
-# def func(x, *y, z=None):
-#     ...
-# """
-#     )
-#     node = mod.body[0]
-#     assert dosig(node) == "x, *y, z=None"
-#
-#
-# def test_signature_kwonly():
-#     mod = ast.parse(
-#         """
-# def func(x, *, y, z=None):
-#     ...
-# """
-#     )
-#     node = mod.body[0]
-#     assert dosig(node) == "x, *, y, z=None"
-#
-#
-# test_signature_pos_or_kw()
-# test_signature_kwarg()
-# test_signature_vararg()
-# test_signature_kwonly()
+
+def test_signature_pos_or_kw():
+    mod = ast.parse(
+        """
+def func(x, z):
+    ...
+"""
+    )
+    node = mod.body[0]
+    assert dosig(node) == "x, z"
+
+
+def test_signature_kwarg():
+    mod = ast.parse(
+        """
+def func(x, z=None):
+    ...
+"""
+    )
+    node = mod.body[0]
+    assert dosig(node) == "x, z=None"
+
+
+def test_signature_vararg():
+    mod = ast.parse(
+        """
+def func(x, *y, z=None):
+    ...
+"""
+    )
+    node = mod.body[0]
+    assert dosig(node) == "x, *y, z=None"
+
+
+def test_signature_kwonly():
+    mod = ast.parse(
+        """
+def func(x, *, y, z=None):
+    ...
+"""
+    )
+    node = mod.body[0]
+    assert dosig(node) == "x, *, y, z=None"
+
+
+test_signature_pos_or_kw()
+test_signature_kwarg()
+test_signature_vararg()
+test_signature_kwonly()
 
 
 toctree_path = reference_path / "toctree.txt"

--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -330,6 +330,8 @@ def dofunction(link, linelink, shortname, name, astfcn):
 
         outfile.write(
             ".. note::\n"
+            "   :class: dropdown\n"
+            "\n"
             "   This function requires the following optional third-party libraries:\n"
             "\n"
         )
@@ -339,7 +341,7 @@ def dofunction(link, linelink, shortname, name, astfcn):
             "\n\n"
             f"   If you use pip, you can install these packages with "
             f"``python -m pip install {install_dependencies_string}``.\n"
-            "    Otherwise, if you use Conda, install the corresponding packages "
+            "   Otherwise, if you use Conda, install the corresponding packages "
             "for the correct versions. "
         )
         if extras:

--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -329,14 +329,29 @@ def dofunction(link, linelink, shortname, name, astfcn):
         extras, dependencies = dependency_spec
 
         outfile.write(
-            ".. note::\n   This function requires the following optional third-party libraries:\n\n"
+            ".. note::\n"
+            "   This function requires the following optional third-party libraries:\n"
+            "\n"
         )
         outfile.write("\n".join([f"   * ``{dep}``" for dep in dependencies]))
+        install_dependencies_string = " ".join(dependencies)
+        outfile.write(
+            "\n\n"
+            f"    If you use pip, you can install these packages with "
+            f"``python -m pip install {install_dependencies_string}``.\n"
+            "    Otherwise, if you use Conda, install the corresponding packages "
+            "for the correct versions. "
+        )
         if extras:
+            extras_string = ",".join(extras)
             outfile.write(
-                "\n\n   These dependencies can be conveniently installed using the following extras:\n\n"
+                "\n\n   These dependencies can also be conveniently installed using the following extras:\n\n"
             )
             outfile.write("\n".join([f"   * ``{extra}``" for extra in extras]))
+            outfile.write(
+                "\n\n   If you use ``pip`` to install your packages, these extras can be installed by running "
+                f"``python -m pip install awkward[{extras_string}]``."
+            )
 
     out = outfile.getvalue()
 
@@ -444,7 +459,6 @@ test_signature_pos_or_kw()
 test_signature_kwarg()
 test_signature_vararg()
 test_signature_kwonly()
-
 
 toctree_path = reference_path / "toctree.txt"
 toctree_contents = toctree_path.read_text()

--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -337,7 +337,7 @@ def dofunction(link, linelink, shortname, name, astfcn):
         install_dependencies_string = " ".join(dependencies)
         outfile.write(
             "\n\n"
-            f"    If you use pip, you can install these packages with "
+            f"   If you use pip, you can install these packages with "
             f"``python -m pip install {install_dependencies_string}``.\n"
             "    Otherwise, if you use Conda, install the corresponding packages "
             "for the correct versions. "

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,7 @@ lark-parser
 sphinx-copybutton
 sphinx-design
 sphinx-sitemap
+sphinx-togglebutton
 pydata-sphinx-theme
 myst-nb
 sphinx-external-toc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,15 @@ PyYAML
 black
 pycparser
 lark-parser
+
+# Pin this
+sphinxcontrib-applehelp==1.0.0
+sphinxcontrib-devhelp==1.0.0
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.0
+sphinxcontrib-serializinghtml==1.1.5
+
 sphinx-copybutton
 sphinx-design
 sphinx-sitemap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ dynamic = [
     "readme"
 ]
 
+[project.optional-dependencies]
+arrow = [
+    "arrow>=7.0.0",
+    "fsspec"
+]
+
+
+
 [project.entry-points.numba_extensions]
 init = "awkward.numba:_register"
 

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,4 +1,4 @@
-fsspec;sys_platform != "win32"
+fsspec
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.12"
 numba>=0.50.0,!=0.58.0rc1;python_version < "3.12"
 numexpr>=2.7; python_version < "3.12"

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,4 +1,4 @@
-fsspec;sys_platform != "win32"
+fsspec
 numpy==1.18.0
 pyarrow==7.0.0
 pytest>=6

--- a/src/awkward/_connect/pyarrow.py
+++ b/src/awkward/_connect/pyarrow.py
@@ -14,6 +14,7 @@ from awkward._backends.numpy import NumpyBackend
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import parameters_union
+from awkward._requirements import import_required_module
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -21,68 +22,27 @@ numpy = Numpy.instance()
 try:
     import pyarrow
 
-    error_message = None
-
-except ModuleNotFoundError:
-    pyarrow = None
-    error_message = """to use {0}, you must install pyarrow:
-
-    pip install pyarrow
-
-or
-
-    conda install -c conda-forge pyarrow
-"""
-
-else:
     if parse_version(pyarrow.__version__) < parse_version("7.0.0"):
-        pyarrow = None
-        error_message = "pyarrow 7.0.0 or later required for {0}"
+        raise ImportError
+
+except (ModuleNotFoundError, ImportError):
+    pyarrow = None
 
 
 def import_pyarrow(name: str) -> ModuleType:
-    if pyarrow is None:
-        raise ImportError(error_message.format(name))
-    return pyarrow
+    return import_required_module("pyarrow")
 
 
 def import_pyarrow_parquet(name: str) -> ModuleType:
-    if pyarrow is None:
-        raise ImportError(error_message.format(name))
-
-    import pyarrow.parquet as out
-
-    return out
+    return import_required_module("pyarrow.parquet")
 
 
 def import_pyarrow_compute(name: str) -> ModuleType:
-    if pyarrow is None:
-        raise ImportError(error_message.format(name))
-
-    import pyarrow.compute as out
-
-    return out
+    return import_required_module("pyarrow.compute")
 
 
 def import_fsspec(name: str) -> ModuleType:
-    try:
-        import fsspec
-
-    except ModuleNotFoundError as err:
-        raise ImportError(
-            f"""to use {name}, you must install fsspec:
-
-    pip install fsspec
-
-or
-
-    conda install -c conda-forge fsspec
-"""
-        ) from err
-
-    import_pyarrow_parquet(name)
-
-    return fsspec
+    return import_required_module("fsspec")
 
 
 if pyarrow is not None:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -2,34 +2,176 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection, Generator
-from functools import wraps
+import importlib
+import sys
+import warnings
+from collections.abc import Callable, Collection, Generator, Mapping
+from functools import lru_cache, wraps
 from inspect import isgenerator
 
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+if sys.version_info < (3, 12):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
 from awkward._errors import OperationErrorContext
-from awkward._typing import Any, TypeAlias, TypeVar
+from awkward._typing import Any, NamedTuple, TypeAlias, TypeVar
 
 T = TypeVar("T")
 DispatcherType: TypeAlias = "Callable[..., Generator[Collection[Any], None, T]]"
 HighLevelType: TypeAlias = "Callable[..., T]"
 
 
+class DependencyGroup(NamedTuple):
+    name: str
+    dependencies: tuple[str, ...]
+
+
+class DependencySpecification(NamedTuple):
+    groups: tuple[DependencyGroup, ...]
+    non_groups: tuple[str, ...]
+
+
+def normalize_dependency_specification(
+    dependencies: Collection[str] | Mapping[str, Collection[str]] | None,
+) -> DependencySpecification:
+    """Normalize a dependency specification into a hashable object"""
+    if dependencies is None:
+        return DependencySpecification((), ())
+    elif isinstance(dependencies, Mapping):
+        return DependencySpecification(
+            groups=tuple(
+                DependencyGroup(key, tuple(values))
+                for key, values in dependencies.items()
+            ),
+            non_groups=(),
+        )
+    else:
+        return DependencySpecification(groups=(), non_groups=tuple(dependencies))
+
+
+def iter_missing_dependencies(dependencies: tuple[str, ...]):
+    """Build an iterator over the requirement, version pairs of dependencies that are not
+    satisfied by the current environment"""
+    for _requirement in dependencies:
+        requirement = Requirement(_requirement)
+        if requirement.extras:
+            raise RuntimeError(
+                "High-level functions must not declare dependencies specifications with extras"
+            )
+
+        try:
+            _version = importlib_metadata.version(requirement.name)
+        except importlib_metadata.PackageNotFoundError:
+            version = None
+        else:
+            # If we found the distribution but did not resolve a version
+            if _version is None:
+                # Let's try and import it
+                mod = importlib.import_module(requirement.name)
+                try:
+                    _version = mod.__version__
+                except AttributeError:
+                    warnings.warn(
+                        f"Could not identify the version of installed package {requirement.name}",
+                        stacklevel=2,
+                    )
+                    continue
+            version = Version(_version)
+
+        if version is None or version not in requirement.specifier:
+            yield requirement, version
+
+
+@lru_cache
+def build_runtime_dependency_validation_error(
+    dependency_spec: DependencySpecification,
+) -> Exception | None:
+    """Build an exception object for the given dependency specification if it
+    is not satisfied by the current environment"""
+    missing_extras = []
+    missing_dependencies: list[tuple[Requirement, Version | None]] = []
+    if dependency_spec.groups:
+        for extra, extra_dependencies in dependency_spec.groups:
+            extra_missing_dependencies = [
+                *iter_missing_dependencies(extra_dependencies)
+            ]
+            missing_dependencies.extend(extra_missing_dependencies)
+            if extra_missing_dependencies:
+                missing_extras.append(extra)
+    else:
+        missing_dependencies[:] = iter_missing_dependencies(dependency_spec.non_groups)
+
+    if not missing_dependencies:
+        return None
+
+    missing_requirement_lines = [
+        (
+            f"    * {req} — you do not have this package"
+            if ver is None
+            else f"    * {req} — you have {ver} installed"
+        )
+        for req, ver in missing_dependencies
+    ]
+    missing_requirement_message = "\n".join(missing_requirement_lines)
+
+    missing_extras_lines = [f"    * {extra}" for extra in missing_extras]
+    missing_extras_string = "\n".join(missing_extras_lines)
+    maybe_missing_extras_message = (
+        (
+            "You can fix this error by installing these packages directly, or install awkward with "
+            "all of the following extras:\n\n"
+            f"{missing_extras_string}"
+        )
+        if missing_extras
+        else ""
+    )
+    return ImportError(
+        f"This function has the following dependency requirements that are not met by your current environment:\n\n"
+        f"{missing_requirement_message}\n\n"
+        f"{maybe_missing_extras_message}"
+    )
+
+
+def validate_runtime_dependencies(
+    dependency_spec: DependencySpecification,
+):
+    exception = build_runtime_dependency_validation_error(dependency_spec)
+    if exception is None:
+        return
+    else:
+        raise exception
+
+
 def high_level_function(
-    module: str = "ak", name: str | None = None
+    module: str = "ak",
+    name: str | None = None,
+    dependencies: Collection[str] | Mapping[str, Collection[str]] | None = None,
 ) -> Callable[[DispatcherType], HighLevelType]:
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""
+
+    dependency_spec = normalize_dependency_specification(dependencies)
 
     def capture_func(func: DispatcherType) -> HighLevelType:
         if name is None:
             captured_name = func.__qualname__
         else:
             captured_name = name
-        return named_high_level_function(func, f"{module}.{captured_name}")
+        return named_high_level_function(
+            func, f"{module}.{captured_name}", dependency_spec
+        )
 
     return capture_func
 
 
-def named_high_level_function(func: DispatcherType, name: str) -> HighLevelType:
+def named_high_level_function(
+    func: DispatcherType,
+    name: str,
+    dependency_spec: DependencySpecification,
+) -> HighLevelType:
     """Decorate a named high-level function such that it may be overloaded by third-party array objects"""
 
     @wraps(func)
@@ -50,14 +192,16 @@ def named_high_level_function(func: DispatcherType, name: str) -> HighLevelType:
                     else:
                         result = custom_impl(dispatch, array_likes, args, kwargs)
 
-                        # Future proof the implementation by permitting the `__awkward_function__` to return `NotImplemented`
-                        # This may later be used to signal that another overload should be used.
+                        # Future-proof the implementation by permitting the `__awkward_function__`
+                        # to return `NotImplemented`. This may later be used to signal that another
+                        # overload should be used.
                         if result is NotImplemented:
                             raise NotImplementedError
                         else:
                             return result
 
                 # Failed to find a custom overload, so resume the original function
+                validate_runtime_dependencies(dependency_spec)
                 try:
                     next(gen_or_result)
                 except StopIteration as err:

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -118,16 +118,29 @@ def build_runtime_dependency_validation_error(
     ]
     missing_requirement_message = "\n".join(missing_requirement_lines)
 
+    # Install string
+    missing_dependencies_string = " ".join(
+        [str(req) for req, ver in missing_dependencies]
+    )
+    missing_requirements_direct_message = (
+        f"If you use pip, you can install these packages with "
+        f"`python -m pip install {missing_dependencies_string}`.\n"
+        "Otherwise, if you use Conda, install the corresponding packages "
+        "for the correct versions. "
+    )
+
     missing_extras_lines = [f"    * {extra}" for extra in missing_extras]
-    missing_extras_string = "\n".join(missing_extras_lines)
+    missing_extras_list_string = "\n".join(missing_extras_lines)
+    missing_extras_string = ",".join(missing_extras)
     maybe_missing_extras_message = (
         (
-            "You can fix this error by installing these packages directly, or install awkward with "
-            "all of the following extras:\n\n"
-            f"{missing_extras_string}"
+            f"{missing_requirements_direct_message}\n\n"
+            "These dependencies can also be conveniently installed using the following extras:\n\n"
+            f"{missing_extras_list_string}\n\n"
+            f"If you're using `pip`, then you can install these extras with `pip install awkward[{missing_extras_string}]`"
         )
         if missing_extras
-        else ""
+        else missing_requirements_direct_message
     )
     return ImportError(
         f"This function has the following dependency requirements that are not met by your current environment:\n\n"
@@ -161,6 +174,7 @@ def high_level_function(
             captured_name = func.__qualname__
         else:
             captured_name = name
+
         return named_high_level_function(
             func, f"{module}.{captured_name}", dependency_spec
         )

--- a/src/awkward/_dispatch.py
+++ b/src/awkward/_dispatch.py
@@ -149,6 +149,7 @@ def validate_runtime_dependencies(
 def high_level_function(
     module: str = "ak",
     name: str | None = None,
+    *,
     dependencies: Collection[str] | Mapping[str, Collection[str]] | None = None,
 ) -> Callable[[DispatcherType], HighLevelType]:
     """Decorate a high-level function such that it may be overloaded by third-party array objects"""

--- a/src/awkward/_requirements.py
+++ b/src/awkward/_requirements.py
@@ -1,0 +1,355 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import sys
+import types
+import warnings
+from collections.abc import Collection, Mapping
+from functools import lru_cache, update_wrapper, wraps
+
+import packaging.version
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from awkward._util import UNSET
+
+if sys.version_info < (3, 12):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+from awkward._typing import NamedTuple, Protocol
+
+
+class UnmetRequirementError(Exception):
+    def __init__(
+        self,
+        msg: str,
+        name: str,
+        distribution: str,
+        dependency: Dependency,
+        version: Version | None,
+    ):
+        super().__init__(msg)
+
+        self._name = name
+        self._distribution = distribution
+        self._dependency = dependency
+        self._version = version
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def distribution(self) -> str:
+        return self._distribution
+
+    @property
+    def dependency(self) -> Dependency:
+        return self._dependency
+
+    @property
+    def version(self) -> Version | None:
+        return self._version
+
+
+class Dependency(NamedTuple):
+    requirement: Requirement
+    group: str | None
+    module_name: str
+    conda_forge_spec: str | None
+    is_on_pypi: bool
+
+
+class DependencySpecification(NamedTuple):
+    unvalidated: dict[str, Dependency]
+    validated: dict[str, Dependency]
+
+    def on_validated(self, name: str):
+        self.validated[name] = self.unvalidated.pop(name)
+
+
+_dependencies_stack: list[DependencySpecification] = []
+
+
+@contextlib.contextmanager
+def dependency_specification_context(spec: DependencySpecification):
+    global _dependencies_stack
+
+    # Optimisation: do not push specification if we have no unvalidated requirements
+    if spec.unvalidated:
+        _dependencies_stack.append(spec)
+        try:
+            yield
+        finally:
+            _dependencies_stack.pop()
+    else:
+        yield
+
+
+def _format_requirement_error(dependency: Dependency, version: Version | None) -> str:
+    maybe_missing_extras_message = (
+        (
+            f"\n\nThis dependency can also be conveniently installed using the {dependency.group!r} extra. "
+            f"If you're using `pip`, then you can install this extra with\n\n"
+            f"    pip install awkward[{dependency.group}]"
+        )
+        if dependency.group
+        else ""
+    )
+    version_string = (
+        f"{dependency.requirement} is not installed."
+        if version is None
+        else f"you have {version} installed."
+    )
+    maybe_pypi_string = (
+        f"If you use pip, you can install this package with\n\n"
+        f"    pip install {dependency.requirement}\n\n"
+        if dependency.is_on_pypi
+        else ""
+    )
+    maybe_conda_forge_string = (
+        ""
+        if dependency.conda_forge_spec is None
+        else (
+            "If you use conda, you can install this package with\n\n"
+            f"    conda install {dependency.conda_forge_spec}\n\n"
+            f"You should check that the installed package satisfies {dependency.requirement}."
+        )
+    )
+    return (
+        f"This function requires {dependency.requirement} which is not met by your current environment: "
+        f"{version_string}\n\n"
+        f"{maybe_pypi_string}"
+        f"{maybe_conda_forge_string}"
+        f"{maybe_missing_extras_message}"
+    )
+
+
+def _find_dependency_for_module(name: str) -> Dependency:
+    # Take only the FOO component of FOO.BAR.BAZ
+    module_name, _, _ = name.partition(".")
+
+    for spec in reversed(_dependencies_stack):
+        for distribution, dependency in spec.unvalidated.items():
+            if dependency.module_name == module_name:
+                return dependency
+        for distribution, dependency in spec.validated.items():
+            if dependency.module_name == module_name:
+                return dependency
+
+    raise LookupError
+
+
+@lru_cache
+def _load_package_distributions():
+    return importlib_metadata.packages_distributions()
+
+
+def _regularize_dunder_version(version: str) -> str:
+    return version.replace("/", ".")
+
+
+class ImplementsRequires(Protocol):
+    def add_requirement(
+        self,
+        requirement: Requirement,
+        group: str | None,
+        module_name: str,
+        conda_forge_spec: str | None,
+        is_on_pypi: bool,
+    ):
+        ...
+
+    def get_specification(self) -> DependencySpecification:
+        ...
+
+
+class _WithHasRequirements(ImplementsRequires):
+    _specification: DependencySpecification
+
+    def __init__(self, func):
+        update_wrapper(self, func)
+        self._func = func
+        self._dependencies = {}
+
+    def __call__(self, *args, **kwargs):
+        return self._func(*args, **kwargs)
+
+    def add_requirement(
+        self,
+        requirement: Requirement,
+        group: str | None,
+        module_name: str,
+        conda_forge_spec: str | None,
+        is_on_pypi: bool,
+    ):
+        if group is not None:
+            assert is_on_pypi
+
+        self._dependencies[requirement.name] = Dependency(
+            requirement,
+            group,
+            module_name=module_name,
+            conda_forge_spec=conda_forge_spec,
+            is_on_pypi=is_on_pypi,
+        )
+
+    def get_specification(self) -> DependencySpecification:
+        try:
+            return self._specification
+        except AttributeError:
+            self._specification = DependencySpecification(self._dependencies, {})
+            return self._specification
+
+
+def with_has_requirements(func):
+    return _WithHasRequirements(func)
+
+
+def requires(
+    spec: str,
+    *,
+    group: str = UNSET,
+    module_name: str = UNSET,
+    conda_forge_spec: str | None = UNSET,
+    is_on_pypi: bool = True,
+):
+    if group is UNSET:
+        group = None
+
+    requirement = Requirement(spec)
+    if module_name is UNSET:
+        module_name = requirement.name
+    if conda_forge_spec is UNSET:
+        conda_forge_spec = str(requirement)
+
+    def decorator(func):
+        if not hasattr(func, "add_requirement"):
+            raise RuntimeError()
+
+        func.add_requirement(
+            requirement,
+            group,
+            module_name=module_name,
+            conda_forge_spec=conda_forge_spec,
+            is_on_pypi=is_on_pypi,
+        )
+
+        return func
+
+    return decorator
+
+
+def _determine_installed_requirement_version(
+    distribution: str, module: types.ModuleType
+) -> Version | None:
+    # Try and find version
+    try:
+        # Try and get the version the canonical way
+        _version = importlib_metadata.version(distribution)
+    except importlib_metadata.PackageNotFoundError:
+        try:
+            # Otherwise, fall back on `__version__` (e.g. for ROOT)
+            mod_version = module.__version__
+        except AttributeError:
+            warnings.warn(
+                f"Could not identify the version of installed package {distribution}",
+                stacklevel=2,
+            )
+            # Don't treat this as an error
+            return None
+        # Packages like ROOT seem to be playing poorly with standards, so we'll apply a simple regularization transform
+        _version = _regularize_dunder_version(mod_version)
+
+    # Try and parse version
+    try:
+        version = Version(_version)
+    except packaging.version.InvalidVersion:
+        warnings.warn(
+            f"Could not parse the version of installed package {distribution}: {_version!r}",
+            stacklevel=2,
+        )
+        # Don't treat this as an error
+        return None
+
+    return version
+
+
+def import_required_module(name: str) -> types.ModuleType:
+    try:
+        module = importlib.import_module(name)
+    except ImportError as err:
+        dependency = _find_dependency_for_module(name)
+
+        raise UnmetRequirementError(
+            _format_requirement_error(dependency, None),
+            name,
+            dependency.requirement.name,
+            dependency,
+            None,
+        )
+
+    # Find the distributions that provide `name`
+    # For now, assume only one! This may struggle with namespace packages
+    # Take only the FOO component of FOO.BAR.BAZ
+    module_name, _, _ = name.partition(".")
+    (distribution,) = _load_package_distributions()[module_name]
+
+    for spec in _dependencies_stack:
+        if distribution in spec.validated:
+            continue
+
+        try:
+            dependency = spec.unvalidated[distribution]
+        except KeyError:
+            continue
+
+        # Dependencies _themselves_ can't specify extras
+        if dependency.requirement.extras:
+            raise RuntimeError(
+                "High-level functions must not declare dependencies specifications with extras"
+            )
+        # Try and find version
+        version = _determine_installed_requirement_version(distribution, module)
+
+        if version is None:
+            continue
+
+        # We need the right version
+        if version not in dependency.requirement.specifier:
+            raise UnmetRequirementError(
+                _format_requirement_error(dependency, version),
+                name,
+                distribution,
+                dependency,
+                version,
+            )
+
+        spec.on_validated(distribution)
+    return module
+
+
+def with_dependency_specification_context(func, specification: DependencySpecification):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with dependency_specification_context(specification):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def build_requirement_context_factory(
+    *spec: Collection[str] | Mapping[str, Collection[str]],
+):
+    # specification = normalize_dependency_specification(spec)
+
+    def context_factory():
+        return contextlib.nullcontext()
+        return dependency_specification_context(specification)
+
+    return context_factory

--- a/src/awkward/cppyy.py
+++ b/src/awkward/cppyy.py
@@ -2,36 +2,14 @@
 
 from __future__ import annotations
 
-import packaging.version
+from awkward._requirements import (
+    build_requirement_context_factory,
+    import_required_module,
+)
 
-_has_checked_version = False
+_requirement_context_factory = build_requirement_context_factory("cppyy>=3.1.0")
 
 
 def register_and_check():
-    global _has_checked_version
-
-    try:
-        import cppyy
-    except ImportError as err:
-        raise ImportError(
-            """install the 'cppyy' package with:
-
-pip install cppyy
-
-or
-
-conda install -c conda-forge cppyy
-
-Note that this must be in a different venv or conda environment from ROOT, if you have installed ROOT.
-"""
-        ) from err
-
-    if not _has_checked_version:
-        if packaging.version.Version(cppyy.__version__) < packaging.version.Version(
-            "3.1.0"
-        ):
-            raise ImportError(
-                "Awkward Array can only work with cppyy 3.1.0 or later "
-                f"(you have version {cppyy.__version__})"
-            )
-        _has_checked_version = True
+    with _requirement_context_factory():
+        return import_required_module("cppyy")

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -6,13 +6,16 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import requires
 
 __all__ = ("from_arrow",)
 
 np = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@requires("fsspec", group="arrow")
+@high_level_function()
 def from_arrow(
     array, *, generate_bitmasks=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -12,7 +12,7 @@ __all__ = ("from_arrow",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
 def from_arrow(
     array, *, generate_bitmasks=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import requires
 
 __all__ = ("from_arrow_schema",)
 
 np = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function()
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_arrow_schema.py
+++ b/src/awkward/operations/ak_from_arrow_schema.py
@@ -10,7 +10,7 @@ __all__ = ("from_arrow_schema",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def from_arrow_schema(schema):
     """
     Args:

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
+from awkward._requirements import requires
 
 __all__ = ("from_cupy",)
 
 
-@high_level_function(dependencies=["cupy"])
+@requires("cupy")
+@high_level_function()
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -8,7 +8,7 @@ from awkward._layout import from_arraylib, wrap_layout
 __all__ = ("from_cupy",)
 
 
-@high_level_function()
+@high_level_function(dependencies=["cupy"])
 def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import awkward as ak
 from awkward._dispatch import high_level_function
+from awkward._requirements import import_required_module, requires
 
 __all__ = ("from_feather",)
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function()
 def from_feather(
     path,
     *,
@@ -71,9 +73,9 @@ def _impl(
     behavior,
     attrs,
 ):
-    import pyarrow.feather
-
-    arrow_table = pyarrow.feather.read_table(path, columns, use_threads, memory_map)
+    arrow_table = import_required_module("pyarrow.feather").read_table(
+        path, columns, use_threads, memory_map
+    )
 
     return ak.operations.ak_from_arrow._impl(
         arrow_table,

--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -8,7 +8,7 @@ from awkward._dispatch import high_level_function
 __all__ = ("from_feather",)
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def from_feather(
     path,
     *,

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -9,7 +9,7 @@ from awkward._layout import from_arraylib, wrap_layout
 __all__ = ("from_jax",)
 
 
-@high_level_function()
+@high_level_function(dependencies=["jax", "jaxlib"])
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from awkward import jax
 from awkward._dispatch import high_level_function
 from awkward._layout import from_arraylib, wrap_layout
+from awkward._requirements import requires
 
 __all__ = ("from_jax",)
 
 
-@high_level_function(dependencies=["jax", "jaxlib"])
+@requires("jax")
+@requires("jaxlib")
+@high_level_function()
 def from_jax(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -24,7 +24,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies=["fsspec"])
 def from_json(
     source,
     *,

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -17,14 +17,18 @@ from awkward._layout import HighLevelContext, wrap_layout
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_integer
+from awkward._requirements import import_required_module
 
 __all__ = ("from_json",)
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
+from awkward._requirements import requires
 
-@high_level_function(dependencies=["fsspec"])
+
+@requires("cupy")
+@high_level_function()
 def from_json(
     source,
     *,
@@ -376,9 +380,7 @@ def _get_reader(source):
         if parsed_url.scheme == "" or parsed_url.netloc == "":
             return open(source, "rb")
         else:
-            import fsspec
-
-            return fsspec.open(source, "rb").open()
+            return import_required_module("fsspec").open(source, "rb").open()
 
     else:
         return nullcontext(source)

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -10,7 +10,7 @@ from awkward._regularize import is_integer
 __all__ = ("from_parquet",)
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
 def from_parquet(
     path,
     *,
@@ -84,7 +84,7 @@ def from_parquet(
     )
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
 def metadata(
     path,
     storage_options=None,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -10,8 +10,11 @@ __all__ = ("from_rdataframe",)
 
 np = NumpyMetadata.instance()
 
+from awkward._requirements import requires
 
-@high_level_function(dependencies=["ROOT"])
+
+@requires("ROOT", is_on_pypi=False, conda_forge_spec="root")
+@high_level_function()
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_from_rdataframe.py
+++ b/src/awkward/operations/ak_from_rdataframe.py
@@ -11,7 +11,7 @@ __all__ = ("from_rdataframe",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies=["ROOT"])
 def from_rdataframe(
     rdf,
     columns,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import requires
 
 __all__ = ("to_arrow",)
 
 np = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function()
 def to_arrow(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -11,7 +11,7 @@ __all__ = ("to_arrow",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def to_arrow(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -14,7 +14,7 @@ __all__ = ("to_arrow_table",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
 def to_arrow_table(
     array,
     *,

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -7,6 +7,7 @@ import json
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import requires
 from awkward._typing import Any
 
 __all__ = ("to_arrow_table",)
@@ -14,7 +15,9 @@ __all__ = ("to_arrow_table",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@requires("fsspec", group="arrow")
+@high_level_function()
 def to_arrow_table(
     array,
     *,

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.cupy import CupyBackend
 from awkward._dispatch import high_level_function
+from awkward._requirements import requires
 
 __all__ = ("to_cupy",)
 
 
-@high_level_function(dependencies=["cupy"])
+@requires("cupy")
+@high_level_function()
 def to_cupy(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_cupy.py
+++ b/src/awkward/operations/ak_to_cupy.py
@@ -9,7 +9,7 @@ from awkward._dispatch import high_level_function
 __all__ = ("to_cupy",)
 
 
-@high_level_function()
+@high_level_function(dependencies=["cupy"])
 def to_cupy(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -17,7 +17,7 @@ def _default_levelname(index: int) -> str:
     return "sub" * index + "entry"
 
 
-@high_level_function()
+@high_level_function(dependencies=["pandas"])
 def to_dataframe(
     array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -6,6 +6,7 @@ import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import import_required_module, requires
 
 __all__ = ("to_dataframe",)
 
@@ -17,7 +18,8 @@ def _default_levelname(index: int) -> str:
     return "sub" * index + "entry"
 
 
-@high_level_function(dependencies=["pandas"])
+@requires("pandas")
+@high_level_function()
 def to_dataframe(
     array, *, how="inner", levelname=_default_levelname, anonymous="values"
 ):
@@ -139,18 +141,7 @@ def to_dataframe(
 
 
 def _impl(array, how, levelname, anonymous):
-    try:
-        import pandas
-    except ImportError as err:
-        raise ImportError(
-            """install the 'pandas' package with:
-
-    pip install pandas --upgrade
-
-or
-
-    conda install pandas"""
-        ) from err
+    pandas = import_required_module("pandas")
 
     if how is not None:
         out = None

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -12,7 +12,7 @@ __all__ = ("to_feather",)
 metadata = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def to_feather(
     array,
     destination,

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -6,13 +6,15 @@ import os
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import import_required_module, requires
 
 __all__ = ("to_feather",)
 
 metadata = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function()
 def to_feather(
     array,
     destination,
@@ -123,8 +125,6 @@ def _impl(
     chunksize,
     feather_version,
 ):
-    import pyarrow.feather
-
     layout = ak.operations.ak_to_layout._impl(
         array,
         allow_record=True,
@@ -159,6 +159,6 @@ def _impl(
             f"'destination' argument of 'ak.to_feather' must be a path-like, not {type(destination).__name__} ('array' argument is first; 'destination' second)"
         ) from None
 
-    pyarrow.feather.write_feather(
+    import_required_module("pyarrow.feather").write_feather(
         table, destination, compression, compression_level, chunksize, feather_version
     )

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import awkward as ak
 from awkward._backends.jax import JaxBackend
 from awkward._dispatch import high_level_function
+from awkward._requirements import requires
 
 __all__ = ("to_jax",)
 
 
-@high_level_function(dependencies=["jax", "jaxlib"])
+@requires("jax")
+@requires("jaxlib")
+@high_level_function()
 def to_jax(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_jax.py
+++ b/src/awkward/operations/ak_to_jax.py
@@ -9,7 +9,7 @@ from awkward._dispatch import high_level_function
 __all__ = ("to_jax",)
 
 
-@high_level_function()
+@high_level_function(dependencies=["jax", "jaxlib"])
 def to_jax(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -21,7 +21,7 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies=["fsspec"])
 def to_json(
     array,
     file=None,

--- a/src/awkward/operations/ak_to_json.py
+++ b/src/awkward/operations/ak_to_json.py
@@ -14,6 +14,7 @@ from awkward._behavior import behavior_of
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import import_required_module
 
 __all__ = ("to_json",)
 
@@ -21,7 +22,11 @@ np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 
 
-@high_level_function(dependencies=["fsspec"])
+from awkward._requirements import requires
+
+
+@requires("fsspec")
+@high_level_function()
 def to_json(
     array,
     file=None,
@@ -207,7 +212,7 @@ def _impl(
                     return open(file, "w", encoding="utf8")
 
             else:
-                import fsspec
+                fsspec = import_required_module("fsspec")
 
                 def opener():
                     return fsspec.open(file, "w", encoding="utf8").open()

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from awkward_cpp.lib import _ext
 
 import awkward as ak
+from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_non_string_like_iterable
 
@@ -15,6 +16,7 @@ __all__ = ("to_list",)
 np = NumpyMetadata.instance()
 
 
+@high_level_function()
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from awkward_cpp.lib import _ext
 
 import awkward as ak
-from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._regularize import is_non_string_like_iterable
 
@@ -16,7 +15,6 @@ __all__ = ("to_list",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>12.0.0"]})
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_list.py
+++ b/src/awkward/operations/ak_to_list.py
@@ -16,7 +16,7 @@ __all__ = ("to_list",)
 np = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>12.0.0"]})
 def to_list(array):
     """
     Args:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -14,7 +14,7 @@ __all__ = ("to_parquet",)
 metadata = NumpyMetadata.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
 def to_parquet(
     array,
     destination,

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -8,13 +8,21 @@ from os import fsdecode
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._requirements import requires
 
 __all__ = ("to_parquet",)
 
 metadata = NumpyMetadata.instance()
 
 
-@high_level_function(dependencies={"arrow": ["pyarrow>=7.0.0", "fsspec"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@requires("fsspec", group="arrow")
+@high_level_function(
+    dependencies=[
+        requires("fsspec", group="arrow"),
+        requires("pyarrow>=7.0.0", group="arrow", module_name="arrow"),
+    ]
+)
 def to_parquet(
     array,
     destination,

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -13,7 +13,7 @@ __all__ = ("to_rdataframe",)
 cpu = NumpyBackend.instance()
 
 
-@high_level_function()
+@high_level_function(dependencies=["ROOT"])
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -12,8 +12,11 @@ __all__ = ("to_rdataframe",)
 
 cpu = NumpyBackend.instance()
 
+from awkward._requirements import requires
 
-@high_level_function(dependencies=["ROOT"])
+
+@requires("ROOT", is_on_pypi=False, conda_forge_spec="root")
+@high_level_function()
 def to_rdataframe(arrays, *, flatlist_as_rvec=True):
     """
     Args:

--- a/src/awkward/operations/str/akstr_capitalize.py
+++ b/src/awkward/operations/str/akstr_capitalize.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("capitalize",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def capitalize(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_capitalize.py
+++ b/src/awkward/operations/str/akstr_capitalize.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("capitalize",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def capitalize(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_center.py
+++ b/src/awkward/operations/str/akstr_center.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("center",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def center(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_center.py
+++ b/src/awkward/operations/str/akstr_center.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("center",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def center(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_count_substring.py
+++ b/src/awkward/operations/str/akstr_count_substring.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("count_substring",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def count_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_count_substring.py
+++ b/src/awkward/operations/str/akstr_count_substring.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("count_substring",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def count_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_count_substring_regex.py
+++ b/src/awkward/operations/str/akstr_count_substring_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("count_substring_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def count_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_count_substring_regex.py
+++ b/src/awkward/operations/str/akstr_count_substring_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("count_substring_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def count_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_ends_with.py
+++ b/src/awkward/operations/str/akstr_ends_with.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("ends_with",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def ends_with(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_ends_with.py
+++ b/src/awkward/operations/str/akstr_ends_with.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("ends_with",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def ends_with(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("extract_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def extract_regex(array, pattern, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_extract_regex.py
+++ b/src/awkward/operations/str/akstr_extract_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("extract_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def extract_regex(array, pattern, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_find_substring.py
+++ b/src/awkward/operations/str/akstr_find_substring.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("find_substring",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def find_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_find_substring.py
+++ b/src/awkward/operations/str/akstr_find_substring.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("find_substring",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def find_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_find_substring_regex.py
+++ b/src/awkward/operations/str/akstr_find_substring_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("find_substring_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def find_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_find_substring_regex.py
+++ b/src/awkward/operations/str/akstr_find_substring_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("find_substring_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def find_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -12,7 +12,7 @@ __all__ = ("index_in",)
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def index_in(
     array, value_set, *, skip_nones=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_index_in.py
+++ b/src/awkward/operations/str/akstr_index_in.py
@@ -6,13 +6,15 @@ import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
+from awkward._requirements import requires
 
 __all__ = ("index_in",)
 
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def index_in(
     array, value_set, *, skip_nones=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_is_alnum.py
+++ b/src/awkward/operations/str/akstr_is_alnum.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_alnum",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_alnum(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_alnum.py
+++ b/src/awkward/operations/str/akstr_is_alnum.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_alnum",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_alnum(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_alpha.py
+++ b/src/awkward/operations/str/akstr_is_alpha.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_alpha",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_alpha(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_alpha.py
+++ b/src/awkward/operations/str/akstr_is_alpha.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_alpha",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_alpha(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_ascii.py
+++ b/src/awkward/operations/str/akstr_is_ascii.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_ascii",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_ascii(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_ascii.py
+++ b/src/awkward/operations/str/akstr_is_ascii.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_ascii",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_ascii(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_decimal.py
+++ b/src/awkward/operations/str/akstr_is_decimal.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_decimal",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_decimal(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_decimal.py
+++ b/src/awkward/operations/str/akstr_is_decimal.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_decimal",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_decimal(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_digit.py
+++ b/src/awkward/operations/str/akstr_is_digit.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_digit",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_digit(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_digit.py
+++ b/src/awkward/operations/str/akstr_is_digit.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_digit",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_digit(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -6,13 +6,15 @@ import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
+from awkward._requirements import requires
 
 __all__ = ("is_in",)
 
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_in(
     array, value_set, *, skip_nones=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_is_in.py
+++ b/src/awkward/operations/str/akstr_is_in.py
@@ -12,7 +12,7 @@ __all__ = ("is_in",)
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_in(
     array, value_set, *, skip_nones=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_is_lower.py
+++ b/src/awkward/operations/str/akstr_is_lower.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_lower",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_lower(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_lower.py
+++ b/src/awkward/operations/str/akstr_is_lower.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_lower",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_lower(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_numeric.py
+++ b/src/awkward/operations/str/akstr_is_numeric.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_numeric",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_numeric(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_numeric.py
+++ b/src/awkward/operations/str/akstr_is_numeric.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_numeric",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_numeric(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_printable.py
+++ b/src/awkward/operations/str/akstr_is_printable.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_printable",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_printable(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_printable.py
+++ b/src/awkward/operations/str/akstr_is_printable.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_printable",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_printable(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_space.py
+++ b/src/awkward/operations/str/akstr_is_space.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_space",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_space(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_space.py
+++ b/src/awkward/operations/str/akstr_is_space.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_space",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_space(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_title.py
+++ b/src/awkward/operations/str/akstr_is_title.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_title",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_title(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_title.py
+++ b/src/awkward/operations/str/akstr_is_title.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_title",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_title(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_upper.py
+++ b/src/awkward/operations/str/akstr_is_upper.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("is_upper",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def is_upper(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_is_upper.py
+++ b/src/awkward/operations/str/akstr_is_upper.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("is_upper",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def is_upper(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -12,7 +12,7 @@ __all__ = ("join",)
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def join(array, separator, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_join.py
+++ b/src/awkward/operations/str/akstr_join.py
@@ -6,13 +6,15 @@ import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
+from awkward._requirements import requires
 
 __all__ = ("join",)
 
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def join(array, separator, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -6,13 +6,15 @@ import awkward as ak
 from awkward._backends.typetracer import TypeTracerBackend
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
+from awkward._requirements import requires
 
 __all__ = ("join_element_wise",)
 
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def join_element_wise(*arrays, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_join_element_wise.py
+++ b/src/awkward/operations/str/akstr_join_element_wise.py
@@ -12,7 +12,7 @@ __all__ = ("join_element_wise",)
 typetracer = TypeTracerBackend.instance()
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def join_element_wise(*arrays, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_length.py
+++ b/src/awkward/operations/str/akstr_length.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("length",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def length(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_length.py
+++ b/src/awkward/operations/str/akstr_length.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("length",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def length(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_lower.py
+++ b/src/awkward/operations/str/akstr_lower.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("lower",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def lower(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_lower.py
+++ b/src/awkward/operations/str/akstr_lower.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("lower",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def lower(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_lpad.py
+++ b/src/awkward/operations/str/akstr_lpad.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("lpad",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def lpad(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_lpad.py
+++ b/src/awkward/operations/str/akstr_lpad.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("lpad",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def lpad(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_ltrim.py
+++ b/src/awkward/operations/str/akstr_ltrim.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("ltrim",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def ltrim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_ltrim.py
+++ b/src/awkward/operations/str/akstr_ltrim.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("ltrim",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def ltrim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_ltrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_ltrim_whitespace.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("ltrim_whitespace",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def ltrim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_ltrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_ltrim_whitespace.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("ltrim_whitespace",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def ltrim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_match_like.py
+++ b/src/awkward/operations/str/akstr_match_like.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("match_like",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def match_like(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_match_like.py
+++ b/src/awkward/operations/str/akstr_match_like.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("match_like",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def match_like(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_match_substring.py
+++ b/src/awkward/operations/str/akstr_match_substring.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("match_substring",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def match_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_match_substring.py
+++ b/src/awkward/operations/str/akstr_match_substring.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("match_substring",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def match_substring(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_match_substring_regex.py
+++ b/src/awkward/operations/str/akstr_match_substring_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("match_substring_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def match_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_match_substring_regex.py
+++ b/src/awkward/operations/str/akstr_match_substring_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("match_substring_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def match_substring_regex(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -16,7 +16,11 @@ typetracer = TypeTracerBackend.instance()
 np = NumpyMetadata.instance()
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+from awkward._requirements import requires
+
+
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def repeat(array, num_repeats, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_repeat.py
+++ b/src/awkward/operations/str/akstr_repeat.py
@@ -16,7 +16,7 @@ typetracer = TypeTracerBackend.instance()
 np = NumpyMetadata.instance()
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def repeat(array, num_repeats, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_replace_slice.py
+++ b/src/awkward/operations/str/akstr_replace_slice.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("replace_slice",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def replace_slice(
     array, start, stop, replacement, *, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_replace_slice.py
+++ b/src/awkward/operations/str/akstr_replace_slice.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("replace_slice",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def replace_slice(
     array, start, stop, replacement, *, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_replace_substring.py
+++ b/src/awkward/operations/str/akstr_replace_substring.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("replace_substring",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def replace_substring(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_replace_substring.py
+++ b/src/awkward/operations/str/akstr_replace_substring.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("replace_substring",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def replace_substring(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_replace_substring_regex.py
+++ b/src/awkward/operations/str/akstr_replace_substring_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("replace_substring_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def replace_substring_regex(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_replace_substring_regex.py
+++ b/src/awkward/operations/str/akstr_replace_substring_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("replace_substring_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def replace_substring_regex(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_reverse.py
+++ b/src/awkward/operations/str/akstr_reverse.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("reverse",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def reverse(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_reverse.py
+++ b/src/awkward/operations/str/akstr_reverse.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("reverse",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def reverse(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rpad.py
+++ b/src/awkward/operations/str/akstr_rpad.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("rpad",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def rpad(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rpad.py
+++ b/src/awkward/operations/str/akstr_rpad.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("rpad",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def rpad(array, width, padding=" ", *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rtrim.py
+++ b/src/awkward/operations/str/akstr_rtrim.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("rtrim",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def rtrim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rtrim.py
+++ b/src/awkward/operations/str/akstr_rtrim.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("rtrim",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def rtrim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rtrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_rtrim_whitespace.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("rtrim_whitespace",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def rtrim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_rtrim_whitespace.py
+++ b/src/awkward/operations/str/akstr_rtrim_whitespace.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("rtrim_whitespace",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def rtrim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_slice.py
+++ b/src/awkward/operations/str/akstr_slice.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("slice",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def slice(
     array, start, stop=None, step=1, *, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_slice.py
+++ b/src/awkward/operations/str/akstr_slice.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("slice",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def slice(
     array, start, stop=None, step=1, *, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("split_pattern",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def split_pattern(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_split_pattern.py
+++ b/src/awkward/operations/str/akstr_split_pattern.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("split_pattern",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def split_pattern(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_split_pattern_regex.py
+++ b/src/awkward/operations/str/akstr_split_pattern_regex.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("split_pattern_regex",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def split_pattern_regex(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_split_pattern_regex.py
+++ b/src/awkward/operations/str/akstr_split_pattern_regex.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("split_pattern_regex",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def split_pattern_regex(
     array,
     pattern,

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("split_whitespace",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def split_whitespace(
     array, *, max_splits=None, reverse=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_split_whitespace.py
+++ b/src/awkward/operations/str/akstr_split_whitespace.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("split_whitespace",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def split_whitespace(
     array, *, max_splits=None, reverse=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_starts_with.py
+++ b/src/awkward/operations/str/akstr_starts_with.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("starts_with",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def starts_with(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_starts_with.py
+++ b/src/awkward/operations/str/akstr_starts_with.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("starts_with",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def starts_with(
     array, pattern, *, ignore_case=False, highlevel=True, behavior=None, attrs=None
 ):

--- a/src/awkward/operations/str/akstr_swapcase.py
+++ b/src/awkward/operations/str/akstr_swapcase.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("swapcase",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def swapcase(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_swapcase.py
+++ b/src/awkward/operations/str/akstr_swapcase.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("swapcase",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def swapcase(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_title.py
+++ b/src/awkward/operations/str/akstr_title.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("title",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def title(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_title.py
+++ b/src/awkward/operations/str/akstr_title.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("title",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def title(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("to_categorical",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def to_categorical(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_to_categorical.py
+++ b/src/awkward/operations/str/akstr_to_categorical.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("to_categorical",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def to_categorical(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_trim.py
+++ b/src/awkward/operations/str/akstr_trim.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("trim",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def trim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_trim.py
+++ b/src/awkward/operations/str/akstr_trim.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("trim",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def trim(array, characters, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_trim_whitespace.py
+++ b/src/awkward/operations/str/akstr_trim_whitespace.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("trim_whitespace",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def trim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_trim_whitespace.py
+++ b/src/awkward/operations/str/akstr_trim_whitespace.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("trim_whitespace",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def trim_whitespace(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_upper.py
+++ b/src/awkward/operations/str/akstr_upper.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._requirements import requires
 
 __all__ = ("upper",)
 
 
-@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
+@requires("pyarrow>=7.0.0", group="arrow", module_name="arrow")
+@high_level_function(module="ak.str")
 def upper(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:

--- a/src/awkward/operations/str/akstr_upper.py
+++ b/src/awkward/operations/str/akstr_upper.py
@@ -9,7 +9,7 @@ from awkward._layout import HighLevelContext
 __all__ = ("upper",)
 
 
-@high_level_function(module="ak.str")
+@high_level_function(module="ak.str", dependencies={"arrow": ["pyarrow>=7.0.0"]})
 def upper(array, *, highlevel=True, behavior=None, attrs=None):
     """
     Args:


### PR DESCRIPTION
Closes #2953 

This PR adds a new `dependencies` argument to `high_level_function`. This let's us fail at runtime if dependency specifications are not met, and also to annotate our documentation to inform the user ahead-of-time.

We will still need to keep these values in sync with our new `pyproject.toml` groups, but we can make a helper for that if needs be.

Examples:
![image](https://github.com/scikit-hep/awkward/assets/1248413/fd9d29d4-4088-4bd5-9b5d-8bf7f1a9dcbe)

![image](https://github.com/scikit-hep/awkward/assets/1248413/b49084f1-014e-4f8b-a375-d07c651f5597)
