### PR TITLE
fix: generate error message and tests for CUDA and CPU kernels

### DIFF
--- a/awkward-cpp/src/cpu-kernels/awkward_ListArray_rpad_axis1.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_ListArray_rpad_axis1.cpp
@@ -25,7 +25,7 @@ ERROR awkward_ListArray_rpad_axis1(
     }
     offset = (target > rangeval) ? tostarts[i] + target : tostarts[i] + rangeval;
     tostops[i] = offset;
-   }
+  }
   return success();
 }
 ERROR awkward_ListArray32_rpad_axis1_64(

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -229,22 +229,23 @@ def checkuint(test_args, args):
     return flag
 
 
-def checkintrange(test_args, args):
+def checkintrange(test_args, error, args):
     flag = True
-    for arg, val in test_args:
-        typename = remove_const(
-            next(argument for argument in args if argument.name == arg).typename
-        )
-        if "int" in typename or "uint" in typename:
-            dtype = gettypename(typename)
-            min_val, max_val = np.iinfo(dtype).min, np.iinfo(dtype).max
-            if "List" in typename:
-                for data in val:
-                    if not (min_val <= data <= max_val):
+    if not error:
+        for arg, val in test_args:
+            typename = remove_const(
+                next(argument for argument in args if argument.name == arg).typename
+            )
+            if "int" in typename or "uint" in typename:
+                dtype = gettypename(typename)
+                min_val, max_val = np.iinfo(dtype).min, np.iinfo(dtype).max
+                if "List" in typename:
+                    for data in val:
+                        if not (min_val <= data <= max_val):
+                            flag = False
+                else:
+                    if not (min_val <= val <= max_val):
                         flag = False
-            else:
-                if not (min_val <= val <= max_val):
-                    flag = False
     return flag
 
 
@@ -581,8 +582,8 @@ def gencpuunittests(specdict):
                         test["inputs"], test["outputs"]
                     )
                     flag = checkuint(unit_tests.items(), spec.args)
-                    range = checkintrange(unit_tests.items(), spec.args)
-                    if flag and range:
+                    range = checkintrange(unit_tests.items(), test["error"], spec.args)
+                    if flag and range and not test["error"]:
                         num += 1
                         f.write(funcName)
                         for i, (arg, val) in enumerate(unit_tests.items()):
@@ -915,7 +916,7 @@ def gencudaunittests(specdict):
                         test["inputs"], test["outputs"]
                     )
                     flag = checkuint(unit_tests.items(), spec.args)
-                    range = checkintrange(unit_tests.items(), spec.args)
+                    range = checkintrange(unit_tests.items(), test["error"], spec.args)
                     if flag and range:
                         num += 1
                         if not status:
@@ -973,24 +974,39 @@ def gencudaunittests(specdict):
                             else:
                                 args += ", " + arg.name
                         f.write(" " * 4 + "funcC(" + args + ")\n")
+                        error_message = test["message"]
                         f.write(
                             """
     try:
         ak_cu.synchronize_cuda()
+"""
+                        )
+                        if test["error"]:
+                            f.write(
+                                f"""
+    except ValueError as e:
+        assert str(e) == "{error_message} in compiled CUDA code ({spec.templatized_kernel_name})"
+"""
+                            )
+                        else:
+                            f.write(
+                                """
     except:
         pytest.fail("This test case shouldn't have raised an error")
 """
-                        )
-                        for arg, val in test["outputs"].items():
-                            f.write(" " * 4 + "pytest_" + arg + " = " + str(val) + "\n")
-                            if isinstance(val, list):
+                            )
+                            for arg, val in test["outputs"].items():
                                 f.write(
-                                    " " * 4
-                                    + f"assert cupy.array_equal({arg}[:len(pytest_{arg})], cupy.array(pytest_{arg}))\n"
+                                    " " * 4 + "pytest_" + arg + " = " + str(val) + "\n"
                                 )
-                            else:
-                                f.write(" " * 4 + f"assert {arg} == pytest_{arg}\n")
-                            f.write("\n")
+                                if isinstance(val, list):
+                                    f.write(
+                                        " " * 4
+                                        + f"assert cupy.array_equal({arg}[:len(pytest_{arg})], cupy.array(pytest_{arg}))\n"
+                                    )
+                                else:
+                                    f.write(" " * 4 + f"assert {arg} == pytest_{arg}\n")
+                        f.write("\n")
 
 
 def genunittests():

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -6,7 +6,6 @@ import copy
 import datetime
 import json
 import os
-import re
 import shutil
 import time
 from collections import OrderedDict
@@ -906,6 +905,7 @@ def gencudaunittests(specdict):
                 )
 
                 f.write(
+                    "import re\n"
                     "import cupy\n"
                     "import pytest\n\n"
                     "import awkward as ak\n"
@@ -983,13 +983,14 @@ def gencudaunittests(specdict):
                             else:
                                 args += ", " + arg.name
                         f.write(" " * 4 + "funcC(" + args + ")\n")
-                        error_message = re.escape(
-                            f"{test['message']} in compiled CUDA code ({spec.templatized_kernel_name})"
-                        )
                         if test["error"]:
                             f.write(
                                 f"""
-    with pytest.raises(ValueError, match=rf"{error_message}"):
+    error_message = re.escape("{test['message']} in compiled CUDA code ({spec.templatized_kernel_name})")
+"""
+                            )
+                            f.write(
+                                """    with pytest.raises(ValueError, match=rf"{error_message}"):
         ak_cu.synchronize_cuda()
 """
                             )

--- a/kernel-test-data.json
+++ b/kernel-test-data.json
@@ -14215,7 +14215,7 @@
                     "message": "index out of range",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
-                        "fromarray": [0, 1, -3, 1],
+                        "fromarray": [0, 1, -10, 1],
                         "fromstarts": [0, 0, 0, 0],
                         "fromstops": [3, 3, 3, 3],
                         "lenarray": 4,

--- a/kernel-test-data.json
+++ b/kernel-test-data.json
@@ -3344,7 +3344,7 @@
             "tests": [
                 {
                     "error": true,
-                    "message": "start[i] > stop[i]",
+                    "message": "stops[i] < starts[i]",
                     "inputs": {
                         "fromstarts": [2, 2, 6],
                         "fromstops": [2, 3, 5],
@@ -14215,7 +14215,7 @@
                     "message": "index out of range",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
-                        "fromarray": [0, 1, -10, 1],
+                        "fromarray": [0, 1, -4, 1],
                         "fromstarts": [0, 0, 0, 0],
                         "fromstops": [3, 3, 3, 3],
                         "lenarray": 4,

--- a/kernel-test-data.json
+++ b/kernel-test-data.json
@@ -293,6 +293,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0],
                         "indexlength": 1,
@@ -305,6 +306,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1],
                         "indexlength": 2,
@@ -317,6 +319,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1],
                         "indexlength": 3,
@@ -329,6 +332,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1],
                         "indexlength": 3,
@@ -341,6 +345,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1],
                         "indexlength": 4,
@@ -353,6 +358,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1],
                         "indexlength": 4,
@@ -365,6 +371,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 1],
                         "indexlength": 5,
@@ -377,6 +384,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 1],
                         "indexlength": 5,
@@ -389,6 +397,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 2],
                         "indexlength": 5,
@@ -401,6 +410,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 2, 3],
                         "indexlength": 6,
@@ -413,6 +423,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2],
                         "indexlength": 4,
@@ -425,6 +436,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 1],
                         "indexlength": 5,
@@ -437,6 +449,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3],
                         "indexlength": 5,
@@ -449,6 +462,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3, 4, 5],
                         "indexlength": 7,
@@ -461,6 +475,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1],
                         "indexlength": 4,
@@ -473,6 +488,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1, 1],
                         "indexlength": 5,
@@ -485,6 +501,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1, 3],
                         "indexlength": 5,
@@ -497,6 +514,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1],
                         "indexlength": 5,
@@ -509,6 +527,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1, 4, 5],
                         "indexlength": 7,
@@ -521,6 +540,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 4, 5],
                         "indexlength": 6,
@@ -533,6 +553,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0],
                         "indexlength": 2,
@@ -545,6 +566,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1],
                         "indexlength": 3,
@@ -557,6 +579,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1],
                         "indexlength": 3,
@@ -569,6 +592,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1],
                         "indexlength": 4,
@@ -581,6 +605,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1],
                         "indexlength": 4,
@@ -593,6 +618,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1, 1],
                         "indexlength": 5,
@@ -605,6 +631,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1, 1],
                         "indexlength": 5,
@@ -617,6 +644,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1, 2],
                         "indexlength": 5,
@@ -629,6 +657,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2],
                         "indexlength": 4,
@@ -641,6 +670,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2, 1],
                         "indexlength": 5,
@@ -653,6 +683,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2, 3],
                         "indexlength": 5,
@@ -665,6 +696,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0],
                         "indexlength": 3,
@@ -677,6 +709,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1],
                         "indexlength": 4,
@@ -689,6 +722,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1],
                         "indexlength": 4,
@@ -701,6 +735,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1, 1],
                         "indexlength": 5,
@@ -713,6 +748,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1, 1],
                         "indexlength": 5,
@@ -725,6 +761,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1, 2],
                         "indexlength": 5,
@@ -737,6 +774,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 0],
                         "indexlength": 4,
@@ -749,6 +787,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 0, 1],
                         "indexlength": 5,
@@ -761,6 +800,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 0, 1],
                         "indexlength": 5,
@@ -773,6 +813,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1],
                         "indexlength": 1,
@@ -785,6 +826,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 1, 0],
                         "indexlength": 5,
@@ -797,6 +839,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 1, 1],
                         "indexlength": 5,
@@ -809,6 +852,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 1],
                         "indexlength": 4,
@@ -821,6 +865,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1],
                         "indexlength": 3,
@@ -833,6 +878,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1],
                         "indexlength": 2,
@@ -851,6 +897,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "target": 2
@@ -861,6 +908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "target": 2
@@ -871,6 +919,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "target": 3
@@ -881,6 +930,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 4
@@ -891,6 +941,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 5
@@ -901,6 +952,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 6
@@ -911,6 +963,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 3
@@ -921,6 +974,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 3
@@ -931,6 +985,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 2
@@ -941,6 +996,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "target": 1
@@ -951,6 +1007,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 1
@@ -961,6 +1018,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 1
@@ -977,6 +1035,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "bitmasklength": 2,
                         "frombitmask": [58, 59],
@@ -989,6 +1048,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "bitmasklength": 1,
                         "frombitmask": [66],
@@ -1001,6 +1061,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "bitmasklength": 2,
                         "frombitmask": [58, 59],
@@ -1019,6 +1080,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "mask": [0, 0],
@@ -1030,6 +1092,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "mask": [0, 0, 1, 1, 0],
@@ -1047,6 +1110,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "mask": [0],
@@ -1059,6 +1123,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "mask": [0, 0, 0, 0],
@@ -1077,6 +1142,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "mask": [0, 0, 0, 0],
@@ -1088,6 +1154,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "mask": [0, 0],
@@ -1099,6 +1166,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "mask": [0],
@@ -1110,6 +1178,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 30,
                         "mask": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
@@ -1121,6 +1190,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 30,
                         "mask": [0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0],
@@ -1132,6 +1202,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 30,
                         "mask": [0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0],
@@ -1143,6 +1214,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "mask": [0, 1, 0, 0],
@@ -1154,6 +1226,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "mask": [0],
@@ -1165,6 +1238,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "mask": [0, 1, 1],
@@ -1176,6 +1250,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "mask": [0, 0, 1, 1, 0, 0],
@@ -1187,6 +1262,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "mask": [0, 0, 1, 1, 0],
@@ -1198,6 +1274,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 9,
                         "mask": [0, 1, 0, 0, 0, 0, 1, 0, 0],
@@ -1209,6 +1286,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "mask": [0, 1, 0, 0, 1, 0],
@@ -1220,6 +1298,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "mask": [0, 1, 0],
@@ -1231,6 +1310,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "mask": [1, 1, 0],
@@ -1242,6 +1322,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 8,
                         "mask": [0, 1, 0, 0, 1, 0, 1, 0],
@@ -1253,6 +1334,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 10,
                         "mask": [0, 1, 1, 0, 1, 0, 0, 1, 1, 0],
@@ -1270,6 +1352,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "mask": [0, 0],
@@ -1281,6 +1364,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "mask": [0, 0, 0, 0],
@@ -1297,7 +1381,20 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "fromindex": [0, 2],
+                        "lencontent": 2,
+                        "lenindex": 2
+                    },
+                    "outputs": {
+                        "tocarry": [0, 1]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1],
                         "lencontent": 2,
@@ -1314,7 +1411,20 @@
             "status": false,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "fromindex": [0, 0, 0, 1, 0, 2, 0],
+                        "lencontent": 1,
+                        "lenindex": 7
+                    },
+                    "outputs": {
+                        "tocarry": [0, 0, 0, 0, 0, 0, 0]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0, 0, 0, 0, 0],
                         "lencontent": 1,
@@ -1326,6 +1436,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0, 0, 0, 0],
                         "lencontent": 1,
@@ -1337,6 +1448,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0, 0, 0],
                         "lencontent": 1,
@@ -1348,6 +1460,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0],
                         "lencontent": 1,
@@ -1359,6 +1472,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0],
                         "lencontent": 1,
@@ -1370,6 +1484,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0, 1, 1, 1, 2, 2, 2],
                         "lencontent": 3,
@@ -1381,6 +1496,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 0, 2, 3, 3, 4],
                         "lencontent": 5,
@@ -1392,6 +1508,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1],
                         "lencontent": 2,
@@ -1403,6 +1520,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2],
                         "lencontent": 3,
@@ -1414,6 +1532,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3],
                         "lencontent": 4,
@@ -1425,6 +1544,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3, 4],
                         "lencontent": 5,
@@ -1436,6 +1556,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 1, 1],
                         "lencontent": 6,
@@ -1447,6 +1568,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1],
                         "lencontent": 5,
@@ -1458,6 +1580,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1],
                         "lencontent": 6,
@@ -1469,6 +1592,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 2],
                         "lencontent": 3,
@@ -1480,6 +1604,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 3],
                         "lencontent": 6,
@@ -1491,6 +1616,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 1, 0, 3, 3, 4],
                         "lencontent": 5,
@@ -1502,6 +1628,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 2, 1, 0],
                         "lencontent": 3,
@@ -1513,6 +1640,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 2, 1, 0, 3],
                         "lencontent": 4,
@@ -1524,6 +1652,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2],
                         "lencontent": 3,
@@ -1535,6 +1664,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2],
                         "lencontent": 5,
@@ -1546,6 +1676,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 4, 4, 0, 8],
                         "lencontent": 10,
@@ -1557,6 +1688,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [3, 2, 1, 0],
                         "lencontent": 4,
@@ -1568,6 +1700,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [4, 3, 2, 1, 0],
                         "lencontent": 5,
@@ -1579,6 +1712,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [4],
                         "lencontent": 5,
@@ -1590,6 +1724,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [6, 4, 4, 8, 0],
                         "lencontent": 10,
@@ -1601,6 +1736,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [6, 5, 4, 3, 2, 1, 0],
                         "lencontent": 7,
@@ -1617,7 +1753,21 @@
             "status": false,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "fromindex": [0, 1, 2, 4],
+                        "lencontent": 4,
+                        "lenindex": 4
+                    },
+                    "outputs": {
+                        "tocarry": [0, 1, 2, 3],
+                        "toindex": [0, 1, 2, 3]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3],
                         "lencontent": 4,
@@ -1630,6 +1780,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [3, 2, 1, 0],
                         "lencontent": 4,
@@ -1648,6 +1799,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1],
                         "lenindex": 2
@@ -1658,6 +1810,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3],
                         "lenindex": 4
@@ -1668,6 +1821,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3, 4, 5, 6],
                         "lenindex": 7
@@ -1678,6 +1832,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 2],
                         "lenindex": 2
@@ -1688,6 +1843,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 2, 3],
                         "lenindex": 3
@@ -1698,6 +1854,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1, 2, 3, 4],
                         "lenindex": 4
@@ -1708,6 +1865,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 3],
                         "lenindex": 2
@@ -1718,6 +1876,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 3, 4],
                         "lenindex": 3
@@ -1728,6 +1887,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [3, 2, 1, 0],
                         "lenindex": 4
@@ -1738,6 +1898,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [3, 4],
                         "lenindex": 2
@@ -1748,6 +1909,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [4, 3, 2, 1, 0],
                         "lenindex": 5
@@ -1758,6 +1920,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [5, 2, 4, 1, 3, 0],
                         "lenindex": 6
@@ -1768,6 +1931,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [5, 4, 3, 2, 1, 0],
                         "lenindex": 6
@@ -1784,6 +1948,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenindex": 4
                     },
@@ -1793,6 +1958,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenindex": 2
                     },
@@ -1802,6 +1968,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenindex": 0
                     },
@@ -1811,6 +1978,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenindex": 3
                     },
@@ -1820,6 +1988,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenindex": 1
                     },
@@ -1835,6 +2004,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [5, 4, 3, 2, 1, 0],
                         "length": 6,
@@ -1852,6 +2022,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 6, 8, 10, 12, 13, 14, 15, 16],
                         "fromstarts": [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
@@ -1865,6 +2036,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 6, 8, 10],
                         "fromstarts": [0, 0, 0, 3, 3],
@@ -1878,6 +2050,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
                         "fromstarts": [0, 0, 0, 3, 3, 5, 5, 5, 8, 8],
@@ -1891,6 +2064,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 15, 18, 21],
                         "fromstarts": [0, 0, 0, 0, 0, 0, 0],
@@ -1904,6 +2078,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 15, 18],
                         "fromstarts": [0, 0, 0, 0, 0, 0],
@@ -1917,6 +2092,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 15],
                         "fromstarts": [0, 0, 0, 0, 0],
@@ -1930,6 +2106,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9],
                         "fromstarts": [0, 0, 0],
@@ -1943,6 +2120,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6],
                         "fromstarts": [0, 0],
@@ -1956,6 +2134,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3],
                         "fromstarts": [0, 3],
@@ -1969,6 +2148,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 8, 13, 18, 23, 28],
                         "fromstarts": [0, 13, 3, 18, 8, 23],
@@ -1982,6 +2162,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4],
                         "fromstarts": [0, 2],
@@ -1995,6 +2176,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 9, 13, 18, 23, 28],
                         "fromstarts": [0, 13, 4, 18, 8, 23],
@@ -2008,6 +2190,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 9, 14, 19, 24, 29],
                         "fromstarts": [0, 14, 4, 19, 9, 24],
@@ -2021,6 +2204,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 18, 21, 24, 29],
                         "fromstarts": [0, 0, 0, 8, 11, 11, 14],
@@ -2034,6 +2218,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 4, 5],
                         "fromstarts": [0, 3, 3, 4],
@@ -2047,6 +2232,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5],
                         "fromstarts": [0, 3, 3],
@@ -2060,6 +2246,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5],
                         "fromstarts": [0, 3, 3],
@@ -2073,6 +2260,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 5, 8],
                         "fromstarts": [0, 3, 3, 10, 10],
@@ -2086,6 +2274,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20],
                         "fromstarts": [0, 10, 15, 25],
@@ -2099,6 +2288,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 11, 12, 17, 22],
                         "fromstarts": [0, 11, 5, 16, 6, 17],
@@ -2112,6 +2302,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 14, 18, 23, 28],
                         "fromstarts": [0, 14, 5, 19, 9, 23],
@@ -2125,6 +2316,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 24, 28],
                         "fromstarts": [0, 14, 5, 19, 10, 24],
@@ -2138,6 +2330,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 6, 10],
                         "fromstarts": [0, 3, 3, 15, 16],
@@ -2151,6 +2344,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20],
                         "fromstarts": [0, 15, 10, 25],
@@ -2164,6 +2358,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 19, 24, 28],
                         "fromstarts": [0, 15, 5, 20, 10, 24],
@@ -2177,6 +2372,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 28],
                         "fromstarts": [0, 15, 5, 20, 10, 25],
@@ -2190,6 +2386,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 29],
                         "fromstarts": [0, 15, 5, 20, 10, 25],
@@ -2203,6 +2400,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [0, 15, 5, 20, 10, 25],
@@ -2216,6 +2414,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [0, 45, 5, 50, 10, 55],
@@ -2229,6 +2428,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6],
                         "fromstarts": [0, 3],
@@ -2242,6 +2442,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6],
                         "fromstarts": [0, 3],
@@ -2255,6 +2456,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 10, 14, 17],
                         "fromstarts": [0, 3, 10, 14, 18],
@@ -2268,6 +2470,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 15],
                         "fromstarts": [0, 3, 11, 14, 17],
@@ -2281,6 +2484,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 15],
                         "fromstarts": [0, 3, 11, 14, 17],
@@ -2294,6 +2498,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 10, 14, 17],
                         "fromstarts": [0, 3, 11, 15, 19],
@@ -2307,6 +2512,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 4, 6, 7],
                         "fromstarts": [0, 3, 3, 4, 6],
@@ -2320,6 +2526,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 7],
                         "fromstarts": [0, 3, 3],
@@ -2333,6 +2540,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 7],
                         "fromstarts": [0, 3],
@@ -2346,6 +2554,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 6, 10],
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -2359,6 +2568,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 8, 8, 10],
                         "fromstarts": [0, 3, 3, 5, 8, 8],
@@ -2372,6 +2582,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10],
                         "fromstarts": [0, 5],
@@ -2385,6 +2596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 7, 7, 9, 9, 11],
                         "fromstarts": [0, 4, 7, 7, 9, 9],
@@ -2398,6 +2610,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 8, 12, 16, 19],
                         "fromstarts": [0, 3, 8, 12, 16],
@@ -2411,6 +2624,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 11, 15, 19, 22],
                         "fromstarts": [0, 3, 6, 11, 15, 19],
@@ -2424,6 +2638,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [0, 5, 10, 15, 20, 25],
@@ -2437,6 +2652,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210],
                         "fromstarts": [0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203],
@@ -2450,6 +2666,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [0, 5, 10, 45, 50, 55],
@@ -2463,6 +2680,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 11, 15, 19, 22],
                         "fromstarts": [0, 3, 8, 13, 17, 21],
@@ -2476,6 +2694,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 8, 11, 14, 19],
                         "fromstarts": [0, 8, 11, 11, 14],
@@ -2489,6 +2708,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 8, 9],
                         "fromstarts": [0, 3, 4, 5, 8],
@@ -2502,6 +2722,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 5, 6, 7, 7, 9],
                         "fromstarts": [0, 4, 6, 3, 6, 7],
@@ -2515,6 +2736,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 5, 6, 7, 9],
                         "fromstarts": [0, 4, 6, 3, 7],
@@ -2528,6 +2750,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 3, 4, 5, 6, 8],
                         "fromstarts": [0, 2, 4, 5, 6, 9],
@@ -2541,6 +2764,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5, 6, 8],
                         "fromstarts": [0, 4, 4, 6, 9],
@@ -2554,6 +2778,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5],
                         "fromstarts": [0, 3, 5],
@@ -2567,6 +2792,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 7],
                         "fromstarts": [0, 3, 5],
@@ -2580,6 +2806,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 7],
                         "fromstarts": [0, 5],
@@ -2593,6 +2820,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 5, 7, 8, 9, 10],
                         "fromstarts": [0, 6, 3, 8, 5, 9],
@@ -2606,6 +2834,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 5, 5, 6, 8, 9],
                         "fromstarts": [0, 6, 3, 8, 3, 5],
@@ -2619,6 +2848,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 7],
                         "fromstarts": [0, 3, 6],
@@ -2632,6 +2862,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 5, 6, 6, 6],
                         "fromstarts": [0, 3, 2, 5, 3, 6],
@@ -2645,6 +2876,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 2, 4, 5, 6],
                         "fromstarts": [0, 3, 3, 5, 8],
@@ -2658,6 +2890,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9],
                         "fromstarts": [11, 14, 17],
@@ -2671,6 +2904,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [1, 16, 6, 21, 11, 26],
@@ -2684,6 +2918,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 3, 5],
                         "fromstarts": [1, 99, 5],
@@ -2697,6 +2932,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20],
                         "fromstarts": [15, 10, 5, 0],
@@ -2710,6 +2946,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20],
                         "fromstarts": [15, 5, 10, 0],
@@ -2723,6 +2960,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4],
                         "fromstarts": [16],
@@ -2736,6 +2974,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 0, 1, 3],
                         "fromstarts": [2, 2, 3],
@@ -2749,6 +2988,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 2, 3],
                         "fromstarts": [2, 4, 5],
@@ -2762,6 +3002,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [25, 10, 20, 5, 15, 0],
@@ -2775,6 +3016,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10, 15, 20, 25, 30],
                         "fromstarts": [25, 20, 15, 10, 5, 0],
@@ -2788,6 +3030,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 2, 2, 5, 7],
                         "fromstarts": [3, 3, 3, 0, 4],
@@ -2801,6 +3044,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 2, 5, 6, 7, 11],
                         "fromstarts": [3, 3, 0, 5, 5, 6],
@@ -2814,6 +3058,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 3],
                         "fromstarts": [3, 15],
@@ -2827,6 +3072,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 4, 7],
                         "fromstarts": [3, 3, 3, 0],
@@ -2840,6 +3086,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 7, 7, 9, 9, 11],
                         "fromstarts": [3, 0, 999, 2, 6, 10],
@@ -2853,6 +3100,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 2, 2, 2, 6],
                         "fromstarts": [3, 5, 5, 5, 5],
@@ -2866,6 +3114,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 6, 9, 12, 14, 16],
                         "fromstarts": [3, 6, 17, 20, 11, 25],
@@ -2879,6 +3128,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 8, 12, 16, 19],
                         "fromstarts": [3, 6, 11, 15, 19],
@@ -2892,6 +3142,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 0, 2, 6],
                         "fromstarts": [3, 3, 6],
@@ -2905,6 +3156,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 6],
                         "fromstarts": [3, 6],
@@ -2918,6 +3170,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 0, 2],
                         "fromstarts": [4, 4],
@@ -2931,6 +3184,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 0, 2, 7],
                         "fromstarts": [4, 4, 7],
@@ -2944,6 +3198,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 2, 5, 5, 7, 7, 11],
                         "fromstarts": [5, 5, 0, 3, 3, 6, 6],
@@ -2957,6 +3212,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 0, 1, 4],
                         "fromstarts": [5, 5, 6],
@@ -2970,6 +3226,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 1, 5],
                         "fromstarts": [5, 6, 6],
@@ -2983,6 +3240,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 5],
                         "fromstarts": [5, 6],
@@ -2996,6 +3254,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 4, 6, 6, 9],
                         "fromstarts": [6, 5, 3, 3, 0],
@@ -3009,6 +3268,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 3, 4, 7, 10],
                         "fromstarts": [6, 5, 6, 0],
@@ -3022,6 +3282,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 1, 6],
                         "fromstarts": [6, 7, 7],
@@ -3035,6 +3296,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 8, 11, 14, 19],
                         "fromstarts": [6, 11, 14, 17, 20],
@@ -3048,6 +3310,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 5, 7, 10],
                         "fromstarts": [6, 5, 3, 0],
@@ -3061,6 +3324,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4, 5, 7, 7, 10],
                         "fromstarts": [6, 5, 3, 3, 0],
@@ -3079,7 +3343,20 @@
             "status": false,
             "tests": [
                 {
+                    "error": true,
+                    "message": "start[i] > stop[i]",
+                    "inputs": {
+                        "fromstarts": [2, 2, 6],
+                        "fromstops": [2, 3, 5],
+                        "length": 3
+                    },
+                    "outputs": {
+                        "tooffsets": [0, 0, 1, 3]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [2, 2, 3],
                         "fromstops": [2, 3, 5],
@@ -3091,6 +3368,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [5, 5, 6],
                         "fromstops": [5, 6, 9],
@@ -3102,6 +3380,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [4, 4],
                         "fromstops": [4, 6],
@@ -3113,6 +3392,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 3, 6],
                         "fromstops": [3, 5, 10],
@@ -3124,6 +3404,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [4, 4, 7],
                         "fromstops": [4, 6, 12],
@@ -3135,6 +3416,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [5, 6, 6],
                         "fromstops": [6, 6, 10],
@@ -3146,6 +3428,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 7, 7],
                         "fromstops": [7, 7, 12],
@@ -3157,6 +3440,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 3, 3, 0, 4],
                         "fromstops": [4, 4, 3, 3, 6],
@@ -3168,6 +3452,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [2, 4, 5],
                         "fromstops": [3, 5, 6],
@@ -3179,6 +3464,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [5, 5, 0, 3, 3, 6, 6],
                         "fromstops": [6, 6, 3, 3, 5, 6, 10],
@@ -3190,6 +3476,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 5, 5, 5, 5],
                         "fromstops": [5, 5, 5, 5, 9],
@@ -3201,6 +3488,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3, 5, 8],
                         "fromstops": [2, 3, 5, 6, 9],
@@ -3212,6 +3500,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 3, 0, 5, 5, 6],
                         "fromstops": [5, 3, 3, 6, 6, 10],
@@ -3223,6 +3512,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 15],
                         "fromstops": [5, 16],
@@ -3234,6 +3524,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 2, 4, 5, 6, 9],
                         "fromstops": [2, 3, 5, 6, 7, 11],
@@ -3245,6 +3536,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 2],
                         "fromstops": [2, 4],
@@ -3256,6 +3548,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 3, 3, 0],
                         "fromstops": [5, 5, 3, 3],
@@ -3267,6 +3560,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 2, 5, 3, 6],
                         "fromstops": [2, 5, 3, 6, 3, 6],
@@ -3278,6 +3572,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 3, 3],
                         "fromstops": [2, 2, 2, 5, 5],
@@ -3289,6 +3584,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 0, 0, 0, 4, 4, 4, 4],
                         "fromstops": [2, 2, 2, 2, 2, 2, 5, 5, 5, 5],
@@ -3300,6 +3596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 3, 3, 5, 5, 5, 8, 8],
                         "fromstops": [2, 2, 2, 5, 5, 7, 7, 7, 10, 10],
@@ -3311,6 +3608,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 6],
                         "fromstops": [5, 10],
@@ -3322,6 +3620,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3],
                         "fromstops": [3, 3],
@@ -3333,6 +3632,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3, 4],
                         "fromstops": [3, 3, 4, 5],
@@ -3344,6 +3644,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3],
                         "fromstops": [3, 3, 5],
@@ -3355,6 +3656,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 5],
                         "fromstops": [3, 3, 7],
@@ -3366,6 +3668,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [1, 99, 5],
                         "fromstops": [4, 99, 7],
@@ -3377,6 +3680,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3, 10, 10],
                         "fromstops": [3, 3, 5, 10, 13],
@@ -3388,6 +3692,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3, 15, 16],
                         "fromstops": [3, 3, 5, 16, 20],
@@ -3399,6 +3704,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 4, 4, 6, 9],
                         "fromstops": [3, 4, 6, 7, 11],
@@ -3410,6 +3716,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -3421,6 +3728,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 5],
                         "fromstops": [3, 3, 9],
@@ -3432,6 +3740,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 6],
                         "fromstops": [3, 3, 10],
@@ -3443,6 +3752,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [9, 6, 5, 3, 3],
@@ -3454,6 +3764,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 6, 0],
                         "fromstops": [9, 6, 9, 3],
@@ -3465,6 +3776,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 6, 3, 8, 3, 5],
                         "fromstops": [3, 8, 3, 9, 5, 6],
@@ -3476,6 +3788,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 4, 6, 3, 6, 7],
                         "fromstops": [3, 6, 7, 4, 6, 9],
@@ -3487,6 +3800,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 4, 6, 3, 7],
                         "fromstops": [3, 6, 7, 4, 9],
@@ -3498,6 +3812,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 6, 3, 8, 5, 9],
                         "fromstops": [3, 8, 5, 9, 6, 10],
@@ -3509,6 +3824,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0],
                         "fromstops": [3, 3],
@@ -3520,6 +3836,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3],
                         "fromstops": [3, 6],
@@ -3531,6 +3848,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 10, 14, 18],
                         "fromstops": [3, 6, 14, 18, 21],
@@ -3542,6 +3860,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 6, 11, 15, 19],
                         "fromstops": [3, 6, 11, 15, 19, 22],
@@ -3553,6 +3872,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0],
                         "fromstops": [3, 3, 3],
@@ -3564,6 +3884,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 6, 17, 20, 11, 25],
                         "fromstops": [6, 9, 20, 23, 13, 27],
@@ -3575,6 +3896,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 0, 0],
                         "fromstops": [3, 3, 3, 3, 3],
@@ -3586,6 +3908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 11, 14, 17],
                         "fromstops": [3, 6, 14, 17, 20],
@@ -3597,6 +3920,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 0, 0, 0],
                         "fromstops": [3, 3, 3, 3, 3, 3],
@@ -3608,6 +3932,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 0, 0, 0, 0],
                         "fromstops": [3, 3, 3, 3, 3, 3, 3],
@@ -3619,6 +3944,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 5],
                         "fromstops": [3, 9],
@@ -3630,6 +3956,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 6, 11, 15, 19],
                         "fromstops": [6, 11, 15, 19, 22],
@@ -3641,6 +3968,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 13, 3, 18, 8, 23],
                         "fromstops": [3, 18, 8, 23, 13, 28],
@@ -3652,6 +3980,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [16],
                         "fromstops": [20],
@@ -3663,6 +3992,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -3674,6 +4004,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -3685,6 +4016,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [3, 0, 999, 2, 6, 10],
                         "fromstops": [7, 3, 999, 4, 6, 12],
@@ -3696,6 +4028,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 13, 4, 18, 8, 23],
                         "fromstops": [4, 18, 8, 23, 13, 28],
@@ -3707,6 +4040,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 14, 4, 19, 9, 24],
                         "fromstops": [4, 19, 9, 24, 14, 29],
@@ -3718,6 +4052,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 11, 5, 16, 6, 17],
                         "fromstops": [5, 16, 6, 17, 11, 22],
@@ -3729,6 +4064,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 14, 5, 19, 9, 23],
                         "fromstops": [5, 19, 9, 23, 14, 28],
@@ -3740,6 +4076,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 0, 0, 8, 11, 11, 14],
                         "fromstops": [5, 5, 5, 11, 14, 14, 19],
@@ -3751,6 +4088,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 15, 5, 20, 10, 24],
                         "fromstops": [5, 20, 10, 24, 15, 28],
@@ -3762,6 +4100,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 10, 15, 25],
                         "fromstops": [5, 15, 20, 30],
@@ -3773,6 +4112,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 15, 10, 25],
                         "fromstops": [5, 20, 15, 30],
@@ -3784,6 +4124,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [15, 10, 5, 0],
                         "fromstops": [20, 15, 10, 5],
@@ -3795,6 +4136,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [15, 5, 10, 0],
                         "fromstops": [20, 10, 15, 5],
@@ -3806,6 +4148,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 14, 5, 19, 10, 24],
                         "fromstops": [5, 19, 10, 24, 14, 28],
@@ -3817,6 +4160,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 15, 5, 20, 10, 25],
                         "fromstops": [5, 20, 10, 25, 15, 28],
@@ -3828,6 +4172,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 15, 5, 20, 10, 25],
                         "fromstops": [5, 20, 10, 25, 15, 29],
@@ -3839,6 +4184,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 15, 5, 20, 10, 25],
                         "fromstops": [5, 20, 10, 25, 15, 30],
@@ -3850,6 +4196,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 45, 5, 50, 10, 55],
                         "fromstops": [5, 50, 10, 55, 15, 60],
@@ -3861,6 +4208,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 5, 10, 15, 20, 25],
                         "fromstops": [5, 10, 15, 20, 25, 30],
@@ -3872,6 +4220,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 5, 10, 45, 50, 55],
                         "fromstops": [5, 10, 15, 50, 55, 60],
@@ -3883,6 +4232,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [1, 16, 6, 21, 11, 26],
                         "fromstops": [6, 21, 11, 26, 16, 31],
@@ -3894,6 +4244,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [25, 10, 20, 5, 15, 0],
                         "fromstops": [30, 15, 25, 10, 20, 5],
@@ -3905,6 +4256,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [25, 20, 15, 10, 5, 0],
                         "fromstops": [30, 25, 20, 15, 10, 5],
@@ -3916,6 +4268,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 8, 11, 11, 14],
                         "fromstops": [5, 11, 14, 14, 19],
@@ -3927,6 +4280,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 11, 14, 17, 20],
                         "fromstops": [11, 14, 17, 20, 25],
@@ -3938,6 +4292,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203],
                         "fromstops": [7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210],
@@ -3955,6 +4310,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "size": 3
@@ -3965,6 +4321,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "size": 5
@@ -3981,6 +4338,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "size": 2,
@@ -3992,6 +4350,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "size": 3,
@@ -4003,6 +4362,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "size": 3,
@@ -4014,6 +4374,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "size": 3,
@@ -4025,6 +4386,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "size": 5,
@@ -4036,6 +4398,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "size": 2,
@@ -4047,6 +4410,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "size": 3,
@@ -4064,6 +4428,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0],
                         "lencarry": 2,
@@ -4075,6 +4440,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 0, 1, 1, 1],
                         "lencarry": 6,
@@ -4086,6 +4452,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 0, 2, 2],
                         "lencarry": 5,
@@ -4097,6 +4464,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4],
                         "lencarry": 10,
@@ -4108,6 +4476,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 1, 0, 1, 0, 1, 3, 4, 3, 4],
                         "lencarry": 10,
@@ -4119,6 +4488,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 1, 1],
                         "lencarry": 4,
@@ -4130,6 +4500,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 0, 0],
                         "lencarry": 4,
@@ -4141,6 +4512,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 1, 1, 2],
                         "lencarry": 4,
@@ -4152,6 +4524,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0],
                         "lencarry": 2,
@@ -4163,6 +4536,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 0, 0, 1, 1, 1],
                         "lencarry": 6,
@@ -4174,6 +4548,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 2, 3, 5],
                         "lencarry": 4,
@@ -4185,6 +4560,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 2, 4],
                         "lencarry": 3,
@@ -4196,6 +4572,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 3, 6, 9],
                         "lencarry": 4,
@@ -4207,6 +4584,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 3, 1, 4, 2, 5],
                         "lencarry": 6,
@@ -4218,6 +4596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 4, 8, 10],
                         "lencarry": 4,
@@ -4229,6 +4608,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 1, 1, 1],
                         "lencarry": 4,
@@ -4240,6 +4620,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2],
                         "lencarry": 12,
@@ -4251,6 +4632,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [0, 1, 2, 3, 4, 5, 3, 4, 5, 3, 4, 5],
                         "lencarry": 12,
@@ -4262,6 +4644,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2, 0, 0, 1],
                         "lencarry": 4,
@@ -4273,6 +4656,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2, 2, 2, 2],
                         "lencarry": 4,
@@ -4284,6 +4668,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2],
                         "lencarry": 1,
@@ -4295,6 +4680,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2, 5, 8, 11],
                         "lencarry": 4,
@@ -4306,6 +4692,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1],
                         "lencarry": 1,
@@ -4317,6 +4704,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [3, 4, 5, 0, 1, 2, 0, 1, 2, 3, 4, 5],
                         "lencarry": 12,
@@ -4328,6 +4716,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [3, 4, 5, 3, 4, 5, 3, 4, 5, 3, 4, 5],
                         "lencarry": 12,
@@ -4339,6 +4728,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [3, 4, 5],
                         "lencarry": 3,
@@ -4350,6 +4740,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [4, 4, 4, 4],
                         "lencarry": 4,
@@ -4361,6 +4752,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [4],
                         "lencarry": 1,
@@ -4372,6 +4764,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2],
                         "lencarry": 1,
@@ -4383,6 +4776,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 0],
                         "lencarry": 2,
@@ -4394,6 +4788,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1],
                         "lencarry": 1,
@@ -4405,6 +4800,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 1, 0, 0],
                         "lencarry": 4,
@@ -4416,6 +4812,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 2],
                         "lencarry": 2,
@@ -4427,6 +4824,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 0, 0, 1],
                         "lencarry": 4,
@@ -4438,6 +4836,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1],
                         "lencarry": 1,
@@ -4449,6 +4848,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 1, 1, 1],
                         "lencarry": 4,
@@ -4460,6 +4860,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2],
                         "lencarry": 1,
@@ -4471,6 +4872,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 2],
                         "lencarry": 2,
@@ -4482,6 +4884,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 2],
                         "lencarry": 2,
@@ -4493,6 +4896,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 2, 3, 4, 5],
                         "lencarry": 5,
@@ -4504,6 +4908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1],
                         "lencarry": 1,
@@ -4515,6 +4920,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 3, 6, 10],
                         "lencarry": 4,
@@ -4526,6 +4932,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [1, 4, 0, 5],
                         "lencarry": 4,
@@ -4537,6 +4944,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromcarry": [2, 1, 1, 2],
                         "lencarry": 4,
@@ -4554,6 +4962,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 4,
@@ -4566,6 +4975,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4578,6 +4988,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 4,
@@ -4590,6 +5001,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4602,6 +5014,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4614,6 +5027,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4626,6 +5040,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4638,6 +5053,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4650,6 +5066,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 2,
@@ -4662,6 +5079,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 7,
@@ -4674,6 +5092,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4686,6 +5105,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4698,6 +5118,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4710,6 +5131,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4722,6 +5144,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 4,
@@ -4734,6 +5157,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 4,
@@ -4746,6 +5170,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4758,6 +5183,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4770,6 +5196,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 2,
                         "regularsize": 2,
@@ -4782,6 +5209,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4794,6 +5222,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4806,6 +5235,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4818,6 +5248,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 2,
@@ -4830,6 +5261,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 4,
@@ -4842,6 +5274,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4854,6 +5287,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4866,6 +5300,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 2,
@@ -4878,6 +5313,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 3,
@@ -4890,6 +5326,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "regularlength": 1,
                         "regularsize": 5,
@@ -4908,6 +5345,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 0, 0],
                         "lenarray": 4,
@@ -4921,6 +5359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0],
                         "lenarray": 2,
@@ -4934,6 +5373,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0],
                         "lenarray": 1,
@@ -4947,6 +5387,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 1, 1, 1, 0],
                         "lenarray": 6,
@@ -4960,6 +5401,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -4973,6 +5415,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -4986,6 +5429,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -4999,6 +5443,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 1, 1],
                         "lenarray": 4,
@@ -5012,6 +5457,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2],
                         "lenarray": 3,
@@ -5025,6 +5471,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2],
                         "lenarray": 3,
@@ -5038,6 +5485,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2, 3],
                         "lenarray": 4,
@@ -5051,6 +5499,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -5064,6 +5513,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2, 4],
                         "lenarray": 4,
@@ -5077,6 +5527,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3],
                         "lenarray": 3,
@@ -5090,6 +5541,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4],
                         "lenarray": 4,
@@ -5103,6 +5555,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 5],
                         "lenarray": 5,
@@ -5116,6 +5569,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 5],
                         "lenarray": 5,
@@ -5129,6 +5583,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 6, 7],
                         "lenarray": 6,
@@ -5142,6 +5597,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 6, 7],
                         "lenarray": 6,
@@ -5155,6 +5611,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4],
                         "lenarray": 3,
@@ -5168,6 +5625,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4, 6, 7],
                         "lenarray": 5,
@@ -5181,6 +5639,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4, 6, 7],
                         "lenarray": 5,
@@ -5194,6 +5653,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2],
                         "lenarray": 2,
@@ -5207,6 +5667,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2],
                         "lenarray": 2,
@@ -5220,6 +5681,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 1, 0],
                         "lenarray": 4,
@@ -5233,6 +5695,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 3],
                         "lenarray": 3,
@@ -5246,6 +5709,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 3, 4],
                         "lenarray": 4,
@@ -5259,6 +5723,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 4],
                         "lenarray": 3,
@@ -5272,6 +5737,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "lenarray": 2,
@@ -5285,6 +5751,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3, 4],
                         "lenarray": 3,
@@ -5298,6 +5765,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "lenarray": 2,
@@ -5311,6 +5779,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "lenarray": 2,
@@ -5324,6 +5793,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 4],
                         "lenarray": 2,
@@ -5337,6 +5807,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 0, 1],
                         "lenarray": 4,
@@ -5350,6 +5821,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0],
                         "lenarray": 2,
@@ -5363,6 +5835,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 1, 1, 1, 0],
                         "lenarray": 6,
@@ -5376,6 +5849,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1],
                         "lenarray": 1,
@@ -5389,6 +5863,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1],
                         "lenarray": 1,
@@ -5402,6 +5877,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 1],
                         "lenarray": 3,
@@ -5415,6 +5891,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0],
                         "lenarray": 2,
@@ -5428,6 +5905,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 1, 1, 1],
                         "lenarray": 4,
@@ -5441,6 +5919,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2],
                         "lenarray": 2,
@@ -5454,6 +5933,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2],
                         "lenarray": 2,
@@ -5467,6 +5947,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 3],
                         "lenarray": 3,
@@ -5480,6 +5961,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 3, 4],
                         "lenarray": 4,
@@ -5493,6 +5975,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 4],
                         "lenarray": 3,
@@ -5506,6 +5989,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3],
                         "lenarray": 2,
@@ -5519,6 +6003,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4],
                         "lenarray": 3,
@@ -5532,6 +6017,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4, 6, 7],
                         "lenarray": 5,
@@ -5545,6 +6031,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4, 6, 7],
                         "lenarray": 5,
@@ -5558,6 +6045,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 4],
                         "lenarray": 2,
@@ -5571,6 +6059,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 4, 0, 5],
                         "lenarray": 4,
@@ -5584,6 +6073,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 1],
                         "lenarray": 4,
@@ -5597,6 +6087,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0],
                         "lenarray": 2,
@@ -5610,6 +6101,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 1, 4],
                         "lenarray": 5,
@@ -5623,6 +6115,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 2],
                         "lenarray": 4,
@@ -5636,6 +6129,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 4],
                         "lenarray": 4,
@@ -5649,6 +6143,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2],
                         "lenarray": 1,
@@ -5662,6 +6157,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2],
                         "lenarray": 1,
@@ -5675,6 +6171,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 1, 1, 2],
                         "lenarray": 4,
@@ -5688,6 +6185,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 1, 1, 3],
                         "lenarray": 4,
@@ -5701,6 +6199,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 1, 1, 3],
                         "lenarray": 4,
@@ -5714,6 +6213,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2],
                         "lenarray": 2,
@@ -5727,6 +6227,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2, 2, 2],
                         "lenarray": 4,
@@ -5740,6 +6241,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2, 2, 2],
                         "lenarray": 4,
@@ -5753,6 +6255,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3],
                         "lenarray": 2,
@@ -5766,6 +6269,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3],
                         "lenarray": 2,
@@ -5779,6 +6283,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3, 4],
                         "lenarray": 3,
@@ -5792,6 +6297,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3, 4, 5, 6],
                         "lenarray": 5,
@@ -5805,6 +6311,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 4],
                         "lenarray": 2,
@@ -5818,6 +6325,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3],
                         "lenarray": 1,
@@ -5831,6 +6339,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 1, 1, 7],
                         "lenarray": 4,
@@ -5844,6 +6353,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 2, 1, 0],
                         "lenarray": 4,
@@ -5857,6 +6367,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 2, 1],
                         "lenarray": 3,
@@ -5870,6 +6381,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 3, 3],
                         "lenarray": 3,
@@ -5883,6 +6395,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 4],
                         "lenarray": 2,
@@ -5896,6 +6409,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 6, 8, 6],
                         "lenarray": 4,
@@ -5909,6 +6423,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4],
                         "lenarray": 1,
@@ -5922,6 +6437,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 3, 2],
                         "lenarray": 3,
@@ -5935,6 +6451,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 3, 2, 1],
                         "lenarray": 4,
@@ -5948,6 +6465,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 4],
                         "lenarray": 2,
@@ -5961,6 +6479,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 4, 4, 4],
                         "lenarray": 4,
@@ -5974,6 +6493,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 5],
                         "lenarray": 2,
@@ -5987,6 +6507,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [7, 3, 0, 2, 3, 7],
                         "lenarray": 6,
@@ -6000,6 +6521,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [7, 3, 2, 0, 2, 3, 7],
                         "lenarray": 7,
@@ -6013,6 +6535,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [7, 3, 2, 0, 3, 7],
                         "lenarray": 6,
@@ -6032,6 +6555,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, 0, 1],
@@ -6046,6 +6570,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 0, 0, 0],
@@ -6060,6 +6585,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, 2, 1],
@@ -6074,6 +6600,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 0, 0, 0],
@@ -6088,6 +6615,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, 4, 1],
@@ -6102,6 +6630,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 1, 0],
@@ -6116,6 +6645,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -6130,6 +6660,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -6144,6 +6675,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 3, 0, 4],
@@ -6158,6 +6690,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [2, 0, 0, 1],
@@ -6172,6 +6705,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [2, 2, 2, 2],
@@ -6186,6 +6720,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [2, 2, 2, 2],
@@ -6200,6 +6735,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [3, 3, 3, 3],
@@ -6214,6 +6750,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [4, 4, 4, 4],
@@ -6234,6 +6771,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 0, 0],
                         "lenarray": 4,
@@ -6245,6 +6783,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 0, 0],
                         "lenarray": 4,
@@ -6256,6 +6795,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 0, 0],
                         "lenarray": 4,
@@ -6267,6 +6807,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0],
                         "lenarray": 2,
@@ -6278,6 +6819,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0],
                         "lenarray": 1,
@@ -6289,6 +6831,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 0, 1],
                         "lenarray": 4,
@@ -6300,6 +6843,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -6311,6 +6855,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -6322,6 +6867,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -6333,6 +6879,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1],
                         "lenarray": 2,
@@ -6344,6 +6891,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 1, 1],
                         "lenarray": 4,
@@ -6355,6 +6903,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2],
                         "lenarray": 3,
@@ -6366,6 +6915,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2],
                         "lenarray": 3,
@@ -6377,6 +6927,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 1, 1],
                         "lenarray": 4,
@@ -6388,6 +6939,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2, 3],
                         "lenarray": 4,
@@ -6399,6 +6951,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 2, 4],
                         "lenarray": 4,
@@ -6410,6 +6963,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3],
                         "lenarray": 3,
@@ -6421,6 +6975,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4],
                         "lenarray": 4,
@@ -6432,6 +6987,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 5],
                         "lenarray": 5,
@@ -6443,6 +6999,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 5],
                         "lenarray": 5,
@@ -6454,6 +7011,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 6, 7],
                         "lenarray": 6,
@@ -6465,6 +7023,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 3, 4, 6, 7],
                         "lenarray": 6,
@@ -6476,6 +7035,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4],
                         "lenarray": 3,
@@ -6487,6 +7047,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4, 6, 7],
                         "lenarray": 5,
@@ -6498,6 +7059,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 1, 4, 6, 7],
                         "lenarray": 5,
@@ -6509,6 +7071,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2],
                         "lenarray": 2,
@@ -6520,6 +7083,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2],
                         "lenarray": 2,
@@ -6531,6 +7095,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 1, 0],
                         "lenarray": 4,
@@ -6542,6 +7107,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 3],
                         "lenarray": 3,
@@ -6553,6 +7119,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 3, 4],
                         "lenarray": 4,
@@ -6564,6 +7131,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 2, 4],
                         "lenarray": 3,
@@ -6575,6 +7143,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "lenarray": 2,
@@ -6586,6 +7155,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "lenarray": 2,
@@ -6597,6 +7167,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3, 4],
                         "lenarray": 3,
@@ -6608,6 +7179,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 4],
                         "lenarray": 2,
@@ -6619,6 +7191,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 0, 1],
                         "lenarray": 4,
@@ -6630,6 +7203,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 0, 1],
                         "lenarray": 4,
@@ -6641,6 +7215,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 0, 1],
                         "lenarray": 4,
@@ -6652,6 +7227,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 1, 0],
                         "lenarray": 4,
@@ -6663,6 +7239,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0],
                         "lenarray": 2,
@@ -6674,6 +7251,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 1],
                         "lenarray": 3,
@@ -6685,6 +7263,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 0, 1, 1, 1, 0],
                         "lenarray": 6,
@@ -6696,6 +7275,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 1, 1, 1],
                         "lenarray": 4,
@@ -6707,6 +7287,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1],
                         "lenarray": 1,
@@ -6718,6 +7299,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1],
                         "lenarray": 1,
@@ -6729,6 +7311,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2],
                         "lenarray": 2,
@@ -6740,6 +7323,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2],
                         "lenarray": 2,
@@ -6751,6 +7335,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 3],
                         "lenarray": 3,
@@ -6762,6 +7347,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 3, 4],
                         "lenarray": 4,
@@ -6773,6 +7359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 2, 4],
                         "lenarray": 3,
@@ -6784,6 +7371,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3],
                         "lenarray": 2,
@@ -6795,6 +7383,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4],
                         "lenarray": 3,
@@ -6806,6 +7395,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4, 6, 7],
                         "lenarray": 5,
@@ -6817,6 +7407,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 3, 4, 6, 7],
                         "lenarray": 5,
@@ -6828,6 +7419,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 4],
                         "lenarray": 2,
@@ -6839,6 +7431,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 1],
                         "lenarray": 4,
@@ -6850,6 +7443,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0, 0, 1],
                         "lenarray": 4,
@@ -6861,6 +7455,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 0],
                         "lenarray": 2,
@@ -6872,6 +7467,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2],
                         "lenarray": 1,
@@ -6883,6 +7479,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2],
                         "lenarray": 1,
@@ -6894,6 +7491,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2, 2, 2],
                         "lenarray": 4,
@@ -6905,6 +7503,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2, 2, 2],
                         "lenarray": 4,
@@ -6916,6 +7515,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 2],
                         "lenarray": 2,
@@ -6927,6 +7527,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3],
                         "lenarray": 2,
@@ -6938,6 +7539,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3],
                         "lenarray": 2,
@@ -6949,6 +7551,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3, 4],
                         "lenarray": 3,
@@ -6960,6 +7563,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 3, 4, 5, 6],
                         "lenarray": 5,
@@ -6971,6 +7575,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 4],
                         "lenarray": 2,
@@ -6982,6 +7587,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 1, 1, 7],
                         "lenarray": 4,
@@ -6993,6 +7599,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 2, 1, 0],
                         "lenarray": 4,
@@ -7004,6 +7611,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 2, 1],
                         "lenarray": 3,
@@ -7015,6 +7623,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3],
                         "lenarray": 1,
@@ -7026,6 +7635,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 3, 3],
                         "lenarray": 3,
@@ -7037,6 +7647,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [3, 4],
                         "lenarray": 2,
@@ -7048,6 +7659,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 3, 2, 1],
                         "lenarray": 4,
@@ -7059,6 +7671,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 3, 2],
                         "lenarray": 3,
@@ -7070,6 +7683,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4],
                         "lenarray": 1,
@@ -7081,6 +7695,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 4],
                         "lenarray": 2,
@@ -7092,6 +7707,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [4, 5],
                         "lenarray": 2,
@@ -7108,7 +7724,32 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "at": -2,
+                        "length": 1,
+                        "size": 1
+                    },
+                    "outputs": {
+                        "tocarry": [0]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "at": 6,
+                        "length": 2,
+                        "size": 5
+                    },
+                    "outputs": {
+                        "tocarry": [0, 5]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 1,
@@ -7120,6 +7761,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 1,
@@ -7131,6 +7773,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 1,
@@ -7142,6 +7785,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 1,
@@ -7153,6 +7797,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 1,
@@ -7164,6 +7809,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "length": 2,
@@ -7175,6 +7821,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 1,
@@ -7186,6 +7833,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 1,
@@ -7197,6 +7845,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 1,
@@ -7208,6 +7857,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 1,
@@ -7219,6 +7869,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 1,
@@ -7230,6 +7881,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "length": 2,
@@ -7241,6 +7893,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 2,
                         "length": 1,
@@ -7252,6 +7905,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 2,
                         "length": 1,
@@ -7263,6 +7917,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 2,
                         "length": 1,
@@ -7274,6 +7929,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 2,
                         "length": 1,
@@ -7285,6 +7941,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 2,
                         "length": 5,
@@ -7296,6 +7953,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 3,
                         "length": 1,
@@ -7307,6 +7965,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 3,
                         "length": 1,
@@ -7318,6 +7977,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 4,
                         "length": 1,
@@ -7329,6 +7989,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 4,
                         "length": 1,
@@ -7346,6 +8007,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7359,6 +8021,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7372,6 +8035,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7385,6 +8049,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7398,6 +8063,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7411,6 +8077,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7424,6 +8091,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7437,6 +8105,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 3,
@@ -7450,6 +8119,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 4,
@@ -7463,6 +8133,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 4,
@@ -7476,6 +8147,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "nextsize": 2,
@@ -7489,6 +8161,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 5,
@@ -7502,6 +8175,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 5,
@@ -7515,6 +8189,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 6,
@@ -7528,6 +8203,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 8,
@@ -7541,6 +8217,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 10,
@@ -7554,6 +8231,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "nextsize": 5,
@@ -7567,6 +8245,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "nextsize": 5,
@@ -7580,6 +8259,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "nextsize": 4,
@@ -7593,6 +8273,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "nextsize": 4,
@@ -7606,6 +8287,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "nextsize": 4,
@@ -7619,6 +8301,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "nextsize": 4,
@@ -7632,6 +8315,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7645,6 +8329,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7658,6 +8343,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 3,
@@ -7671,6 +8357,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 3,
@@ -7684,6 +8371,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "nextsize": 3,
@@ -7697,6 +8385,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "nextsize": 3,
@@ -7710,6 +8399,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 4,
@@ -7723,6 +8413,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7736,6 +8427,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7749,6 +8441,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7762,6 +8455,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7775,6 +8469,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7788,6 +8483,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7801,6 +8497,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7814,6 +8511,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 3,
@@ -7827,6 +8525,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 4,
@@ -7840,6 +8539,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 5,
@@ -7853,6 +8553,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "nextsize": 4,
@@ -7866,6 +8567,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "nextsize": 4,
@@ -7879,6 +8581,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "nextsize": 4,
@@ -7892,6 +8595,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "nextsize": 4,
@@ -7905,6 +8609,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7918,6 +8623,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -7931,6 +8637,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7944,6 +8651,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7957,6 +8665,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7970,6 +8679,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 1,
@@ -7983,6 +8693,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 3,
@@ -7996,6 +8707,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "nextsize": 2,
@@ -8015,6 +8727,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0],
                         "fromoffsets": [0, 3],
@@ -8026,6 +8739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromoffsets": [0, 3, 6],
@@ -8037,6 +8751,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromoffsets": [0, 4, 5, 7, 10],
@@ -8054,6 +8769,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0],
                         "length": 1,
@@ -8065,6 +8781,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "length": 2,
@@ -8082,6 +8799,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0],
                         "inneroffsetslen": 1,
@@ -8094,6 +8812,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 2, 3],
                         "inneroffsetslen": 4,
@@ -8106,6 +8825,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 2, 3, 4, 5, 6],
                         "inneroffsetslen": 7,
@@ -8118,6 +8838,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 1, 5],
                         "inneroffsetslen": 4,
@@ -8130,6 +8851,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 1, 6, 6],
                         "inneroffsetslen": 5,
@@ -8142,6 +8864,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 4, 8, 12, 14, 16],
                         "inneroffsetslen": 6,
@@ -8154,6 +8877,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 2, 5, 5, 7, 7, 11],
                         "inneroffsetslen": 8,
@@ -8166,6 +8890,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 1, 2, 3, 4, 5, 6],
                         "inneroffsetslen": 7,
@@ -8178,6 +8903,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 5, 10, 15, 20, 25, 30],
                         "inneroffsetslen": 7,
@@ -8190,6 +8916,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 2, 6],
                         "inneroffsetslen": 3,
@@ -8202,6 +8929,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 0, 2, 6],
                         "inneroffsetslen": 4,
@@ -8214,6 +8942,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 0, 0, 2, 6],
                         "inneroffsetslen": 5,
@@ -8226,6 +8955,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 0, 0, 0, 2, 7, 7],
                         "inneroffsetslen": 7,
@@ -8238,6 +8968,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 5, 6, 6],
                         "inneroffsetslen": 5,
@@ -8250,6 +8981,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84, 91, 98, 105, 112, 119, 126, 133, 140, 147, 154, 161, 168, 175, 182, 189, 196, 203, 210],
                         "inneroffsetslen": 31,
@@ -8262,6 +8994,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 2, 4, 6, 8, 10, 12, 13, 14, 15, 16],
                         "inneroffsetslen": 11,
@@ -8274,6 +9007,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 5, 6, 6, 10],
                         "inneroffsetslen": 6,
@@ -8286,6 +9020,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 3, 5, 6, 6, 10],
                         "inneroffsetslen": 7,
@@ -8298,6 +9033,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 3, 3, 5, 6, 6, 10],
                         "inneroffsetslen": 8,
@@ -8310,6 +9046,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 3, 5, 5, 8],
                         "inneroffsetslen": 6,
@@ -8322,6 +9059,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 6, 9, 12, 14, 16],
                         "inneroffsetslen": 7,
@@ -8334,6 +9072,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 2, 4, 6, 8, 10],
                         "inneroffsetslen": 6,
@@ -8346,6 +9085,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
                         "inneroffsetslen": 11,
@@ -8358,6 +9098,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 4, 4, 4, 4, 6, 7, 7, 12, 12],
                         "inneroffsetslen": 10,
@@ -8370,6 +9111,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 6, 9, 11, 13, 14],
                         "inneroffsetslen": 7,
@@ -8382,6 +9124,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 5, 6, 6],
                         "inneroffsetslen": 5,
@@ -8394,6 +9137,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 3, 5, 6, 6, 10],
                         "inneroffsetslen": 7,
@@ -8406,6 +9150,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "inneroffsets": [0, 3, 3, 3, 5, 6, 6, 10],
                         "inneroffsetslen": 8,
@@ -8424,6 +9169,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 1, 2, 3],
                         "offsetslength": 4
@@ -8434,6 +9180,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4],
                         "offsetslength": 3
@@ -8444,6 +9191,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 6],
                         "offsetslength": 4
@@ -8454,6 +9202,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 4],
                         "offsetslength": 2
@@ -8464,6 +9213,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 5, 10],
                         "offsetslength": 3
@@ -8480,6 +9230,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3],
                         "length": 4,
@@ -8493,6 +9244,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3],
                         "length": 4,
@@ -8506,6 +9258,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3],
                         "length": 4,
@@ -8519,6 +9272,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3],
                         "length": 4,
@@ -8538,6 +9292,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 2, 3, 5]
@@ -8549,6 +9304,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 2, 4, 6]
@@ -8560,6 +9316,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 3, 3, 5]
@@ -8571,6 +9328,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 3, 5, 6, 8, 9]
@@ -8582,6 +9340,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 3, 3, 5, 6, 9]
@@ -8593,6 +9352,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 5, 5, 6, 8, 9]
@@ -8604,6 +9364,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 5, 6, 7, 7, 9]
@@ -8615,6 +9376,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 3, 5, 6, 7, 9]
@@ -8626,6 +9388,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 5, 7, 8, 9, 10]
@@ -8637,6 +9400,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "offsets": [0, 3, 6]
@@ -8648,6 +9412,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 3, 6, 9, 12, 15]
@@ -8659,6 +9424,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 9,
                         "offsets": [0, 0, 1, 3, 6, 10, 13, 15, 16, 16]
@@ -8670,6 +9436,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 3, 3, 7]
@@ -8681,6 +9448,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 3, 6, 10]
@@ -8692,6 +9460,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 4, 4, 6]
@@ -8703,6 +9472,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "offsets": [0, 4, 6]
@@ -8714,6 +9484,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 4, 8, 12]
@@ -8725,6 +9496,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 8, 13, 18, 23, 28]
@@ -8736,6 +9508,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 4, 9, 13, 18, 23, 28]
@@ -8747,6 +9520,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 4, 9, 14, 19, 24, 29]
@@ -8758,6 +9532,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 11, 12, 17, 22]
@@ -8769,6 +9544,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 14, 18, 23, 28]
@@ -8780,6 +9556,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 5, 10, 15]
@@ -8791,6 +9568,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 15, 19, 24, 28]
@@ -8802,6 +9580,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "offsets": [0, 5, 10, 15, 20]
@@ -8813,6 +9592,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 15, 20, 24, 28]
@@ -8824,6 +9604,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 5, 10, 15, 20, 25]
@@ -8835,6 +9616,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 15, 20, 25, 28]
@@ -8846,6 +9628,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 15, 20, 25, 29]
@@ -8857,6 +9640,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 10, 15, 20, 25, 30]
@@ -8868,6 +9652,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 5, 6, 11, 16, 17, 22]
@@ -8879,6 +9664,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 5, 8, 11, 14, 17]
@@ -8890,6 +9676,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 5, 9, 12]
@@ -8907,6 +9694,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "mymask": [0, 0],
@@ -8925,6 +9713,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 1, 1, 6],
                         "offsetslength": 4,
@@ -8937,6 +9726,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 3, 3, 5],
                         "offsetslength": 4,
@@ -8949,6 +9739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 3, 3, 4, 7],
                         "offsetslength": 5,
@@ -8961,6 +9752,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 3, 3, 5, 6, 6, 10],
                         "offsetslength": 7,
@@ -8973,6 +9765,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 4, 4, 6],
                         "offsetslength": 4,
@@ -8985,6 +9778,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 4, 4, 6, 7, 7, 12],
                         "offsetslength": 7,
@@ -8997,6 +9791,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "offsets": [0, 5, 5, 6, 9],
                         "offsetslength": 5,
@@ -9015,6 +9810,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1],
                         "length": 2,
@@ -9028,6 +9824,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 4, 5, 6],
                         "length": 7,
@@ -9041,6 +9838,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 2],
                         "length": 2,
@@ -9054,6 +9852,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 2, 3],
                         "length": 3,
@@ -9067,6 +9866,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 2, 3, 4],
                         "length": 4,
@@ -9080,6 +9880,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [2, 3],
                         "length": 2,
@@ -9093,6 +9894,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [2, 3, 4],
                         "length": 3,
@@ -9106,6 +9908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [3, 4],
                         "length": 2,
@@ -9119,6 +9922,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [4, 3, 2, 1, 0],
                         "length": 5,
@@ -9132,6 +9936,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [5, 2, 4, 1, 3, 0],
                         "length": 6,
@@ -9145,6 +9950,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [5, 4, 3, 2, 1, 0],
                         "length": 6,
@@ -9163,7 +9969,21 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "innerindex": [0, 1],
+                        "innerlength": 2,
+                        "outerindex": [0, 3],
+                        "outerlength": 2
+                    },
+                    "outputs": {
+                        "toindex": [0, 1]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1],
                         "innerlength": 2,
@@ -9176,6 +9996,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 2],
                         "innerlength": 5,
@@ -9188,6 +10009,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 4],
                         "innerlength": 5,
@@ -9200,6 +10022,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2],
                         "innerlength": 3,
@@ -9212,6 +10035,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 1, 1],
                         "innerlength": 5,
@@ -9224,6 +10048,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 2],
                         "innerlength": 5,
@@ -9236,6 +10061,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 4],
                         "innerlength": 5,
@@ -9248,6 +10074,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 1],
                         "innerlength": 4,
@@ -9260,6 +10087,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 2],
                         "innerlength": 4,
@@ -9272,6 +10100,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 2],
                         "innerlength": 4,
@@ -9284,6 +10113,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 3],
                         "innerlength": 4,
@@ -9296,6 +10126,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 3],
                         "innerlength": 4,
@@ -9308,6 +10139,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2],
                         "innerlength": 3,
@@ -9320,6 +10152,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 3],
                         "innerlength": 4,
@@ -9332,6 +10165,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 1, 4],
                         "innerlength": 5,
@@ -9344,6 +10178,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 2, 3, 4, 5, 6, 7, 1, 1],
                         "innerlength": 10,
@@ -9356,6 +10191,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 2, 1, 1, 3, 4],
                         "innerlength": 8,
@@ -9368,6 +10204,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [13, 9, 13, 4, 8, 3, 15, 1, 16, 2, 8],
                         "innerlength": 11,
@@ -9380,6 +10217,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [13, 9, 13, 4, 8, 3, 15, 1, 16, 2, 8],
                         "innerlength": 11,
@@ -9392,6 +10230,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [13, 9, 13, 4, 8, 3, 15, 1, 16, 2, 8],
                         "innerlength": 11,
@@ -9404,6 +10243,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [2, 1, 1, 0],
                         "innerlength": 4,
@@ -9416,6 +10256,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [3, 1, 1, 7],
                         "innerlength": 4,
@@ -9428,6 +10269,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [3, 1, 2, 1],
                         "innerlength": 4,
@@ -9440,6 +10282,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 3, 2, 1, 0],
                         "innerlength": 5,
@@ -9452,6 +10295,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 3, 2, 1, 0],
                         "innerlength": 5,
@@ -9464,6 +10308,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 5, 6, 7, 3, 1, 2, 0, 1, 1],
                         "innerlength": 10,
@@ -9476,6 +10321,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 3, 2, 1, 0],
                         "innerlength": 5,
@@ -9488,6 +10334,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 3, 2, 1, 0],
                         "innerlength": 5,
@@ -9500,6 +10347,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [4, 3, 2, 1, 0],
                         "innerlength": 5,
@@ -9512,6 +10360,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 2, 3, 4, 5, 6, 7],
                         "innerlength": 10,
@@ -9524,6 +10373,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 2, 3, 4, 5, 6, 7],
                         "innerlength": 10,
@@ -9536,6 +10386,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [0, 1, 1, 1, 2, 3, 4, 5, 6, 7],
                         "innerlength": 10,
@@ -9548,6 +10399,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [6, 5, 1, 3, 1, 1, 0],
                         "innerlength": 7,
@@ -9560,6 +10412,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "innerindex": [6, 5, 4, 3, 2, 1, 0],
                         "innerlength": 7,
@@ -9577,7 +10430,30 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index[i] >= len(content)",
+                    "inputs": {
+                        "index": [0, 1, 1, 1, 1, 3],
+                        "isoption": true,
+                        "lencontent": 3,
+                        "length": 6
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "index[i] < 0",
+                    "inputs": {
+                        "index": [2, -4, 4, 0, 8],
+                        "isoption": false,
+                        "lencontent": 10,
+                        "length": 5
+                    },
+                    "outputs": {}
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 1, 2],
                         "isoption": true,
@@ -9588,6 +10464,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 1],
                         "isoption": true,
@@ -9598,6 +10475,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 2, 3, 4],
                         "isoption": true,
@@ -9608,6 +10486,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 2, 3],
                         "isoption": true,
@@ -9618,6 +10497,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1, 2],
                         "isoption": true,
@@ -9628,6 +10508,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 1],
                         "isoption": true,
@@ -9638,6 +10519,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 1, 3],
                         "isoption": true,
@@ -9648,6 +10530,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 1],
                         "isoption": true,
@@ -9658,6 +10541,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3, 1, 4, 5, 6],
                         "isoption": true,
@@ -9668,6 +10552,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3, 4, 1, 5],
                         "isoption": true,
@@ -9678,6 +10563,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3, 4, 5, 6, 7],
                         "isoption": true,
@@ -9688,6 +10574,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3, 4, 5],
                         "isoption": true,
@@ -9698,6 +10585,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2, 3],
                         "isoption": true,
@@ -9708,6 +10596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1, 2],
                         "isoption": true,
@@ -9718,6 +10607,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 1],
                         "isoption": true,
@@ -9728,6 +10618,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1, 1],
                         "isoption": true,
@@ -9738,6 +10629,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1, 3, 1, 4],
                         "isoption": true,
@@ -9748,6 +10640,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1, 3],
                         "isoption": true,
@@ -9758,6 +10651,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 1],
                         "isoption": true,
@@ -9768,6 +10662,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1, 4, 5, 6, 7, 8, 1, 9],
                         "isoption": true,
@@ -9778,6 +10673,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1, 4, 5, 6],
                         "isoption": true,
@@ -9788,6 +10684,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1, 4],
                         "isoption": true,
@@ -9798,6 +10695,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 1],
                         "isoption": true,
@@ -9808,6 +10706,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1, 1],
                         "isoption": true,
@@ -9818,6 +10717,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 1, 2],
                         "isoption": true,
@@ -9828,6 +10728,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2, 1, 3],
                         "isoption": true,
@@ -9838,6 +10739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2, 1],
                         "isoption": true,
@@ -9848,6 +10750,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2, 3],
                         "isoption": true,
@@ -9858,6 +10761,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 0, 1, 2],
                         "isoption": true,
@@ -9868,6 +10772,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1, 1],
                         "isoption": true,
@@ -9878,6 +10783,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 0, 1, 2],
                         "isoption": true,
@@ -9888,6 +10794,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 1, 1, 0, 1],
                         "isoption": true,
@@ -9898,6 +10805,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [1, 4, 4, 1, 0],
                         "isoption": true,
@@ -9908,6 +10816,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [2, 1, 4, 0, 8],
                         "isoption": true,
@@ -9918,6 +10827,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [2, 2, 0, 1, 4],
                         "isoption": true,
@@ -9928,6 +10838,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [2, 4, 4, 0, 8],
                         "isoption": false,
@@ -9938,6 +10849,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [6, 4, 4, 8, 0],
                         "isoption": false,
@@ -9948,6 +10860,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [6, 5, 4, 3, 2, 1, 0],
                         "isoption": false,
@@ -9964,6 +10877,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "frommask": [0, 0, 0, 0],
                         "length": 4
@@ -9980,6 +10894,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "target": 1
@@ -9991,6 +10906,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 1
@@ -10002,6 +10918,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 1
@@ -10013,6 +10930,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "target": 2
@@ -10024,6 +10942,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 7,
                         "target": 2
@@ -10035,6 +10954,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 2
@@ -10046,6 +10966,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 2
@@ -10057,6 +10978,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 3
@@ -10068,6 +10990,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 3
@@ -10079,6 +11002,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 4
@@ -10090,6 +11014,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 4
@@ -10101,6 +11026,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "target": 5
@@ -10112,6 +11038,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "target": 5
@@ -10129,6 +11056,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "n": 3,
@@ -10143,6 +11071,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "n": 2,
@@ -10157,6 +11086,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "n": 2,
@@ -10171,6 +11101,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "n": 2,
@@ -10185,6 +11116,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "n": 2,
@@ -10199,6 +11131,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "n": 3,
@@ -10213,6 +11146,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "n": 2,
@@ -10233,6 +11167,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 0, 0, 0],
@@ -10244,6 +11179,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 0, 0],
@@ -10255,6 +11191,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 0, 1, 1],
@@ -10266,6 +11203,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 6,
                         "slicestarts": [0, 1, 3, 5, 6, 8],
@@ -10277,6 +11215,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 5, 5, 6, 8],
@@ -10288,6 +11227,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 3, 4, 7],
@@ -10299,6 +11239,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 6,
                         "slicestarts": [0, 1, 3, 6, 7, 9],
@@ -10310,6 +11251,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 0, 0],
@@ -10321,6 +11263,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 2, 2],
@@ -10332,6 +11275,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 1, 1],
@@ -10343,6 +11287,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 1, 1, 2, 2],
@@ -10354,6 +11299,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 2, 2],
@@ -10365,6 +11311,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 2, 3, 3],
@@ -10376,6 +11323,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 2, 2, 2, 2],
@@ -10387,6 +11335,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 2, 2],
@@ -10398,6 +11347,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 2,
                         "slicestarts": [0, 3],
@@ -10409,6 +11359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 1, 1, 3, 3],
@@ -10420,6 +11371,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 2, 3],
@@ -10431,6 +11383,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 2, 3, 3],
@@ -10442,6 +11395,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 3, 3],
@@ -10453,6 +11407,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 4, 5],
@@ -10464,6 +11419,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 1, 3, 4],
@@ -10475,6 +11431,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 2, 2, 2, 2],
@@ -10486,6 +11443,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 2,
                         "slicestarts": [0, 3],
@@ -10497,6 +11455,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 4, 5],
@@ -10508,6 +11467,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 4, 6],
@@ -10519,6 +11479,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 3,
                         "slicestarts": [0, 2, 5],
@@ -10530,6 +11491,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 3, 3, 3, 4],
@@ -10541,6 +11503,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 1, 4, 5],
@@ -10552,6 +11515,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 7,
                         "slicestarts": [0, 2, 2, 4, 4, 5, 5],
@@ -10563,6 +11527,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 2, 2, 4, 5],
@@ -10574,6 +11539,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 4,
                         "slicestarts": [0, 3, 0, 3],
@@ -10585,6 +11551,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 3, 3, 4, 5],
@@ -10596,6 +11563,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 2, 2, 4, 5],
@@ -10607,6 +11575,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "sliceouterlen": 5,
                         "slicestarts": [0, 3, 3, 5, 6],
@@ -10624,6 +11593,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 2],
                         "fromstops": [2, 4],
@@ -10637,6 +11607,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3, 4],
                         "fromstops": [3, 3, 4, 5],
@@ -10650,6 +11621,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 3],
                         "fromstops": [3, 3, 5],
@@ -10663,6 +11635,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3],
                         "fromstops": [3, 6],
@@ -10681,7 +11654,40 @@
             "status": false,
             "tests": [
                 {
+                    "error": true,
+                    "message": "cannot fit jagged slice into nested list",
+                    "inputs": {
+                        "fromstarts": [0, 2],
+                        "fromstops": [2, 4],
+                        "jaggedsize": 1,
+                        "length": 2,
+                        "singleoffsets": [0, 3, 4]
+                    },
+                    "outputs": {
+                        "multistarts": [0, 3, 0, 3],
+                        "multistops": [3, 4, 3, 4],
+                        "tocarry": [0, 1, 2, 3]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "stops[i] < starts[i]",
+                    "inputs": {
+                        "fromstarts": [5],
+                        "fromstops": [4],
+                        "jaggedsize": 2,
+                        "length": 1,
+                        "singleoffsets": [0, 3, 4]
+                    },
+                    "outputs": {
+                        "multistarts": [0, 3],
+                        "multistops": [3, 4],
+                        "tocarry": [2, 3]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 2],
                         "fromstops": [2, 4],
@@ -10697,6 +11703,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [2],
                         "fromstops": [4],
@@ -10717,7 +11724,56 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "fromarray": [-3, 0, 1, 1],
+                        "fromstarts": [0],
+                        "fromstops": [2],
+                        "lenarray": 4,
+                        "lencontent": 3,
+                        "lenstarts": 1
+                    },
+                    "outputs": {
+                        "toadvanced": [0, 1, 2, 3],
+                        "tocarry": [0, 0, 1, 1]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "stops[i] < starts[i]",
+                    "inputs": {
+                        "fromarray": [0, 3],
+                        "fromstarts": [5, 4, 8],
+                        "fromstops": [4, 8, 12],
+                        "lenarray": 2,
+                        "lencontent": 13,
+                        "lenstarts": 3
+                    },
+                    "outputs": {
+                        "toadvanced": [0, 1, 0, 1, 0, 1],
+                        "tocarry": [0, 3, 4, 7, 8, 11]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "stops[i] > len(content)",
+                    "inputs": {
+                        "fromarray": [0, 3],
+                        "fromstarts": [4, 8],
+                        "fromstops": [8, 14],
+                        "lenarray": 2,
+                        "lencontent": 13,
+                        "lenstarts": 2
+                    },
+                    "outputs": {
+                        "toadvanced": [0, 1, 0, 1],
+                        "tocarry": [4, 7, 8, 11]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 0, 1, 1],
                         "fromstarts": [0],
@@ -10733,6 +11789,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "fromstarts": [0, 4, 8],
@@ -10748,6 +11805,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [1, 1, 0, 0],
                         "fromstarts": [0],
@@ -10763,6 +11821,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [0, 3],
                         "fromstarts": [4, 8],
@@ -10778,6 +11837,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromarray": [2, 1, 1, 0],
                         "fromstarts": [6],
@@ -10799,6 +11859,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -10810,6 +11871,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 5],
                         "fromstops": [3, 3, 7],
@@ -10821,6 +11883,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -10832,6 +11895,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -10849,6 +11913,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -10861,6 +11926,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -10873,6 +11939,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -10885,6 +11952,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -10897,6 +11965,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -10909,6 +11978,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -10921,6 +11991,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -10933,6 +12004,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -10945,6 +12017,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -10957,6 +12030,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -10969,6 +12043,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 5],
                         "fromstops": [3, 3, 7],
@@ -10986,7 +12061,41 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "start[i] > stop[i]",
+                    "inputs": {
+                        "lencontent": 1,
+                        "length": 3,
+                        "starts": [1, 0, 1],
+                        "stops": [0, 1, 1]
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "stop[i] > len(content)",
+                    "inputs": {
+                        "lencontent": 4,
+                        "length": 3,
+                        "starts": [0, 0, 1],
+                        "stops": [0, 1, 5]
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "start[i] < 0",
+                    "inputs": {
+                        "lencontent": 1,
+                        "length": 4,
+                        "starts": [-1, 0, 1, 1],
+                        "stops": [0, 1, 1, 1]
+                    },
+                    "outputs": {}
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 0,
                         "length": 5,
@@ -10997,6 +12106,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 0,
                         "length": 4,
@@ -11007,6 +12117,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 0,
                         "length": 3,
@@ -11017,6 +12128,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 1,
                         "length": 3,
@@ -11027,6 +12139,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 4,
                         "length": 3,
@@ -11037,6 +12150,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 1,
                         "length": 4,
@@ -11047,6 +12161,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 4,
@@ -11057,6 +12172,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 10,
                         "length": 5,
@@ -11067,6 +12183,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 19,
                         "length": 8,
@@ -11077,6 +12194,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 19,
                         "length": 9,
@@ -11087,6 +12205,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 3,
@@ -11097,6 +12216,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 15,
                         "length": 5,
@@ -11107,6 +12227,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 12,
                         "length": 6,
@@ -11117,6 +12238,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 8,
                         "length": 4,
@@ -11127,6 +12249,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 3,
                         "length": 3,
@@ -11137,6 +12260,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 4,
                         "length": 3,
@@ -11147,6 +12271,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 3,
                         "length": 2,
@@ -11157,6 +12282,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 4,
                         "length": 2,
@@ -11167,6 +12293,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 8,
                         "length": 7,
@@ -11177,6 +12304,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 5,
@@ -11187,6 +12315,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 9,
                         "length": 5,
@@ -11197,6 +12326,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 3,
                         "length": 3,
@@ -11207,6 +12337,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 4,
                         "length": 3,
@@ -11217,6 +12348,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 5,
                         "length": 3,
@@ -11227,6 +12359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 3,
@@ -11237,6 +12370,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 5,
                         "length": 4,
@@ -11247,6 +12381,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 7,
                         "length": 4,
@@ -11257,6 +12392,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 3,
@@ -11267,6 +12403,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 7,
                         "length": 3,
@@ -11277,6 +12414,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 8,
                         "length": 3,
@@ -11287,6 +12425,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 5,
                         "length": 3,
@@ -11297,6 +12436,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 7,
                         "length": 3,
@@ -11307,6 +12447,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 8,
                         "length": 3,
@@ -11317,6 +12458,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 4,
                         "length": 2,
@@ -11327,6 +12469,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 9,
                         "length": 4,
@@ -11337,6 +12480,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 11,
                         "length": 6,
@@ -11347,6 +12491,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 9,
                         "length": 5,
@@ -11357,6 +12502,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 9,
                         "length": 6,
@@ -11367,6 +12513,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 2,
@@ -11377,6 +12524,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 7,
                         "length": 2,
@@ -11387,6 +12535,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 11,
                         "length": 4,
@@ -11397,6 +12546,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 25,
                         "length": 7,
@@ -11407,6 +12557,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 20,
                         "length": 6,
@@ -11417,6 +12568,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 19,
                         "length": 5,
@@ -11427,6 +12579,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 10,
                         "length": 3,
@@ -11437,6 +12590,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 11,
                         "length": 3,
@@ -11447,6 +12601,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 21,
                         "length": 9,
@@ -11457,6 +12612,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 21,
                         "length": 8,
@@ -11467,6 +12623,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 22,
                         "length": 9,
@@ -11477,6 +12634,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 22,
                         "length": 8,
@@ -11487,6 +12645,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 24,
                         "length": 9,
@@ -11497,6 +12656,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 24,
                         "length": 8,
@@ -11507,6 +12667,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 9,
                         "length": 3,
@@ -11517,6 +12678,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 10,
                         "length": 2,
@@ -11527,6 +12689,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 6,
                         "length": 3,
@@ -11537,6 +12700,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 10,
                         "length": 3,
@@ -11547,6 +12711,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 14,
                         "length": 4,
@@ -11557,6 +12722,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 11,
                         "length": 6,
@@ -11567,6 +12733,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 12,
                         "length": 3,
@@ -11577,6 +12744,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 30,
                         "length": 6,
@@ -11587,6 +12755,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 10,
                         "length": 2,
@@ -11597,6 +12766,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lencontent": 12,
                         "length": 6,
@@ -11613,6 +12783,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 0,
                         "fromstarts": [0, 0, 0, 0],
@@ -11630,6 +12801,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11647,6 +12819,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11664,6 +12837,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11681,6 +12855,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11698,6 +12873,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 10,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11715,6 +12891,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11732,6 +12909,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 4,
                         "fromstarts": [0, 1, 1, 1, 1],
@@ -11749,6 +12927,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11766,6 +12945,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11783,6 +12963,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11800,6 +12981,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11817,6 +12999,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 9,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11834,6 +13017,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 9,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11851,6 +13035,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 9,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11868,6 +13053,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 9,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11885,6 +13071,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11902,6 +13089,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 5,
                         "fromstarts": [0, 3, 3],
@@ -11919,6 +13107,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 9,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -11936,6 +13125,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 6,
                         "fromstarts": [0, 3],
@@ -11953,6 +13143,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 6,
                         "fromstarts": [0, 3, 5],
@@ -11970,6 +13161,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 6,
                         "fromstarts": [0, 3, 5],
@@ -11987,6 +13179,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 8,
                         "fromstarts": [0, 4, 7],
@@ -12004,6 +13197,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "contentlen": 13,
                         "fromstarts": [0, 4, 4, 7, 8],
@@ -12027,6 +13221,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [0, 1, 0, 1, 0, 1],
                         "length": 6,
@@ -12039,6 +13234,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [1, 0, 1, 1],
                         "length": 4,
@@ -12051,6 +13247,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [1, 1, 0, 0, 1, 0, 1, 1],
                         "length": 8,
@@ -12069,6 +13266,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [0, 1, 0, 1, 0, 1],
                         "length": 6
@@ -12079,6 +13277,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [1, 0, 1, 1],
                         "length": 4
@@ -12089,6 +13288,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromtags": [1, 1, 0, 0, 1, 0, 1, 1],
                         "length": 8
@@ -12105,6 +13305,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0, 1, -1, -1, 4],
@@ -12117,6 +13318,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0, 1, 2, 3, -1],
@@ -12129,6 +13331,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0, 1, 2],
@@ -12141,6 +13344,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [-1, -1, 0, -1, 1, 2],
@@ -12153,6 +13357,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [2, 0, -1, 0, 1, 2],
@@ -12171,6 +13376,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "length": 5,
@@ -12182,6 +13388,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "length": 3,
@@ -12193,6 +13400,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 3,
                         "length": 4,
@@ -12204,6 +13412,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 3,
                         "length": 5,
@@ -12221,6 +13430,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 0, 1],
@@ -12236,6 +13446,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 2, 2],
@@ -12251,6 +13462,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 2, 4],
@@ -12266,6 +13478,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 3, 3, 5, 6],
@@ -12281,6 +13494,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 3, 3],
@@ -12296,6 +13510,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 3, 6],
@@ -12311,6 +13526,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 5, 10],
@@ -12326,6 +13542,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [0, 7],
@@ -12341,6 +13558,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [1, 3, 3, 3],
@@ -12356,6 +13574,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromstarts": [3, 5],
@@ -12377,6 +13596,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0, 1, 1],
                         "length": 4,
@@ -12388,6 +13608,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 0, 1, 2],
                         "length": 6,
@@ -12404,7 +13625,56 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "tags[i] < 0",
+                    "inputs": {
+                        "index": [0, 1, 2, 3, 0, 1],
+                        "lencontents": [4, 2, 0, 945],
+                        "length": 6,
+                        "numcontents": 2,
+                        "tags": [-1, 0, 0, 0, 1, 1]
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "index[i] < 0",
+                    "inputs": {
+                        "index": [-1, 1, 2, 0, 1, 2, 3],
+                        "lencontents": [3, 4],
+                        "length": 7,
+                        "numcontents": 2,
+                        "tags": [0, 0, 0, 1, 1, 1, 1]
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "tags[i] >= len(contents)",
+                    "inputs": {
+                        "index": [0, 1, 0, 1, 2, 3],
+                        "lencontents": [2, 4, 32, 49, 0, 0],
+                        "length": 6,
+                        "numcontents": 2,
+                        "tags": [0, 0, 1, 1, 1, 2]
+                    },
+                    "outputs": {}
+                },
+                {
+                    "error": true,
+                    "message": "index[i] >= len(content[tags[i]])",
+                    "inputs": {
+                        "index": [5, 0, 1, 1, 2, 3, 2, 4],
+                        "lencontents": [5, 3, 32, 33],
+                        "length": 8,
+                        "numcontents": 2,
+                        "tags": [0, 1, 1, 0, 0, 0, 1, 0]
+                    },
+                    "outputs": {}
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 3, 0, 1],
                         "lencontents": [4, 2, 0, 945],
@@ -12416,6 +13686,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, 0, 1, 2, 3],
                         "lencontents": [3, 4],
@@ -12427,6 +13698,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 0, 1, 2, 3],
                         "lencontents": [2, 4, 32, 49, 0, 0],
@@ -12438,6 +13710,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 0, 1, 1, 2, 3, 2, 4],
                         "lencontents": [5, 3, 32, 33],
@@ -12449,6 +13722,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 0, 1, 1, 2, 3, 2, 4],
                         "lencontents": [5, 3, 32, 625, 0, 0, 0],
@@ -12460,6 +13734,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 0, 1, 1, 2, 2, 3],
                         "lencontents": [3, 4, 32, 177],
@@ -12477,6 +13752,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 7,
                         "mask": [0, 0, 0, 1, 1, 0, 0],
@@ -12494,6 +13770,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, -1, 0, 1, 2, -1, -1, -1, 3, -1, 4, 5, -1, -1, 6, 7, 8],
                         "lenindex": 17,
@@ -12506,6 +13783,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, -1, 3, 5, 6, -1, -1, -1, -1, 7, 0, -1, 4, -1, 8, 1, 2],
                         "lenindex": 17,
@@ -12518,6 +13796,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, -1, 0, 1, 2],
                         "lenindex": 5,
@@ -12530,6 +13809,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, -1, 3, 5, 6, 1, -1, 4, -1, 7, 2, -1, -1, -1, 8, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                         "lenindex": 25,
@@ -12542,6 +13822,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, -1, 1, 2, -1, 3, 4, 5],
                         "lenindex": 8,
@@ -12554,6 +13835,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, 2],
                         "lenindex": 4,
@@ -12566,6 +13848,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, -1, 4],
                         "lenindex": 5,
@@ -12578,6 +13861,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, 2, 3, -1],
                         "lenindex": 6,
@@ -12590,6 +13874,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, 2, 3, -1, 4, 5, -1, 6, 7, -1],
                         "lenindex": 12,
@@ -12602,6 +13887,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, -1, -1, -1, -1, 7, 8],
                         "lenindex": 9,
@@ -12620,6 +13906,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 6,
                         "starts": [0, 1, 2, 5],
@@ -12631,6 +13918,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 2,
                         "starts": [0],
@@ -12642,6 +13930,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 9,
                         "starts": [0, 3, 3, 5, 6],
@@ -12653,6 +13942,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 6,
                         "starts": [0, 3],
@@ -12664,6 +13954,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 4,
                         "starts": [0],
@@ -12675,6 +13966,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 5,
                         "starts": [0],
@@ -12686,6 +13978,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "outindexlength": 8,
                         "starts": [0],
@@ -12703,6 +13996,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, -1, 3, -1, 4],
                         "length": 7
@@ -12713,6 +14007,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, 2, -1, -1, -1, -1, 7, 8],
                         "length": 9
@@ -12723,6 +14018,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, -1, 2, 3, -1],
                         "length": 6
@@ -12733,6 +14029,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, -1, 2, 3, 4],
                         "length": 6
@@ -12743,6 +14040,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, -1, 2, 3, -1, 4],
                         "length": 7
@@ -12753,6 +14051,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, -1, 2, 3, -1, 4, 5, -1, 6, 7, -1],
                         "length": 12
@@ -12763,6 +14062,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 1, -1, -1, 4],
                         "length": 5
@@ -12773,6 +14073,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [4, 2, -1, -1, 1, 0, 1],
                         "length": 7
@@ -12783,6 +14084,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [-1, -1, 0, 1, 2],
                         "length": 5
@@ -12793,6 +14095,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [-1, -1, 0, 1, 2, -1, -1, -1, 3, -1, 4, 5, -1, -1, 6, 7, 8],
                         "length": 17
@@ -12809,6 +14112,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 3, 4, 1, -1, 5, 2],
                         "length": 7,
@@ -12820,6 +14124,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, 3, 4, 1, -1, 5, 2],
                         "length": 7,
@@ -12831,6 +14136,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, -1, 3, 5, 6, 1, -1, 4, -1, 7, 2, -1, -1, -1, 8, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                         "length": 25,
@@ -12842,6 +14148,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [0, -1, 4, 1, 3, 5, 2],
                         "length": 7,
@@ -12853,6 +14160,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index": [-1, -1, 3, 5, 6, -1, -1, -1, -1, 7, 0, -1, 4, -1, 8, 1, 2],
                         "length": 17,
@@ -12869,7 +14177,59 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "stops[i] < starts[i]",
+                    "inputs": {
+                        "fromadvanced": [0, 1],
+                        "fromarray": [0, 0],
+                        "fromstarts": [0, 0],
+                        "fromstops": [-1, 1],
+                        "lenarray": 2,
+                        "lencontent": 5,
+                        "lenstarts": 2
+                    },
+                    "outputs": {
+                        "toadvanced": [0, 1],
+                        "tocarry": [0, 0]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "stops[i] > len(content)",
+                    "inputs": {
+                        "fromadvanced": [0],
+                        "fromarray": [0],
+                        "fromstarts": [0],
+                        "fromstops": [5],
+                        "lenarray": 1,
+                        "lencontent": 4,
+                        "lenstarts": 1
+                    },
+                    "outputs": {
+                        "toadvanced": [0],
+                        "tocarry": [0]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "fromadvanced": [0, 1, 2, 3],
+                        "fromarray": [0, 1, -3, 1],
+                        "fromstarts": [0, 0, 0, 0],
+                        "fromstops": [3, 3, 3, 3],
+                        "lenarray": 4,
+                        "lencontent": 6,
+                        "lenstarts": 4
+                    },
+                    "outputs": {
+                        "toadvanced": [0, 1, 2, 3],
+                        "tocarry": [0, 1, 2, 1]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [0, 0],
@@ -12886,6 +14246,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0],
                         "fromarray": [0],
@@ -12902,6 +14263,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -12918,6 +14280,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 0, 0, 0],
@@ -12934,6 +14297,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [1, 0],
@@ -12950,6 +14314,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -12966,6 +14331,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [0, 0],
@@ -12982,6 +14348,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -12998,6 +14365,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0],
                         "fromarray": [0],
@@ -13014,6 +14382,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13030,6 +14399,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, -2, 0, -1],
@@ -13046,6 +14416,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, -2, 0, -1],
@@ -13062,6 +14433,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13078,6 +14450,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [1, 2],
@@ -13094,6 +14467,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [2, 0, 0, 1],
@@ -13110,6 +14484,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [2, 2, 2, 2],
@@ -13126,6 +14501,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-2, -2, -2, -2],
@@ -13142,6 +14518,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-2, -2, -2, -2],
@@ -13158,6 +14535,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13174,6 +14552,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13190,6 +14569,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -13206,6 +14586,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -13222,6 +14603,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13238,6 +14620,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13254,6 +14637,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [-1, 0],
@@ -13270,6 +14654,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13286,6 +14671,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [1, 2],
@@ -13302,6 +14688,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13318,6 +14705,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 0, 0, 0],
@@ -13334,6 +14722,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0],
                         "fromarray": [1],
@@ -13350,6 +14739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [-1, 0],
@@ -13366,6 +14756,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -13382,6 +14773,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 0, 0, 0],
@@ -13398,6 +14790,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -13414,6 +14807,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1],
                         "fromarray": [1, 1],
@@ -13430,6 +14824,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 1, 0, 0],
@@ -13446,6 +14841,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13462,6 +14858,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, -1, 0, 0],
@@ -13478,6 +14875,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 0, 0, 1],
@@ -13494,6 +14892,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13510,6 +14909,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3, 4, 5],
                         "fromarray": [2, 0, 1, 1, 2, 0],
@@ -13526,6 +14926,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [0, 1, -1, 1],
@@ -13542,6 +14943,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13558,6 +14960,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [1, 1, 0, 0],
@@ -13574,6 +14977,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromadvanced": [0, 1, 2, 3],
                         "fromarray": [-1, -1, -1, -1],
@@ -13595,7 +14999,34 @@
             "status": true,
             "tests": [
                 {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "at": -2,
+                        "fromstarts": [0],
+                        "fromstops": [1],
+                        "lenstarts": 1
+                    },
+                    "outputs": {
+                        "tocarry": [0]
+                    }
+                },
+                {
+                    "error": true,
+                    "message": "index out of range",
+                    "inputs": {
+                        "at": 1,
+                        "fromstarts": [3, 5, 6],
+                        "fromstops": [5, 6, 9],
+                        "lenstarts": 3
+                    },
+                    "outputs": {
+                        "tocarry": [3, 5, 6]
+                    }
+                },
+                {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [],
@@ -13608,6 +15039,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0],
@@ -13620,6 +15052,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0],
@@ -13632,6 +15065,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0],
@@ -13644,6 +15078,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -5,
                         "fromstarts": [0],
@@ -13656,6 +15091,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0, 1],
@@ -13668,6 +15104,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0, 1, 2, 3],
@@ -13680,6 +15117,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0, 1, 2, 3, 4],
@@ -13692,6 +15130,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0, 2, 3],
@@ -13704,6 +15143,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [0, 3, 5, 6],
@@ -13716,6 +15156,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [10],
@@ -13728,6 +15169,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [0],
@@ -13740,6 +15182,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [0],
@@ -13752,6 +15195,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -2,
                         "fromstarts": [0],
@@ -13764,6 +15208,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [0],
@@ -13776,6 +15221,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [10],
@@ -13788,6 +15234,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [1],
@@ -13800,6 +15247,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [1],
@@ -13812,6 +15260,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -2,
                         "fromstarts": [10],
@@ -13824,6 +15273,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [0, 3],
@@ -13836,6 +15286,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [0, 5],
@@ -13848,6 +15299,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [15],
@@ -13860,6 +15312,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -2,
                         "fromstarts": [15],
@@ -13872,6 +15325,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [15],
@@ -13884,6 +15338,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [0],
@@ -13896,6 +15351,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [1],
@@ -13908,6 +15364,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [1],
@@ -13920,6 +15377,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [2],
@@ -13932,6 +15390,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [2],
@@ -13944,6 +15403,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [3],
@@ -13956,6 +15416,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [3],
@@ -13968,6 +15429,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [3, 5, 6],
@@ -13980,6 +15442,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [0],
@@ -13992,6 +15455,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 4,
                         "fromstarts": [0],
@@ -14004,6 +15468,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [3],
@@ -14016,6 +15481,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [3],
@@ -14028,6 +15494,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -2,
                         "fromstarts": [3],
@@ -14040,6 +15507,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [3, 5, 6],
@@ -14052,6 +15520,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [0, 5],
@@ -14064,6 +15533,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [5, 10],
@@ -14076,6 +15546,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [3],
@@ -14088,6 +15559,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 0,
                         "fromstarts": [5],
@@ -14100,6 +15572,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -5,
                         "fromstarts": [5],
@@ -14112,6 +15585,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [5, 10],
@@ -14124,6 +15598,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [5],
@@ -14136,6 +15611,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [6],
@@ -14148,6 +15624,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 1,
                         "fromstarts": [6],
@@ -14160,6 +15637,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -2,
                         "fromstarts": [5],
@@ -14172,6 +15650,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [5, 10],
@@ -14184,6 +15663,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": -1,
                         "fromstarts": [5],
@@ -14196,6 +15676,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "at": 4,
                         "fromstarts": [5],
@@ -14214,6 +15695,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 2, 4, 4, 5, 6, 7, 9, 9],
                         "lenstarts": 9
@@ -14224,6 +15706,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromoffsets": [0, 2, 4, 5, 6, 7, 9],
                         "lenstarts": 6
@@ -14240,6 +15723,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "offsets": [0, 1]
@@ -14250,6 +15734,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 2, 3, 5]
@@ -14260,6 +15745,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "offsets": [0, 2, 3, 3, 6]
@@ -14270,6 +15756,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "offsets": [0, 2, 3]
@@ -14280,6 +15767,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "offsets": [0, 2]
@@ -14290,6 +15778,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "offsets": [0, 3, 3, 4, 5]
@@ -14300,6 +15789,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 7,
                         "offsets": [0, 3, 3, 5, 6, 10, 10, 13]
@@ -14310,6 +15800,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 3, 3, 5, 6, 10]
@@ -14320,6 +15811,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 6,
                         "offsets": [0, 3, 3, 5, 6, 6, 10]
@@ -14330,6 +15822,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "offsets": [0, 3, 3, 5]
@@ -14340,6 +15833,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "offsets": [0, 4, 4, 7, 8, 13]
@@ -14356,6 +15850,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -14370,6 +15865,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -14384,6 +15880,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 5],
                         "fromstops": [3, 3, 7],
@@ -14398,6 +15895,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -14412,6 +15910,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [0, 3, 4, 5, 8],
                         "fromstops": [3, 3, 6, 8, 9],
@@ -14426,6 +15925,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -14440,6 +15940,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -14454,6 +15955,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -14468,6 +15970,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -14482,6 +15985,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 3, 0],
                         "fromstops": [10, 6, 5, 3, 3],
@@ -14496,6 +16000,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromstarts": [6, 5, 3, 0],
                         "fromstops": [10, 6, 5, 3],
@@ -14516,6 +16021,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 1,
@@ -14527,6 +16033,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 1,
                         "outlength": 1,
@@ -14538,6 +16045,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 3,
@@ -14549,6 +16057,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 4,
@@ -14560,6 +16069,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 3,
@@ -14571,6 +16081,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 4,
                         "outlength": 3,
@@ -14582,6 +16093,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 2,
                         "outlength": 1,
@@ -14593,6 +16105,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 5,
@@ -14604,6 +16117,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 7,
                         "outlength": 5,
@@ -14615,6 +16129,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 2,
@@ -14626,6 +16141,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 4,
                         "outlength": 2,
@@ -14637,6 +16153,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 1,
@@ -14648,6 +16165,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 2,
@@ -14659,6 +16177,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 4,
                         "outlength": 1,
@@ -14670,6 +16189,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 3,
@@ -14681,6 +16201,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 8,
                         "outlength": 2,
@@ -14692,6 +16213,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 5,
                         "outlength": 1,
@@ -14703,6 +16225,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 1,
@@ -14714,6 +16237,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 7,
                         "outlength": 1,
@@ -14725,6 +16249,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 8,
                         "outlength": 1,
@@ -14736,6 +16261,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 1,
@@ -14753,6 +16279,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "maxcount": 5,
@@ -14770,6 +16297,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "maxcount": 3,
@@ -14787,6 +16315,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "maxcount": 5,
@@ -14804,6 +16333,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "maxcount": 5,
@@ -14821,6 +16351,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "maxcount": 3,
@@ -14838,6 +16369,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "maxcount": 4,
@@ -14855,6 +16387,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 10,
                         "maxcount": 3,
@@ -14872,6 +16405,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -14889,6 +16423,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -14906,6 +16441,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "maxcount": 4,
@@ -14923,6 +16459,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "maxcount": 3,
@@ -14940,6 +16477,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "maxcount": 3,
@@ -14957,6 +16495,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -14974,6 +16513,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -14991,6 +16531,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -15008,6 +16549,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -15025,6 +16567,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 11,
                         "maxcount": 3,
@@ -15042,6 +16585,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15059,6 +16603,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15076,6 +16621,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15093,6 +16639,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15110,6 +16657,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15127,6 +16675,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15144,6 +16693,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15161,6 +16711,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15178,6 +16729,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15195,6 +16747,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15212,6 +16765,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 12,
                         "maxcount": 3,
@@ -15229,6 +16783,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 13,
                         "maxcount": 3,
@@ -15246,6 +16801,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 13,
                         "maxcount": 3,
@@ -15263,6 +16819,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 9,
                         "maxcount": 4,
@@ -15286,6 +16843,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 18,
                         "nextparents": [0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 1, 1, 1, 4, 4, 4, 2, 5]
@@ -15296,6 +16854,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 21,
                         "nextparents": [0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 1, 1, 1, 4, 4, 4, 4, 2, 5, 5, 5]
@@ -15306,6 +16865,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 3,
                         "nextparents": [0, 1, 2]
@@ -15316,6 +16876,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 5,
                         "nextparents": [0, 0, 1, 2, 3]
@@ -15326,6 +16887,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 6,
                         "nextparents": [0, 0, 1, 1, 2, 2]
@@ -15336,6 +16898,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 6,
                         "nextparents": [0, 0, 1, 1, 2, 3]
@@ -15346,6 +16909,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 8,
                         "nextparents": [0, 0, 1, 1, 2, 2, 3, 3]
@@ -15356,6 +16920,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 7,
                         "nextparents": [0, 0, 1, 1, 2, 2, 3]
@@ -15366,6 +16931,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 6,
                         "nextparents": [0, 0, 0, 1, 1, 1]
@@ -15376,6 +16942,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 5,
                         "nextparents": [0, 0, 0, 1, 1]
@@ -15386,6 +16953,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 7,
                         "nextparents": [0, 0, 0, 1, 1, 2, 3]
@@ -15396,6 +16964,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 9,
                         "nextparents": [0, 0, 0, 1, 1, 2, 2, 3, 4]
@@ -15406,6 +16975,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 7,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2]
@@ -15416,6 +16986,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 9,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2, 2, 3]
@@ -15426,6 +16997,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 10,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3]
@@ -15436,6 +17008,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 12,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
@@ -15446,6 +17019,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 12,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4]
@@ -15456,6 +17030,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 15,
                         "nextparents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4]
@@ -15466,6 +17041,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 15,
                         "nextparents": [0, 5, 5, 1, 6, 6, 2, 7, 7, 3, 8, 8, 4, 9, 9]
@@ -15476,6 +17052,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 15,
                         "nextparents": [0, 5, 10, 1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14]
@@ -15486,6 +17063,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 15,
                         "nextparents": [0, 0, 5, 1, 1, 6, 2, 2, 7, 3, 3, 8, 4, 4, 9]
@@ -15496,6 +17074,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 6,
                         "nextparents": [0, 0, 0, 0, 1, 1]
@@ -15506,6 +17085,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 9,
                         "nextparents": [0, 0, 0, 0, 1, 1, 1, 2, 2]
@@ -15516,6 +17096,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 20,
                         "nextparents": [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4]
@@ -15526,6 +17107,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 20,
                         "nextparents": [0, 0, 5, 5, 1, 1, 6, 6, 2, 2, 7, 7, 3, 3, 8, 8, 4, 4, 9, 9]
@@ -15536,6 +17118,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 9,
                         "nextparents": [0, 0, 3, 3, 1, 1, 4, 4, 2]
@@ -15546,6 +17129,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 12,
                         "nextparents": [0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]
@@ -15556,6 +17140,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 15,
                         "nextparents": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2]
@@ -15566,6 +17151,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 17,
                         "nextparents": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 4]
@@ -15576,6 +17162,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 25,
                         "nextparents": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4]
@@ -15586,6 +17173,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 9,
                         "nextparents": [0, 0, 0, 3, 3, 1, 1, 4, 2]
@@ -15596,6 +17184,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 22,
                         "nextparents": [0, 0, 0, 5, 5, 5, 1, 1, 6, 6, 2, 2, 7, 7, 3, 3, 8, 8, 4, 4, 9, 9]
@@ -15606,6 +17195,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "nextlen": 16,
                         "nextparents": [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3]
@@ -15622,6 +17212,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1],
                         "lendistincts": 15,
@@ -15634,6 +17225,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0],
                         "lendistincts": 2,
@@ -15646,6 +17238,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0],
                         "lendistincts": 3,
@@ -15658,6 +17251,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 1, 1, -1],
                         "lendistincts": 6,
@@ -15670,6 +17264,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 1, 1, 1],
                         "lendistincts": 6,
@@ -15682,6 +17277,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 1, 1, -1, 2, -1, -1],
                         "lendistincts": 9,
@@ -15694,6 +17290,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 1, -1, -1, 2, 1, -1, 3, -1, -1],
                         "lendistincts": 12,
@@ -15706,6 +17303,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, -1, 1, -1, -1, -1, -1, -1, 2, 1, 0],
                         "lendistincts": 12,
@@ -15718,6 +17316,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0],
                         "lendistincts": 4,
@@ -15730,6 +17329,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, -1, 1, 1, 1, 0],
                         "lendistincts": 8,
@@ -15742,6 +17342,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0],
                         "lendistincts": 5,
@@ -15754,6 +17355,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, -1],
                         "lendistincts": 15,
@@ -15766,6 +17368,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
                         "lendistincts": 15,
@@ -15778,6 +17381,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, -1, -1, -1, -1, 2, 1, 1, 1, 1],
                         "lendistincts": 15,
@@ -15790,6 +17394,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, 1, 1, 1, -1, 2, 2, 2, 2, 1],
                         "lendistincts": 15,
@@ -15802,6 +17407,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1],
                         "lendistincts": 15,
@@ -15814,6 +17420,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
                         "lendistincts": 10,
@@ -15826,6 +17433,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, -1, -1, -1, 1, 1, -1],
                         "lendistincts": 9,
@@ -15838,6 +17446,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, -1, -1, -1, 1, 1, 1],
                         "lendistincts": 9,
@@ -15850,6 +17459,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, -1, -1, -1, -1, 1, -1, -1, 2, 1, 0],
                         "lendistincts": 12,
@@ -15862,6 +17472,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, -1, -1, -1, -1, -1, -1, -1, 1, 1, 0],
                         "lendistincts": 12,
@@ -15874,6 +17485,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [0, 0, 0, -1, -1, -1, -1, -1, -1, 1, 1, 1],
                         "lendistincts": 12,
@@ -15886,6 +17498,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "distincts": [],
                         "lendistincts": 0,
@@ -15904,6 +17517,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "tooffset": 0,
                         "fromptr": [0, 1, 3],
@@ -15915,6 +17529,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "tooffset": 0,
                         "fromptr": [1, 3, 3, 5],
@@ -15926,6 +17541,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "tooffset": 0,
                         "fromptr": [3, 5],
@@ -15937,6 +17553,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "tooffset": 0,
                         "fromptr": [0, 3, 3, 5, 6],
@@ -15954,6 +17571,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 30,
                         "outlength": 15,
@@ -15965,6 +17583,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 30,
                         "outlength": 10,
@@ -15976,6 +17595,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 30,
                         "outlength": 6,
@@ -15987,6 +17607,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 18,
                         "outlength": 6,
@@ -15998,6 +17619,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 21,
                         "outlength": 6,
@@ -16009,6 +17631,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 20,
                         "outlength": 4,
@@ -16020,6 +17643,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 20,
                         "outlength": 5,
@@ -16031,6 +17655,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 15,
                         "outlength": 3,
@@ -16042,6 +17667,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 12,
                         "outlength": 3,
@@ -16053,6 +17679,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 15,
                         "outlength": 5,
@@ -16064,6 +17691,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 12,
                         "outlength": 5,
@@ -16075,6 +17703,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 5,
@@ -16086,6 +17715,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 2,
@@ -16097,6 +17727,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 4,
@@ -16108,6 +17739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 7,
                         "outlength": 4,
@@ -16119,6 +17751,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 4,
@@ -16130,6 +17763,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 5,
@@ -16141,6 +17775,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 3,
@@ -16152,6 +17787,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 3,
@@ -16163,6 +17799,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 5,
                         "outlength": 1,
@@ -16174,6 +17811,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 3,
@@ -16185,6 +17823,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 5,
                         "outlength": 3,
@@ -16196,6 +17835,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 3,
@@ -16207,6 +17847,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 22,
                         "outlength": 8,
@@ -16218,6 +17859,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 5,
@@ -16229,6 +17871,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 8,
@@ -16240,6 +17883,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 12,
                         "outlength": 9,
@@ -16251,6 +17895,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 4,
@@ -16262,6 +17907,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 4,
@@ -16273,6 +17919,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 4,
@@ -16284,6 +17931,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 6,
@@ -16295,6 +17943,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 5,
@@ -16306,6 +17955,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 3,
@@ -16317,6 +17967,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 3,
@@ -16328,6 +17979,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 7,
@@ -16345,6 +17997,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, -1, -1, -1, -1],
                         "length": 5
@@ -16355,6 +18008,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, -1, 0, -1, 1, 2, 3, 4, 5, -1, -1, -1],
                         "length": 12
@@ -16365,6 +18019,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [-1, 0, 1, -1],
                         "length": 4
@@ -16375,6 +18030,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, -1, 1],
                         "length": 3
@@ -16385,6 +18041,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, -1, 1, -1, 2],
                         "length": 5
@@ -16395,6 +18052,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, -1, 1, 2],
                         "length": 4
@@ -16405,6 +18063,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1],
                         "length": 3
@@ -16415,6 +18074,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, 2],
                         "length": 4
@@ -16425,6 +18085,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, -1, 2, 3, -1, 4],
                         "length": 7
@@ -16435,6 +18096,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, -1, -1, -1],
                         "length": 6
@@ -16445,6 +18107,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, -1, -1, 3, 4, 5, -1, -1],
                         "length": 10
@@ -16455,6 +18118,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3, 4, -1, -1],
                         "length": 7
@@ -16465,6 +18129,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [13, 9, 13, 4, 8, 3, 15, -1, 16, 2, 8],
                         "length": 11
@@ -16481,6 +18146,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromtags": [0, 0, 0, 1, 1, 1],
@@ -16499,6 +18165,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "length": 6,
@@ -16510,6 +18177,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 3,
                         "length": 5,
@@ -16521,6 +18189,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "length": 3,
@@ -16532,6 +18201,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 2,
                         "length": 2,
@@ -16549,6 +18219,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [],
                         "fromtags": [],
@@ -16562,6 +18233,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [],
                         "fromtags": [],
@@ -16575,6 +18247,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [1],
                         "fromtags": [1],
@@ -16588,6 +18261,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 0],
                         "fromtags": [1, 1],
@@ -16601,6 +18275,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1],
                         "fromtags": [0, 0],
@@ -16614,6 +18289,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1],
                         "fromtags": [1, 1],
@@ -16627,6 +18303,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 3],
                         "fromtags": [0, 0],
@@ -16640,6 +18317,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [2, 3],
                         "fromtags": [1, 1],
@@ -16653,6 +18331,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2],
                         "fromtags": [0, 0, 0],
@@ -16666,6 +18345,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2],
                         "fromtags": [1, 1, 1],
@@ -16679,6 +18359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3, 4],
                         "fromtags": [0, 0, 0, 0, 0],
@@ -16692,6 +18373,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromindex": [0, 1, 2, 3, 4],
                         "fromtags": [1, 1, 1, 1, 1],
@@ -16711,6 +18393,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [],
@@ -16726,6 +18409,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0, 0, 0, 0, 0],
@@ -16741,6 +18425,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 9,
                         "fromindex": [0, 1, 2, 3, 4, 5, 6, 7, 8],
@@ -16756,6 +18441,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0, 1],
@@ -16771,6 +18457,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [0],
@@ -16786,6 +18473,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [],
@@ -16801,6 +18489,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "fromindex": [],
@@ -16822,6 +18511,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 0
                     },
@@ -16831,6 +18521,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2
                     },
@@ -16840,6 +18531,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4
                     },
@@ -16849,6 +18541,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5
                     },
@@ -16864,6 +18557,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "bitmasklength": 2,
                         "frombitmask": [58, 59],
@@ -16876,6 +18570,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "bitmasklength": 2,
                         "frombitmask": [58, 59],
@@ -16894,6 +18589,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 1,
                         "missing": [0, 0, 0, 0],
@@ -16908,6 +18604,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "missing": [0, 0, 0, 0],
@@ -16922,6 +18619,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "missing": [0, 0, 0, 0],
@@ -16936,6 +18634,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "missing": [0, 0, 0, 0],
@@ -16950,6 +18649,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "missing": [0, 0, 0, 0],
@@ -16970,6 +18670,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1],
                         "length": 2,
@@ -16983,6 +18684,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1],
                         "length": 2,
@@ -16996,6 +18698,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, -1],
                         "length": 3,
@@ -17009,6 +18712,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1],
                         "length": 3,
@@ -17022,6 +18726,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1],
                         "length": 3,
@@ -17035,6 +18740,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, -1, 1],
                         "length": 4,
@@ -17048,6 +18754,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, -1, 1],
                         "length": 4,
@@ -17061,6 +18768,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, -1],
                         "length": 4,
@@ -17074,6 +18782,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, -1, 2],
                         "length": 5,
@@ -17087,6 +18796,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17100,6 +18810,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17113,6 +18824,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2],
                         "length": 4,
@@ -17126,6 +18838,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17139,6 +18852,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17152,6 +18866,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17165,6 +18880,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2],
                         "length": 4,
@@ -17178,6 +18894,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17191,6 +18908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17204,6 +18922,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2],
                         "length": 4,
@@ -17217,6 +18936,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17230,6 +18950,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, 1, -1, 2],
                         "length": 4,
@@ -17243,6 +18964,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2],
                         "length": 4,
@@ -17256,6 +18978,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2, -1, 3, 4, 5],
                         "length": 8,
@@ -17269,6 +18992,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "index_in": [0, -1, 1, 2, 3, 4, 5, 6],
                         "length": 8,
@@ -17288,6 +19012,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
                         "lenparents": 10,
@@ -17300,6 +19025,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 1, 0, 0, 1, 0, 1, 1],
                         "lenparents": 9,
@@ -17312,6 +19038,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 1, 0, 1, 0, 0, 1, 1],
                         "lenparents": 9,
@@ -17324,6 +19051,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 1, 0, 1, 0, 0, 0, 0, 0],
                         "lenparents": 10,
@@ -17336,6 +19064,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 0, 2, 0, 0, 0, 0, 0],
                         "lenparents": 10,
@@ -17348,6 +19077,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 2, 2, 0, 3, 0, 0, 0],
                         "lenparents": 10,
@@ -17360,6 +19090,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -17372,6 +19103,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -17390,6 +19122,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 1, 0, 1, 0, 0, 1, 1],
                         "lenparents": 9,
@@ -17402,6 +19135,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 0, 1, 1, 1],
                         "lenparents": 6,
@@ -17414,6 +19148,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 1, 0, 0, 1, 0, 1, 1],
                         "lenparents": 9,
@@ -17426,6 +19161,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 1, 1, 1, 1, 0, 0, 1],
                         "lenparents": 10,
@@ -17438,6 +19174,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 2, 2, 2, 3, 0, 0, 4],
                         "lenparents": 10,
@@ -17450,6 +19187,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 10,
@@ -17462,6 +19200,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 25,
@@ -17474,6 +19213,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
                         "lenparents": 15,
@@ -17486,6 +19226,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
                         "lenparents": 22,
@@ -17498,6 +19239,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 0, 1, 0, 0, 1, 0, 1],
                         "lenparents": 10,
@@ -17510,6 +19252,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 19,
@@ -17522,6 +19265,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 0, 2, 0, 0, 2, 0, 4],
                         "lenparents": 10,
@@ -17534,6 +19278,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 0, 0, 0],
                         "lenparents": 6,
@@ -17546,6 +19291,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 0, 0, 0],
                         "lenparents": 9,
@@ -17558,6 +19304,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                         "lenparents": 15,
@@ -17570,6 +19317,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 11,
@@ -17582,6 +19330,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 17,
@@ -17594,6 +19343,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 19,
@@ -17606,6 +19356,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                         "lenparents": 22,
@@ -17618,6 +19369,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -17630,6 +19382,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -17648,6 +19401,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, -1, 1, -1, 1, 21],
                         "lenparents": 6,
@@ -17660,6 +19414,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 6, 7],
                         "lenparents": 6,
@@ -17672,6 +19427,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [6, 1, 10, 33, -1, 21, 2, 45, 4],
                         "lenparents": 9,
@@ -17684,6 +19440,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 6],
                         "lenparents": 5,
@@ -17696,6 +19453,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 4, 2, 1, 2, 3, 6, 1, -1, 1, 7, 4],
                         "lenparents": 12,
@@ -17708,6 +19466,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -17720,6 +19479,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 6],
                         "lenparents": 6,
@@ -17732,6 +19492,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 1, 6, 1, 4, 4, 2, 1, 7, 2, 3, -1],
                         "lenparents": 12,
@@ -17744,6 +19505,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 4, 4, 6],
                         "lenparents": 5,
@@ -17756,6 +19518,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 6],
                         "lenparents": 5,
@@ -17768,6 +19531,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -17786,6 +19550,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 13, 17, 23, 3, 11, 19, 5],
                         "identity": -9223372036854775808,
@@ -17799,6 +19564,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 3, 4, 5, 6],
                         "identity": -9223372036854775808,
@@ -17812,6 +19578,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "identity": -9223372036854775808,
@@ -17825,6 +19592,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 4, 1, 3, 5, 6],
                         "identity": -9223372036854775808,
@@ -17838,6 +19606,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 5, 3, 3, 5, 1, 4, 2],
                         "identity": -9223372036854775808,
@@ -17851,6 +19620,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 2, 3, 1, 5],
                         "identity": 4,
@@ -17864,6 +19634,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 6, 4, 2, 2, 3, 1, 6],
                         "identity": 4,
@@ -17877,6 +19648,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 2, 5, 3, 7, 3, 1, 5, 8, 1, 9, 4, 2, 7, 10, 2, 4, 7, 2],
                         "identity": -9223372036854775808,
@@ -17890,6 +19662,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 3, 7, 8, 2, 4, 2, 3, 1, 7, 7, 5, 1, 9, 10, 2],
                         "identity": -9223372036854775808,
@@ -17903,6 +19676,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23],
                         "identity": -9223372036854775808,
@@ -17916,6 +19690,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 2, 3, 1, 5],
                         "identity": -9223372036854775808,
@@ -17929,6 +19704,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "identity": -9223372036854775808,
@@ -17948,6 +19724,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 2, 2, 2, 3, 0, 0, 4],
                         "lenparents": 10,
@@ -17960,6 +19737,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23],
                         "lenparents": 9,
@@ -17972,6 +19750,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 0, 2, 0, 0, 2, 0, 4],
                         "lenparents": 10,
@@ -17984,6 +19763,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -17996,6 +19776,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 13, 17, 23, 3, 11, 19, 5],
                         "lenparents": 9,
@@ -18008,6 +19789,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -18026,6 +19808,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 19,
                         "outlength": 9,
@@ -18037,6 +19820,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 19,
                         "outlength": 8,
@@ -18048,6 +19832,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 1696,
                         "outlength": 331,
@@ -18059,6 +19844,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 3,
@@ -18070,6 +19856,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 3,
                         "outlength": 1,
@@ -18081,6 +19868,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 6,
@@ -18092,6 +19880,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 8,
@@ -18103,6 +19892,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 21,
                         "outlength": 9,
@@ -18114,6 +19904,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 21,
                         "outlength": 8,
@@ -18125,6 +19916,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 22,
                         "outlength": 9,
@@ -18136,6 +19928,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 22,
                         "outlength": 8,
@@ -18147,6 +19940,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 24,
                         "outlength": 9,
@@ -18158,6 +19952,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 24,
                         "outlength": 8,
@@ -18169,6 +19964,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 9,
                         "outlength": 3,
@@ -18180,6 +19976,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 4,
@@ -18191,6 +19988,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 18,
                         "outlength": 6,
@@ -18202,6 +20000,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 21,
                         "outlength": 7,
@@ -18213,6 +20012,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 30,
                         "outlength": 10,
@@ -18224,6 +20024,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 23,
                         "outlength": 7,
@@ -18235,6 +20036,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 23,
                         "outlength": 7,
@@ -18246,6 +20048,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 3,
@@ -18257,6 +20060,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 43,
                         "outlength": 10,
@@ -18268,6 +20072,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 39,
                         "outlength": 10,
@@ -18279,6 +20084,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 11,
                         "outlength": 3,
@@ -18290,6 +20096,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 20,
                         "outlength": 6,
@@ -18301,6 +20108,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 25,
                         "outlength": 7,
@@ -18312,6 +20120,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 5,
                         "outlength": 1,
@@ -18323,6 +20132,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 10,
                         "outlength": 2,
@@ -18334,6 +20144,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 29,
                         "outlength": 7,
@@ -18345,6 +20156,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "lenparents": 6,
                         "outlength": 1,
@@ -18362,6 +20174,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0],
                         "lenparents": 1,
@@ -18374,6 +20187,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 5, 20, 1, 6, 21, 2, 7, 22, 3, 8, 23, 4, 9, 24],
                         "lenparents": 15,
@@ -18386,6 +20200,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23],
                         "lenparents": 9,
@@ -18398,6 +20213,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 1, 0, 0],
                         "lenparents": 6,
@@ -18410,6 +20226,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21, 22, 23, 24],
                         "lenparents": 15,
@@ -18422,6 +20239,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
                         "lenparents": 30,
@@ -18434,6 +20252,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -18446,6 +20265,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 5, 10, 15, 25, 1, 11, 16, 26, 2, 12, 17, 27, 8, 18, 28, 4, 9, 14, 29],
                         "lenparents": 20,
@@ -18458,6 +20278,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [15, 20, 25, 16, 21, 26, 17, 22, 27, 18, 23, 28, 19, 24, 29],
                         "lenparents": 15,
@@ -18470,6 +20291,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 15, 5, 10, 25, 1, 16, 11, 26, 2, 17, 12, 27, 18, 8, 28, 4, 9, 14, 29],
                         "lenparents": 20,
@@ -18482,6 +20304,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 15, 5, 20, 10, 25, 1, 16, 6, 21, 11, 26, 2, 17, 7, 22, 12, 27, 3, 18, 8, 23, 13, 28, 4, 19, 9, 24, 14, 29],
                         "lenparents": 30,
@@ -18494,6 +20317,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 5, 10, 15, 20, 25, 1, 6, 11, 16, 21, 26, 2, 7, 12, 17, 22, 27, 3, 8, 13, 18, 23, 28, 4, 9, 14, 19, 24, 29],
                         "lenparents": 30,
@@ -18506,6 +20330,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 4, 8, 16, 32, 64, 128, 0, 0, 0, 0],
                         "lenparents": 12,
@@ -18518,6 +20343,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
                         "lenparents": 10,
@@ -18530,6 +20356,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -18542,6 +20369,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 13, 17, 23, 3, 11, 19, 5],
                         "lenparents": 9,
@@ -18554,6 +20382,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 16, 0, 2, 32, 0, 4, 64, 0, 8, 128, 0],
                         "lenparents": 12,
@@ -18566,6 +20395,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 5],
                         "lenparents": 6,
@@ -18578,6 +20408,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 4, 1, 3, 5, 6],
                         "lenparents": 6,
@@ -18590,6 +20421,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 4, 9, 16, 25, 1, 4, 9, 16, 25],
                         "lenparents": 10,
@@ -18602,6 +20434,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 4, 9, 16, 26, 1, 4, 10, 16, 24],
                         "lenparents": 10,
@@ -18614,6 +20447,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 5, 20, 1, 6, 21, 2, 7, 22, 3, 8, 23, 4, 9, 24],
                         "lenparents": 15,
@@ -18626,6 +20460,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [15, 20, 25, 16, 21, 26, 17, 22, 27, 18, 23, 28, 19, 24, 29],
                         "lenparents": 15,
@@ -18638,6 +20473,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -18650,6 +20486,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 4, 5, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18, 25, 26, 27, 28, 29],
                         "lenparents": 20,
@@ -18662,6 +20499,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 2, 4, 5, 5],
                         "lenparents": 5,
@@ -18674,6 +20512,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
                         "lenparents": 15,
@@ -18686,6 +20525,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [4, 1, 0, 1, 4, 5, 1, 0, 1, 3],
                         "lenparents": 10,
@@ -18698,6 +20538,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [4, 1, 0, 1, 4, 4, 1, 0, 1, 4],
                         "lenparents": 10,
@@ -18716,6 +20557,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 0, 0, 1, 0, 0],
                         "lenparents": 6,
@@ -18728,6 +20570,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 5],
                         "lenparents": 6,
@@ -18740,6 +20583,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 31, 101, 3, 59, 37, 103, 5, 61, 41, 107, 7, 67, 43, 109, 11, 71, 47, 113],
                         "lenparents": 20,
@@ -18752,6 +20596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 109, 11, 71, 47, 113],
                         "lenparents": 28,
@@ -18764,6 +20609,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 11, 71, 29, 97, 47],
                         "lenparents": 28,
@@ -18776,6 +20622,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 109, 11, 71, 29, 97],
                         "lenparents": 28,
@@ -18788,6 +20635,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 109, 11, 71, 29, 97, 47],
                         "lenparents": 29,
@@ -18800,6 +20648,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 109, 11, 71, 29, 97, 47, 113],
                         "lenparents": 30,
@@ -18812,6 +20661,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 53, 13, 73, 31, 101, 3, 59, 17, 79, 37, 103, 5, 61, 19, 83, 41, 107, 7, 67, 23, 89, 43, 109, 11, 71, 29, 47],
                         "lenparents": 28,
@@ -18824,6 +20674,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0],
                         "lenparents": 1,
@@ -18836,6 +20687,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 103, 107, 109, 113, 53, 59, 61, 67, 71, 31, 37, 41, 43, 47, 2, 3, 5, 7, 11],
                         "lenparents": 20,
@@ -18848,6 +20700,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 103, 107, 109, 113, 73, 79, 83, 89, 97, 53, 59, 61, 67, 71, 31, 37, 41, 43, 47, 13, 17, 19, 23, 29, 2, 3, 5, 7, 11],
                         "lenparents": 30,
@@ -18860,6 +20713,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 103, 107, 109, 113, 53, 59, 61, 67, 71, 31, 37, 41, 43, 47, 2, 3, 5, 7, 11],
                         "lenparents": 20,
@@ -18872,6 +20726,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 17, 29, 3, 11, 19, 31, 5, 13, 23, 37],
                         "lenparents": 12,
@@ -18884,6 +20739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 53, 13, 73, 31, 101, 5, 59, 17, 79, 37, 103, 7, 61, 19, 83, 41, 107, 67, 23, 89, 43, 109, 71, 29, 97, 47, 113],
                         "lenparents": 28,
@@ -18896,6 +20752,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 53, 13, 73, 31, 101, 5, 59, 17, 79, 37, 103, 7, 61, 19, 83, 41, 107, 11, 67, 23, 89, 43, 109, 71, 29, 97, 47, 113],
                         "lenparents": 29,
@@ -18908,6 +20765,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 53, 13, 73, 31, 101, 5, 59, 17, 79, 37, 103, 7, 61, 19, 83, 41, 107, 11, 67, 23, 89, 43, 109, 71, 97, 47, 113],
                         "lenparents": 28,
@@ -18920,6 +20778,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 13, 17, 23, 3, 11, 19, 5],
                         "lenparents": 9,
@@ -18932,6 +20791,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37],
                         "lenparents": 12,
@@ -18944,6 +20804,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 101, 103, 107, 109, 113],
                         "lenparents": 20,
@@ -18956,6 +20817,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113],
                         "lenparents": 30,
@@ -18968,6 +20830,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 101, 103, 107, 109, 113],
                         "lenparents": 20,
@@ -18980,6 +20843,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 3, 11, 5],
                         "lenparents": 5,
@@ -18992,6 +20856,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [5, 53, 13, 73, 31, 101, 7, 59, 17, 79, 37, 103, 11, 61, 19, 83, 41, 107, 67, 23, 89, 43, 109, 71, 29, 97, 47, 113],
                         "lenparents": 28,
@@ -19004,6 +20869,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37],
                         "lenparents": 12,
@@ -19016,6 +20882,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13],
                         "lenparents": 6,
@@ -19028,6 +20895,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23],
                         "lenparents": 9,
@@ -19040,6 +20908,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19],
                         "lenparents": 8,
@@ -19052,6 +20921,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [6, 5, 7, 11, 13, 17, 19],
                         "lenparents": 7,
@@ -19064,6 +20934,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11],
                         "lenparents": 5,
@@ -19076,6 +20947,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5],
                         "lenparents": 3,
@@ -19088,6 +20960,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11],
                         "lenparents": 5,
@@ -19100,6 +20973,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11],
                         "lenparents": 5,
@@ -19112,6 +20986,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 31, 53, 2, 103, 37, 59, 3, 107, 41, 61, 5, 109, 43, 67, 7, 113, 47, 71, 11],
                         "lenparents": 20,
@@ -19124,6 +20999,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 31, 73, 13, 53, 2, 103, 37, 79, 17, 59, 3, 107, 41, 83, 19, 61, 5, 109, 43, 89, 23, 67, 7, 113, 47, 97, 29, 71, 11],
                         "lenparents": 30,
@@ -19136,6 +21012,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 7, 29, 3, 19, 11, 31, 13, 37],
                         "lenparents": 11,
@@ -19148,6 +21025,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 7, 29, 3, 19, 11, 31, 13, 37],
                         "lenparents": 11,
@@ -19160,6 +21038,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, 7, 29, 3, 19, 11, 31, 13, 37],
                         "lenparents": 10,
@@ -19172,6 +21051,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 29, 3, 19, 31, 37],
                         "lenparents": 8,
@@ -19184,6 +21064,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 29, 3, 19, 31, 37],
                         "lenparents": 8,
@@ -19196,6 +21077,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, 29, 3, 19, 31, 37],
                         "lenparents": 7,
@@ -19208,6 +21090,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 39, 7, 29, 3, 19, 11, 31, 13, 37],
                         "lenparents": 12,
@@ -19220,6 +21103,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 39, 29, 3, 19, 31, 37],
                         "lenparents": 9,
@@ -19232,6 +21116,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, 7, 29, 3, 19, 11, 31, 5, 23, 13, 37],
                         "lenparents": 12,
@@ -19244,6 +21129,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 39, 7, 29, 3, 19, 11, 31, 13, 37],
                         "lenparents": 12,
@@ -19256,6 +21142,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, -1, 39, 29, 3, 19, 31, 37],
                         "lenparents": 9,
@@ -19268,6 +21155,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, 7, 23, 13, 29, 3, 19, 11, 5],
                         "lenparents": 10,
@@ -19280,6 +21168,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 17, 23, 7, 13, 3, 19, 11, 5],
                         "lenparents": 9,
@@ -19292,6 +21181,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 11, 17, 7, 19, 3, 13, 23, 5],
                         "lenparents": 9,
@@ -19304,6 +21194,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 73, 53, 31, 13, 2, 103, 79, 59, 37, 17, 3, 107, 83, 61, 41, 19, 5, 109, 89, 67, 43, 23, 7, 113, 97, 71, 47, 29, 11],
                         "lenparents": 30,
@@ -19316,6 +21207,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 11, 23, 3, 13, 29, 5, 17, 31, 7, 19, 37],
                         "lenparents": 12,
@@ -19328,6 +21220,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [101, 53, 31, 2, 103, 59, 37, 3, 107, 61, 41, 5, 109, 67, 43, 7, 113, 71, 47, 11],
                         "lenparents": 20,
@@ -19340,6 +21233,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -19352,6 +21246,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 31, 53, 101, 3, 37, 59, 103, 5, 41, 61, 107, 7, 43, 67, 109, 11, 47, 71, 113],
                         "lenparents": 20,
@@ -19364,6 +21259,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19],
                         "lenparents": 8,
@@ -19376,6 +21272,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19],
                         "lenparents": 8,
@@ -19388,6 +21285,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -19400,6 +21298,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 13, 31, 53, 73, 101, 3, 17, 37, 59, 79, 103, 5, 19, 41, 61, 83, 107, 7, 23, 43, 67, 89, 109, 11, 29, 47, 71, 97, 113],
                         "lenparents": 30,
@@ -19418,6 +21317,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 4, 1, 3, 5, 6],
                         "identity": 9223372036854775807,
@@ -19431,6 +21331,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 3, 4, 5, 6],
                         "identity": 9223372036854775807,
@@ -19444,6 +21345,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 2, 5, 3, 7, 3, 1, 5, 8, 1, 9, 4, 2, 7, 10, 2, 4, 7, 2],
                         "identity": 9223372036854775807,
@@ -19457,6 +21359,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "identity": 9223372036854775807,
@@ -19470,6 +21373,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "identity": 9223372036854775807,
@@ -19483,6 +21387,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 6, 4, 2, 2, 3, 1, 6],
                         "identity": 4,
@@ -19496,6 +21401,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 3, 7, 8, 2, 4, 2, 3, 1, 7, 7, 5, 1, 9, 10, 2],
                         "identity": 9223372036854775807,
@@ -19509,6 +21415,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 4, 4, 2, 2, 5, 3, 3, 3, 6, 2, 4],
                         "identity": 9223372036854775807,
@@ -19522,6 +21429,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 5, 3, 3, 5, 1, 4, 2],
                         "identity": 9223372036854775807,
@@ -19535,6 +21443,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 2, 3, 1, 5],
                         "identity": 4,
@@ -19548,6 +21457,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 3, 5, 4, 2, 2, 3, 1, 5],
                         "identity": 9223372036854775807,
@@ -19561,6 +21471,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 7, 13, 17, 23, 3, 11, 19, 5],
                         "identity": 9223372036854775807,
@@ -19574,6 +21485,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 3, 5, 7, 11, 13, 17, 19, 23],
                         "identity": 9223372036854775807,
@@ -19593,6 +21505,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 0, 4, 4, 6],
                         "lenparents": 5,
@@ -19605,6 +21518,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
@@ -19617,6 +21531,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
@@ -19629,6 +21544,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [0, 1, 2, 3, 4, 6],
                         "lenparents": 6,
@@ -19641,6 +21557,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 4, 2, 6, 3, 0, -10],
                         "lenparents": 7,
@@ -19653,6 +21570,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 1, 3, 4, 6, 6, -4, -6, -7],
                         "lenparents": 9,
@@ -19665,6 +21583,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 1, 3, -4, -6, -7],
                         "lenparents": 6,
@@ -19677,6 +21596,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 1, 3, 2, 1],
                         "lenparents": 5,
@@ -19689,6 +21609,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 2, 1, 0, 1, 0],
                         "lenparents": 6,
@@ -19701,6 +21622,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [2, 0, 2, 1, 1, 0],
                         "lenparents": 6,
@@ -19713,6 +21635,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, -3, 4, 4, 2, 2, 2, 2, 2, -2, 1, 1, 6, -6, 1, 1, 4, 4, 1, 1, 3, -3, 3, 3, 4, 4, 6, 6, 6, -6],
                         "lenparents": 30,
@@ -19725,6 +21648,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 1, 6, 1, 4, 4, 2, 1, 7, 2, 3, -1],
                         "lenparents": 12,
@@ -19737,6 +21661,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [-4, -6, -7, 6, 4, 6, 2, 1, 3],
                         "lenparents": 9,
@@ -19749,6 +21674,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [-4, -6, -7, 6, -4, -6, -7, 2, 1, 3],
                         "lenparents": 10,
@@ -19761,6 +21687,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 4, 2, 1, 2, 3, 6, 1, -1, 1, 7, 4],
                         "lenparents": 12,
@@ -19773,6 +21700,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 4, 2, 2, 2, 1, 6, 1, 4, 1, 3, 3, 4, 6, 6],
                         "lenparents": 15,
@@ -19785,6 +21713,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 4, 2, -3, 4, 2, 2, 2, 1, 2, -2, 1, 6, 1, 4, -6, 1, 4, 1, 3, 3, 1, -3, 3, 4, 6, 6, 4, 6, -6],
                         "lenparents": 30,
@@ -19797,6 +21726,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [6, 3, 2, 1, 2],
                         "lenparents": 5,
@@ -19809,6 +21739,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 2, 6, 1, 4, 4, 2, 1, 3, 6, 2, 1, 4, 3, 6, -3, 2, -6, 1, 4, 4, -2, 1, -3, 6, 2, 1, 4, 3, -6],
                         "lenparents": 30,
@@ -19821,6 +21752,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [3, 2, 6, 1, 4, 4, 2, 1, 3, 6, 2, 1, 4, 3, 6],
                         "lenparents": 15,
@@ -19833,6 +21765,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 999, 1, 1, 1, 1, 999, 1, 2, 2, 2, 2, 2, 2, 3, 3],
                         "lenparents": 18,
@@ -19845,6 +21778,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 999, 1, 1, 1, 1, 999, 1, 2, 2, 2, 999, 2, 2, 2, 3, 999, 999, 3, 999],
                         "lenparents": 22,
@@ -19857,6 +21791,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "fromptr": [1, 1, 1, 999, 1, 1, 1, 1, 999, 1, 2, 2, 2, 999, 2, 2, 2, 3, 999, 999, 3],
                         "lenparents": 21,
@@ -19875,6 +21810,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "toindexoffset": 4
@@ -19885,6 +21821,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "toindexoffset": 2
@@ -19895,6 +21832,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 2,
                         "toindexoffset": 0
@@ -19905,6 +21843,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "toindexoffset": 6
@@ -19915,6 +21854,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 3,
                         "toindexoffset": 0
@@ -19925,6 +21865,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "toindexoffset": 9
@@ -19935,6 +21876,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 4,
                         "toindexoffset": 5
@@ -19945,6 +21887,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "length": 5,
                         "toindexoffset": 0
@@ -19961,6 +21904,7 @@
             "tests": [
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 0,
                         "innerindex": [0, 0, 1, 1, 2, 3, 2],
@@ -19979,6 +21923,7 @@
                 },
                 {
                     "error": false,
+                    "message": "",
                     "inputs": {
                         "base": 5,
                         "innerindex": [0, 0, 1, 1, 2, 3, 2],

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -215,9 +215,6 @@ def synchronize_cuda(stream=None):
             cupy.array(NO_ERROR),
             [],
         )
-        raise invoked_kernel.error_context.decorate_exception(
-            ValueError,
-            ValueError(
-                f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
-            ),
+        raise ValueError(
+            f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
         )

--- a/src/awkward/_connect/cuda/__init__.py
+++ b/src/awkward/_connect/cuda/__init__.py
@@ -215,6 +215,14 @@ def synchronize_cuda(stream=None):
             cupy.array(NO_ERROR),
             [],
         )
-        raise ValueError(
-            f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
-        )
+        if invoked_kernel.error_context is None:
+            raise ValueError(
+                f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
+            )
+        else:
+            raise invoked_kernel.error_context.decorate_exception(
+                ValueError,
+                ValueError(
+                    f"{kernel_errors[invoked_kernel.name][int(invocation_index % math.pow(2, ERROR_BITS))]} in compiled CUDA code ({invoked_kernel.name})"
+                ),
+            )

--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_compact_offsets.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_compact_offsets.cu
@@ -1,7 +1,7 @@
 // BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 
 enum class LISTARRAY_COMPACT_OFFSETS_ERRORS {
-  ERROR_START_STOP,  // message: "start[i] > stop[i]"
+  ERROR_START_STOP,  // message: "stops[i] < starts[i]"
 };
 
 // BEGIN PYTHON


### PR DESCRIPTION
Generate error message and add tests for checking if the correct error message is generated or not.

- tests-spec-explicit
======= 1625 passed in 1.32s =====
- tests-cpu-kernels-explicit
======= 5479 passed in 2.62s =====
- tests-cuda-kernels-explicit
======= 2042 passed, 1736 skipped in 3.97s =====