### PR TITLE
fix: return ufunc as it is for user defined `vectorize`d funcs

### DIFF
--- a/src/awkward/_connect/jax/__init__.py
+++ b/src/awkward/_connect/jax/__init__.py
@@ -9,4 +9,4 @@ from awkward._connect.jax.trees import register_pytree_class  # noqa: F401
 
 
 def get_jax_ufunc(ufunc):
-    return getattr(jax.numpy, ufunc.__name__)
+    return getattr(jax.numpy, ufunc.__name__, ufunc)

--- a/tests/test_2603_custom_behaviors_with_jax.py
+++ b/tests/test_2603_custom_behaviors_with_jax.py
@@ -1,0 +1,38 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+numba = pytest.importorskip("numba")
+
+
+def test():
+    behavior = {}
+
+    ak.jax.register_and_check()
+
+    input_arr = ak.Array([1.0], backend="jax")
+
+    @numba.vectorize(
+        [
+            numba.float32(numba.float32, numba.float32),
+            numba.float64(numba.float64, numba.float64),
+        ]
+    )
+    def _some_kernel(x, y):
+        return x * x + y * y
+
+    @ak.mixin_class(behavior)
+    class SomeClass:
+        @property
+        def some_kernel(self):
+            return _some_kernel(self.x, self.y)
+
+    ak.behavior.update(behavior)
+
+    arr = ak.zip({"x": input_arr, "y": input_arr}, with_name="SomeClass")
+
+    assert ak.all(arr.some_kernel == ak.Array([2.0], backend="jax"))


### PR DESCRIPTION
Fixes #2603 