### PR TITLE
feat!: __array__ is no longer allowed on NumpyArray and EmptyArray

### DIFF
--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -8,7 +8,6 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
 from awkward._meta.emptymeta import EmptyMeta
 from awkward._nplikes.array_like import ArrayLike
@@ -109,13 +108,6 @@ class EmptyArray(EmptyMeta, Content):
 
     def __deepcopy__(self, memo):
         return self.copy()
-
-    def __array__(self, dtype=None):
-        deprecate(
-            f"np.asarray(content) is deprecated for {type(self).__name__}. Use ak.to_numpy(content) instead",
-            version="2.6.0",
-        )
-        return numpy.empty(0, dtype=dtype)
 
     @classmethod
     def simplified(cls, *, parameters=None, backend=None):

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -10,7 +10,6 @@ from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of_obj
 from awkward._backends.numpy import NumpyBackend
 from awkward._backends.typetracer import TypeTracerBackend
-from awkward._errors import deprecate
 from awkward._layout import maybe_posaxis
 from awkward._meta.numpymeta import NumpyMeta
 from awkward._nplikes import to_nplike
@@ -165,13 +164,6 @@ class NumpyArray(NumpyMeta, Content):
             data=copy.deepcopy(self._data, memo),
             parameters=copy.deepcopy(self._parameters, memo),
         )
-
-    def __array__(self, dtype=None):
-        deprecate(
-            f"np.asarray(content) is deprecated for {type(self).__name__}. Use ak.to_numpy(content) instead",
-            version="2.6.0",
-        )
-        return numpy.asarray(self._data, dtype=dtype)
 
     @classmethod
     def simplified(cls, data, *, parameters=None, backend=None):


### PR DESCRIPTION
As per https://github.com/scikit-hep/awkward/wiki#api-breaking-changes-after-20 for 2.6.0, we now longer allow `__array__` to be called on NumpyArray and EmptyArray.