### PR TITLE
ci: Update scientific-python/upload-nightly-action from 0.3.0 to 0.4.0

### DIFF
--- a/.github/workflows/upload_nightly_wheels.yml
+++ b/.github/workflows/upload_nightly_wheels.yml
@@ -58,7 +58,7 @@ jobs:
           ls -l dist/
 
       - name: Upload wheels to Anaconda Cloud as nightlies
-        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
+        uses: scientific-python/upload-nightly-action@95f7bf6a22281b8072fae929429dd0408f09ea63 # 0.4.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_organization: scikit-hep-nightly-wheels


### PR DESCRIPTION
* Update the scientific-python/upload-nightly-action to v0.4.0 to avoid issues with uploading wheels of the same name to Anaconda Cloud where the project being uploaded to only contains one wheel (the one being replaced).
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.4.0

I know that Dependabot manages the GitHub Actions updates, but this release was made specifically to try to fix the issues that `networkx` and Awkward has been having around uploads, so I wanted to get this in sooner than later.