### PR TITLE
fix: issue #3118 and #3185

### DIFF
--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -1180,10 +1180,11 @@ class IndexedArray(IndexedMeta[Content], Content):
         )
 
     def _trim(self) -> Self:
-        if self._index.length == 0:
+        nplike = self._backend.index_nplike
+
+        if not nplike.known_data or self._index.length == 0:
             return self
 
-        nplike = self._backend.index_nplike
         idx_buf = nplike.asarray(self._index.data, copy=True)
         min_idx = nplike.min(idx_buf)
         max_idx = nplike.max(idx_buf)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -626,7 +626,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             if isinstance(
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
-                array = array._trim() # see: #3185 and #3119
+                array = array._trim()  # see: #3185 and #3119
                 parameters = parameters_intersect(parameters, array._parameters)
 
                 contents.append(array.content)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -761,7 +761,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             if isinstance(
                 array, (ak.contents.IndexedOptionArray, ak.contents.IndexedArray)
             ):
-                array = array._trim() # see: #3185 and #3119
+                array = array._trim()  # see: #3185 and #3119
                 # If we're merging an option, then merge parameters before pulling out `content`
                 parameters = parameters_intersect(parameters, array._parameters)
                 contents.append(array.content)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -431,7 +431,7 @@ class UnionArray(UnionMeta[Content], Content):
             ]
 
         if len(contents) == 1:
-            next = contents[0]._carry(index, False)
+            next = contents[0]._carry(index, True)
             return next.copy(parameters=parameters_union(next._parameters, parameters))
 
         else:
@@ -702,7 +702,7 @@ class UnionArray(UnionMeta[Content], Content):
         nextcarry = ak.index.Index64(
             tmpcarry.data[: lenout[0]], nplike=self._backend.index_nplike
         )
-        return self._contents[index]._carry(nextcarry, False)
+        return self._contents[index]._carry(nextcarry, True)
 
     @staticmethod
     def regular_index(

--- a/tests/test_2713_from_buffers_allow_noncanonical.py
+++ b/tests/test_2713_from_buffers_allow_noncanonical.py
@@ -122,8 +122,8 @@ def test_union_simplification():
     )
 
     assert projected.layout.form.to_dict(verbose=False) == {
-        "class": "RecordArray",
-        "fields": ["x"],
-        "contents": ["int64"],
+        "class": "IndexedArray",
+        "index": "i64",
+        "content": {"class": "RecordArray", "fields": ["x"], "contents": ["int64"]},
     }
     assert ak.almost_equal(array[["x"]], projected)

--- a/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
+++ b/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
@@ -5,7 +5,37 @@ from __future__ import annotations
 import awkward as ak
 
 
-def test():
+def check(layout, assert_length):
+    if hasattr(layout, "contents"):
+        for x in layout.contents:
+            check(x, assert_length)
+    elif hasattr(layout, "content"):
+        check(layout.content, assert_length)
+    else:
+        assert layout.length <= assert_length
+
+
+def test_2arrays():
+    one_a = ak.Array([{"x": 1, "y": 2}], with_name="T")
+    one_b = ak.Array([{"x": 1, "y": 2}], with_name="T")
+    two_a = ak.Array([{"x": 1, "z": 3}], with_name="T")
+    two_b = ak.Array([{"x": 1, "z": 3}], with_name="T")
+    three = ak.Array([{"x": 4}, {"x": 4}], with_name="T")
+
+    first = ak.zip({"a": one_a, "b": one_b})
+    second = ak.zip({"a": two_a, "b": two_b})
+
+    cat = ak.concatenate([first, second], axis=0)
+
+    cat["another"] = three
+
+    for _ in range(5):
+        check(cat.layout, 2)
+
+        cat["another", "w"] = three.x
+
+
+def test_3arrays():
     zero_a = ak.Array([{"x": 1, "y": 1}], with_name="T")
     zero_b = ak.Array([{"x": 1, "v": 1}], with_name="T")
     one_a = ak.Array([{"x": 1, "y": 2}], with_name="T")
@@ -22,16 +52,7 @@ def test():
 
     cat["another"] = three
 
-    def check(layout):
-        if hasattr(layout, "contents"):
-            for x in layout.contents:
-                check(x)
-        elif hasattr(layout, "content"):
-            check(layout.content)
-        else:
-            assert layout.length <= 3
-
     for _ in range(5):
-        check(cat.layout)
+        check(cat.layout, 3)
 
         cat["another", "w"] = three.x

--- a/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
+++ b/tests/test_3118_prevent_exponential_memory_growth_in_unionarray.py
@@ -6,16 +6,19 @@ import awkward as ak
 
 
 def test():
+    zero_a = ak.Array([{"x": 1, "y": 1}], with_name="T")
+    zero_b = ak.Array([{"x": 1, "v": 1}], with_name="T")
     one_a = ak.Array([{"x": 1, "y": 2}], with_name="T")
     one_b = ak.Array([{"x": 1, "y": 2}], with_name="T")
     two_a = ak.Array([{"x": 1, "z": 3}], with_name="T")
     two_b = ak.Array([{"x": 1, "z": 3}], with_name="T")
-    three = ak.Array([{"x": 4}, {"x": 4}], with_name="T")
+    three = ak.Array([{"x": 4}, {"x": 4}, {"x": 4}], with_name="T")
 
+    zeroth = ak.zip({"a": zero_a, "b": zero_b})
     first = ak.zip({"a": one_a, "b": one_b})
     second = ak.zip({"a": two_a, "b": two_b})
 
-    cat = ak.concatenate([first, second], axis=0)
+    cat = ak.concatenate([zeroth, first, second], axis=0)
 
     cat["another"] = three
 
@@ -26,7 +29,7 @@ def test():
         elif hasattr(layout, "content"):
             check(layout.content)
         else:
-            assert layout.length <= 2
+            assert layout.length <= 3
 
     for _ in range(5):
         check(cat.layout)


### PR DESCRIPTION
After a longer discussion with @jpivarski and @maxgalli we came up with a solution for issue #3118.

This PR addresses issue #3118 and  by trimming the `Index*Arrays` safely before concatenation and thus avoiding memory growth of the underlying `NumpyArrays`.

In addition, it allows to re-enable laziness (disabled recently in https://github.com/scikit-hep/awkward/pull/3119) for `UnionArray.simplified` and thus avoids touching too many columns as described in https://github.com/scikit-hep/awkward/issues/3185 and https://github.com/scikit-hep/awkward/pull/3119#issuecomment-2234227019.

Best, Peter