### PR TITLE
feat: add __dask_tokenize__ hook

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -348,6 +348,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     _histogram_module_ = awkward._connect.hist
 
+    def __dask_tokenize__(self):
+        return self.layout.form.to_json(), self.behavior, self.attrs
+    
     def _update_class(self):
         self._numbaview = None
         self.__class__ = get_array_class(self._layout, self._behavior)

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -349,7 +349,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     _histogram_module_ = awkward._connect.hist
 
     def __dask_tokenize__(self):
-        return self.layout.form.to_json(), self.behavior, self.attrs
+        return id(self)
 
     def _update_class(self):
         self._numbaview = None

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -350,7 +350,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     def __dask_tokenize__(self):
         return self.layout.form.to_json(), self.behavior, self.attrs
-    
+
     def _update_class(self):
         self._numbaview = None
         self.__class__ = get_array_class(self._layout, self._behavior)


### PR DESCRIPTION
This is related to https://github.com/dask/dask/pull/10918

In particular with https://github.com/dask/dask/pull/10883 even those changes don't fix everything.

This at least makes it so that only shape is touched in the present error and with future changes.

This rest is that `array.layout.form` touches shape.