### PR TITLE
ci: Ensure attestations for awkward-cpp sdist and wheels

### DIFF
--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -37,6 +37,6 @@ jobs:
     - name: Generate artifact attestation for sdist and wheel
       uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
       with:
-        subject-path: "dist/awkward-cpp-*"
+        subject-path: "dist/awkward*cpp-*"
 
     - uses: pypa/gh-action-pypi-publish@v1.8.14


### PR DESCRIPTION
* awkward-cpp's sdists are named `awkward-cpp-*.tar.gz` while the wheels are named `awkward_cpp-*.whl`, so to ensure that both the sdist and wheels get attestations use a wildcard to capture both `-` and `_`.
* Amends PR https://github.com/scikit-hep/awkward/pull/3126.