### PR TITLE
ci: use official GHA for uv

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -100,7 +100,7 @@ jobs:
         python-version: '3.12'
 
     - name: Setup uv
-      uses: yezz123/setup-uv@v4
+      uses: astral-sh/setup-uv@v3
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -150,7 +150,7 @@ jobs:
         python-version: '3.12'
 
     - name: Setup uv
-      uses: yezz123/setup-uv@v4
+      uses: astral-sh/setup-uv@v3
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -192,7 +192,7 @@ jobs:
         submodules: true
 
     - name: Setup uv
-      uses: yezz123/setup-uv@v4
+      uses: astral-sh/setup-uv@v3
 
     - name: Prepare build files
       run: pipx run nox -s prepare

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -63,7 +63,7 @@ jobs:
         submodules: true
 
     - name: Setup uv
-      uses: yezz123/setup-uv@v4
+      uses: astral-sh/setup-uv@v3
 
     - name: Prepare build files
       run: pipx run nox -s prepare


### PR DESCRIPTION
Gets rid of the using "latest" messages in the log annotations, too.
