### PR TITLE
docs: pybind11 demo project should have NumPy own the data

### DIFF
--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -51,9 +51,16 @@ py::object snapshot_builder(const T &builder) {
     for (auto name_nbytes : names_nbytes) {
       int nbytes = name_nbytes.second;
 
-      py::object array = np.attr("empty")(nbytes, dtype_u1);
+      py::object array = np.attr("ones")(nbytes, dtype_u1);
 
-      py::module::import("builtins").attr("print")(array);
+      size_t pointer = py::cast<size_t>(array.attr("ctypes").attr("data"));
+      void* raw_data = (void*)pointer;
+
+      int c0 = ((unsigned char*)raw_data)[0];
+      int c1 = ((unsigned char*)raw_data)[1];
+      int c2 = ((unsigned char*)raw_data)[2];
+
+      std::cout << "pointer = " << pointer << " raw data = " << c0 << " " << c1 << " " << c2 << std::endl;
 
     }
 

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -62,32 +62,8 @@ py::object snapshot_builder(const T &builder) {
     // Write non-contiguous contents to memory.
     builder.to_buffers(cpp_container);
 
-    py::module::import("builtins").attr("print")(py_container);
-
-    // ak.attr("from_buffers")(py_container);
-
-    // // Build Python dictionary containing arrays
-    // // dtypes not important here as long as they match the underlying buffer
-    // // as Awkward Array calls `frombuffer` to convert to the correct type
-    // py::dict container;
-    // for (auto it: buffers) {
-
-    //     py::capsule free_when_done(it.second, [](void *data) {
-    //         uint8_t *dataPtr = reinterpret_cast<uint8_t *>(data);
-    //         delete[] dataPtr;
-    //     });
-
-    //     uint8_t *data = reinterpret_cast<uint8_t *>(it.second);
-    //     container[py::str(it.first)] = py::array_t<uint8_t>(
-    //             {names_nbytes[it.first]},
-    //             {sizeof(uint8_t)},
-    //             data,
-    //             free_when_done
-    //     );
-    // }
-    // return from_buffers(builder.form(), builder.length(), container);
-
-  return py::none();
+    // Build Python dictionary containing arrays.
+    return ak.attr("from_buffers")(builder.form(), builder.length(), py_container);
 }
 
 

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -49,22 +49,17 @@ py::object snapshot_builder(const T &builder) {
     py::dict py_container;
     std::map<std::string, void*> cpp_container;
     for (auto name_nbytes : names_nbytes) {
-      int nbytes = name_nbytes.second;
-
-      py::object array = np.attr("ones")(nbytes, dtype_u1);
+      py::object array = np.attr("empty")(name_nbytes.second, dtype_u1);
 
       size_t pointer = py::cast<size_t>(array.attr("ctypes").attr("data"));
       void* raw_data = (void*)pointer;
 
-      int c0 = ((unsigned char*)raw_data)[0];
-      int c1 = ((unsigned char*)raw_data)[1];
-      int c2 = ((unsigned char*)raw_data)[2];
-
-      std::cout << "pointer = " << pointer << " raw data = " << c0 << " " << c1 << " " << c2 << std::endl;
-
+      py::str py_name(name_nbytes.first);
+      py_container[py_name] = array;
+      cpp_container[name_nbytes.first] = raw_data;
     }
 
-
+    py::module::import("builtins").attr("print")(py_container);
 
 
     // // Write non-contiguous contents to memory

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -34,42 +34,44 @@ using MyBuilder = RecordBuilder<
  */
 template<typename T>
 py::object snapshot_builder(const T &builder) {
-    // How much memory to allocate?
-    std::map <std::string, size_t> names_nbytes = {};
-    builder.buffer_nbytes(names_nbytes);
 
-    // Allocate memory
-    std::map<std::string, void *> buffers = {};
-    for (auto it: names_nbytes) {
-        uint8_t *ptr = new uint8_t[it.second];
-        buffers[it.first] = (void *) ptr;
-    }
+    // // How much memory to allocate?
+    // std::map <std::string, size_t> names_nbytes = {};
+    // builder.buffer_nbytes(names_nbytes);
 
-    // Write non-contiguous contents to memory
-    builder.to_buffers(buffers);
-    auto from_buffers = py::module::import("awkward").attr("from_buffers");
+    // // Allocate memory
+    // std::map<std::string, void *> buffers = {};
+    // for (auto it: names_nbytes) {
+    //     uint8_t *ptr = new uint8_t[it.second];
+    //     buffers[it.first] = (void *) ptr;
+    // }
 
-    // Build Python dictionary containing arrays
-    // dtypes not important here as long as they match the underlying buffer
-    // as Awkward Array calls `frombuffer` to convert to the correct type
-    py::dict container;
-    for (auto it: buffers) {
+    // // Write non-contiguous contents to memory
+    // builder.to_buffers(buffers);
+    // auto from_buffers = py::module::import("awkward").attr("from_buffers");
 
-        py::capsule free_when_done(it.second, [](void *data) {
-            uint8_t *dataPtr = reinterpret_cast<uint8_t *>(data);
-            delete[] dataPtr;
-        });
+    // // Build Python dictionary containing arrays
+    // // dtypes not important here as long as they match the underlying buffer
+    // // as Awkward Array calls `frombuffer` to convert to the correct type
+    // py::dict container;
+    // for (auto it: buffers) {
 
-        uint8_t *data = reinterpret_cast<uint8_t *>(it.second);
-        container[py::str(it.first)] = py::array_t<uint8_t>(
-                {names_nbytes[it.first]},
-                {sizeof(uint8_t)},
-                data,
-                free_when_done
-        );
-    }
-    return from_buffers(builder.form(), builder.length(), container);
+    //     py::capsule free_when_done(it.second, [](void *data) {
+    //         uint8_t *dataPtr = reinterpret_cast<uint8_t *>(data);
+    //         delete[] dataPtr;
+    //     });
 
+    //     uint8_t *data = reinterpret_cast<uint8_t *>(it.second);
+    //     container[py::str(it.first)] = py::array_t<uint8_t>(
+    //             {names_nbytes[it.first]},
+    //             {sizeof(uint8_t)},
+    //             data,
+    //             free_when_done
+    //     );
+    // }
+    // return from_buffers(builder.form(), builder.length(), container);
+
+  return py::none();
 }
 
 

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -34,17 +34,27 @@ using MyBuilder = RecordBuilder<
  */
 template<typename T>
 py::object snapshot_builder(const T &builder) {
+    // We need NumPy (to allocate arrays) and Awkward Array (ak.from_buffers).
+    // pybind11 will raise a ModuleNotFoundError if they aren't installed.
+    auto np = py::module::import("numpy");
+    auto ak = py::module::import("awkward");
 
-    // // How much memory to allocate?
-    // std::map <std::string, size_t> names_nbytes = {};
-    // builder.buffer_nbytes(names_nbytes);
+    auto dtype_u1 = np.attr("dtype")("u1");
 
-    // // Allocate memory
-    // std::map<std::string, void *> buffers = {};
-    // for (auto it: names_nbytes) {
-    //     uint8_t *ptr = new uint8_t[it.second];
-    //     buffers[it.first] = (void *) ptr;
-    // }
+    // How much memory to allocate?
+    std::map<std::string, size_t> names_nbytes;
+    builder.buffer_nbytes(names_nbytes);
+
+    // Ask NumPy to allocate memory and get pointers to the raw buffers.
+    py::dict py_container;
+    std::map<std::string, void*> cpp_container;
+    for (auto name_nbytes : names_nbytes) {
+      int nbytes = name_nbytes.second;
+      std::cout << "nbytes = " << nbytes << std::endl;
+    }
+
+
+
 
     // // Write non-contiguous contents to memory
     // builder.to_buffers(buffers);

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -59,12 +59,12 @@ py::object snapshot_builder(const T &builder) {
       cpp_container[name_nbytes.first] = raw_data;
     }
 
+    // Write non-contiguous contents to memory.
+    builder.to_buffers(cpp_container);
+
     py::module::import("builtins").attr("print")(py_container);
 
-
-    // // Write non-contiguous contents to memory
-    // builder.to_buffers(buffers);
-    // auto from_buffers = py::module::import("awkward").attr("from_buffers");
+    // ak.attr("from_buffers")(py_container);
 
     // // Build Python dictionary containing arrays
     // // dtypes not important here as long as they match the underlying buffer

--- a/header-only/examples/pybind11/demo.cpp
+++ b/header-only/examples/pybind11/demo.cpp
@@ -50,7 +50,11 @@ py::object snapshot_builder(const T &builder) {
     std::map<std::string, void*> cpp_container;
     for (auto name_nbytes : names_nbytes) {
       int nbytes = name_nbytes.second;
-      std::cout << "nbytes = " << nbytes << std::endl;
+
+      py::object array = np.attr("empty")(nbytes, dtype_u1);
+
+      py::module::import("builtins").attr("print")(array);
+
     }
 
 


### PR DESCRIPTION
The original demo _does_ link the memory-release to when the `py::capsule` does out of scope in Python, but [there are issues](https://indico.cern.ch/event/855454/contributions/4605044/) with crossing ownership of arrays between Python and C++.

The (nontrivial) back-and-forth API for LayoutBuilder snapshots was explicitly intended to allow Python to fully own the data, so I'm updating the example to make it do that.

@HavryliukAY, I'm approaching this as I would always approach a problem like this, doing it in small steps that can be individually tested. I don't ordinarily make a git-commit for each step, but I'll be doing that in this PR to show what this looks like. Between each commit, I do

```bash
pip uninstall demo
pip install .
python -c 'import demo; print(repr(demo.create_demo_array()))'
```

to see what I'm doing. In the first commit, "step 0", it returns `None`.