### PR TITLE
fix: proper typetracer array slicing in `BitMaskedArray`

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -471,7 +471,9 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 self._lsb_order,
             )
         )
-        return bytemask.data[: self._length].view(np.bool_)
+        return bytemask.data[
+            : self._backend.index_nplike.shape_item_as_index(self._length)
+        ].view(np.bool_)
 
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)

--- a/tests/test_3028_mask_bitmaskedarray.py
+++ b/tests/test_3028_mask_bitmaskedarray.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+from awkward.typetracer import unknown_length
+
+
+def test():
+    arr = (
+        ak.mask([1, 2, 3], [True, False, False], highlevel=False)
+        .to_BitMaskedArray(valid_when=True, lsb_order=True)
+        .to_typetracer(forget_length=True)
+    )
+
+    result = arr.mask_as_bool()
+    assert result.dtype == np.dtype("bool")
+    assert result.ndim == 1
+    assert result.size is unknown_length


### PR DESCRIPTION
A long-running design choice was to avoid handling unknown-lengths as indices in `TypeTracerArray`; the caller (usually `Content` methods) would normalise to unknown-scalars (0D arrays).

This PR fixes a place where this assumption is not properly ensured, which was surfaced during testing of dask-awkward.

In the long run, I'd be in favour of relaxing this assumption and requiring that `TypeTracerArray` properly normalise unknown lengths to unknown scalars, but that's out of scope for this fix.