### PR TITLE
fix: allow int as placeholder array index type

### DIFF
--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -8,6 +8,7 @@ from operator import mul
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
+from awkward._regularize import is_array_like
 from awkward._typing import TYPE_CHECKING, Any, DType, Self
 
 np = NumpyMetadata.instance()
@@ -95,6 +96,8 @@ class PlaceholderArray(ArrayLike):
             return type(self)(self._nplike, (new_length,), self._dtype)
         elif isinstance(index, int):
             return type(self)(self._nplike, (1,), self._dtype)
+        elif is_array_like(index) and np.issubdtype(index.dtype, np.integer):
+            return type(self)(self._nplike, index.shape, self._dtype)
         else:
             raise TypeError(
                 f"{type(self).__name__} supports only trivial slices, not {type(index).__name__}"

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -93,6 +93,8 @@ class PlaceholderArray(ArrayLike):
                 new_length = (stop - start) // step
 
             return type(self)(self._nplike, (new_length,), self._dtype)
+        elif isinstance(index, int):
+            return type(self)(self._nplike, (1,), self._dtype)
         else:
             raise TypeError(
                 f"{type(self).__name__} supports only trivial slices, not {type(index).__name__}"


### PR DESCRIPTION
This PR allows integer indexing on Placeholder arrays, because we know that an int will return a `new_length` of 1. This is a typical operation that happens when calling repr of an awkward-array.

This is useful, because instead the repr building for (usually broken) awkward-arrays that contain Placeholder arrays will currently generate a rather cryptic error:
```python
...
TypeError: PlaceholderArray supports only trivial slices, not int
```
where it's rather unclear what the underlying reason was.

With this PR, the repr can be built, and it shows the missing entries as `??`:
```python
<Array [{run: [??], ...}, ..., {run: ..., ...}] type='40 * {run: uint32, lu...'>
```
which at least gives a better hint on which columns are still placeholders given that they have `??` as entry.

This is a problem that typically occurs if the ak.Form of an array has entries without matching buffers.

cc @ikrommyd 