### PR TITLE
feat: Add ak.array_equal

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -173,12 +173,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     ) -> bool:
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        if equal_nan:
-            both_nan = self._module.logical_and(x1 == np.nan, x2 == np.nan)
-            both_equal = x1 == x2
-            return self._module.all(self._module.logical_or(both_equal, both_nan))
-        else:
-            return self._module.array_equal(x1, x2)
+        return self._module.array_equal(x1, x2, equal_nan=equal_nan)
 
     def searchsorted(
         self,

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -175,7 +175,9 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         assert not isinstance(x2, PlaceholderArray)
         if equal_nan:
             # Only newer numpy.array_equal supports the equal_nan parameter.
-            both_nan = self._module.logical_and(self._module.isnan(x1), self._module.isnan(x2))
+            both_nan = self._module.logical_and(
+                self._module.isnan(x1), self._module.isnan(x2)
+            )
             both_equal = x1 == x2
             return self._module.all(self._module.logical_or(both_equal, both_nan))
         else:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -173,7 +173,13 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     ) -> bool:
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        return self._module.array_equal(x1, x2, equal_nan=equal_nan)
+        if equal_nan:
+            # Only newer numpy.array_equal supports the equal_nan parameter.
+            both_nan = self._module.logical_and(self._module.isnan(x1), self._module.isnan(x2))
+            both_equal = x1 == x2
+            return self._module.all(self._module.logical_or(both_equal, both_nan))
+        else:
+            return self._module.array_equal(x1, x2)
 
     def searchsorted(
         self,

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -12,6 +12,7 @@ from awkward.operations.ak_argcombinations import *
 from awkward.operations.ak_argmax import *
 from awkward.operations.ak_argmin import *
 from awkward.operations.ak_argsort import *
+from awkward.operations.ak_array_equal import *
 from awkward.operations.ak_backend import *
 from awkward.operations.ak_broadcast_arrays import *
 from awkward.operations.ak_broadcast_fields import *

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -106,7 +106,7 @@ def _impl(
 
     def visitor(left, right) -> bool:
         # Most firstly, check same_content_types before any transformations
-        if same_content_types and left.__class__ != right.__class__:
+        if same_content_types and left.__class__ is right.__class__:
             return False
 
         # First, erase indexed types!

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -60,20 +60,23 @@ def almost_equal(
         dtype_exact=dtype_exact,
         check_parameters=check_parameters,
         check_regular=check_regular,
+        exact_eq=False,
+        same_content_types=False,
+        equal_nan=False,
     )
 
 
 def _impl(
     left,
     right,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
-    dtype_exact: bool = True,
-    check_parameters: bool = True,
-    check_regular: bool = True,
-    exact_eq: bool = False,
-    same_content_types: bool = False,
-    equal_nan: bool = False,
+    rtol: float,
+    atol: float,
+    dtype_exact: bool,
+    check_parameters: bool,
+    check_regular: bool,
+    exact_eq: bool,
+    same_content_types: bool,
+    equal_nan: bool,
 ):
     # Implementation
     left_behavior = behavior_of(left)

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -109,7 +109,7 @@ def _impl(
 
     def visitor(left, right) -> bool:
         # Most firstly, check same_content_types before any transformations
-        if same_content_types and left.__class__ is right.__class__:
+        if same_content_types and left.__class__ is not right.__class__:
             return False
 
         # First, erase indexed types!

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -52,6 +52,26 @@ def almost_equal(
     # Dispatch
     yield left, right
 
+    return _impl(
+        left,
+        right,
+        rtol=rtol,
+        atol=atol,
+        dtype_exact=dtype_exact,
+        check_parameters=check_parameters,
+        check_regular=check_regular,
+    )
+
+
+def _impl(
+    left,
+    right,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+    dtype_exact: bool = True,
+    check_parameters: bool = True,
+    check_regular: bool = True,
+):
     # Implementation
     left_behavior = behavior_of(left)
     right_behavior = behavior_of(right)

--- a/src/awkward/operations/ak_array_equal.py
+++ b/src/awkward/operations/ak_array_equal.py
@@ -1,0 +1,52 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+from awkward._dispatch import high_level_function
+
+__all__ = ("array_equal",)
+
+
+@high_level_function()
+def array_equal(
+    a1,
+    a2,
+    equal_nan: bool = False,
+    dtype_exact: bool = True,
+    same_content_types: bool = True,
+    check_parameters: bool = True,
+    check_regular: bool = True,
+):
+    """
+    True if two arrays have the same shape and elements, False otherwise.
+
+    Args:
+        a1: Array-like data (anything #ak.to_layout recognizes).
+        a2: Array-like data (anything #ak.to_layout recognizes).
+        equal_nan: bool (default=False)
+            Whether to count NaN values as equal to each other.
+        dtype_exact: bool (default=True) whether the dtypes must be exactly the same, or just the
+            same family.
+        same_content_types: bool (default=False)
+            Whether to require all content classes to match
+        check_parameters: bool (default=True) whether to compare parameters.
+        check_regular: bool (default=True) whether to consider ragged and regular dimensions as
+            unequal.
+
+    TypeTracer arrays are not supported, as there is very little information to
+    be compared.
+    """
+    # Dispatch
+    yield a1, a2
+
+    return ak.operations.ak_almost_equal._impl(
+        a1,
+        a2,
+        equal_nan=equal_nan,
+        dtype_exact=dtype_exact,
+        same_content_types=same_content_types,
+        check_parameters=check_parameters,
+        check_regular=check_regular,
+        exact_eq=True,
+    )

--- a/src/awkward/operations/ak_array_equal.py
+++ b/src/awkward/operations/ak_array_equal.py
@@ -43,10 +43,12 @@ def array_equal(
     return ak.operations.ak_almost_equal._impl(
         a1,
         a2,
-        equal_nan=equal_nan,
+        rtol=0.,
+        atol=0.,
         dtype_exact=dtype_exact,
-        same_content_types=same_content_types and check_regular,
         check_parameters=check_parameters,
         check_regular=check_regular,
         exact_eq=True,
+        same_content_types=same_content_types and check_regular,
+        equal_nan=equal_nan,
     )

--- a/src/awkward/operations/ak_array_equal.py
+++ b/src/awkward/operations/ak_array_equal.py
@@ -45,7 +45,7 @@ def array_equal(
         a2,
         equal_nan=equal_nan,
         dtype_exact=dtype_exact,
-        same_content_types=same_content_types,
+        same_content_types=same_content_types and check_regular,
         check_parameters=check_parameters,
         check_regular=check_regular,
         exact_eq=True,

--- a/src/awkward/operations/ak_array_equal.py
+++ b/src/awkward/operations/ak_array_equal.py
@@ -28,7 +28,7 @@ def array_equal(
             Whether to count NaN values as equal to each other.
         dtype_exact: bool (default=True) whether the dtypes must be exactly the same, or just the
             same family.
-        same_content_types: bool (default=False)
+        same_content_types: bool (default=True)
             Whether to require all content classes to match
         check_parameters: bool (default=True) whether to compare parameters.
         check_regular: bool (default=True) whether to consider ragged and regular dimensions as

--- a/src/awkward/operations/ak_array_equal.py
+++ b/src/awkward/operations/ak_array_equal.py
@@ -43,8 +43,8 @@ def array_equal(
     return ak.operations.ak_almost_equal._impl(
         a1,
         a2,
-        rtol=0.,
-        atol=0.,
+        rtol=0.0,
+        atol=0.0,
         dtype_exact=dtype_exact,
         check_parameters=check_parameters,
         check_regular=check_regular,

--- a/tests/test_1105_ak_aray_equal.py
+++ b/tests/test_1105_ak_aray_equal.py
@@ -2,13 +2,89 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 import awkward as ak
+from awkward.contents import NumpyArray
+from awkward.index import Index64
 
 
-def test_array_equal():
+def test_array_equal_simple():
     assert ak.array_equal(
         ak.Array([[1, 2], [], [3, 4, 5]]),
         ak.Array([[1, 2], [], [3, 4, 5]]),
     )
 
-    # TODO: More test cases!
+
+def test_array_equal_mixed_dtype():
+    assert not ak.array_equal(
+        ak.Array(np.array([1.5, 2.0, 3.25], dtype=np.float32)),
+        ak.Array(np.array([1.5, 2.0, 3.25], dtype=np.float64)),
+    )
+    assert ak.array_equal(
+        ak.Array(np.array([1.5, 2.0, 3.25], dtype=np.float32)),
+        ak.Array(np.array([1.5, 2.0, 3.25], dtype=np.float64)),
+        dtype_exact=False,
+    )
+
+
+def test_array_equal_on_listoffsets():
+    a1 = ak.contents.ListOffsetArray(
+        Index64(np.array([0, 3, 3, 5])), NumpyArray(np.arange(5) * 1.5)
+    )
+    a2 = ak.contents.ListOffsetArray(
+        Index64(np.array([0, 3, 3, 5])),
+        NumpyArray(np.arange(10) * 1.5),  # Longer array content than a1
+    )
+    assert ak.array_equal(a1, a2)
+
+
+def test_array_equal_mixed_content_type():
+    a1 = ak.Array([[1, 2, 3], [4, 5, 6], [7, 8]])
+    a1r = ak.to_regular(a1[:2])
+    assert not ak.array_equal(a1[:2], a1r)
+    assert ak.array_equal(a1[:2], a1r, check_regular=False)
+    assert not ak.array_equal(a1, a1r, check_regular=False)
+
+    assert ak.array_equal(
+        a1, a1.layout
+    )  # high-level automatically converted to layout in pre-check
+
+    a2_np = ak.contents.NumpyArray(np.arange(3))
+    a2_ia = ak.contents.IndexedArray(
+        Index64(np.array([0, 1, 2])), NumpyArray(np.arange(3))
+    )
+    assert ak.array_equal(a2_np, a2_ia, same_content_types=False)
+
+
+def test_array_equal_opion_types():
+    a1 = ak.Array([1, 2, None, 4])
+    a2 = ak.concatenate([ak.Array([1, 2]), ak.Array([None, 4])])
+    assert ak.array_equal(a1, a2)
+
+    a3 = a1.layout.to_ByteMaskedArray(valid_when=True)
+    assert not ak.array_equal(a1, a3, same_content_types=True)
+    assert ak.array_equal(a1, a3, same_content_types=False)
+    assert not ak.array_equal(
+        a1, ak.Array([1, 2, 3, 4]), same_content_types=False, dtype_exact=False
+    )
+
+
+def test_array_equal_nan():
+    a = ak.Array([1.0, 2.5, np.nan])
+    nplike = a.layout.backend.nplike
+    assert not nplike.array_equal(a.layout.data, a.layout.data)
+    assert nplike.array_equal(a.layout.data, a.layout.data, equal_nan=True)
+    assert not ak.array_equal(a, a)
+    assert ak.array_equal(a, a, equal_nan=True)
+
+
+def test_array_equal_with_params():
+    a1 = NumpyArray(
+        np.array([1, 2, 3], dtype=np.uint32), parameters={"foo": {"bar": "baz"}}
+    )
+    a2 = NumpyArray(
+        np.array([1, 2, 3], dtype=np.uint32), parameters={"foo": {"bar": "Not so fast"}}
+    )
+    assert not ak.array_equal(a1, a2)
+    assert ak.array_equal(a1, a2, check_parameters=False)

--- a/tests/test_1105_ak_aray_equal.py
+++ b/tests/test_1105_ak_aray_equal.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_array_equal():
+    assert ak.array_equal(
+        ak.Array([[1, 2], [], [3, 4, 5]]),
+        ak.Array([[1, 2], [], [3, 4, 5]]),
+    )
+
+    # TODO: More test cases!


### PR DESCRIPTION
Adding `ak.operations.array_equal`, based on `numpy.array_equal`

This uses `...ak_almost_equal._impl()` which now has more parameters to
suit some particular needs of array_equal. Even so, `ak.almost_equal()` remains
unchanged operationally.

Note that there was broken code in `src/awkward/_nplikes/array_module.py`:
```
both_nan = self._module.logical_and(x1 == np.nan, x2 == np.nan)
```
The expressions like `x1 == np.nan` is all False even when x1 contains NaN values.
I'm hoping that my fix works for older versions of numpy. It works for numpy 1.26.4 and 2.0.1.