### PR TITLE
fix: 2881 akconcatenate fails trying to concatenate too many nested arrays

### DIFF
--- a/awkward-cpp/src/cpu-kernels/awkward_UnionArray_nestedfill_tags_index.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_UnionArray_nestedfill_tags_index.cpp
@@ -55,3 +55,13 @@ ERROR awkward_UnionArray8_64_nestedfill_tags_index_64(
   return awkward_UnionArray_nestedfill_tags_index<int8_t, int64_t, int64_t>(
     totags, toindex, tmpstarts, tag, fromcounts, length);
 }
+ERROR awkward_UnionArray64_64_nestedfill_tags_index_64(
+  int64_t* totags,
+  int64_t* toindex,
+  int64_t* tmpstarts,
+  int64_t tag,
+  const int64_t* fromcounts,
+  int64_t length) {
+  return awkward_UnionArray_nestedfill_tags_index<int64_t, int64_t, int64_t>(
+    totags, toindex, tmpstarts, tag, fromcounts, length);
+}

--- a/awkward-cpp/src/cpu-kernels/awkward_UnionArray_simplify.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_UnionArray_simplify.cpp
@@ -258,3 +258,28 @@ ERROR awkward_UnionArray8_64_simplify8_64_to8_64(
     length,
     base);
 }
+ERROR awkward_UnionArray64_64_simplify8_64_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int64_t* outertags,
+  const int64_t* outerindex,
+  const int8_t* innertags,
+  const int64_t* innerindex,
+  int64_t towhich,
+  int64_t innerwhich,
+  int64_t outerwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_UnionArray_simplify<int64_t, int64_t, int8_t, int64_t, int8_t, int64_t>(
+    totags,
+    toindex,
+    outertags,
+    outerindex,
+    innertags,
+    innerindex,
+    towhich,
+    innerwhich,
+    outerwhich,
+    length,
+    base);
+}

--- a/awkward-cpp/src/cpu-kernels/awkward_UnionArray_simplify_one.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_UnionArray_simplify_one.cpp
@@ -82,3 +82,22 @@ ERROR awkward_UnionArray8_64_simplify_one_to8_64(
     length,
     base);
 }
+ERROR awkward_UnionArray64_64_simplify_one_to8_64(
+  int8_t* totags,
+  int64_t* toindex,
+  const int64_t* fromtags,
+  const int64_t* fromindex,
+  int64_t towhich,
+  int64_t fromwhich,
+  int64_t length,
+  int64_t base) {
+  return awkward_UnionArray_simplify_one<int64_t, int64_t, int8_t, int64_t>(
+    totags,
+    toindex,
+    fromtags,
+    fromindex,
+    towhich,
+    fromwhich,
+    length,
+    base);
+}

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -3396,6 +3396,14 @@ kernels:
           - {name: tag, type: "int8_t", dir: in, role: default}
           - {name: fromcounts, type: "Const[List[int64_t]]", dir: in, role: default}
           - {name: length, type: "int64_t", dir: in, role: default}
+      - name: awkward_UnionArray64_64_nestedfill_tags_index_64
+        args:
+          - {name: totags, type: "List[int64_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: tmpstarts, type: "List[int64_t]", dir: out}
+          - {name: tag, type: "int64_t", dir: in, role: default}
+          - {name: fromcounts, type: "Const[List[int64_t]]", dir: in, role: default}
+          - {name: length, type: "int64_t", dir: in, role: default}
     description: null
     definition: |
       def awkward_UnionArray_nestedfill_tags_index(
@@ -3620,6 +3628,19 @@ kernels:
           - {name: outerwhich, type: "int64_t", dir: in, role: UnionArray2-which}
           - {name: length, type: "int64_t", dir: in, role: default}
           - {name: base, type: "int64_t", dir: in, role: default}
+      - name: awkward_UnionArray64_64_simplify8_64_to8_64
+        args:
+          - {name: totags, type: "List[int8_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: outertags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
+          - {name: outerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: innertags, type: "Const[List[int8_t]]", dir: in, role: UnionArray2-tags}
+          - {name: innerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray2-index}
+          - {name: towhich, type: "int64_t", dir: in, role: default}
+          - {name: innerwhich, type: "int64_t", dir: in, role: UnionArray1-which}
+          - {name: outerwhich, type: "int64_t", dir: in, role: UnionArray2-which}
+          - {name: length, type: "int64_t", dir: in, role: default}
+          - {name: base, type: "int64_t", dir: in, role: default}
     description: null
     definition: |
       def awkward_UnionArray_simplify(
@@ -3671,6 +3692,16 @@ kernels:
           - {name: toindex, type: "List[int64_t]", dir: out}
           - {name: fromtags, type: "Const[List[int8_t]]", dir: in, role: UnionArray-tags}
           - {name: fromindex, type: "Const[List[uint32_t]]", dir: in, role: IndexedArray-index}
+          - {name: towhich, type: "int64_t", dir: in, role: default}
+          - {name: fromwhich, type: "int64_t", dir: in, role: UnionArray-which}
+          - {name: length, type: "int64_t", dir: in, role: default}
+          - {name: base, type: "int64_t", dir: in, role: default}
+      - name: awkward_UnionArray64_64_simplify_one_to8_64
+        args:
+          - {name: totags, type: "List[int8_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: fromtags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
+          - {name: fromindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
           - {name: towhich, type: "int64_t", dir: in, role: default}
           - {name: fromwhich, type: "int64_t", dir: in, role: UnionArray-which}
           - {name: length, type: "int64_t", dir: in, role: default}

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -3372,6 +3372,14 @@ kernels:
 
   - name: awkward_UnionArray_nestedfill_tags_index
     specializations:
+      - name: awkward_UnionArray64_64_nestedfill_tags_index_64
+        args:
+          - {name: totags, type: "List[int64_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: tmpstarts, type: "List[int64_t]", dir: out}
+          - {name: tag, type: "int64_t", dir: in, role: default}
+          - {name: fromcounts, type: "Const[List[int64_t]]", dir: in, role: default}
+          - {name: length, type: "int64_t", dir: in, role: default}
       - name: awkward_UnionArray8_32_nestedfill_tags_index_64
         args:
           - {name: totags, type: "List[int8_t]", dir: out}
@@ -3394,14 +3402,6 @@ kernels:
           - {name: toindex, type: "List[uint32_t]", dir: out}
           - {name: tmpstarts, type: "List[int64_t]", dir: out}
           - {name: tag, type: "int8_t", dir: in, role: default}
-          - {name: fromcounts, type: "Const[List[int64_t]]", dir: in, role: default}
-          - {name: length, type: "int64_t", dir: in, role: default}
-      - name: awkward_UnionArray64_64_nestedfill_tags_index_64
-        args:
-          - {name: totags, type: "List[int64_t]", dir: out}
-          - {name: toindex, type: "List[int64_t]", dir: out}
-          - {name: tmpstarts, type: "List[int64_t]", dir: out}
-          - {name: tag, type: "int64_t", dir: in, role: default}
           - {name: fromcounts, type: "Const[List[int64_t]]", dir: in, role: default}
           - {name: length, type: "int64_t", dir: in, role: default}
     description: null
@@ -3511,6 +3511,19 @@ kernels:
 
   - name: awkward_UnionArray_simplify
     specializations:
+      - name: awkward_UnionArray64_64_simplify8_64_to8_64
+        args:
+          - {name: totags, type: "List[int8_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: outertags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
+          - {name: outerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: innertags, type: "Const[List[int8_t]]", dir: in, role: UnionArray2-tags}
+          - {name: innerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray2-index}
+          - {name: towhich, type: "int64_t", dir: in, role: default}
+          - {name: innerwhich, type: "int64_t", dir: in, role: UnionArray1-which}
+          - {name: outerwhich, type: "int64_t", dir: in, role: UnionArray2-which}
+          - {name: length, type: "int64_t", dir: in, role: default}
+          - {name: base, type: "int64_t", dir: in, role: default}
       - name: awkward_UnionArray8_32_simplify8_32_to8_64
         args:
           - {name: totags, type: "List[int8_t]", dir: out}
@@ -3628,19 +3641,6 @@ kernels:
           - {name: outerwhich, type: "int64_t", dir: in, role: UnionArray2-which}
           - {name: length, type: "int64_t", dir: in, role: default}
           - {name: base, type: "int64_t", dir: in, role: default}
-      - name: awkward_UnionArray64_64_simplify8_64_to8_64
-        args:
-          - {name: totags, type: "List[int8_t]", dir: out}
-          - {name: toindex, type: "List[int64_t]", dir: out}
-          - {name: outertags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
-          - {name: outerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
-          - {name: innertags, type: "Const[List[int8_t]]", dir: in, role: UnionArray2-tags}
-          - {name: innerindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray2-index}
-          - {name: towhich, type: "int64_t", dir: in, role: default}
-          - {name: innerwhich, type: "int64_t", dir: in, role: UnionArray1-which}
-          - {name: outerwhich, type: "int64_t", dir: in, role: UnionArray2-which}
-          - {name: length, type: "int64_t", dir: in, role: default}
-          - {name: base, type: "int64_t", dir: in, role: default}
     description: null
     definition: |
       def awkward_UnionArray_simplify(
@@ -3666,6 +3666,16 @@ kernels:
 
   - name: awkward_UnionArray_simplify_one
     specializations:
+      - name: awkward_UnionArray64_64_simplify_one_to8_64
+        args:
+          - {name: totags, type: "List[int8_t]", dir: out}
+          - {name: toindex, type: "List[int64_t]", dir: out}
+          - {name: fromtags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
+          - {name: fromindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
+          - {name: towhich, type: "int64_t", dir: in, role: default}
+          - {name: fromwhich, type: "int64_t", dir: in, role: UnionArray-which}
+          - {name: length, type: "int64_t", dir: in, role: default}
+          - {name: base, type: "int64_t", dir: in, role: default}
       - name: awkward_UnionArray8_32_simplify_one_to8_64
         args:
           - {name: totags, type: "List[int8_t]", dir: out}
@@ -3692,16 +3702,6 @@ kernels:
           - {name: toindex, type: "List[int64_t]", dir: out}
           - {name: fromtags, type: "Const[List[int8_t]]", dir: in, role: UnionArray-tags}
           - {name: fromindex, type: "Const[List[uint32_t]]", dir: in, role: IndexedArray-index}
-          - {name: towhich, type: "int64_t", dir: in, role: default}
-          - {name: fromwhich, type: "int64_t", dir: in, role: UnionArray-which}
-          - {name: length, type: "int64_t", dir: in, role: default}
-          - {name: base, type: "int64_t", dir: in, role: default}
-      - name: awkward_UnionArray64_64_simplify_one_to8_64
-        args:
-          - {name: totags, type: "List[int8_t]", dir: out}
-          - {name: toindex, type: "List[int64_t]", dir: out}
-          - {name: fromtags, type: "Const[List[int64_t]]", dir: in, role: UnionArray-tags}
-          - {name: fromindex, type: "Const[List[int64_t]]", dir: in, role: IndexedArray-index}
           - {name: towhich, type: "int64_t", dir: in, role: default}
           - {name: fromwhich, type: "int64_t", dir: in, role: UnionArray-which}
           - {name: length, type: "int64_t", dir: in, role: default}

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -275,7 +275,7 @@ class UnionArray(UnionMeta[Content], Content):
                                     "awkward_UnionArray_simplify",
                                     tags.dtype.type,
                                     index.dtype.type,
-                                    self_tags.dtype.type,
+                                    self_tags.dtype.type,  # TPH: hardcode I8?
                                     self_index.dtype.type,
                                     innertags.dtype.type,
                                     innerindex.dtype.type,
@@ -441,6 +441,63 @@ class UnionArray(UnionMeta[Content], Content):
                 contents,
                 parameters=parameters,
             )
+
+    @classmethod
+    def batch_simplified(
+        cls,
+        contents,
+        parameters=None,
+        mergebool=False,
+    ):
+        """
+        Developed for ak.concatenate, this assumes that contents are all instances
+        of akcontents.Content, and all have the same backend.
+        """
+        # Get backend (simplify or use _layout.ensure_same_backend)
+        backend = None
+        for content in contents:
+            if backend is None:
+                backend = content.backend
+            elif backend is not content.backend:
+                raise TypeError(
+                    f"{cls.__name__} 'contents' must use the same array library (backend): {type(backend).__name__} vs {type(content.backend).__name__}"
+                )
+
+        batches = [[contents[0]]]
+        for x in contents[1:]:
+            batch = batches[-1]
+            if ak._do.mergeable(batch[0], x, mergebool=mergebool):
+                batch.append(x)
+            else:
+                batches.append([x])
+
+        contents = [ak._do.mergemany(b) if len(b) > 0 else b for b in batches]
+        if len(contents) == 1:
+            return contents[0]
+
+        length = sum(c.length for c in contents)
+        first = contents[0]
+        tags = ak.index.Index8.empty(length, first.backend.index_nplike)
+        index = ak.index.Index64.empty(length, first.backend.index_nplike)
+
+        offset = 0
+        for i, content in enumerate(contents):
+            content.backend.maybe_kernel_error(
+                content.backend["awkward_UnionArray_filltags_const", tags.dtype.type](
+                    tags.data, offset, content.length, i
+                )
+            )
+            content.backend.maybe_kernel_error(
+                content.backend["awkward_UnionArray_fillindex_count", index.dtype.type](
+                    index.data, offset, content.length
+                )
+            )
+            offset += content.length
+
+        out = ak.contents.UnionArray.simplified(
+            tags, index, contents, parameters=parameters
+        )
+        return out
 
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> UnionForm:
         form_key = getkey(self)

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
+MAX_UNION_CONTENTS = 2**7  # We use int8 tags, 0-127
 
 
 @final
@@ -230,6 +231,10 @@ class UnionArray(UnionMeta[Content], Content):
         parameters=None,
         mergebool=False,
     ):
+        # Note: to help merge more than 128 arrays, tags *can* have type ak.index.Index64.
+        # This is only supported when index is also Index64,
+        # and all indexed contents are also Index64.
+        # We still require that this reduces to no more than 128 variants.
         self_index = index
         self_tags = tags
         self_contents = contents
@@ -299,6 +304,10 @@ class UnionArray(UnionMeta[Content], Content):
 
                     # Did we fail to merge any of the final outer contents with this inner union content?
                     if unmerged:
+                        if len(contents) >= MAX_UNION_CONTENTS:
+                            raise ValueError(
+                                "UnionArray does not support more than 128 content types"
+                            )
                         backend.maybe_kernel_error(
                             backend[
                                 "awkward_UnionArray_simplify",
@@ -373,6 +382,10 @@ class UnionArray(UnionMeta[Content], Content):
                         break
 
                 if unmerged:
+                    if len(contents) >= MAX_UNION_CONTENTS:
+                        raise ValueError(
+                            "UnionArray does not support more than 128 content types"
+                        )
                     backend.maybe_kernel_error(
                         backend[
                             "awkward_UnionArray_simplify_one",
@@ -392,12 +405,6 @@ class UnionArray(UnionMeta[Content], Content):
                         )
                     )
                     contents.append(self_cont)
-
-        if len(contents) > 2**7:
-            # TODO: Catch this condition in the loops above.
-            raise NotImplementedError(
-                "FIXME: handle UnionArray with more than 127 contents"
-            )
 
         # If any contents are non-categorical index types, we can merge them into the union
         # This is safe, because any remaining index types at this point in the routine are not considered
@@ -1108,8 +1115,8 @@ class UnionArray(UnionMeta[Content], Content):
             )
         )
 
-        if len(contents) > 2**7:
-            raise AssertionError("FIXME: handle UnionArray with more than 127 contents")
+        if len(contents) > MAX_UNION_CONTENTS:
+            raise ValueError("UnionArray cannot have more than 128 content types")
 
         return ak.contents.UnionArray.simplified(
             tags, index, contents, parameters=self._parameters
@@ -1237,8 +1244,8 @@ class UnionArray(UnionMeta[Content], Content):
 
                 nextcontents.append(array)
 
-        if len(nextcontents) > 127:
-            raise ValueError("FIXME: handle UnionArray with more than 127 contents")
+        if len(nextcontents) > MAX_UNION_CONTENTS:
+            raise ValueError("UnionArray cannot have more than 128 content types")
 
         next = ak.contents.UnionArray.simplified(
             nexttags,

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -308,7 +308,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                 all_flatten = []
 
                 for x in nextinputs:
-                    o, f = x._offsets_and_flattened(1, 1)  # axis=1, depth=1
+                    o, f = x._offsets_and_flattened(axis=1, depth=1)
                     c = o.data[1:] - o.data[:-1]
                     backend.index_nplike.add(counts, c, maybe_out=counts)
                     all_counts.append(c)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -152,7 +152,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
         batches = [[content_or_others[0]]]
         for x in content_or_others[1:]:
             batch = batches[-1]
-            if ak._do.mergeable(batch[0], x, mergebool=mergebool):
+            if ak._do.mergeable(batch[-1], x, mergebool=mergebool):
                 batch.append(x)
             else:
                 batches.append([x])

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -152,7 +152,7 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
         batches = [[content_or_others[0]]]
         for x in content_or_others[1:]:
             batch = batches[-1]
-            if ak._do.mergeable(batch[-1], x, mergebool=mergebool):
+            if ak._do.mergeable(batch[0], x, mergebool=mergebool):
                 batch.append(x)
             else:
                 batches.append([x])
@@ -246,7 +246,12 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                     prototype[start : start + size] = tag
                     start += size
 
-                tags = ak.index.Index8(
+                if len(regulararrays) < 2**7:
+                    tags_cls = ak.index.Index8
+                else:
+                    tags_cls = ak.index.Index64
+
+                tags = tags_cls(
                     backend.index_nplike.reshape(
                         backend.index_nplike.broadcast_to(
                             prototype, (length, prototype.size)
@@ -265,10 +270,9 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                 return (ak.contents.RegularArray(inner, prototype.size),)
 
             elif all(
-                isinstance(x, ak.contents.Content)
-                and x.is_list
-                or (isinstance(x, ak.contents.NumpyArray) and x.data.ndim > 1)
-                or not isinstance(x, ak.contents.Content)
+                (isinstance(x, ak.contents.Content) and x.is_list)  # Case 1
+                or (isinstance(x, ak.contents.NumpyArray) and x.data.ndim > 1)  # Case 2
+                or not isinstance(x, ak.contents.Content)  # Case 3: scalar value
                 for x in inputs
             ):
                 nextinputs = []
@@ -276,6 +280,8 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                     if isinstance(x, ak.contents.Content):
                         nextinputs.append(x)
                     else:
+                        # Treat non-content inputs as scalars.
+                        # These become arrays of matching length.
                         nextinputs.append(
                             ak.contents.ListOffsetArray(
                                 ak.index.Index64(
@@ -298,14 +304,14 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                 counts = backend.index_nplike.zeros(
                     nextinputs[0].length, dtype=np.int64
                 )
-                # all_counts = []
+                all_counts = []
                 all_flatten = []
 
                 for x in nextinputs:
                     o, f = x._offsets_and_flattened(1, 1)  # axis=1, depth=1
                     c = o.data[1:] - o.data[:-1]
                     backend.index_nplike.add(counts, c, maybe_out=counts)
-                    # all_counts.append(c)
+                    all_counts.append(c)
                     all_flatten.append(f)
 
                 offsets = backend.index_nplike.empty(
@@ -316,11 +322,22 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
 
                 offsets = ak.index.Index64(offsets, nplike=backend.index_nplike)
 
-                as_unionarray = ak.contents.UnionArray.batch_simplified(
-                    all_flatten, mergebool=mergebool
+                if len(nextinputs) < 2**7:
+                    tags_cls = ak.index.Index8
+                else:
+                    tags_cls = ak.index.Index64
+                tags, index = ak.contents.UnionArray.nested_tags_index(
+                    offsets,
+                    [ak.index.Index64(x) for x in all_counts],
+                    backend=backend,
+                    tags_cls=tags_cls,
                 )
 
-                return (ak.contents.ListOffsetArray(offsets, as_unionarray),)
+                inner = ak.contents.UnionArray.simplified(
+                    tags, index, all_flatten, mergebool=mergebool
+                )
+
+                return (ak.contents.ListOffsetArray(offsets, inner),)
 
             else:
                 return None

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -298,14 +298,14 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
                 counts = backend.index_nplike.zeros(
                     nextinputs[0].length, dtype=np.int64
                 )
-                all_counts = []
+                # all_counts = []
                 all_flatten = []
 
                 for x in nextinputs:
-                    o, f = x._offsets_and_flattened(1, 1)
+                    o, f = x._offsets_and_flattened(1, 1)  # axis=1, depth=1
                     c = o.data[1:] - o.data[:-1]
                     backend.index_nplike.add(counts, c, maybe_out=counts)
-                    all_counts.append(c)
+                    # all_counts.append(c)
                     all_flatten.append(f)
 
                 offsets = backend.index_nplike.empty(
@@ -316,17 +316,11 @@ def _impl(arrays, axis, mergebool, highlevel, behavior, attrs):
 
                 offsets = ak.index.Index64(offsets, nplike=backend.index_nplike)
 
-                tags, index = ak.contents.UnionArray.nested_tags_index(
-                    offsets,
-                    [ak.index.Index64(x) for x in all_counts],
-                    backend=backend,
+                as_unionarray = ak.contents.UnionArray.batch_simplified(
+                    all_flatten, mergebool=mergebool
                 )
 
-                inner = ak.contents.UnionArray.simplified(
-                    tags, index, all_flatten, mergebool=mergebool
-                )
-
-                return (ak.contents.ListOffsetArray(offsets, inner),)
+                return (ak.contents.ListOffsetArray(offsets, as_unionarray),)
 
             else:
                 return None

--- a/tests/test_2881_ak_concatenate_fails_on_too_many_nested_arrays.py
+++ b/tests/test_2881_ak_concatenate_fails_on_too_many_nested_arrays.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+# from awkward.operations import to_list
+
+
+def test_concatenate_as_reported():
+    a = ak.Array([[1]])
+    a_concat_128 = ak.concatenate([a for i in range(128)], axis=1)
+    assert a_concat_128.to_list() == [[1] * 128]
+
+    a_concat_129 = ak.concatenate([a for i in range(129)], axis=1)
+    assert a_concat_129.to_list() == [[1] * 129]
+
+
+def test_concatenate_inner_union():
+    a = ak.Array([[99]])
+    astr = ak.Array(['a b c d'.split()])
+    aa = [a for i in range(129)] + [astr]
+
+    cu = ak.concatenate(aa, axis=1)
+    assert cu.to_list() == [[99] * 129 + ['a', 'b', 'c', 'd']]

--- a/tests/test_2881_ak_concatenate_fails_on_too_many_nested_arrays.py
+++ b/tests/test_2881_ak_concatenate_fails_on_too_many_nested_arrays.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import awkward as ak
+
 # from awkward.operations import to_list
 
 
@@ -15,10 +16,19 @@ def test_concatenate_as_reported():
     assert a_concat_129.to_list() == [[1] * 129]
 
 
-def test_concatenate_inner_union():
+def test_concatenate_inner_union_simplify_one():
     a = ak.Array([[99]])
-    astr = ak.Array(['a b c d'.split()])
+    astr = ak.Array(["a b c d".split()])
     aa = [a for i in range(129)] + [astr]
 
     cu = ak.concatenate(aa, axis=1)
-    assert cu.to_list() == [[99] * 129 + ['a', 'b', 'c', 'd']]
+    assert cu.to_list() == [[99] * 129 + ["a", "b", "c", "d"]]
+
+
+def test_concatenate_inner_union_simplify():
+    a = ak.Array([[99]])
+    amulti = ak.Array([[1, 2, "a", "b"]])
+    aa = [a for i in range(129)] + [amulti]
+
+    cu = ak.concatenate(aa, axis=1)
+    assert cu.to_list() == [[99] * 129 + [1, 2, "a", "b"]]


### PR DESCRIPTION
When concatenating arrays at a depth > 0 (not outermost), current code has a limitation
of 128 arrays to be combined.

This PR relaxes that requirement.