### PR TITLE
test: TEMPORARY edits to get tests working for all PRs: NumPy 2.0 cap and turned off Try-It

### DIFF
--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "30"
 dependencies = [
-    "numpy>=1.18.0",
+    "numpy>=1.18.0,<2.0",
     "importlib_resources;python_version < \"3.9\""
 ]
 readme = "README.md"

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -10,7 +10,7 @@ subtrees:
       - file: getting-started/index
         subtrees:
             - entries:
-              - file: getting-started/try-awkward-array
+#              - file: getting-started/try-awkward-array
               - file: getting-started/community-tutorials
               - file: getting-started/papers-and-talks
       - file: user-guide/index

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "myst_nb",
     # Preserve old links
-    "jupyterlite_sphinx",
+    # "jupyterlite_sphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
 ]

--- a/docs/getting-started/demo/what-is-an-awkward-array.ipynb
+++ b/docs/getting-started/demo/what-is-an-awkward-array.ipynb
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "# Install Awkward Array in the browser\n",
-    "import piplite; await piplite.install(\"awkward-cpp\"); await piplite.install(\"awkward>=2.0\")\n",
+    "import piplite; await piplite.install(\"awkward-cpp\"); await piplite.install(\"awkward==2.5.0\")\n",
     "\n",
     "# Import normal libraries\n",
     "import numpy as np\n",

--- a/docs/getting-started/try-awkward-array.md
+++ b/docs/getting-started/try-awkward-array.md
@@ -1,5 +1,9 @@
 # Try it
 
+<!--
+
 :::{retrolite} demo/what-is-an-awkward-array.ipynb
    :height: auto
 :::
+
+-->

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,12 +28,12 @@ Awkward Array is a library for **nested, variable-sized data**, including arbitr
 :class: shield-badge
 :::
 
-% Unfortunately, `target` does not support document references
-:::{image} https://img.shields.io/badge/-Try%20It%21-orange?style=for-the-badge
-:alt: Try It!
-:target: getting-started/try-awkward-array.html
-:class: shield-badge
-:::
+% % Unfortunately, `target` does not support document references
+% :::{image} https://img.shields.io/badge/-Try%20It%21-orange?style=for-the-badge
+% :alt: Try It!
+% :target: getting-started/try-awkward-array.html
+% :class: shield-badge
+% :::
 
 ::::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==30",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.18.0",
+    "numpy>=1.18.0,<2.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"


### PR DESCRIPTION
This must not propagate into any non-RC releases of Awkward because [upper caps on version dependencies are bad for libraries](https://iscinumpy.dev/post/bound-version-constraints/). But, for the sake of merging PRs into `main`, we want to see that they pass all tests without NumPy 2.0, at least.

Note for @tcawlfield: when successful, I'll be merging this PR into `main` and from there into all of the open PRs. Naturally, it should not go into your PR that is fixing #2936. (Your PR can just remove these `,<2.0` constraints, and when it works, it will merge into `main` and everyone else will get the benefits at that time.)