### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -18,6 +18,8 @@ jobs:
     if: inputs.publish-pypi
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     environment:
       name: "pypi"
       url: "https://pypi.org/project/awkward-cpp/"
@@ -31,5 +33,10 @@ jobs:
 
     - name: List distributions to be deployed
       run: ls -l dist/
+
+    - name: Generate artifact attestation for sdist and wheel
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      with:
+        subject-path: "dist/awkward-cpp-*"
 
     - uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,10 @@ jobs:
     name: "Build wheel & sdist"
     runs-on: ubuntu-latest
     needs: [determine-source-date-epoch]
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     steps:
@@ -82,6 +86,11 @@ jobs:
 
     - name: Check metadata
       run: pipx run twine check dist/*
+
+    - name: Generate artifact attestation for sdist and wheel
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      with:
+        subject-path: "dist/awkward-*"
 
     - uses: actions/upload-artifact@v4
       with:
@@ -112,6 +121,19 @@ jobs:
       with:
         name: distributions
         path: dist
+
+    - name: List distributions to be deployed
+      run: ls -l dist/
+
+    - name: Verify sdist artifact attestation
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/awkward-*.tar.gz --repo ${{ github.repository }}
+
+    - name: Verify wheel artifact attestation
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/awkward-*.whl --repo ${{ github.repository }}
 
     - uses: pypa/gh-action-pypi-publish@v1.8.14
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     files: ^tests/
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.2
+  rev: 0.28.4
   hooks:
     - id: check-github-workflows
       args: ["--verbose"]


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing awkward to PyPI using the 'gh attestation verify' CLI API, added in v2.49.0.
   - c.f. https://github.com/cli/cli/releases/tag/v2.49.0

As an example c.f. https://github.com/scikit-hep/pyhf/pull/2473.