### PR TITLE
fix: GPU complex reducer prod for empty lists

### DIFF
--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_reduce_prod_complex.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_reduce_prod_complex.cu
@@ -59,8 +59,8 @@ awkward_reduce_prod_complex_b(
 
     if (thread_id < lenparents) {
       for (int64_t stride = 1; stride < blockDim.x; stride *= 2) {
-        T real = (T)1.0f;
-        T imag = (T)0.0f;
+        T real = (T)1;
+        T imag = (T)0;
         if (idx >= stride && thread_id < lenparents && parents[thread_id] == parents[thread_id - stride]) {
           real = temp[(idx - stride) * 2];
           imag = temp[(idx - stride) * 2 + 1];

--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_reduce_prod_complex.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_reduce_prod_complex.cu
@@ -30,8 +30,8 @@ awkward_reduce_prod_complex_a(
     int64_t thread_id = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (thread_id < outlength) {
-      toptr[thread_id * 2] = (T)1.0f;
-      toptr[thread_id * 2 + 1] = (T)0.0f;
+      toptr[thread_id * 2] = (T)1;
+      toptr[thread_id * 2 + 1] = (T)0;
     }
   }
 }


### PR DESCRIPTION
fixes issue #3214

The test failure is due to a mismatch between the expected and actual results in the assertion `cpt.assert_allclose`. The issue arises when comparing the results of the `ak.prod `operation on arrays converted to the CUDA backend (`cuda_depth1`) and the original CPU backend (`depth1`). Specifically, there's a discrepancy in the third element of the arrays (which is an `EmptyArray`) being compared: `0j` versus (`1.4641 - 0j`).

The product of no element is defined as 1. 