### PR TITLE
fix: current failing jax tests for `jax>=0.4.36`

### DIFF
--- a/tests/test_1447_jax_autodiff_slices_ufuncs.py
+++ b/tests/test_1447_jax_autodiff_slices_ufuncs.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
-jax.config.update("jax_data_dependent_tracing_fallback", True)
+if parse_version(jax.__version__) >= parse_version("0.4.36"):
+    jax.config.update("jax_data_dependent_tracing_fallback", True)
 
 ak.jax.register_and_check()
 

--- a/tests/test_1447_jax_autodiff_slices_ufuncs.py
+++ b/tests/test_1447_jax_autodiff_slices_ufuncs.py
@@ -10,6 +10,7 @@ import awkward as ak
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
 jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_data_dependent_tracing_fallback", True)
 
 ak.jax.register_and_check()
 


### PR DESCRIPTION
This PR fixes the current failing JAX tests since jax version 0.4.36. It adds a flag to restore old (jax<0.4.36) tracing behavior, see more at: https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-36-dec-5-2024

At some point we likely want to address this properly, but for now this should make our jax tests pass again.