### PR TITLE
fix: don't let CuPy iterate over Index with Python for loops

### DIFF
--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -498,7 +498,9 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
             cumsum[1:] = item_backend.index_nplike.asarray(
                 item_backend.nplike.cumsum(flat_mask.data)
             )
-            nextoffsets = ak.index.Index(cumsum[item.offsets])
+
+            item_offsets = item_backend.index_nplike.asarray(item.offsets)
+            nextoffsets = ak.index.Index(cumsum[item_offsets])
 
         else:
             item._touch_data(recursive=False)
@@ -546,7 +548,8 @@ def _normalise_item_bool_to_int(item: Content, backend: Backend) -> Content:
             cumsum = item_backend.nplike.empty(expanded.shape[0] + 1, dtype=np.int64)
             cumsum[0] = 0
             cumsum[1:] = item_backend.nplike.cumsum(expanded)
-            nextoffsets = ak.index.Index(cumsum[item.offsets])
+            item_offsets = item_backend.index_nplike.asarray(item.offsets)
+            nextoffsets = ak.index.Index(cumsum[item_offsets])
 
             # outindex fits into the lists; non-missing are sequential
             outindex = ak.index.Index64(


### PR DESCRIPTION
Arguably, this is a performance thing, but it's so catastrophic that I'd call it a bug-fix.

@lgray noticed that slicing an Awkward-CUDA array was significantly slower than slicing an Awkward Array on the CPU. It's because CuPy thought that an `ak.index.Index` is a generic Python iterable, not a CUDA array.

We assumed that adding a `Index.__cuda_array_interface__` property would make CuPy notice that Index is a CUDA capable array. The [CuPy documentation](https://docs.cupy.dev/en/stable/user_guide/interoperability.html) describes instances in which it produces (for Numba) and consumes (from PyTorch) the `__cuda_array_interface__` property. However, none of those examples illustrate the pattern

```python
cupy_array[object_that_implements_cuda_interface]
```

(with a `cp.ndarray.__getitem__`). Since they don't promise to promote CUDA arrays on slices, I can't be sure that this is a CuPy bug.

At least to support existing versions of CuPy, we _can't_ make this assumption. I temporarily added this to Index:

```diff
--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -161,6 +161,31 @@ class Index:
     def __len__(self) -> int:
         return int(self.length)
 
+    _cycler = 0
+    def __getattr__(self, name):
+        if name == "__array_struct__":
+            self._cycler = 1
+            raise AttributeError(name)
+        elif name == "__array_interface__":
+            if self._cycler == 1:
+                self._cycler = 2
+            else:
+                self._cycler = 0
+            return self._data.__array_interface__
+        elif name == "__array__":
+            if self._cycler == 2:
+                self._cycler = 3
+                raise Exception(
+                    "CuPy is coming to the conclusion that Index is a Python iterable"
+                )
+            else:
+                self._cycler = 0
+            raise AttributeError(name)
+        elif name in self.__dict__:
+            return self.__dict__[name]
+        else:
+            raise AttributeError(name)
+
     @property
     def __cuda_array_interface__(self):
         return self._data.__cuda_array_interface__  # type: ignore[attr-defined]
```

and ran `pytest tests-cuda` to catch all instances that are covered by the tests.[^1] There were two (fixed in this PR).

@ManasviGoyal, can you check this?

@agoose77, do you think there might be other cases in which you assumed that CuPy would auto-promote an Index as a CUDA array?

Meanwhile, I'm going to report this to CuPy, just in case it is unintended/a bug.

[^1]: We have to do this "cycler" thing to identify requests for `__array_struct__`, `__array_interface__`, `__array__` in succession because CuPy does not appear in the stack trace. It's implemented in Cython, which doesn't emit Python stack frames.