### PR TITLE
fix: placeholder arrays in record `__repr__`

### DIFF
--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -93,6 +93,9 @@ def get_at(data: Content, index: int):
 
 
 def get_field(data: Content, field: str):
+    if isinstance(data._layout, ak.record.Record):
+        if data._layout._array.content(field)._is_getitem_at_placeholder():
+            return PlaceholderValue()
     out = data._layout._getitem_field(field)
     if isinstance(out, ak.contents.NumpyArray):
         array_param = out.parameter("__array__")


### PR DESCRIPTION
Follow-up of #3341 
This fixes the `__repr__` for Record arrays that contain PlaceholderArrays:
```python
import awkward as ak
import numpy as np
from awkward._nplikes.numpy import Numpy
from awkward._nplikes.placeholder import PlaceholderArray

numpy = Numpy.instance()

form = {
    "class": "RecordArray",
    "fields": [
        "foo"
    ],
    "contents": [
        {
            "class": "NumpyArray",
            "primitive": "int64",
            "form_key": "node1"
        }
    ],
    "form_key": "node0"
}

# without this PR
ak.from_buffers(form, 3, {"node1-data": PlaceholderArray(numpy, (3,), np.int64)}, highlevel=True)
# ... TypeError: PlaceholderArray supports only trivial slices, not int

# with this PR
ak.from_buffers(form, 3, {"node1-data": PlaceholderArray(numpy, (3,), np.int64)}, highlevel=True)
# <Array [{foo: ??}, {foo: ??}, {foo: ??}] type='3 * {foo: int64}'>
```

Another cool thing: It can show mixtures of e.g. PlaceholderArrays and numpy (or others) now too:
```python
form = {
    "class": "RecordArray",
    "fields": [
        "foo",
        "bar"
    ],
    "contents": [
        {
            "class": "NumpyArray",
            "primitive": "int64",
            "form_key": "node1"
        },
        {
            "class": "NumpyArray",
            "primitive": "int64",
            "form_key": "node2"
        }
    ],
    "form_key": "node0"
}

containers = {
    "node1-data": PlaceholderArray(numpy, (3,), np.int64),
    "node2-data": np.array([4,5,6], np.int64),
}
ak.from_buffers(form, 3, containers, highlevel=True)
# <Array [{foo: ??, bar: 4}, {...}, {...}] type='3 * {foo: int64, bar: int64}'>
```