### PR TITLE
ci: Upload nightly wheels to scientific-python-nightly-wheels org

### DIFF
--- a/.github/workflows/upload_nightly_wheels.yml
+++ b/.github/workflows/upload_nightly_wheels.yml
@@ -61,5 +61,4 @@ jobs:
         uses: scientific-python/upload-nightly-action@95f7bf6a22281b8072fae929429dd0408f09ea63 # 0.4.0
         with:
           artifacts_path: dist
-          anaconda_nightly_upload_organization: scikit-hep-nightly-wheels
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
On 2024-02-22 Awkward was given approval to upload nightly wheels to the `scientific-python-nightly-wheels` Anaconda Cloud org (https://github.com/scientific-python/upload-nightly-action/issues/29#issuecomment-1960383256). As the [default org for the `scientific-python/upload-nightly-action` GitHub Action is `scientific-python/upload-nightly-action`](https://github.com/scientific-python/upload-nightly-action/blob/2c7042c3f27f5e3b8626afb090bb73ece46b485f/action.yml#L17-L20) then the `anaconda_nightly_upload_organization` key can just be removed.
   - c.f. https://anaconda.org/scientific-python-nightly-wheels