### PR TITLE
fix: restrict `named_axis` inferring to `ak.Arrays/ak.Records/ak.HighLevelContexts` by default

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -463,7 +463,7 @@ def apply_step(
                         named_axis = _add_named_axis(named_axis, depth, ndim)
                         depth_context[NAMED_AXIS_KEY][i] = (
                             _unify_named_axis(named_axis, seen_named_axis),
-                            ndim + 1,
+                            ndim + 1 if ndim is not None else ndim,
                         )
                         if o.is_leaf:
                             _export_named_axis_from_depth_to_lateral(
@@ -645,7 +645,7 @@ def apply_step(
                         # rightbroadcasting adds a new first(!) dimension as depth
                         depth_context[NAMED_AXIS_KEY][i] = (
                             _add_named_axis(named_axis, depth, ndim),
-                            ndim + 1,
+                            ndim + 1 if ndim is not None else ndim,
                         )
                         if x.is_leaf:
                             _export_named_axis_from_depth_to_lateral(
@@ -734,7 +734,7 @@ def apply_step(
                     # leftbroadcasting adds a new last dimension at depth + 1
                     depth_context[NAMED_AXIS_KEY][i] = (
                         _add_named_axis(named_axis, depth + 1, ndim),
-                        ndim + 1,
+                        ndim + 1 if ndim is not None else ndim,
                     )
                     if x.is_leaf:
                         _export_named_axis_from_depth_to_lateral(

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -106,7 +106,9 @@ def _get_named_axis(ctx: tp.Any, allow_any: bool = False) -> AxisMapping:
     from awkward._layout import HighLevelContext
     from awkward.highlevel import Array, Record
 
-    if hasattr(ctx, "attrs") and isinstance(ctx, (HighLevelContext, Array, Record)):
+    if hasattr(ctx, "attrs") and (
+        isinstance(ctx, (HighLevelContext, Array, Record)) or allow_any
+    ):
         return _get_named_axis(ctx.attrs, allow_any=True)
     elif allow_any and isinstance(ctx, tp.Mapping) and NAMED_AXIS_KEY in ctx:
         return dict(ctx[NAMED_AXIS_KEY])

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -82,7 +82,7 @@ def _prettify_named_axes(
     return delimiter.join(items)
 
 
-def _get_named_axis(ctx: tp.Any) -> AxisMapping:
+def _get_named_axis(ctx: tp.Any, allow_any: bool = False) -> AxisMapping:
     """
     Retrieves the named axis from the provided context.
 
@@ -103,9 +103,12 @@ def _get_named_axis(ctx: tp.Any) -> AxisMapping:
         >>> _get_named_axis({"other_key": "other_value"})
         {}
     """
-    if hasattr(ctx, "attrs"):
-        return _get_named_axis(ctx.attrs)
-    elif isinstance(ctx, tp.Mapping) and NAMED_AXIS_KEY in ctx:
+    from awkward._layout import HighLevelContext
+    from awkward.highlevel import Array, Record
+
+    if hasattr(ctx, "attrs") and isinstance(ctx, (HighLevelContext, Array, Record)):
+        return _get_named_axis(ctx.attrs, allow_any=True)
+    elif allow_any and isinstance(ctx, tp.Mapping) and NAMED_AXIS_KEY in ctx:
         return dict(ctx[NAMED_AXIS_KEY])
     else:
         return {}

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -270,7 +270,7 @@ def _impl(x, weight, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         )
         return ak.operations.ak_with_named_axis._impl(
             wrapped,
-            named_axis=_get_named_axis(attrs_of_obj(out) or {}),
+            named_axis=_get_named_axis(attrs_of_obj(out), allow_any=True),
             highlevel=highlevel,
             behavior=None,
             attrs=None,

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -168,7 +168,7 @@ def _impl(
         # propagate named axis to output
         return ak.operations.ak_with_named_axis._impl(
             wrapped,
-            named_axis=_get_named_axis(attrs_of_obj(out)),
+            named_axis=_get_named_axis(attrs_of_obj(out), allow_any=True),
             highlevel=highlevel,
             behavior=None,
             attrs=None,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -145,7 +145,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
         # propagate named axis to output
         return ak.operations.ak_with_named_axis._impl(
             wrapped,
-            named_axis=_get_named_axis(attrs_of_obj(out)),
+            named_axis=_get_named_axis(attrs_of_obj(out), allow_any=True),
             highlevel=highlevel,
             behavior=None,
             attrs=None,

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -233,7 +233,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, highlevel, behavior, a
         # propagate named axis to output
         return ak.operations.ak_with_named_axis._impl(
             wrapped,
-            named_axis=_get_named_axis(attrs_of_obj(out)),
+            named_axis=_get_named_axis(attrs_of_obj(out), allow_any=True),
             highlevel=highlevel,
             behavior=None,
             attrs=None,

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -285,7 +285,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, highlevel, behavior, a
         # propagate named axis to output
         return ak.operations.ak_with_named_axis._impl(
             wrapped,
-            named_axis=_get_named_axis(attrs_of_obj(out)),
+            named_axis=_get_named_axis(attrs_of_obj(out), allow_any=True),
             highlevel=highlevel,
             behavior=None,
             attrs=None,


### PR DESCRIPTION
This PR is a follow-up to PR https://github.com/scikit-hep/awkward/pull/3299. The `named_axis` mapping is now only inferred from awkward-constructs (`ak.Array`, `ak.Record`, and `HighLevelContext`) by default. This avoids likely unwanted clashes with objects that implements the `named_axis` mapping interface (for whatever reason) but are not meant to be used this way. I expect this to happen in very rare corner-cases. This PR covers them now. An example is given below:

Old behavior:
```python
from awkward._namedaxis import _get_named_axis, NAMED_AXIS_KEY


class some:
  @property
  def attrs(self):
    return {NAMED_AXIS_KEY: {"x": 0}}
    
_get_named_axis(some())
>> {"x": 0}
```

New behavior:
```python
from awkward._namedaxis import _get_named_axis, NAMED_AXIS_KEY


class some:
  @property
  def attrs(self):
    return {NAMED_AXIS_KEY: {"x": 0}}
    
_get_named_axis(some())
>> {}
 
# old behavior can be enforced by:
_get_named_axis(some(), allow_any=True)
>> {"x": 0} 
```
 
If we want to infer `named_axis` from any types again somewhere in the future, the `allow_any` argument will allow us to do so. 