### PR TITLE
fix: `datetime.datetime.utcfromtimestamp` deprecation warning

### DIFF
--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -143,9 +143,16 @@ cuda_kernels_impl = [
 
 
 def reproducible_datetime():
-    build_date = datetime.datetime.utcfromtimestamp(
-        int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
-    )
+    import sys
+
+    timestamp = int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+
+    if sys.version_info >= (3, 11):
+        build_date = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC)
+    else:
+        build_date = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+        )
     return build_date.isoformat().replace("T", " AT ")[:22]
 
 

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -19,9 +19,16 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def reproducible_datetime():
-    build_date = datetime.datetime.utcfromtimestamp(
-        int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
-    )
+    import sys
+
+    timestamp = int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+
+    if sys.version_info >= (3, 11):
+        build_date = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC)
+    else:
+        build_date = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+        )
     return build_date.isoformat().replace("T", " AT ")[:22]
 
 


### PR DESCRIPTION
Fixes issue #3337