### PR TITLE
fix: Windows and 32-bit Linux default to 32-bit integers in sums and prods UNLESS it's NumPy 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,14 @@ jobs:
             python-architecture: x64
             runs-on: ubuntu-latest
             dependencies-kind: numpy2
+          - python-version: '3.11'
+            python-architecture: x64
+            runs-on: macos-11
+            dependencies-kind: numpy2
+          - python-version: '3.11'
+            python-architecture: x64
+            runs-on: windows-latest
+            dependencies-kind: numpy2
 
     runs-on: ${{ matrix.runs-on }}
 

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -64,11 +64,14 @@ class KernelReducer(Reducer):
 
     @classmethod
     def _promote_integer_rank(cls, given_dtype: DTypeLike) -> DTypeLike:
-        if given_dtype in (np.bool_, np.int8, np.int16, np.int32):
-            return np.int32 if ak._util.win or ak._util.bits32 else np.int64
+        if (ak._util.win or ak._util.bits32) and isinstance(given_dtype, type):
+            return numpy._module.sum([given_dtype(0)]).dtype.type
+
+        elif given_dtype in (np.bool_, np.int8, np.int16, np.int32):
+            return np.int64
 
         elif given_dtype in (np.uint8, np.uint16, np.uint32):
-            return np.uint32 if ak._util.win or ak._util.bits32 else np.uint64
+            return np.uint64
 
         else:
             return given_dtype

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -62,16 +62,15 @@ class KernelReducer(Reducer):
         else:
             return dtype
 
+    _use32 = (ak._util.win or ak._util.bits32) and not ak._util.numpy2
+
     @classmethod
     def _promote_integer_rank(cls, given_dtype: DTypeLike) -> DTypeLike:
-        if (ak._util.win or ak._util.bits32) and isinstance(given_dtype, type):
-            return numpy._module.sum([given_dtype(0)]).dtype.type
-
-        elif given_dtype in (np.bool_, np.int8, np.int16, np.int32):
-            return np.int64
+        if given_dtype in (np.bool_, np.int8, np.int16, np.int32):
+            return np.int32 if cls._use32 else np.int64
 
         elif given_dtype in (np.uint8, np.uint16, np.uint32):
-            return np.uint64
+            return np.uint32 if cls._use32 else np.uint64
 
         else:
             return given_dtype

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -8,10 +8,15 @@ import struct
 import sys
 from collections.abc import Collection
 
+import numpy as np  # noqa: TID251
+import packaging
+
 from awkward._typing import TypeVar
 
 win = os.name == "nt"
 bits32 = struct.calcsize("P") * 8 == 32
+numpy2 = packaging.version.parse(np.__version__) >= packaging.version.Version("2.0.0b1")
+
 
 # matches include/awkward/common.h
 kMaxInt8 = 127  # 2**7  - 1

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import Collection
 
 import numpy as np  # noqa: TID251
-import packaging
+import packaging.version
 
 from awkward._typing import TypeVar
 


### PR DESCRIPTION
Caught in this test: https://github.com/scikit-hep/awkward/actions/runs/8511994785/job/23312715586

Although we could check all platforms with

```python
numpy._module.sum([given_dtype(0)]).dtype.type
```

I want to limit that to only the unusual platforms (Windows and 32-bit Linux) because the others are a quick lookup, and I don't want to slow down metadata-checking any more.