### PR TITLE
fix: Upstream API changes in cuDF 24.10

### DIFF
--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2013,7 +2013,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         index = self._offsets.raw(cupy).astype("int32")
         buf = cudf.core.buffer.as_buffer(index)
         ind_buf = cudf.core.column.numerical.NumericalColumn(
-            buf, index.dtype, None, size=len(index)
+            data=buf, dtype=index.dtype, mask=None, size=len(index)
         )
         cont = self._content._to_cudf(cudf, None, len(self._content))
         if mask is not None:
@@ -2035,7 +2035,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
         return cudf.core.column.lists.ListColumn(
-            length,
+            size=length,
+            data=None,
             mask=m,
             children=(ind_buf, cont),
             dtype=cudf.core.dtypes.ListDtype(cont.dtype),

--- a/src/awkward/operations/ak_to_cudf.py
+++ b/src/awkward/operations/ak_to_cudf.py
@@ -18,4 +18,7 @@ def to_cudf(
     """
     import cudf
 
+    if hasattr(cudf.Series, "_from_column"):
+        return cudf.Series._from_column(array.layout._to_cudf(cudf, None, len(array)))
+    # older Series invocation
     return cudf.Series(array.layout._to_cudf(cudf, None, len(array)))


### PR DESCRIPTION
This is exactly the same as PR #3309, except that it doesn't touch awkward-cpp/rapidjson. It supersedes that PR.