### PR TITLE
feat: Content.form_with_key_path()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ GPATH
 GRTAGS
 .vscode
 pyrightconfig.json
+.ropeproject
 # ...
 
 ############################################################# LaTeX

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -288,7 +288,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> BitMaskedForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> BitMaskedForm:
         return self.form_cls(
             self._mask.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -38,7 +38,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.forms.bitmaskedform import BitMaskedForm
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.index import Index
 
 if TYPE_CHECKING:
@@ -288,7 +288,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> BitMaskedForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> BitMaskedForm:
         return self.form_cls(
             self._mask.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -288,6 +288,16 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> BitMaskedForm:
+        return self.form_cls(
+            self._mask.form,
+            self._content._form_with_key_path((*path, None)),
+            self._valid_when,
+            self._lsb_order,
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -42,7 +42,7 @@ from awkward.contents.content import (
 )
 from awkward.errors import AxisError
 from awkward.forms.bytemaskedform import ByteMaskedForm
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.index import Index
 
 if TYPE_CHECKING:
@@ -218,7 +218,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> ByteMaskedForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> ByteMaskedForm:
         return self.form_cls(
             self._mask.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -218,7 +218,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> ByteMaskedForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> ByteMaskedForm:
         return self.form_cls(
             self._mask.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -218,6 +218,15 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> ByteMaskedForm:
+        return self.form_cls(
+            self._mask.form,
+            self._content._form_with_key_path((*path, None)),
+            self._valid_when,
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -238,10 +238,10 @@ class Content(Meta):
     ) -> Form:
         raise NotImplementedError
 
-    def form_with_key_path(self, root: (str | None) = ()) -> Form:
+    def form_with_key_path(self, root: (str | int | None) = ()) -> Form:
         return self._form_with_key_path(root)
 
-    def _form_with_key_path(self, path: (str | None)) -> Form:
+    def _form_with_key_path(self, path: (str | int | None)) -> Form:
         raise NotImplementedError
 
     @property

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -54,7 +54,7 @@ from awkward._typing import (
     TypedDict,
 )
 from awkward._util import UNSET
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.index import Index, Index64
 
 if TYPE_CHECKING:
@@ -241,7 +241,7 @@ class Content(Meta):
     def form_with_key_path(self, root: (str | int | None) = ()) -> Form:
         return self._form_with_key_path(root)
 
-    def _form_with_key_path(self, path: (str | int | None)) -> Form:
+    def _form_with_key_path(self, path: FormKeyPathT) -> Form:
         raise NotImplementedError
 
     @property

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -238,7 +238,7 @@ class Content(Meta):
     ) -> Form:
         raise NotImplementedError
 
-    def form_with_key_path(self, root: (str | int | None) = ()) -> Form:
+    def form_with_key_path(self, root: FormKeyPathT = ()) -> Form:
         return self._form_with_key_path(root)
 
     def _form_with_key_path(self, path: FormKeyPathT) -> Form:

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -238,6 +238,12 @@ class Content(Meta):
     ) -> Form:
         raise NotImplementedError
 
+    def form_with_key_path(self, root: (str | None) = ()) -> Form:
+        return self._form_with_key_path(root)
+
+    def _form_with_key_path(self, path: (str | None)) -> Form:
+        raise NotImplementedError
+
     @property
     def form_cls(self) -> type[Form]:
         raise NotImplementedError

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -35,7 +35,7 @@ from awkward.contents.content import (
 )
 from awkward.errors import AxisError
 from awkward.forms.emptyform import EmptyForm
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.index import Index
 
 if TYPE_CHECKING:
@@ -118,7 +118,7 @@ class EmptyArray(EmptyMeta, Content):
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
         return self.form_cls(form_key=getkey(self))
 
-    def _form_with_key_path(self, path: (str | int | None)) -> EmptyForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> EmptyForm:
         return self.form_cls(form_key=repr(path))
 
     def _to_buffers(

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -118,6 +118,9 @@ class EmptyArray(EmptyMeta, Content):
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
         return self.form_cls(form_key=getkey(self))
 
+    def _form_with_key_path(self, path: (str | None)) -> EmptyForm:
+        return self.form_cls(form_key=repr(path))
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -118,7 +118,7 @@ class EmptyArray(EmptyMeta, Content):
     def _form_with_key(self, getkey: Callable[[Content], str | None]) -> EmptyForm:
         return self.form_cls(form_key=getkey(self))
 
-    def _form_with_key_path(self, path: (str | None)) -> EmptyForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> EmptyForm:
         return self.form_cls(form_key=repr(path))
 
     def _to_buffers(

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -214,7 +214,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> IndexedForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> IndexedForm:
         return self.form_cls(
             self._index.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -39,7 +39,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.indexedform import IndexedForm
 from awkward.index import Index
 
@@ -214,7 +214,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> IndexedForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> IndexedForm:
         return self.form_cls(
             self._index.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -214,6 +214,14 @@ class IndexedArray(IndexedMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> IndexedForm:
+        return self.form_cls(
+            self._index.form,
+            self._content._form_with_key_path((*path, None)),
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -202,7 +202,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> IndexedOptionForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> IndexedOptionForm:
         return self.form_cls(
             self._index.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -202,6 +202,14 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> IndexedOptionForm:
+        return self.form_cls(
+            self._index.form,
+            self._content._form_with_key_path((*path, None)),
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -39,7 +39,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.indexedoptionform import IndexedOptionForm
 from awkward.index import Index
 
@@ -202,7 +202,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> IndexedOptionForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> IndexedOptionForm:
         return self.form_cls(
             self._index.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -207,6 +207,15 @@ class ListArray(ListMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> ListForm:
+        return self.form_cls(
+            self._starts.form,
+            self._stops.form,
+            self._content._form_with_key_path((*path, None)),
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -207,7 +207,7 @@ class ListArray(ListMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> ListForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> ListForm:
         return self.form_cls(
             self._starts.form,
             self._stops.form,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -38,7 +38,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.contents.listoffsetarray import ListOffsetArray
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.listform import ListForm
 from awkward.index import Index
 
@@ -207,7 +207,7 @@ class ListArray(ListMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> ListForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> ListForm:
         return self.form_cls(
             self._starts.form,
             self._stops.form,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -39,7 +39,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.listoffsetform import ListOffsetForm
 from awkward.index import Index, Index64
 
@@ -199,7 +199,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> ListOffsetForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> ListOffsetForm:
         return self.form_cls(
             self._offsets.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -199,7 +199,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> ListOffsetForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> ListOffsetForm:
         return self.form_cls(
             self._offsets.form,
             self._content._form_with_key_path((*path, None)),

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -199,6 +199,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> ListOffsetForm:
+        return self.form_cls(
+            self._offsets.form,
+            self._content._form_with_key_path((*path, None)),
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -45,7 +45,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.numpyform import NumpyForm
 from awkward.index import Index
 from awkward.types.numpytype import primitive_to_dtype
@@ -200,7 +200,7 @@ class NumpyArray(NumpyMeta, Content):
             form_key=getkey(self),
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> NumpyForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> NumpyForm:
         return self.form_cls(
             ak.types.numpytype.dtype_to_primitive(self._data.dtype),
             self.inner_shape,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -200,6 +200,14 @@ class NumpyArray(NumpyMeta, Content):
             form_key=getkey(self),
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> NumpyForm:
+        return self.form_cls(
+            ak.types.numpytype.dtype_to_primitive(self._data.dtype),
+            self.inner_shape,
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -200,7 +200,7 @@ class NumpyArray(NumpyMeta, Content):
             form_key=getkey(self),
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> NumpyForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> NumpyForm:
         return self.form_cls(
             ak.types.numpytype.dtype_to_primitive(self._data.dtype),
             self.inner_shape,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -40,7 +40,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.recordform import RecordForm
 from awkward.index import Index
 from awkward.record import Record
@@ -316,16 +316,14 @@ class RecordArray(RecordMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> RecordForm:
-        if self._fields is None:
-            contents = [
-                x._form_with_key_path((*path, i)) for i, x in enumerate(self._contents)
-            ]
-        else:
-            contents = [
-                x._form_with_key_path((*path, k))
-                for k, x in zip(self._fields, self._contents)
-            ]
+    def _form_with_key_path(self, path: FormKeyPathT) -> RecordForm:
+        # explicitely use `self.fields` instead of `self._fields`,
+        # because we want string-typed field names in the path -
+        # also for tuple records
+        contents = [
+            x._form_with_key_path((*path, k))
+            for k, x in zip(self.fields, self._contents)
+        ]
 
         return self.form_cls(
             contents,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -316,6 +316,24 @@ class RecordArray(RecordMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> RecordForm:
+        if self._fields is None:
+            contents = [
+                x._form_with_key_path((*path, i)) for i, x in enumerate(self._contents)
+            ]
+        else:
+            contents = [
+                x._form_with_key_path((*path, k))
+                for k, x in zip(self._fields, self._contents)
+            ]
+
+        return self.form_cls(
+            contents,
+            self._fields,
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -316,7 +316,7 @@ class RecordArray(RecordMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> RecordForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> RecordForm:
         if self._fields is None:
             contents = [
                 x._form_with_key_path((*path, i)) for i, x in enumerate(self._contents)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -317,7 +317,7 @@ class RecordArray(RecordMeta[Content], Content):
         )
 
     def _form_with_key_path(self, path: FormKeyPathT) -> RecordForm:
-        # explicitely use `self.fields` instead of `self._fields`,
+        # explicitly use `self.fields` instead of `self._fields`,
         # because we want string-typed field names in the path -
         # also for tuple records
         contents = [

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -211,7 +211,7 @@ class RegularArray(RegularMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> RegularForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> RegularForm:
         return self.form_cls(
             self._content._form_with_key_path((*path, None)),
             self._size,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -211,6 +211,14 @@ class RegularArray(RegularMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> RegularForm:
+        return self.form_cls(
+            self._content._form_with_key_path((*path, None)),
+            self._size,
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -37,7 +37,7 @@ from awkward.contents.content import (
     RemoveStructureOptions,
     ToArrowOptions,
 )
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.regularform import RegularForm
 from awkward.index import Index
 
@@ -211,7 +211,7 @@ class RegularArray(RegularMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> RegularForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> RegularForm:
         return self.form_cls(
             self._content._form_with_key_path((*path, None)),
             self._size,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -39,7 +39,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.unionform import UnionForm
 from awkward.index import Index, Index8, Index64
 
@@ -460,7 +460,7 @@ class UnionArray(UnionMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> UnionForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> UnionForm:
         return self.form_cls(
             self._tags.form,
             self._index.form,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -460,7 +460,7 @@ class UnionArray(UnionMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> UnionForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> UnionForm:
         return self.form_cls(
             self._tags.form,
             self._index.form,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -460,6 +460,15 @@ class UnionArray(UnionMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> UnionForm:
+        return self.form_cls(
+            self._tags.form,
+            self._index.form,
+            [x._form_with_key_path((*path, i)) for i, x in enumerate(self._contents)],
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -138,7 +138,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | None)) -> UnmaskedForm:
+    def _form_with_key_path(self, path: (str | int | None)) -> UnmaskedForm:
         return self.form_cls(
             self._content._form_with_key_path((*path, None)),
             parameters=self._parameters,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -138,6 +138,13 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             form_key=form_key,
         )
 
+    def _form_with_key_path(self, path: (str | None)) -> UnmaskedForm:
+        return self.form_cls(
+            self._content._form_with_key_path((*path, None)),
+            parameters=self._parameters,
+            form_key=repr(path),
+        )
+
     def _to_buffers(
         self,
         form: Form,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -39,7 +39,7 @@ from awkward.contents.content import (
     ToArrowOptions,
 )
 from awkward.errors import AxisError
-from awkward.forms.form import Form
+from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.unmaskedform import UnmaskedForm
 from awkward.index import Index
 
@@ -138,7 +138,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             form_key=form_key,
         )
 
-    def _form_with_key_path(self, path: (str | int | None)) -> UnmaskedForm:
+    def _form_with_key_path(self, path: FormKeyPathT) -> UnmaskedForm:
         return self.form_cls(
             self._content._form_with_key_path((*path, None)),
             parameters=self._parameters,

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -27,9 +27,9 @@ from awkward._typing import (
     Iterator,
     JSONMapping,
     Self,
+    Tuple,
     TypeAlias,
     Union,
-    Tuple,
 )
 
 __all__ = ("from_dict", "from_type", "from_json", "reserved_nominal_parameters", "Form")

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -27,6 +27,9 @@ from awkward._typing import (
     Iterator,
     JSONMapping,
     Self,
+    TypeAlias,
+    Union,
+    Tuple,
 )
 
 __all__ = ("from_dict", "from_type", "from_json", "reserved_nominal_parameters", "Form")
@@ -34,6 +37,7 @@ __all__ = ("from_dict", "from_type", "from_json", "reserved_nominal_parameters",
 np = NumpyMetadata.instance()
 numpy_backend = NumpyBackend.instance()
 
+FormKeyPathT: TypeAlias = Tuple[Union[str, int, None], ...]
 
 reserved_nominal_parameters: Final = frozenset(
     {

--- a/tests/test_3311_form_with_key_path.py
+++ b/tests/test_3311_form_with_key_path.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_record_tuple():
+    form = ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": None,
+            "contents": [
+                {"class": "NumpyArray", "primitive": "int64", "form_key": "('0',)"},
+                {"class": "NumpyArray", "primitive": "int64", "form_key": "('1',)"},
+            ],
+            "form_key": "()",
+        }
+    )
+    array = ak.Array([(1, 2)])
+    assert array.layout.form_with_key_path() == form
+
+
+def test_record_dict():
+    form = ak.forms.from_dict(
+        {
+            "class": "RecordArray",
+            "fields": ["foo", "bar"],
+            "contents": [
+                {"class": "NumpyArray", "primitive": "int64", "form_key": "('foo',)"},
+                {"class": "NumpyArray", "primitive": "int64", "form_key": "('bar',)"},
+            ],
+            "form_key": "()",
+        }
+    )
+    array = ak.Array({"foo": [1], "bar": [2]})
+    assert array.layout.form_with_key_path() == form
+
+
+def test_numpy():
+    form = ak.forms.from_dict(
+        {"class": "NumpyArray", "primitive": "int64", "form_key": "()"}
+    )
+    array = ak.Array([1, 2, 3])
+    assert array.layout.form_with_key_path() == form
+
+
+def test_listoffset():
+    form = ak.forms.from_dict(
+        {
+            "class": "ListOffsetArray",
+            "offsets": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    array = ak.Array([[1, 2], [3]])
+    assert array.layout.form_with_key_path() == form
+
+
+def test_empty():
+    form = ak.forms.from_dict({"class": "EmptyArray", "form_key": "()"})
+    array = ak.Array([])
+    assert array.layout.form_with_key_path() == form
+
+
+def test_bitmasked():
+    form = ak.forms.from_dict(
+        {
+            "class": "BitMaskedArray",
+            "mask": "u8",
+            "valid_when": True,
+            "lsb_order": False,
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    content = ak.Array([0.0, 1.1, 2.2, 3.3, 4.4]).layout
+    mask = ak.index.IndexU8(
+        np.packbits(np.array([False, True, True, False, False], dtype=np.int8))
+    )
+    bitmaskedarray = ak.contents.BitMaskedArray(mask, content, True, 5, False)
+    assert bitmaskedarray.form_with_key_path() == form
+
+
+def test_bytemasked():
+    form = ak.forms.from_dict(
+        {
+            "class": "ByteMaskedArray",
+            "mask": "i8",
+            "valid_when": True,
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    content = ak.Array([0.0, 1.1, 2.2, 3.3, 4.4]).layout
+    mask = ak.index.Index8(np.array([False, True, True, False, False], dtype=np.int8))
+    bytemaskedarray = ak.contents.ByteMaskedArray(mask, content, True)
+    assert bytemaskedarray.form_with_key_path() == form
+
+
+def test_indexedarray():
+    form = ak.forms.from_dict(
+        {
+            "class": "IndexedArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+
+    content = ak.Array([0.0, 1.1, 2.2, 3.3, 4.4]).layout
+    index = ak.index.Index64(np.array([3, 1, 1, 4, 2], dtype=np.int64))
+    indexedarray = ak.contents.IndexedArray(index, content)
+    assert indexedarray.form_with_key_path() == form
+
+
+def test_indexedoptionarray():
+    form = ak.forms.from_dict(
+        {
+            "class": "IndexedOptionArray",
+            "index": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    content = ak.Array(
+        np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    ).layout
+    index = ak.index.Index64(np.array([2, -1, 4, 0, 8], dtype=np.int64))
+    layout = ak.Array(ak.contents.IndexedOptionArray(index, content)).layout
+    assert layout.form_with_key_path() == form
+
+
+def test_listarray():
+    form = ak.forms.from_dict(
+        {
+            "class": "ListArray",
+            "starts": "i64",
+            "stops": "i64",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "float64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    content = ak.contents.NumpyArray(
+        np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9])
+    )
+    starts = ak.index.Index64(np.array([0, 3, 3, 5, 6]))
+    stops = ak.index.Index64(np.array([3, 3, 5, 6, 9]))
+    layout = ak.contents.ListArray(starts, stops, content)
+    assert layout.form_with_key_path() == form
+
+
+def test_regulararray():
+    form = ak.forms.from_dict(
+        {
+            "class": "RegularArray",
+            "size": 3,
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+    content = ak.Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]).layout
+    layout = ak.contents.RegularArray(content, 3, zeros_length=0)
+    assert layout.form_with_key_path() == form
+
+
+def test_unionarray():
+    form = ak.forms.from_dict(
+        {
+            "class": "UnionArray",
+            "tags": "i8",
+            "index": "i64",
+            "contents": [
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "NumpyArray",
+                        "primitive": "float64",
+                        "form_key": "(0, None)",
+                    },
+                    "form_key": "(0,)",
+                },
+                {
+                    "class": "ListOffsetArray",
+                    "offsets": "i64",
+                    "content": {
+                        "class": "ListOffsetArray",
+                        "offsets": "i64",
+                        "content": {
+                            "class": "NumpyArray",
+                            "primitive": "uint8",
+                            "parameters": {"__array__": "char"},
+                            "form_key": "(1, None, None)",
+                        },
+                        "parameters": {"__array__": "string"},
+                        "form_key": "(1, None)",
+                    },
+                    "form_key": "(1,)",
+                },
+            ],
+            "form_key": "()",
+        }
+    )
+    content1 = ak.operations.from_iter([[], [1.1], [2.2, 2.2]], highlevel=False)
+    content2 = ak.operations.from_iter([["two", "two"], ["one"], []], highlevel=False)
+    tags = ak.index.Index8(np.array([0, 1, 0, 1, 0, 1], dtype=np.int8))
+    index = ak.index.Index64(np.array([0, 0, 1, 1, 2, 2], dtype=np.int64))
+    layout = ak.contents.UnionArray(tags, index, [content1, content2])
+    assert layout.form_with_key_path() == form
+
+
+def test_unmaskedarray():
+    form = ak.forms.from_dict(
+        {
+            "class": "UnmaskedArray",
+            "content": {
+                "class": "NumpyArray",
+                "primitive": "int64",
+                "form_key": "(None,)",
+            },
+            "form_key": "()",
+        }
+    )
+
+    content = ak.Array([1, 2, 3, 4, 5]).layout
+    layout = ak.contents.UnmaskedArray(content)
+    assert layout.form_with_key_path() == form


### PR DESCRIPTION
As it stands, this PR lacks tests, but the new feature is:

```python
>>> array = ak.Array([{"event": 123, "muons": [{"pt": 1.1}, {"pt": 2.2}]}])
>>> print(array.layout.form_with_key_path())
{
    "class": "RecordArray",
    "fields": [
        "event",
        "muons"
    ],
    "contents": [
        {
            "class": "NumpyArray",
            "primitive": "int64",
            "form_key": "('event',)"
        },
        {
            "class": "ListOffsetArray",
            "offsets": "i64",
            "content": {
                "class": "RecordArray",
                "fields": [
                    "pt"
                ],
                "contents": [
                    {
                        "class": "NumpyArray",
                        "primitive": "float64",
                        "form_key": "('muons', None, 'pt')"
                    }
                ],
                "form_key": "('muons', None)"
            },
            "form_key": "('muons',)"
        }
    ],
    "form_key": "()"
}
```

These form keys can be turned back into tuples with [ast.literal_eval](https://docs.python.org/3/library/ast.html#ast.literal_eval) to get a full path from root to each node.

The new function takes `root` as an argument to put a prefix in the tuple, for uniqueness beyond the tree.

Maybe those `None` values should optionally be `0`? They're needed for nodes to be unique, so that the form keys of this list are not all identical:

```python
>>> array = ak.Array([[[[[1]]]]])
>>> print(array.layout.form_with_key_path())
{
    "class": "ListOffsetArray",
    "offsets": "i64",
    "content": {
        "class": "ListOffsetArray",
        "offsets": "i64",
        "content": {
            "class": "ListOffsetArray",
            "offsets": "i64",
            "content": {
                "class": "ListOffsetArray",
                "offsets": "i64",
                "content": {
                    "class": "NumpyArray",
                    "primitive": "int64",
                    "form_key": "(None, None, None, None)"
                },
                "form_key": "(None, None, None)"
            },
            "form_key": "(None, None)"
        },
        "form_key": "(None,)"
    },
    "form_key": "()"
}
```

But maybe we don't care about those extra 3 characters per nesting level. How much nesting is there going to be, anyway? Yeah, I think this is fine.