### PR TITLE
fix: stacktraces for custom exception handling

### DIFF
--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import sys
 import threading
 import warnings

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -86,7 +86,7 @@ class ErrorContext:
 
     def decorate_exception(self, cls: type[E], exception: E) -> Exception:
         def _add_note(exception: E, note: str) -> E:
-            if sys.version_info >= (3, 11, 0, "final"):
+            if hasattr(exception, "add_note"):
                 exception.add_note(note)
             else:
                 exception.__notes__ = [note]

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import threading
 import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -80,6 +80,9 @@ class ErrorContext:
             and issubclass(exception_type, Exception)
             and self.primary() is self
         ):
+            # Step out of the way so that another ErrorContext can become primary.
+            # Is this necessary to do here? (We're about to raise an exception anyway)
+            self._slate.__dict__.clear()
             # Handle caught exception
             raise self.decorate_exception(exception_type, exception_value) from exception_value
         else:

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -84,7 +84,9 @@ class ErrorContext:
             # Is this necessary to do here? (We're about to raise an exception anyway)
             self._slate.__dict__.clear()
             # Handle caught exception
-            raise self.decorate_exception(exception_type, exception_value) from exception_value
+            raise self.decorate_exception(
+                exception_type, exception_value
+            ) from exception_value
         else:
             # Step out of the way so that another ErrorContext can become primary.
             if self.primary() is self:

--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -84,9 +84,7 @@ class ErrorContext:
             # Is this necessary to do here? (We're about to raise an exception anyway)
             self._slate.__dict__.clear()
             # Handle caught exception
-            raise self.decorate_exception(
-                exception_type, exception_value
-            ) from exception_value
+            raise self.decorate_exception(exception_type, exception_value)
         else:
             # Step out of the way so that another ErrorContext can become primary.
             if self.primary() is self:
@@ -102,18 +100,15 @@ class ErrorContext:
                 exception.add_note(self.note)
             return exception
         else:
-            new_exception: Exception
             if issubclass(cls, (NotImplementedError, AssertionError)):
-                # Raise modified exception
-                new_exception = cls(
-                    str(exception)
-                    + "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward/issues"
-                )
+                note = "\n\nSee if this has been reported at https://github.com/scikit-hep/awkward/issues"
+                exception.__notes__ = [note]
             elif issubclass(cls, builtins.KeyError):
-                new_exception = KeyError(self.format_exception(exception))
+                exception: Exception = KeyError(self.format_exception(exception))
+                exception.__notes__ = [self.note]
             else:
-                new_exception = cls(self.format_exception(exception))
-            return new_exception
+                exception.__notes__ = [self.note]
+            return exception
 
     def format_argument(self, width, value):
         from awkward import contents, highlevel, record


### PR DESCRIPTION
This PR fixes stack traces for awkward's custom error handling. It allows to use debuggers like "pdb" that try to go through the stack traces again, before they've been evicted from the stack (or wrongly ordered?) (I'm not sure what causes that exactly). This PR does not affect the custom decoration of errors.