### PR TITLE
feat: allow `np.array`s in `ak.full_like` as fill_value

### DIFF
--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -8,7 +8,7 @@ from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext, ensure_same_backend
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import is_unknown_scalar
-from awkward._regularize import is_integer_like
+from awkward._regularize import is_array_like, is_integer_like
 from awkward.operations.ak_zeros_like import _ZEROS
 
 __all__ = ("full_like",)
@@ -222,7 +222,9 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
         else:
             return None
 
-    out = ak._do.recursively_apply(layout, action)
+    out = ak._do.recursively_apply(
+        layout, action, numpy_to_regular=not is_array_like(fill_value)
+    )
     return ctx.wrap(out, highlevel=highlevel)
 
 

--- a/tests/test_2787_ak_full_like_with_broadcasting.py
+++ b/tests/test_2787_ak_full_like_with_broadcasting.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test_ak_full_like_with_broadcasting():
+    a = ak.Array(np.ones((2, 2)))
+    b = ak.full_like(a, fill_value=np.array([2.0, 3.0]))
+
+    assert ak.to_list(b) == [[2.0, 3.0], [2.0, 3.0]]


### PR DESCRIPTION
This PR allows to pass numpy arrays as fill value to `ak.full_like`. They are then broadcasted accordingly into the shape of the reference array, e.g.:

```python
ref = ak.Array(np.ones((2, 2)))
ak.full_like(ref, fill_value=np.array([2.0, 3.0]))
# >> <Array [[2, 3], [2, 3]] type='2 * 2 * float64'>
```

Fixes https://github.com/scikit-hep/awkward/issues/2787.

Currently, this only works with numpy arrays. Maybe at some point this should be extended with arbitrary awkward-arrays?