### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -68,12 +68,12 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         arch: [auto64]
         build: ["cp", "pp"]
 
         include:
-        - os: macos-latest
+        - os: macos-13
           type: "Universal"
           arch: universal2
           build: "cp"

--- a/.github/workflows/header-only-test.yml
+++ b/.github/workflows/header-only-test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Run Tests"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-13, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-13, ubuntu-latest]
+        os: [windows-latest, macos-12, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

The previous meaning was macos-12, now it is switching to macos-14.