### PR TITLE
chore: upgrade macos-12 -> macos-13

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -71,12 +71,12 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-13]
         arch: [auto64]
         build: ["cp", "pp"]
 
         include:
-        - os: macos-12
+        - os: macos-13
           type: "Universal"
           arch: universal2
           build: "cp"

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-12, ubuntu-latest]
+        os: [windows-latest, macos-13, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It was downgraded in 65928c144d88c07381a7b4aaf4b926e255b1a8ed because of a problem that I hope was temporary. The reason this is a problem now is because macos-12 was removed on December 3 (https://github.com/actions/runner-images/issues/10721). We first saw this as a blocker in #3325. I hope that PR #3167 lets us use newer MacOS with the classic linker, which is what I think the problem was.