### PR TITLE
fix: refuse dak.Array in hidden-but-public-functions

### DIFF
--- a/src/awkward/operations/ak_backend.py
+++ b/src/awkward/operations/ak_backend.py
@@ -14,7 +14,7 @@ def backend(*arrays):
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).
 
-    Returns the names of the backend used by `arrays`. This name may be
+    Returns the name of the backend used by `arrays`. This name may be
 
     * `"cpu"` for arrays backed by NumPy;
     * `"cuda"` for arrays backed by CuPy;

--- a/src/awkward/typetracer.py
+++ b/src/awkward/typetracer.py
@@ -61,6 +61,11 @@ def _length_0_1_if_typetracer(
 ) -> T:
     typetracer_backend = TypeTracerBackend.instance()
 
+    if type(array).__module__.startswith("dask_awkward."):
+        raise TypeError(
+            "ak.typetracer._length_0_1_if_typetracer cannot take a dask-awkward Array; pass its '_meta' instead"
+        )
+
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(
             array,
@@ -149,6 +154,12 @@ def touch_data(
 
     Recursively touches the data and returns a shall copy of the given array.
     """
+
+    if type(array).__module__.startswith("dask_awkward."):
+        raise TypeError(
+            "ak.typetracer.touch_data cannot take a dask-awkward Array; pass its '_meta' instead"
+        )
+
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(
             array,


### PR DESCRIPTION
This is solution (3) from https://github.com/scikit-hep/awkward/issues/3077#issuecomment-2050099114, but I made it a "refuse if dask-awkward," rather than "convert if dask-awkward." They're hidden-but-public (L2) functions, so they can be restrictive. If dask-awkward ever does write overloads for them, those overloads can be a way to avoid this behavior (so we're not making decisions _for_ dask-awkward).

To fix the ATLAS problem, Coffea will need to make an update, to be more careful about `dak.Array` versus `dak.Array._meta`.