### PR TITLE
chore: pin pyarrow to 16.0.0

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -3,7 +3,7 @@ jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.12"
 numba>=0.50.0;sys_platform != "win32" and python_version < "3.12"
 numexpr>=2.7; python_version < "3.12"
 pandas>=0.24.0;sys_platform != "win32" and python_version < "3.12"
-pyarrow>=7.0.0;sys_platform != "win32" and python_version < "3.12"
+pyarrow==16.0.0;sys_platform != "win32" and python_version < "3.12"
 pytest>=6
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
until the issue https://github.com/apache/arrow/issues/41696 is fixed we cannot use 16.1.0