### PR TITLE
docs: add a link to documentation of AwkwardArray in Julia

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Spotted a typo in the documentation? Want to add to the codebase? The contributi
 :link: https://juliahep.github.io/AwkwardArray.jl/dev/
 :class-card: admonition warning
 
-Looking for the documentation for Awkward Array in Julia? Click this card.
+<img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNC4zNzYyMzk4bW0iIGhlaWdodD0iNC4wNzkxODE3bW0iIHZpZXdCb3g9IjAgMCA0LjM3NjIzOTggNC4wNzkxODE3IiB2ZXJzaW9uPSIxLjEiIHN0eWxlPSJmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6MC4wNTgxODI7IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPiA8Y2lyY2xlIHN0eWxlPSJmaWxsOiNjYjNjMzM7IiBjeD0iMS4wNzA5NSIgY3k9IjMuMDA4MjMxIiByPSIwLjk3MDk1MTU2IiAvPiA8Y2lyY2xlIHN0eWxlPSJmaWxsOiM5NTU4YjI7IiBjeD0iMy4zMDUyOSIgY3k9IjMuMDA4MjMxIiByPSIwLjk3MDk1MTU2IiAvPiA8Y2lyY2xlIHN0eWxlPSJmaWxsOiMzODk4MjY7IiBjeD0iMi4xODgxNCIgY3k9IjEuMDcwOTUyIiByPSIwLjk3MDk1MTU2IiAvPiA8L3N2Zz4="> Looking for the documentation for Awkward Array in Julia? Click this card.
 ::::
     
 :::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Spotted a typo in the documentation? Want to add to the codebase? The contributi
 :link: https://juliahep.github.io/AwkwardArray.jl/dev/
 :class-card: admonition warning
 
-{fas}`ellipsis` Looking for the documentation for Awkward Array in Julia? Click this card.
+Looking for the documentation for Awkward Array in Julia? Click this card.
 ::::
     
 :::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,15 @@ Spotted a typo in the documentation? Want to add to the codebase? The contributi
 :class-card: admonition warning
 
 {fas}`history` Need the documentation for version 1 of Awkward Array? Click this card.
+
+:::
+
+:::{grid-item-card} 
+:columns: 12
+:link: https://juliahep.github.io/AwkwardArray.jl/dev/
+:class-card: admonition warning
+
+{fas}`history` Looking for the documentation for Awkward Array in Julia? Click this card.
 ::::
     
 :::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Spotted a typo in the documentation? Want to add to the codebase? The contributi
 :link: https://juliahep.github.io/AwkwardArray.jl/dev/
 :class-card: admonition warning
 
-{fas}`history` Looking for the documentation for Awkward Array in Julia? Click this card.
+{fas}`ellipsis` Looking for the documentation for Awkward Array in Julia? Click this card.
 ::::
     
 :::::


### PR DESCRIPTION
AwkwardArray in Julia documentation is created by Documenter.jl.