### PR TITLE
docs: fix styling of icons

### DIFF
--- a/docs/_static/css/awkward.css
+++ b/docs/_static/css/awkward.css
@@ -8,7 +8,7 @@ html[data-theme="dark"] .sd-card {
     background: var(--pst-color-surface);
 }
 
-.sd-card-header .fas {
+.sd-card-header .svg-inline--fa {
     font-size: 3em;
 }
 

--- a/docs/_static/css/try-awkward-array.css
+++ b/docs/_static/css/try-awkward-array.css
@@ -1,12 +1,12 @@
 /*Styles for our try-awkward-array demo*/
-[role=main] {
+.bd-article {
     flex-grow: 1;
     /*Allow children to grow*/
     display: flex;
     flex-direction: column;
 }
 
-[role=main] > * {
+.bd-article > * {
     /*Accomodate parent size*/
     flex-grow: 1;
     /*Allow children to grow*/


### PR DESCRIPTION
It looks like the CSS selector for the fontawesome icons has changed, leading to too-small icons. This PR rectifies that!

Closes #3040, fixes #3041