### PR TITLE
fix: throw more meaningful error message for non-NumPy buffers

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -82,7 +82,7 @@ class NumpyKernel(BaseKernel):
                 return ctypes.cast(x, t)
             else:
                 raise AssertionError(
-                    "CuPy buffers shouldn't be passed to Numpy Kernels."
+                    f"Only NumPy buffers should be passed to Numpy Kernels, received {type(t).__name__}"
                 )
         else:
             return x


### PR DESCRIPTION
Improves dask-contrib/dask-awkward#472