### PR TITLE
test: update test_2799 for Numba 0.59.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - python-version: '3.9'
             python-architecture: x86
-            runs-on: windows-2019
+            runs-on: windows-latest
             dependencies-kind: full
           - python-version: '3.8'
             python-architecture: x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - python-version: '3.9'
             python-architecture: x86
-            runs-on: windows-latest
+            runs-on: windows-2019
             dependencies-kind: full
           - python-version: '3.8'
             python-architecture: x64

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,6 +1,6 @@
 fsspec;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.12"
-numba>=0.50.0,!=0.58.0rc1;python_version < "3.12"
+numba>=0.50.0;sys_platform != "win32" and python_version < "3.12"
 numexpr>=2.7; python_version < "3.12"
 pandas>=0.24.0;sys_platform != "win32" and python_version < "3.12"
 pyarrow>=7.0.0;sys_platform != "win32" and python_version < "3.12"

--- a/tests/test_2799_numba_ufunc_resolution.py
+++ b/tests/test_2799_numba_ufunc_resolution.py
@@ -22,8 +22,6 @@ ak.numba.register_and_check()
 
 @pytest.mark.skipif(not NUMBA_HAS_NEP_50, reason="Numba does not have NEP-50 support")
 def test_numba_ufunc_nep_50():
-    raise NotImplementedError
-
     @numba.vectorize(nopython=True)
     def add(x, y):
         return x + y
@@ -35,7 +33,7 @@ def test_numba_ufunc_nep_50():
         result = add(array, np.int16(np.iinfo(np.int8).max + 1))
 
     flattened = ak.to_numpy(ak.flatten(result))
-    assert flattened.dtype == np.dtype(np.int8)
+    assert flattened.dtype == np.dtype(np.int64)
 
 
 @pytest.mark.skipif(NUMBA_HAS_NEP_50, reason="Numba has NEP-50 support")


### PR DESCRIPTION
Numba 0.59.0 is now available (on PyPI), so test_2799 was failing because its first line was

```python
raise NotImplementedError
```

I think you were waiting on information about how Numba would be dealing with this issue when 0.59.0 comes out. Your expectation that `flattened.dtype` would be `int8` doesn't seem to be right. Experimentally, it returns `int64`. Even for pure NumPy (no Awkward Array):

```python
>>> import numba
>>> import numpy as np
>>> @numba.vectorize(nopython=True)
... def add(x, y):
...     return x + y
... 
>>> array = np.array([1, 2, 3, 4], np.int8)
>>> result = add(array, np.int16(np.iinfo(np.int8).max + 1))
>>> result.dtype
dtype('int64')
```

I've updated the test with this correction (what I believe to be a correction).

#2996 and #2997 both need it to be merged, and they need to be merged to release Awkward 2.6.0. (In fact, any subsequent runs of the CI tests will need this, since they get Numba through PyPI and that's 0.59.0 now.)

Two other-library updates came out on the same day, both of which complicate our tests! (pytest 8.0.0 came out, which breaks pytest-asyncio, and Numba 0.59.0 came out.)