### PR TITLE
fix: sorting of record arrays without fields (`ak.zip(tuple(...))`)

### DIFF
--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -829,7 +829,7 @@ class RecordArray(RecordMeta[Content], Content):
         raise NotImplementedError
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
-        if self._fields is None or len(self._fields) == 0:
+        if len(self.fields) == 0:
             return ak.contents.NumpyArray(
                 self._backend.nplike.instance().empty(0, dtype=np.int64),
                 parameters=None,

--- a/tests/test_1316_sort_recordarrays.py
+++ b/tests/test_1316_sort_recordarrays.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_sort_record():
+    a = ak.contents.NumpyArray(np.array([50, 500, 100, 1, 200, 1000]))
+
+    record = ak.Array(ak.contents.RecordArray([a, a[::-1]], ["a", "b"]))
+
+    assert ak.to_list(ak.sort(record)["a"]) == [1, 50, 100, 200, 500, 1000]
+    assert ak.to_list(ak.sort(record)["b"]) == [1, 50, 100, 200, 500, 1000]
+
+
+def test_sort_record_tuple():
+    a = ak.contents.NumpyArray(np.array([50, 500, 100, 1, 200, 1000]))
+
+    record = ak.Array(ak.contents.RecordArray([a, a[::-1]], None))
+
+    assert ak.to_list(ak.sort(record)["0"]) == [1, 50, 100, 200, 500, 1000]
+    assert ak.to_list(ak.sort(record)["1"]) == [1, 50, 100, 200, 500, 1000]


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/1361#issuecomment-1901389735.

It does not affect `ak.argsort`, because that does not even have an implementation for record arrays in the first place - it will raise a `NotImplementedError` as for now.