### PR TITLE
fix: ak.from_numpy should fail on zero-dimensional arrays.

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -341,6 +341,11 @@ def from_arraylib(array, regulararray, recordarray):
     if array.dtype == np.dtype("O"):
         raise TypeError("Awkward Array does not support arrays with object dtypes.")
 
+    if array.ndim == 0:
+        raise TypeError(
+            "Encountered a scalar (ndarray), but scalar conversion is not allowed."
+        )
+
     if isinstance(array, numpy.ma.MaskedArray):
         mask = numpy.ma.getmask(array)
         array = numpy.ma.getdata(array)

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -250,7 +250,12 @@ def maybe_highlevel_to_lowlevel(obj):
         return obj
 
 
-def from_arraylib(array, regulararray, recordarray):
+def from_arraylib(
+    array,
+    regulararray,
+    recordarray,
+    primitive_policy: Literal["error", "promote", "pass-through"] = "promote",
+):
     from awkward.contents import (
         ByteMaskedArray,
         ListArray,
@@ -341,9 +346,9 @@ def from_arraylib(array, regulararray, recordarray):
     if array.dtype == np.dtype("O"):
         raise TypeError("Awkward Array does not support arrays with object dtypes.")
 
-    if array.ndim == 0:
+    if primitive_policy == "error" and array.ndim == 0:
         raise TypeError(
-            "Encountered a scalar (ndarray), but scalar conversion is not allowed."
+            f"Encountered a scalar ({type(array).__name__}), but scalar conversion/promotion is disabled"
         )
 
     if isinstance(array, numpy.ma.MaskedArray):

--- a/src/awkward/operations/ak_from_cupy.py
+++ b/src/awkward/operations/ak_from_cupy.py
@@ -9,7 +9,15 @@ __all__ = ("from_cupy",)
 
 
 @high_level_function()
-def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
+def from_cupy(
+    array,
+    *,
+    regulararray=False,
+    highlevel=True,
+    behavior=None,
+    primitive_policy="error",
+    attrs=None,
+):
     """
     Args:
         array (cp.ndarray): The CuPy array to convert into an Awkward Array.
@@ -36,7 +44,7 @@ def from_cupy(array, *, regulararray=False, highlevel=True, behavior=None, attrs
     See also #ak.to_cupy, #ak.from_numpy and #ak.from_jax.
     """
     return wrap_layout(
-        from_arraylib(array, regulararray, False),
+        from_arraylib(array, regulararray, False, primitive_policy=primitive_policy),
         highlevel=highlevel,
         behavior=behavior,
     )

--- a/src/awkward/operations/ak_from_dlpack.py
+++ b/src/awkward/operations/ak_from_dlpack.py
@@ -20,6 +20,7 @@ def from_dlpack(
     regulararray=False,
     highlevel=True,
     behavior=None,
+    primitive_policy="error",
     attrs=None,
 ):
     """
@@ -77,7 +78,7 @@ def from_dlpack(
 
     array = nplike.from_dlpack(array)
     return wrap_layout(
-        from_arraylib(array, regulararray, False),
+        from_arraylib(array, regulararray, False, primitive_policy=primitive_policy),
         highlevel=highlevel,
         behavior=behavior,
     )

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -10,7 +10,15 @@ __all__ = ("from_jax",)
 
 
 @high_level_function()
-def from_jax(array, *, regulararray=False, highlevel=True, behavior=None, attrs=None):
+def from_jax(
+    array,
+    *,
+    regulararray=False,
+    highlevel=True,
+    behavior=None,
+    attrs=None,
+    primitive_policy="error",
+):
     """
     Args:
         array (jax.numpy.DeviceArray): The JAX DeviceArray to convert into an Awkward Array.
@@ -38,7 +46,7 @@ def from_jax(array, *, regulararray=False, highlevel=True, behavior=None, attrs=
     """
     jax.assert_registered()
     return wrap_layout(
-        from_arraylib(array, regulararray, False),
+        from_arraylib(array, regulararray, False, primitive_policy=primitive_policy),
         highlevel=highlevel,
         behavior=behavior,
     )

--- a/src/awkward/operations/ak_from_numpy.py
+++ b/src/awkward/operations/ak_from_numpy.py
@@ -16,6 +16,7 @@ def from_numpy(
     recordarray=True,
     highlevel=True,
     behavior=None,
+    primitive_policy="error",
     attrs=None,
 ):
     """
@@ -52,7 +53,9 @@ def from_numpy(
     See also #ak.to_numpy and #ak.from_cupy.
     """
     return wrap_layout(
-        from_arraylib(array, regulararray, recordarray),
+        from_arraylib(
+            array, regulararray, recordarray, primitive_policy=primitive_policy
+        ),
         highlevel=highlevel,
         behavior=behavior,
     )

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -179,20 +179,27 @@ def _impl(
             regulararray=regulararray,
             recordarray=True,
             highlevel=False,
+            primitive_policy=primitive_policy,
         )
         return _handle_array_like(
             obj, promoted_layout, primitive_policy=primitive_policy
         )
     elif Cupy.is_own_array(obj):
         promoted_layout = ak.operations.from_cupy(
-            obj, regulararray=regulararray, highlevel=False
+            obj,
+            regulararray=regulararray,
+            highlevel=False,
+            primitive_policy=primitive_policy,
         )
         return _handle_array_like(
             obj, promoted_layout, primitive_policy=primitive_policy
         )
     elif Jax.is_own_array(obj):
         promoted_layout = ak.operations.from_jax(
-            obj, regulararray=regulararray, highlevel=False
+            obj,
+            regulararray=regulararray,
+            highlevel=False,
+            primitive_policy=primitive_policy,
         )
         return _handle_array_like(
             obj, promoted_layout, primitive_policy=primitive_policy
@@ -215,7 +222,9 @@ def _impl(
     elif ak._util.in_module(obj, "pyarrow"):
         return ak.operations.from_arrow(obj, highlevel=False)
     elif hasattr(obj, "__dlpack__") and hasattr(obj, "__dlpack_device__"):
-        return ak.operations.from_dlpack(obj, highlevel=False)
+        return ak.operations.from_dlpack(
+            obj, highlevel=False, primitive_policy=primitive_policy
+        )
     # Typed scalars
     elif isinstance(obj, np.generic):
         promoted_layout = ak.operations.from_numpy(
@@ -223,6 +232,7 @@ def _impl(
             regulararray=regulararray,
             recordarray=True,
             highlevel=False,
+            primitive_policy=primitive_policy,
         )
         return _handle_array_like(
             obj, promoted_layout, primitive_policy=primitive_policy

--- a/tests/test_1057_akarray_and_akfrom_numpy_should_not_accept_zero_dimensional_arrays.py
+++ b/tests/test_1057_akarray_and_akfrom_numpy_should_not_accept_zero_dimensional_arrays.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_akarray_from_zero_dim_nparray():
+    np_scalar = np.array(2.7)  # A kind of scalar in numpy.
+    assert np_scalar.ndim == 0 and np_scalar.shape == ()
+    with pytest.raises(TypeError):
+        # Conversion to ak.Array ought to throw here:
+        b = ak.Array(np_scalar)  # (bugged) value: <Array [2.7] type='1 * int64'>
+        # Now we're failing. Here's why.
+        c = ak.to_numpy(b)  # value: array([2.7])
+        assert np_scalar.shape == c.shape  # this fails
+
+    with pytest.raises(TypeError):
+        b = ak.from_numpy(np_scalar)
+        c = ak.to_numpy(b)
+        assert np_scalar.shape == c.shape


### PR DESCRIPTION
At this point, the first tests, `ak.Array()`, was already passing without modifications.
But the second test was not -- `ak.from_numpy()`.
Fix is in `_layout.py`. No policy options are passed to `_layout.from_arraylib()`.