### PR TITLE
feat!: printing a typetracer array should not touch it

### DIFF
--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -72,6 +72,8 @@ is_identifier = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
 
 
 def get_at(data: Content, index: int):
+    if data._layout._is_getitem_at_placeholder():
+        return "??"
     out = data._layout._getitem_at(index)
     if isinstance(out, ak.contents.NumpyArray):
         array_param = out.parameter("__array__")

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -344,7 +344,6 @@ def valuestr(
     if isinstance(data, (ak.highlevel.Array, ak.highlevel.Record)) and (
         not data.layout.backend.nplike.known_data
     ):
-        data.layout._touch_data(recursive=True)
         if isinstance(data, ak.highlevel.Array):
             return "[...]"
 

--- a/src/awkward/_prettyprint.py
+++ b/src/awkward/_prettyprint.py
@@ -71,9 +71,14 @@ is_identifier = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
 # to form an error string: private reimplementation of ak.Array.__getitem__
 
 
+class PlaceholderValue:
+    def __str__(self):
+        return "??"
+
+
 def get_at(data: Content, index: int):
     if data._layout._is_getitem_at_placeholder():
-        return "??"
+        return PlaceholderValue()
     out = data._layout._getitem_at(index)
     if isinstance(out, ak.contents.NumpyArray):
         array_param = out.parameter("__array__")

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -476,6 +476,11 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        if isinstance(self._mask, ak._nplikes.placeholder.PlaceholderArray):
+            return True
+        return self._content._is_getitem_at_placeholder()
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -13,6 +13,7 @@ from awkward._meta.bitmaskedmeta import BitMaskedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._regularize import is_integer, is_integer_like
@@ -477,7 +478,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._mask, ak._nplikes.placeholder.PlaceholderArray):
+        if isinstance(self._mask, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -376,6 +376,11 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        if isinstance(self._mask, ak._nplikes.placeholder.PlaceholderArray):
+            return True
+        return self._content._is_getitem_at_placeholder()
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -14,6 +14,7 @@ from awkward._meta.bytemaskedmeta import ByteMaskedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._parameters import (
@@ -377,7 +378,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._mask, ak._nplikes.placeholder.PlaceholderArray):
+        if isinstance(self._mask, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -697,6 +697,9 @@ class Content(Meta):
                 + repr(where).replace("\n", "\n    ")
             )
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        raise NotImplementedError
+
     def _getitem_at(self, where: IndexType):
         raise NotImplementedError
 

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -171,6 +171,9 @@ class EmptyArray(EmptyMeta, Content):
     def _getitem_nothing(self):
         return self
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return False
+
     def _getitem_at(self, where: IndexType):
         raise ak._errors.index_error(self, where, "array is empty")
 

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -281,6 +281,11 @@ class IndexedArray(IndexedMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        if isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray):
+            return True
+        return self._content._is_getitem_at_placeholder()
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -12,6 +12,7 @@ from awkward._meta.indexedmeta import IndexedMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._parameters import (
@@ -282,7 +283,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray):
+        if isinstance(self._index, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -12,6 +12,7 @@ from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
 from awkward._parameters import (
@@ -303,7 +304,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray):
+        if isinstance(self._index, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -302,6 +302,11 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        if isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray):
+            return True
+        return self._content._is_getitem_at_placeholder()
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -11,6 +11,7 @@ from awkward._layout import maybe_posaxis
 from awkward._meta.listmeta import ListMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
 from awkward._parameters import (
@@ -309,9 +310,8 @@ class ListArray(ListMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        return (
-            isinstance(self._starts, ak._nplikes.placeholder.PlaceholderArray)
-            or isinstance(self._stops, ak._nplikes.placeholder.PlaceholderArray)
+        return isinstance(self._starts, PlaceholderArray) or isinstance(
+            self._stops, PlaceholderArray
         )
 
     def _getitem_at(self, where: IndexType):

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -308,6 +308,12 @@ class ListArray(ListMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return (
+            isinstance(self._starts, ak._nplikes.placeholder.PlaceholderArray)
+            or isinstance(self._stops, ak._nplikes.placeholder.PlaceholderArray)
+        )
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -305,6 +305,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return isinstance(self._offsets, ak._nplikes.placeholder.PlaceholderArray)
+
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -12,6 +12,7 @@ from awkward._meta.listoffsetmeta import ListOffsetMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
 from awkward._parameters import (
@@ -306,7 +307,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        return isinstance(self._offsets, ak._nplikes.placeholder.PlaceholderArray)
+        return isinstance(self._offsets, PlaceholderArray)
 
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -245,9 +245,15 @@ class NumpyArray(NumpyMeta, Content):
             )
 
         extra = self._repr_extra(indent + "    ")
-        arraystr_lines = self._backend.nplike.array_str(
-            self._data, max_line_width=30
-        ).split("\n")
+
+        if isinstance(
+            self._data, (TypeTracerArray, ak._nplikes.placeholder.PlaceholderArray)
+        ):
+            arraystr_lines = ["[## ... ##]"]
+        else:
+            arraystr_lines = self._backend.nplike.array_str(
+                self._data, max_line_width=30
+            ).split("\n")
 
         if len(extra) != 0 or len(arraystr_lines) > 1:
             arraystr_lines = self._backend.nplike.array_str(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -298,6 +298,9 @@ class NumpyArray(NumpyMeta, Content):
             backend=self._backend,
         )
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return isinstance(self._data, ak._nplikes.placeholder.PlaceholderArray)
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data and len(self._data.shape) == 1:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -17,6 +17,7 @@ from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracerArray
 from awkward._parameters import (
@@ -246,9 +247,7 @@ class NumpyArray(NumpyMeta, Content):
 
         extra = self._repr_extra(indent + "    ")
 
-        if isinstance(
-            self._data, (TypeTracerArray, ak._nplikes.placeholder.PlaceholderArray)
-        ):
+        if isinstance(self._data, (TypeTracerArray, PlaceholderArray)):
             arraystr_lines = ["[## ... ##]"]
         else:
             arraystr_lines = self._backend.nplike.array_str(
@@ -305,7 +304,7 @@ class NumpyArray(NumpyMeta, Content):
         )
 
     def _is_getitem_at_placeholder(self) -> bool:
-        return isinstance(self._data, ak._nplikes.placeholder.PlaceholderArray)
+        return isinstance(self._data, PlaceholderArray)
 
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data and len(self._data.shape) == 1:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -437,6 +437,9 @@ class RecordArray(RecordMeta[Content], Content):
     def _getitem_nothing(self) -> Content:
         return self._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return False
+
     def _getitem_at(self, where: IndexType):
         if self._backend.nplike.known_data and where < 0:
             where += self.length

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -293,6 +293,9 @@ class RegularArray(RegularMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return False
+
     def _getitem_at(self, where: IndexType):
         index_nplike = self._backend.index_nplike
         where = index_nplike.regularize_index_for_length(where, self._length)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -14,6 +14,7 @@ from awkward._meta.unionmeta import UnionMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
 from awkward._parameters import parameters_intersect, parameters_union
@@ -541,9 +542,8 @@ class UnionArray(UnionMeta[Content], Content):
         return self._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if (
-            isinstance(self._tags, ak._nplikes.placeholder.PlaceholderArray)
-            or isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray)
+        if isinstance(self._tags, PlaceholderArray) or isinstance(
+            self._index, PlaceholderArray
         ):
             return False
         for content in self._contents:

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -540,6 +540,17 @@ class UnionArray(UnionMeta[Content], Content):
     def _getitem_nothing(self):
         return self._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        if (
+            isinstance(self._tags, ak._nplikes.placeholder.PlaceholderArray)
+            or isinstance(self._index, ak._nplikes.placeholder.PlaceholderArray)
+        ):
+            return False
+        for content in self._contents:
+            if content._is_getitem_at_placeholder():
+                return False
+        return True
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -231,6 +231,9 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
 
+    def _is_getitem_at_placeholder(self) -> bool:
+        return self._content._is_getitem_at_placeholder()
+
     def _getitem_at(self, where: IndexType):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -183,9 +183,16 @@ class Index:
         out.append(" len=")
         out.append(repr(str(self._data.shape[0])))
 
-        arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
-            "\n"
-        )
+        if isinstance(
+            self._data,
+            (ak._nplikes.typetracer.TypeTracerArray, ak._nplikes.placeholder.PlaceholderArray)
+        ):
+            arraystr_lines = ["[## ... ##]"]
+        else:
+            arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
+                "\n"
+            )
+
         if len(arraystr_lines) > 1 or self._metadata is not None:
             arraystr_lines = self._nplike.array_str(
                 self._data, max_line_width=max(80 - len(indent) - 4, 40)

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -11,8 +11,9 @@ from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
+from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem
-from awkward._nplikes.typetracer import TypeTracer
+from awkward._nplikes.typetracer import TypeTracer, TypeTracerArray
 from awkward._slicing import normalize_slice
 from awkward._typing import Any, DType, Final, Self, cast
 
@@ -183,15 +184,12 @@ class Index:
         out.append(" len=")
         out.append(repr(str(self._data.shape[0])))
 
-        if isinstance(
-            self._data,
-            (ak._nplikes.typetracer.TypeTracerArray, ak._nplikes.placeholder.PlaceholderArray)
-        ):
+        if isinstance(self._data, (TypeTracerArray, PlaceholderArray)):
             arraystr_lines = ["[## ... ##]"]
         else:
-            arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
-                "\n"
-            )
+            arraystr_lines = self._nplike.array_str(
+                self._data, max_line_width=30
+            ).split("\n")
 
         if len(arraystr_lines) > 1 or self._metadata is not None:
             arraystr_lines = self._nplike.array_str(

--- a/tests/test_2027_add_data_touch_reporting_to_TypeTracerArray.py
+++ b/tests/test_2027_add_data_touch_reporting_to_TypeTracerArray.py
@@ -82,6 +82,7 @@ def test_prototypical_example():
         "numpy-pt",
     ]
 
+    # changed behavior: printing should not touch data anymore
     print(restructured.muons.mass)
     assert report.data_touched == [
         "listoffset-1",
@@ -90,5 +91,4 @@ def test_prototypical_example():
         "listoffset-4",
         "numpy-eta",
         "numpy-pt",
-        "numpy-mass",
     ]


### PR DESCRIPTION
I think the rationale for having `print(array)` touch all of the data in `array` (whether it's high-level or a layout) is so that the delayed operation is exactly the same as an eager operation. In Dask, a DAG-builder has to touch everything in a `print(array)` operation so that all of the data will be available to the Dask worker to actually print that string.

However,

* The Dask worker is by definition non-interactive. No one is looking at the `print` output.
* A `print` operation on deeply nested data is probably not sensitive to all of the deeply nested data—it's limited to a line width or 80 characters (configurable), so only a few parts of it are going to get printed. The Awkward 1 VirtualArray was careful to only materialize that which appears in the printed string, for a point of comparison.
* Even if the Dask worker saves the `__str__` or `__repr__` string to a variable and does some computations with it, and even if the relevant data are close enough to the beginning or end of the array to appear in that string, I don't think there is (or should be) a strong user expectation that this string will be exactly the same as a string you'd get from an eager array. The string representation of a Python object, intended for interactive feedback, should not be relied upon programmatically. For example, whenever anyone does

```python
[float(x) for x in str(a).lstrip("[").rstrip("]").split(" ")]
```

to get the values of a NumPy array, they are doing a Bad Thing™.

I think there's a stronger user expectation that observing the string representation of a Python object does not change that object, and that inclusion in the set of "touched" buffers is an important enough change to worry about.

This PR does two things:

1. It makes high-level and layout string representations (`__str__` and `__repr__`) non-touching, and it only affects the string representation context (i.e. not changing every use of `array_str`, just those in `__str__` and `__repr__`).
2. It gives PlaceholderArray a string representation, instead of an error, when it is accessed in the string representation context (only).

There is now a difference between `__str__` and `__repr__` on eager arrays versus in delayed operations: on eager arrays, the string representations contain values, and in delayed operations, they contain values _if_ some other operation touched that data, and `??` placeholders otherwise.

To demonstrate that high-level and layout string representations no longer touch:

```python
>>> a = ak.Array([1, 2, 3])
>>> layout, report = ak.typetracer.typetracer_with_report(a.layout.form_with_key())
>>> report.data_touched, report.shape_touched
([], [])
>>> b = ak.Array(layout)
>>> report.data_touched, report.shape_touched
([], [])
>>> b
<Array-typetracer [...] type='## * int64'>
>>> report.data_touched, report.shape_touched
([], ['node0'])
```

and

```python
>>> layout, report = ak.typetracer.typetracer_with_report(a.layout.form_with_key())
>>> report.data_touched, report.shape_touched
([], [])
>>> layout
<NumpyArray dtype='int64' len='##'>[## ... ##]</NumpyArray>
>>> report.data_touched, report.shape_touched
([], ['node0'])
```

They touch the shape but not the data. I'm 90% sure that touching the shape does not invoke data-reading, only metadata, right @agoose77 and @martindurant?

Now to show that the Dask worker will not explode when trying to work with the data that now has PlaceholderArrays anywhere that hasn't been touched by some operation other than the printing:

```python
>>> from awkward._nplikes.numpy import Numpy
>>> from awkward._nplikes.placeholder import PlaceholderArray
>>> z = ak.contents.NumpyArray(PlaceholderArray(Numpy.instance(), (3,), np.int64))
>>> z
<NumpyArray dtype='int64' len='3'>[## ... ##]</NumpyArray>
>>> ak.Array(z)
<Array [??, ??, ??] type='3 * int64'>
```

_I have not added tests, and therefore, this PR is not ready to be merged!_

@agoose77, which test files should I fill with tests of `str(array)` for arrays containing TypeTracerArrays and PlaceholderArrays to be sure that the TypeTracerArrays don't report as data-touching and that the PlaceholderArrays don't raise TypeErrors? I want to efficiently cover all of the cases. (I could make a new suite of examples to test, but I think there are probably examples in some test file already.)