### PR TITLE
feat: provide a way for `Form.select_columns` to distinguish structural dots from dots in the names of record fields

### DIFF
--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -437,6 +437,19 @@ class Form(Meta):
     def select_columns(
         self, specifier, expand_braces=True, *, prune_unions_and_records: bool = True
     ):
+        """
+        select_columns returns a new Form with only columns and sub-columns selected.
+        Returns an empty Form if no columns matched the specifier(s).
+
+        `specifier` can be a `str | Iterator[str | list[str] | tuple[str]]`.
+        Strings may include shell-globbing-style wildcards "*" and "?".
+        If `expand_braces` is `True` (the default), strings may include alternatives in braces.
+        For example, `["a.{b,c}.d"]` is equivalent to `["a.b.d", "a.c.d"]`.
+        Glob-style matching would also suit this single-character instance: `"a.[bc].d"`.
+        If specifier is a list which contains a list/tuple, that inner list will be interpreted as
+        column and subcolumn specifiers. They *may* contain wildcards, but "." will not be
+        interpreted as a `<field>.<subfield>` pattern.
+        """
         if isinstance(specifier, str):
             specifier = {specifier}
 

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -441,7 +441,7 @@ class Form(Meta):
         select_columns returns a new Form with only columns and sub-columns selected.
         Returns an empty Form if no columns matched the specifier(s).
 
-        `specifier` can be a `str | Iterator[str | list[str] | tuple[str]]`.
+        `specifier` can be a `str | Iterable[str | Iterable[str]]`.
         Strings may include shell-globbing-style wildcards "*" and "?".
         If `expand_braces` is `True` (the default), strings may include alternatives in braces.
         For example, `["a.{b,c}.d"]` is equivalent to `["a.b.d", "a.c.d"]`.
@@ -458,15 +458,15 @@ class Form(Meta):
             if isinstance(item, str):
                 if item == "":
                     raise ValueError(
-                        "A column-selection specifier cannot be an empty string"
+                        "a column-selection specifier cannot be an empty string"
                     )
-            elif isinstance(item, (tuple, list)):
+            elif isinstance(item, Iterable):
                 for field in item:
                     if not isinstance(field, str):
-                        raise ValueError("A sub-column specifier must be a string")
+                        raise ValueError("a sub-column specifier must be a string")
             else:
                 raise TypeError(
-                    "A column-selection specifier must be a list of strings, lists, or tuples"
+                    "a column specifier must be a string or an iterable of strings"
                 )
 
         if expand_braces:

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -32,10 +32,11 @@ def from_parquet(
     Args:
         path (str): Local filename or remote URL, passed to fsspec for resolution.
             May contain glob patterns.
-        columns (None, str, or list of str): Glob pattern(s) with bash-like curly
+        columns (None, str, or list of (str or list of str)): Glob pattern(s) including bash-like curly
             brackets for matching column names. Nested records are separated by dots.
             If a list of patterns, the logical-or is matched. If None, all columns
-            are read.
+            are read. A list of lists can be provided to select columns with literal dots
+            in their names -- The inner list provides column names or patterns.
         row_groups (None or set of int): Row groups to read; must be non-negative.
             Order is ignored: the output array is presented in the order specified by
             Parquet metadata. If None, all row groups/all rows are read.

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -32,7 +32,7 @@ def from_parquet(
     Args:
         path (str): Local filename or remote URL, passed to fsspec for resolution.
             May contain glob patterns.
-        columns (None, str, or list of (str or list of str)): Glob pattern(s) including bash-like curly
+        columns (None, str, or iterable of (str or iterable of str)): Glob pattern(s) including bash-like curly
             brackets for matching column names. Nested records are separated by dots.
             If a list of patterns, the logical-or is matched. If None, all columns
             are read. A list of lists can be provided to select columns with literal dots

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -202,23 +202,3 @@ def test_very_large_record():
             ],
         }
     )
-
-
-def test_alternative_specifiers():
-    form = ak.Array(
-        [
-            {
-                "x": [
-                    {
-                        "y": {
-                            "z": [1, 2, 3],
-                            "w.1": 4,
-                        }
-                    }
-                ]
-            }
-        ]
-    ).layout.form
-    assert form.select_columns("*") == form
-    assert form.select_columns([("x", "y", "w.1")]) == form.select_columns("x.y.w*")
-    assert form.select_columns([["x", "y", "w.1"], "x.y.z"]) == form

--- a/tests/test_2536_select_columns.py
+++ b/tests/test_2536_select_columns.py
@@ -202,3 +202,23 @@ def test_very_large_record():
             ],
         }
     )
+
+
+def test_alternative_specifiers():
+    form = ak.Array(
+        [
+            {
+                "x": [
+                    {
+                        "y": {
+                            "z": [1, 2, 3],
+                            "w.1": 4,
+                        }
+                    }
+                ]
+            }
+        ]
+    ).layout.form
+    assert form.select_columns("*") == form
+    assert form.select_columns([("x", "y", "w.1")]) == form.select_columns("x.y.w*")
+    assert form.select_columns([["x", "y", "w.1"], "x.y.z"]) == form

--- a/tests/test_3088_select_columns_supports_literal_dots.py
+++ b/tests/test_3088_select_columns_supports_literal_dots.py
@@ -1,9 +1,10 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 
 from __future__ import annotations
+
 import os
 
-import pytest  # noqa: F401
+import pytest
 
 import awkward as ak
 
@@ -53,17 +54,19 @@ def test_columns_with_dots_from_parquet(tmp_path):
         }
     ]
 
-    ambig_array = ak.Array([
-        {
-            'crazy': {
-                'dot': [11, 12, 13],
-            },
-            'crazy.dot': [21, 22, 23],
-        }
-    ])
+    ambig_array = ak.Array(
+        [
+            {
+                "crazy": {
+                    "dot": [11, 12, 13],
+                },
+                "crazy.dot": [21, 22, 23],
+            }
+        ]
+    )
     parquet_file_ambig = os.path.join(tmp_path, "test_3088_array_ambig.parquet")
     ak.to_parquet(ambig_array, parquet_file_ambig)
-    ambig_selected = ak.from_parquet(parquet_file_ambig, columns=[("crazy.dot", )])
+    ambig_selected = ak.from_parquet(parquet_file_ambig, columns=[("crazy.dot",)])
     # Note: Currently, pyarrow.parquet cannot distinguish dots as separators
     # from dots as field names. It builds a dict of all possible indices,
     # and returns those. Even so, we still need the ability within Awkward to

--- a/tests/test_3088_select_columns_supports_literal_dots.py
+++ b/tests/test_3088_select_columns_supports_literal_dots.py
@@ -1,0 +1,73 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+import os
+
+import pytest  # noqa: F401
+
+import awkward as ak
+
+
+def array_with_dotted_fields():
+    return ak.Array(
+        [
+            {
+                "x": [
+                    {
+                        "y": {
+                            "z": [1, 2, 3],
+                            "w.1": 4,
+                        }
+                    }
+                ]
+            }
+        ]
+    )
+
+
+def test_alternative_specifiers():
+    array = array_with_dotted_fields()
+    form = array.layout.form
+    assert form.select_columns("*") == form
+    assert form.select_columns([("x", "y", "w.1")]) == form.select_columns("x.y.w*")
+    assert form.select_columns([["x", "y", "w.1"], "x.y.z"]) == form
+
+
+def test_columns_with_dots_from_parquet(tmp_path):
+    # ruff: noqa: F841
+    _pq = pytest.importorskip("pyarrow.parquet")
+    array = array_with_dotted_fields()
+    parquet_file = os.path.join(tmp_path, "test_3088_array1.parquet")
+    ak.to_parquet(array, parquet_file)
+    array_selected = ak.from_parquet(parquet_file, columns=[("x", "y", "w.1")])
+    assert array_selected.to_list() == [
+        {
+            "x": [
+                {
+                    "y": {
+                        #  "z": [1, 2, 3],  Excluded
+                        "w.1": 4,  # Selected
+                    }
+                }
+            ]
+        }
+    ]
+
+    ambig_array = ak.Array([
+        {
+            'crazy': {
+                'dot': [11, 12, 13],
+            },
+            'crazy.dot': [21, 22, 23],
+        }
+    ])
+    parquet_file_ambig = os.path.join(tmp_path, "test_3088_array_ambig.parquet")
+    ak.to_parquet(ambig_array, parquet_file_ambig)
+    ambig_selected = ak.from_parquet(parquet_file_ambig, columns=[("crazy.dot", )])
+    # Note: Currently, pyarrow.parquet cannot distinguish dots as separators
+    # from dots as field names. It builds a dict of all possible indices,
+    # and returns those. Even so, we still need the ability within Awkward to
+    # disambiguate these two, which we now have. We would need further
+    # feature work to create column name substitutions to work around this pyarrow
+    # limitation should this be justified.
+    assert ak.array_equal(ambig_selected, ambig_array)  # Slurped everything.


### PR DESCRIPTION
Addressing the need to select field names with literal dots in them.

This is a change to `Form.select_columns()`. This change allows a user to supply a `specifier` as a list of lists of field (or column) names.