### PR TITLE
test: loosen message on test_2757 due to upstream Cython changes

### DIFF
--- a/tests/test_2757_attrs_metadata.py
+++ b/tests/test_2757_attrs_metadata.py
@@ -42,7 +42,8 @@ def test_serialise_with_nonserialisable_attrs(array_pickler):
     attrs = {**SOME_ATTRS, "non_transient_key": lambda: None}
     array = ak.Array([1, 2, 3], attrs=attrs)
     with pytest.raises(
-        (AttributeError, array_pickler.PicklingError), match=r"Can't pickle"
+        (AttributeError, array_pickler.PicklingError),
+        match=r"(pickle|local object)",
     ):
         array_pickler.loads(array_pickler.dumps(array))
 


### PR DESCRIPTION
Over the years, the message has been "Can't pickle local object", "Can't pickle", and "Can't get local object". This regex captures all three and likely future rephrasings.