### PR TITLE
fix: Support structured arrays in option type to_numpy

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1596,11 +1596,11 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
                 if content.dtype.names is not None:
                     missing_data = tuple(
-                        create_missing_data(each_dtype)
+                        create_missing_data(each_dtype, backend)
                         for each_dtype, _ in content.dtype.fields.values()
                     )
                 else:
-                    missing_data = create_missing_data(content.dtype)
+                    missing_data = create_missing_data(content.dtype, backend)
 
                 data[mask0] = missing_data
 
@@ -1766,7 +1766,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         )
 
 
-def create_missing_data(dtype):
+def create_missing_data(dtype, backend):
     """Create missing data based on the input dtype
 
     Missing data are represented differently based on the Numpy array
@@ -1784,7 +1784,7 @@ def create_missing_data(dtype):
     elif np.issubdtype(dtype.type, np.datetime64) or np.issubdtype(
         dtype.type, np.timedelta64
     ):
-        return nplike.asarray([np.iinfo(np.int64).max], dtype=dtype)[0]
+        return backend.nplike.asarray([np.iinfo(np.int64).max], dtype=dtype)[0]
     elif np.issubdtype(dtype, np.str_):
         return ""
     elif np.issubdtype(dtype, np.bytes_):

--- a/tests/test_3060_indexoption_to_numpy_record_array.py
+++ b/tests/test_3060_indexoption_to_numpy_record_array.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_to_numpy_record_array():
+    test_array = ak.Array([{"x": 1, "y": 1.1}, None]).to_numpy()
+    expected_numpy = np.ma.masked_array(
+        data=[(1, 1.1), (np.iinfo(np.int64).max, np.nan)],
+        mask=[(False, False), (True, True)],
+        dtype=[("x", "<i8"), ("y", "<f8")],
+    )
+    assert np.array_equal(test_array["x"], expected_numpy["x"])
+    # equal_nan not supported on integer arrays
+    assert np.array_equal(test_array["y"], expected_numpy["y"], equal_nan=True)

--- a/tests/test_3060_indexoption_to_numpy_record_array.py
+++ b/tests/test_3060_indexoption_to_numpy_record_array.py
@@ -16,4 +16,8 @@ def test_to_numpy_record_array():
     )
     assert np.array_equal(test_array["x"], expected_numpy["x"])
     # equal_nan not supported on integer arrays
-    assert np.array_equal(test_array["y"], expected_numpy["y"], equal_nan=True)
+    try:
+        assert np.array_equal(test_array["y"], expected_numpy["y"], equal_nan=True)
+    except TypeError:
+        # older numpy versions do not support `equal_nan`
+        assert np.array_equal(test_array["y"].filled(), expected_numpy["y"].filled())


### PR DESCRIPTION
- [test] implement unit test for `to_numpy` on option-type of record type
- [fix] handle structured arrays for option-type

See https://github.com/scikit-hep/awkward/issues/3056
