### PR TITLE
fix: proposal for #2947

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -136,6 +136,9 @@ def _impl(
     elif isinstance(form, dict):
         form = ak.forms.from_dict(form)
 
+    if isinstance(length, np.integer):
+        length = int(length)
+
     if not (is_integer(length) and length >= 0):
         raise TypeError("'length' argument must be a non-negative integer")
 

--- a/tests/test_2947_to_list_numpy_integer.py
+++ b/tests/test_2947_to_list_numpy_integer.py
@@ -1,10 +1,13 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+from __future__ import annotations
 
-import awkward as ak
 import numpy as np
 
+import awkward as ak
+
+
 def test():
-    """ Check that to_list() does not break when the array is built from buffers
+    """Check that to_list() does not break when the array is built from buffers
     with a length of type np.int64.
     """
     awk = ak.Array(np.ones((7, 0)))

--- a/tests/test_2947_to_list_numpy_integer.py
+++ b/tests/test_2947_to_list_numpy_integer.py
@@ -1,0 +1,15 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+import awkward as ak
+import numpy as np
+
+def test():
+    """ Check that to_list() does not break when the array is built from buffers
+    with a length of type np.int64.
+    """
+    awk = ak.Array(np.ones((7, 0)))
+    form, length, container = ak.to_buffers(ak.to_packed(awk))
+    awk_from_buf = ak.from_buffers(form, np.int64(length), container)
+    lst = awk_from_buf.to_list()
+
+    assert len(lst) == length


### PR DESCRIPTION
Test against np.integer as well in ArrayModuleNumpyLike.shape_item_as_index such that it does not break if ak.from_buffers is built with a numpy integer instead of an integer.
I have the feeling that this might be an "easy fix" and that maybe the fix should be implemented at a deeper level - please let me know if this is the case. 