### PR TITLE
fix: handle type tracer correctly in indexed option array flattening

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -600,7 +600,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
             offsets, flattened = next._offsets_and_flattened(axis, depth)
 
-            if offsets.length == 0:
+            if offsets.length is not unknown_length and offsets.length == 0:
                 return (
                     offsets,
                     ak.contents.IndexedOptionArray(

--- a/tests/test_3325_ak_flatten_indexed_option_array.py
+++ b/tests/test_3325_ak_flatten_indexed_option_array.py
@@ -49,6 +49,6 @@ ttlayout, report = ak.typetracer.typetracer_with_report(form)
 ttarray = ak.Array(ttlayout)
 
 
-@pytest.mark.parametrize("ax", [None, *list(i for i in range(4))])
+@pytest.mark.parametrize("ax", [None, 0, 1, 2, 3])
 def test_3325_flatten_index_option_array(ax):
     ak.flatten(ttarray, axis=ax)

--- a/tests/test_3325_ak_flatten_indexed_option_array.py
+++ b/tests/test_3325_ak_flatten_indexed_option_array.py
@@ -49,6 +49,6 @@ ttlayout, report = ak.typetracer.typetracer_with_report(form)
 ttarray = ak.Array(ttlayout)
 
 
-@pytest.mark.parametrize("ax", [None] + [i for i in range(4)])
+@pytest.mark.parametrize("ax", [None] + list(i for i in range(4)))
 def test_3325_flatten_index_option_array(ax):
     ak.flatten(ttarray, axis=ax)

--- a/tests/test_3325_ak_flatten_indexed_option_array.py
+++ b/tests/test_3325_ak_flatten_indexed_option_array.py
@@ -49,6 +49,6 @@ ttlayout, report = ak.typetracer.typetracer_with_report(form)
 ttarray = ak.Array(ttlayout)
 
 
-@pytest.mark.parametrize("ax", [None] + list(i for i in range(4)))
+@pytest.mark.parametrize("ax", [None, *list(i for i in range(4))])
 def test_3325_flatten_index_option_array(ax):
     ak.flatten(ttarray, axis=ax)

--- a/tests/test_3325_ak_flatten_indexed_option_array.py
+++ b/tests/test_3325_ak_flatten_indexed_option_array.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+fromdict = {
+    "class": "ListOffsetArray",
+    "offsets": "i64",
+    "content": {
+        "class": "ListOffsetArray",
+        "offsets": "i64",
+        "content": {
+            "class": "IndexedOptionArray",
+            "index": "i64",
+            "content": {
+                "class": "ListOffsetArray",
+                "offsets": "i64",
+                "content": {
+                    "class": "IndexedOptionArray",
+                    "index": "i64",
+                    "content": {
+                        "class": "NumpyArray",
+                        "primitive": "float32",
+                        "inner_shape": [],
+                        "parameters": {},
+                        "form_key": None,
+                    },
+                    "parameters": {},
+                    "form_key": None,
+                },
+                "parameters": {},
+                "form_key": None,
+            },
+            "parameters": {},
+            "form_key": None,
+        },
+        "parameters": {},
+        "form_key": None,
+    },
+    "parameters": {},
+    "form_key": None,
+}
+
+form = ak.forms.from_dict(fromdict)
+
+ttlayout, report = ak.typetracer.typetracer_with_report(form)
+
+ttarray = ak.Array(ttlayout)
+
+
+@pytest.mark.parametrize("ax", [None] + [i for i in range(4)])
+def test_3325_flatten_index_option_array(ax):
+    ak.flatten(ttarray, axis=ax)


### PR DESCRIPTION
Fixes #3324

@pfackeldey if my little patch breaks things please give it a try. I'll try to cook up a test in the mean time.