### PR TITLE
fix: Header-only fix is_valid for empty Indexed or IndexedOption

### DIFF
--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1235,6 +1235,7 @@ namespace awkward {
           out << "Indexed node" << id_ << " has a negative index\n";
           error.append(out.str());
           return false;
+        } else if ((content_.length() == 0) && (max_index_ == 0)) { // catches empty object
         } else if (max_index_ >= content_.length()) {
           std::stringstream out;
           out << "Indexed node" << id_ << " has index " << max_index_
@@ -1452,7 +1453,8 @@ namespace awkward {
       /// @brief Checks for validity and consistency.
       bool
       is_valid(std::string& error) const noexcept {
-        if (max_index_ >= content_.length()) {
+        if ((content_.length() == 0) && (max_index_ == 0)) { // catches empty object
+        } else if (max_index_ >= content_.length()) {
           std::stringstream out;
           out << "IndexedOption node" << id_ << " has index " << max_index_
               << " but content has length "

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -1149,8 +1149,7 @@ namespace awkward {
       /// returns the reference to the builder content.
       BUILDER&
       append_index() noexcept {
-        index_.append(content_.length());
-        return content_;
+        return append_index(content_.length());
       }
 
       /// @brief Inserts an explicit value in the `index` buffer and

--- a/header-only/tests/test_3091-layout-builder-is-valid.cpp
+++ b/header-only/tests/test_3091-layout-builder-is-valid.cpp
@@ -108,6 +108,16 @@ test_IndexedOption_categorical_invalid_index() {
 
 void
 test_Indexed_empty() {
+  IndexedBuilder<uint32_t, StringBuilder<double>> builder;
+  assert(builder.length() == 0);
+
+  // empty indexed builder should be valid
+  std::string error;
+  assert(builder.is_valid(error));
+}
+
+void
+test_IndexedOption_empty() {
   IndexedOptionBuilder<uint32_t, StringBuilder<double>> builder;
   assert(builder.length() == 0);
 
@@ -125,6 +135,7 @@ int main(int /* argc */, char ** /* argv */) {
   test_Indexed_categorical_invalid_index();
   test_IndexedOption_categorical();
   test_IndexedOption_categorical_invalid_index();
+  test_IndexedOption_empty();
   test_Indexed_empty();
 
   return 0;

--- a/header-only/tests/test_3091-layout-builder-is-valid.cpp
+++ b/header-only/tests/test_3091-layout-builder-is-valid.cpp
@@ -106,11 +106,26 @@ test_IndexedOption_categorical_invalid_index() {
   assert(assertion);
 }
 
+void
+test_Indexed_empty() {
+  IndexedOptionBuilder<uint32_t, StringBuilder<double>> builder;
+  assert(builder.length() == 0);
+
+  // empty indexed builder should be valid
+  std::string error;
+  assert(builder.is_valid(error));
+
+  // content has length 0 but still should be valid
+  builder.append_invalid();
+  assert(builder.is_valid(error));
+}
+
 int main(int /* argc */, char ** /* argv */) {
   test_Indexed_categorical();
   test_Indexed_categorical_invalid_index();
   test_IndexedOption_categorical();
   test_IndexedOption_categorical_invalid_index();
+  test_Indexed_empty();
 
   return 0;
 }

--- a/header-only/tests/test_3091-layout-builder-is-valid.cpp
+++ b/header-only/tests/test_3091-layout-builder-is-valid.cpp
@@ -53,7 +53,7 @@ test_Indexed_categorical_invalid_index() {
   subbuilder.append("two");
   builder.append_index(9);
   bool assertion = builder.is_valid(error) == !BUG_FIXED;
-  std::cout << error << std::endl;
+  // std::cout << error << std::endl;
   assert(assertion);
 }
 
@@ -71,7 +71,7 @@ test_IndexedOption_categorical() {
 
   std::string error;
   bool assertion = builder.is_valid(error);
-  std::cout << error << std::endl;
+  // std::cout << error << std::endl;
   assert(assertion);
 
   // index and content could have different lengths
@@ -95,14 +95,14 @@ test_IndexedOption_categorical_invalid_index() {
 
   std::string error;
   bool assertion = builder.is_valid(error);
-  std::cout << error << std::endl;
+  // std::cout << error << std::endl;
   assert(assertion);
 
   // index should be less than the length of content
   builder.append_valid(9);
   subbuilder.append("two");
   assertion = builder.is_valid(error) == !BUG_FIXED;
-  std::cout << error << std::endl;
+  // std::cout << error << std::endl;
   assert(assertion);
 }
 


### PR DESCRIPTION
Noticed that the implementation of `is_valid` in #3901
did not handle correctly empty objects.
In that case `max_index_` has the initial value of 0
the length of content is also 0.
Therefore `is_valid` fails because they are equal.

Added 2 test cases for this to the same file given they are related.

- test: test empty IndexedOption builders are valid
- test: suppress printout to avoid thinking tests fail
- fix: append_index() should call append_index(i)
- fix: specific case of is_valid to catch empty objects
- test: separate test case for empty Indexed and IndexedOption
