### PR TITLE
docs: Add installation of nightly wheels instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,3 +303,14 @@ To make an `awkward` release:
 3. A `docs/switcher.json` entry must be added for new minor/major versions.
 
 Pushes that modify `docs/switcher.json` on `main` will automatically be synchronised with AWS.
+
+#### Nightly wheels
+
+Nightly wheels of `awkward-cpp` and `awkward` are built and published to the [Scientific Python Nightly Wheels Anaconda Cloud organization](https://anaconda.org/scientific-python-nightly-wheels).
+As the `awkward-cpp` and `awkward` nightly wheels do not include version control system information, they will have the same version numbers as the last released versions on the public PyPI. To avoid resolution conflicts when installing the nightly wheels, it is recommended to first install `awkward-cpp` and `awkward` from PyPI to get all of their dependencies, then uninstall `awkward-cpp` and `awkward` and install the nightly wheels from the Scientific Python nightly index.
+
+```
+python -m pip install --upgrade awkward
+python -m pip uninstall --yes awkward awkward-cpp
+python -m pip install --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple awkward
+```


### PR DESCRIPTION
* Add installation instructions for the awkward-cpp and awkward nightly wheels to the contributing / developer documentation under the releases section.

Example of why the multiple steps are needed (until PR https://github.com/scikit-hep/awkward/pull/3007 is merged):

* Trying to install everything in a single command results in download from PyPI

```console
$ docker run --rm -ti python:3.12 /bin/bash
root@114e4c8010d2:/# python -m venv venv && . venv/bin/activate
(venv) root@114e4c8010d2:/# python -m pip --quiet install --upgrade pip wheel
(venv) root@114e4c8010d2:/# python -m pip install --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple awkward
Looking in indexes: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple, https://pypi.org/simple
Collecting awkward
  Downloading awkward-2.6.3-py3-none-any.whl.metadata (7.0 kB)
Collecting awkward-cpp==32 (from awkward)
  Downloading awkward_cpp-32-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.2 kB)
Collecting fsspec>=2022.11.0 (from awkward)
  Downloading fsspec-2024.3.1-py3-none-any.whl.metadata (6.8 kB)
Collecting numpy>=1.18.0 (from awkward)
  Downloading numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.0/61.0 kB 1.2 MB/s eta 0:00:00
Collecting packaging (from awkward)
  Downloading packaging-24.0-py3-none-any.whl.metadata (3.2 kB)
Downloading awkward-2.6.3-py3-none-any.whl (787 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 787.9/787.9 kB 8.0 MB/s eta 0:00:00
Downloading awkward_cpp-32-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (707 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 707.2/707.2 kB 57.6 MB/s eta 0:00:00
Downloading fsspec-2024.3.1-py3-none-any.whl (171 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 172.0/172.0 kB 22.8 MB/s eta 0:00:00
Downloading numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (18.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 18.0/18.0 MB 53.4 MB/s eta 0:00:00
Downloading packaging-24.0-py3-none-any.whl (53 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 53.5/53.5 kB 12.2 MB/s eta 0:00:00
Installing collected packages: packaging, numpy, fsspec, awkward-cpp, awkward
Successfully installed awkward-2.6.3 awkward-cpp-32 fsspec-2024.3.1 numpy-1.26.4 packaging-24.0
(venv) root@114e4c8010d2:/#
```

* Getting dependencies first allows for installing from the nightly index

```console
$ docker run --rm -ti python:3.12 /bin/bash
root@3ff6f2d3abac:/# python -m venv venv && . venv/bin/activate
(venv) root@3ff6f2d3abac:/# python -m pip --quiet install --upgrade pip wheel
(venv) root@3ff6f2d3abac:/# python -m pip --quiet install awkward
(venv) root@3ff6f2d3abac:/# python -m pip uninstall --yes awkward awkward-cpp
Found existing installation: awkward 2.6.3
Uninstalling awkward-2.6.3:
  Successfully uninstalled awkward-2.6.3
Found existing installation: awkward-cpp 32
Uninstalling awkward-cpp-32:
  Successfully uninstalled awkward-cpp-32
(venv) root@3ff6f2d3abac:/# python -m pip install --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple awkward
Looking in indexes: https://pypi.org/simple, https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
Collecting awkward
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/awkward/2.6.3/awkward-2.6.3-py3-none-any.whl (788 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 788.1/788.1 kB 3.9 MB/s eta 0:00:00
Collecting awkward-cpp==32 (from awkward)
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/awkward-cpp/32/awkward_cpp-32-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (707 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 707.2/707.2 kB 28.9 MB/s eta 0:00:00
Requirement already satisfied: fsspec>=2022.11.0 in /venv/lib/python3.12/site-packages (from awkward) (2024.3.1)
Requirement already satisfied: numpy>=1.18.0 in /venv/lib/python3.12/site-packages (from awkward) (1.26.4)
Requirement already satisfied: packaging in /venv/lib/python3.12/site-packages (from awkward) (24.0)
Installing collected packages: awkward-cpp, awkward
Successfully installed awkward-2.6.3 awkward-cpp-32
(venv) root@3ff6f2d3abac:/# 
```