### PR TITLE
ci: Add nightly upload of wheels to Anaconda Cloud

### DIFF
--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -2,6 +2,9 @@ name: Packaging Tests
 
 on:
   pull_request:
+  # Run daily at 1:23 UTC
+  schedule:
+    - cron: '23 1 * * *'
   workflow_dispatch:
 
 

--- a/.github/workflows/upload_nightly_wheels.yml
+++ b/.github/workflows/upload_nightly_wheels.yml
@@ -1,0 +1,65 @@
+name: Upload nightly wheels to Anaconda Cloud
+
+on:
+  # Run daily at 2:34 UTC to upload nightly wheels to Anaconda Cloud
+  schedule:
+    - cron: '34 2 * * *'
+  # Run on demand with workflow dispatch
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+jobs:
+  upload_nightly_wheels:
+    name: Upload nightly wheels to Anaconda Cloud
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # The login shell is necessary for the setup-micromamba setup
+        # to work in subsequent jobs.
+        # https://github.com/mamba-org/setup-micromamba#about-login-shells
+        shell: bash -e -l {0}
+    if: github.repository_owner == 'scikit-hep'
+
+    steps:
+      # https://github.com/actions/download-artifact/issues/3#issuecomment-1017141067
+      - name: Download wheel artifacts from last build on 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROJECT_REPO="scikit-hep/awkward"
+          BRANCH="main"
+          WORKFLOW_NAME="packaging-test.yml"
+          ARTIFACT_PATTERN="awkward*wheel*"  # awkward-wheel and awkward-cpp-wheels-*
+
+          gh run --repo "${PROJECT_REPO}" \
+             list --branch "${BRANCH}" \
+                  --workflow "${WORKFLOW_NAME}" \
+                  --json event,status,conclusion,databaseId > runs.json
+          RUN_ID=$(
+            jq --compact-output \
+              '[
+                .[] |
+                # Filter on "schedule" events to main (nightly build) ...
+                select(.event == "schedule") |
+                # that have completed successfully ...
+                select(.status == "completed" and .conclusion == "success")
+               ] |
+              # and get ID of latest build of wheels.
+              sort_by(.databaseId) | reverse | .[0].databaseId' runs.json
+          )
+          gh run --repo "${PROJECT_REPO}" view "${RUN_ID}"
+          gh run --repo "${PROJECT_REPO}" \
+             download "${RUN_ID}" --pattern "${ARTIFACT_PATTERN}"
+
+          mkdir dist
+          mv ${ARTIFACT_PATTERN}/*.whl dist/
+          ls -l dist/
+
+      - name: Upload wheels to Anaconda Cloud as nightlies
+        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_organization: scikit-hep-nightly-wheels
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}

--- a/.github/workflows/upload_nightly_wheels.yml
+++ b/.github/workflows/upload_nightly_wheels.yml
@@ -41,8 +41,8 @@ jobs:
             jq --compact-output \
               '[
                 .[] |
-                # Filter on "schedule" events to main (nightly build) ...
-                select(.event == "schedule") |
+                # Filter on "schedule" and "workflow_dispatch" events to main (nightly build) ...
+                select(.event == "schedule" or .event == "workflow_dispatch") |
                 # that have completed successfully ...
                 select(.status == "completed" and .conclusion == "success")
                ] |


### PR DESCRIPTION
Resolves #3011 

* Add nightly schedule job for Packaging Tests workflow at 01:23 UTC to generate wheels.
* Add nightly wheels workflow that uses the `gh` command line tool to search and find the artifacts that were uploaded, downlod them, and then upload them to the [`scikit-hep-nightly-wheels` Anaconda Cloud org](https://anaconda.org/scikit-hep-nightly-wheels) using the [`scientific-python/upload-nightly-action` GitHub Action](https://github.com/scientific-python/upload-nightly-action).

I'm putting this in draft mode so that I can clean it up before this gets approved and merged.