### PR TITLE
fix: `ak.merge_union_of_records` error message for cases that can't use `axis < 0`

### DIFF
--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -164,6 +164,12 @@ def _impl(array, axis, highlevel, behavior, attrs):
 
     def apply(layout, depth, backend, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)
+        if posaxis is None:
+            mindepth, maxdepth = layout.minmax_depth
+            raise TypeError(
+                f"cannot merge_union_of_records with axis={axis} if the array has multiple levels of nesting depth; this array has depths from {mindepth} to {maxdepth} (inclusive); try setting axis to a non-negative value"
+            )
+
         if depth < posaxis + 1 and layout.is_leaf:
             raise AxisError(f"axis={axis} exceeds the depth of this array ({depth})")
         elif depth == posaxis + 1 and layout.is_union:


### PR DESCRIPTION
`maybe_posaxis` can return `None` if the `layout`'s depth branches, and that was unguarded in `ak.merge_union_of_records`. (It might be unguarded in other functions; I didn't check them all.)

Maybe the default `axis` for this function should not have been `-1`, but I don't think it's necessary to change that. The new error message suggests changing the `axis`, which is the fix for #2994.

@agoose77, this would be easy to review. I'm asking you just in case it makes you remember something that you think we should also check. Thanks!