### PR TITLE
fix: prevent exponential memory growth in UnionArray

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -431,7 +431,7 @@ class UnionArray(UnionMeta[Content], Content):
             ]
 
         if len(contents) == 1:
-            next = contents[0]._carry(index, True)
+            next = contents[0]._carry(index, False)
             return next.copy(parameters=parameters_union(next._parameters, parameters))
 
         else:
@@ -702,7 +702,7 @@ class UnionArray(UnionMeta[Content], Content):
         nextcarry = ak.index.Index64(
             tmpcarry.data[: lenout[0]], nplike=self._backend.index_nplike
         )
-        return self._contents[index]._carry(nextcarry, True)
+        return self._contents[index]._carry(nextcarry, False)
 
     @staticmethod
     def regular_index(

--- a/tests/test_2713_from_buffers_allow_noncanonical.py
+++ b/tests/test_2713_from_buffers_allow_noncanonical.py
@@ -120,9 +120,10 @@ def test_union_simplification():
     projected = ak.from_buffers(
         projected_form, length, container, allow_noncanonical_form=True
     )
+
     assert projected.layout.form.to_dict(verbose=False) == {
-        "class": "IndexedArray",
-        "index": "i64",
-        "content": {"class": "RecordArray", "fields": ["x"], "contents": ["int64"]},
+        "class": "RecordArray",
+        "fields": ["x"],
+        "contents": ["int64"],
     }
     assert ak.almost_equal(array[["x"]], projected)

--- a/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
+++ b/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
@@ -1,0 +1,34 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test():
+    one_a = ak.Array([{"x": 1, "y": 2}], with_name="T")
+    one_b = ak.Array([{"x": 1, "y": 2}], with_name="T")
+    two_a = ak.Array([{"x": 1, "z": 3}], with_name="T")
+    two_b = ak.Array([{"x": 1, "z": 3}], with_name="T")
+    three = ak.Array([{"x": 4}, {"x": 4}], with_name="T")
+
+    first = ak.zip({"a": one_a, "b": one_b})
+    second = ak.zip({"a": two_a, "b": two_b})
+
+    cat = ak.concatenate([first, second], axis=0)
+
+    cat["another"] = three
+
+    def check(layout):
+        if hasattr(layout, "contents"):
+            for x in layout.contents:
+                check(x)
+        elif hasattr(layout, "content"):
+            check(layout.content)
+        else:
+            assert layout.length <= 2
+
+    for _ in range(5):
+        check(cat.layout)
+
+        cat["another", "w"] = three.x


### PR DESCRIPTION
I decided to just make `UnionArray.simplified` not allow lazy carries. It should always return correct results and it can only have a performance impact on wide RecordArrays that go through `UnionArray.simplified` (perhaps via `ak.concatenate`).

The new test would fail for the old code: for 5 loops, the NumpyArray length gets up to 32, and we assert `<= 2`.

I only had to change one test, which was hard-coded to a particular Form. It was for testing `allow_noncanonical_form=True` in `ak.from_buffers`. I think that feature is still being tested with the updated test.

@agoose77, am I missing anything here? Would you do anything differently?