### PR TITLE
fix: remove redundant(?) Jax.is_tracer_type check in _layout

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -13,7 +13,6 @@ from awkward._backends.dispatch import (
 from awkward._backends.numpy import NumpyBackend
 from awkward._behavior import behavior_of
 from awkward._nplikes.dispatch import nplike_of_obj
-from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._typing import TYPE_CHECKING, Any, NamedTuple, Self, TypeVar
@@ -266,10 +265,6 @@ def from_arraylib(array, regulararray, recordarray):
     nplike = nplike_of_obj(array)
 
     def recurse(array, mask=None):
-        cls = type(array)
-        if Jax.is_tracer_type(cls):
-            raise TypeError("Jax tracers cannot be used with `ak.from_arraylib`")
-
         if regulararray and len(array.shape) > 1:
             new_shape = (-1,) + array.shape[2:]
             return RegularArray(

--- a/tests/test_2556_jax_tracer_error.py
+++ b/tests/test_2556_jax_tracer_error.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+from __future__ import annotations
+
+import jax
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def test():
+    ak.jax.register_and_check()
+
+    arr = ak.Array([[1.0, 2, 3], [5, 6]], backend="jax")
+    grad_arr = ak.Array([[34.0, 34.0, 34.0], [34.0, 34.0]], backend="jax")
+
+    def f(x):
+        return ak.sum(ak.sum(x) * x)
+
+    assert ak.all(grad_arr == jax.grad(f)(arr))

--- a/tests/test_2556_jax_tracer_error.py
+++ b/tests/test_2556_jax_tracer_error.py
@@ -1,10 +1,11 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 from __future__ import annotations
 
-import jax
-import pytest  # noqa: F401
+import pytest
 
 import awkward as ak
+
+jax = pytest.importorskip("jax")
 
 
 def test():

--- a/tests/test_2637_jax_tracer_error.py
+++ b/tests/test_2637_jax_tracer_error.py
@@ -1,0 +1,37 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+jax = pytest.importorskip("jax")
+
+
+def test():
+    ak.jax.register_and_check()
+
+    jets = ak.Array(
+        [
+            [
+                {"pt": 1.0, "eta": 1.1, "phi": 0.1, "mass": 0.01},
+                {"pt": 2, "eta": 2.2, "phi": 0.2, "mass": 0.02},
+            ],
+            [
+                {"pt": 4.0, "eta": 4.4, "phi": 0.4, "mass": 0.04},
+                {"pt": 5.0, "eta": 5.5, "phi": 0.5, "mass": 0.05},
+                {"pt": 6.0, "eta": 6.6, "phi": 0.6, "mass": 0.06},
+            ],
+        ],
+        backend="jax",
+    )
+
+    def correct_jets(jets, alpha):
+        new_pt = jets["pt"] + 25.0 * alpha
+        jets["pt"] = new_pt
+        return ak.sum(jets["pt"])
+
+    val, grad = jax.value_and_grad(correct_jets, argnums=1)(jets, 0.1)
+
+    assert val == 30.5
+    assert grad == 125.0


### PR DESCRIPTION
Fixes #2556 #2637

I am still not completely sure if removing the check is safe, but everything works for me locally, including the non-jax part of awkward.

#2637 now exits with a new error which is on the user side and not on the awkward side -
```py
In [1]: import awkward as ak
   ...: import jax
   ...: import uproot
   ...: 
   ...: ak.jax.register_and_check()
   ...: 
   ...: ttbar_file = "https://github.com/scikit-hep/scikit-hep-testdata/"\
   ...:     "raw/main/src/skhep_testdata/data/nanoAOD_2015_CMS_Open_Data_ttbar.root"
   ...: 
   ...: def correct_jets(jets, alpha):
   ...:     jets = ak.Array(jets)
   ...:     new_pt = jets["pt"] + 25*alpha
   ...:     jets["pt"] = new_pt
   ...:     return jets
   ...: 
   ...: with uproot.open(ttbar_file) as f:
   ...:     arr = f["Events"].arrays(["Jet_pt","Jet_eta", "Jet_phi", "Jet_mass"])
   ...:     evtfilter = ak.num(arr["Jet_pt"]) >= 2
   ...:     jets = ak.zip(dict(zip(["pt","eta", "phi", "mass"], ak.unzip(arr))), with_name="Momentum4D")[evtfilter]
   ...:     jets = ak.to_backend(jets, "jax")
   ...: 
   ...: 
   ...: jax.value_and_grad(correct_jets, argnums=1)(jets, 0.1)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
    [... skipping hidden 1 frame]

/opt/homebrew/lib/python3.11/site-packages/jax/_src/core.py in get_aval(x)
   1497   else:
-> 1498     return concrete_aval(x)
   1499 

/opt/homebrew/lib/python3.11/site-packages/jax/_src/core.py in concrete_aval(x)
   1489     return concrete_aval(x.__jax_array__())
-> 1490   raise TypeError(f"Value {x!r} with type {type(x)} is not a valid JAX "
   1491                    "type")

TypeError: Value <Array [[{eta: -3.1967773, ...}, ...], ...] type='140 * var * Momentum4D[et...'> with type <class 'awkward.highlevel.Array'> is not a valid JAX type

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
<ipython-input-1-d13645fe92dc> in <cell line: 0>()
     21 
     22 
---> 23 jax.value_and_grad(correct_jets, argnums=1)(jets, 0.1)

    [... skipping hidden 2 frame]

/opt/homebrew/lib/python3.11/site-packages/jax/_src/api.py in _check_scalar(x)
    753     aval = core.get_aval(x)
    754   except TypeError as e:
--> 755     raise TypeError(msg(f"was {x}")) from e
    756   else:
    757     if isinstance(aval, ShapedArray):

TypeError: Gradient only defined for scalar-output functions. Output was [[{eta: -3.1967773, phi: 2.9589844, mass: 3.3886719, pt: ..., ...}, ...], ...].
```

cc: @alexander-held 