### PR TITLE
perf: make the ak.Array.mask weakly dependent on the array itself

### DIFF
--- a/docs/user-guide/how-to-create-missing.md
+++ b/docs/user-guide/how-to-create-missing.md
@@ -265,6 +265,6 @@ def faster_example():
 
 data, mask = faster_example()
 
-array = ak.Array(data).mask[mask]
+array = ak.mask(data, mask)
 array
 ```

--- a/tests-cuda/test_2922a_new_cuda_kernels.py
+++ b/tests-cuda/test_2922a_new_cuda_kernels.py
@@ -1003,7 +1003,8 @@ def test_2064_fill_none_record_axis_last():
 
 
 def test_2064_fill_none_record_option_outside_record():
-    record = ak.zip({"x": [1, 4], "y": [2, 3]}).mask[[True, False]]
+    record = ak.zip({"x": [1, 4], "y": [2, 3]})
+    record = record.mask[[True, False]]
 
     cuda_record = ak.to_backend(record, "cuda")
 

--- a/tests-cuda/test_3136_cuda_reducers.py
+++ b/tests-cuda/test_3136_cuda_reducers.py
@@ -271,9 +271,7 @@ def test_2020_reduce_axis_none_sum():
     arr = ak.Array([[63.0]], backend="cuda")
     assert ak.almost_equal(
         ak.sum(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[True]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
     assert ak.sum(array[2], axis=None, mask_identity=True) is None
     del array
@@ -297,11 +295,7 @@ def test_2020_reduce_axis_none_prod():
     arr = ak.Array([[4838400.0]], backend="cuda")
     assert ak.almost_equal(
         ak.prod(array[1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[
-                ak.Array([[True]], backend="cuda")
-            ]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
     assert ak.prod(array[2], axis=None, mask_identity=True) is None
     del array
@@ -324,19 +318,13 @@ def test_2020_reduce_axis_none_min():
     arr = ak.Array([[0.0]], backend="cuda")
     assert ak.almost_equal(
         ak.min(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[True]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
 
     arr = ak.Array(ak.Array([[np.inf]], backend="cuda"))
     assert ak.almost_equal(
         ak.min(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[
-                ak.Array([[False]], backend="cuda")
-            ]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[False]], backend="cuda")]),
     )
     assert ak.min(array[2], axis=None, mask_identity=True) is None
     del array
@@ -359,19 +347,13 @@ def test_2020_reduce_axis_none_max():
     arr = ak.Array([[10.0]], backend="cuda")
     assert ak.almost_equal(
         ak.max(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[True]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
 
     arr = ak.Array(ak.Array([[np.inf]], backend="cuda"))
     assert ak.almost_equal(
         ak.max(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[
-                ak.Array([[False]], backend="cuda")
-            ]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[False]], backend="cuda")]),
     )
     assert ak.max(array[2], axis=None, mask_identity=True) is None
     del array
@@ -390,17 +372,13 @@ def test_2020_reduce_axis_none_count():
     arr = ak.Array([[12]], backend="cuda")
     assert ak.almost_equal(
         ak.count(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[True]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
 
     arr = ak.Array([[0]], backend="cuda")
     assert ak.almost_equal(
         ak.count(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[False]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[False]], backend="cuda")]),
     )
     assert ak.count(array[2], axis=None, mask_identity=True) is None
     assert ak.count(array[2], axis=None, mask_identity=False) == 0
@@ -420,17 +398,13 @@ def test_2020_reduce_axis_none_count_nonzero():
     arr = ak.Array([[11]], backend="cuda")
     assert ak.almost_equal(
         ak.count_nonzero(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[True]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
 
     arr = ak.Array([[0]], backend="cuda")
     assert ak.almost_equal(
         ak.count_nonzero(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[ak.Array([[False]], backend="cuda")]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[False]], backend="cuda")]),
     )
     assert ak.count_nonzero(array[2], axis=None, mask_identity=True) is None
     assert ak.count_nonzero(array[2], axis=None, mask_identity=False) == 0
@@ -444,9 +418,7 @@ def test_2020_reduce_axis_none_std_no_mask_axis_none():
     out1 = ak.std(array[-1:], axis=None, keepdims=True, mask_identity=True)
 
     arr = ak.Array([[0.0]], backend="cuda")
-    out2 = ak.to_regular(
-        arr.mask[ak.Array([[False]], backend="cuda")]
-    )
+    out2 = ak.to_regular(arr.mask[ak.Array([[False]], backend="cuda")])
     assert ak.almost_equal(out1, out2)
 
     out3 = ak.std(array[2], axis=None, mask_identity=True)
@@ -468,11 +440,7 @@ def test_2020_reduce_axis_none_std():
     arr = ak.Array([[3.139134700306227]], backend="cuda")
     cpt.assert_allclose(
         ak.std(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(
-            arr.mask[
-                ak.Array([[True]], backend="cuda")
-            ]
-        ),
+        ak.to_regular(arr.mask[ak.Array([[True]], backend="cuda")]),
     )
     assert np.isnan(ak.std(array[2], axis=None, mask_identity=False))
     del array

--- a/tests-cuda/test_3136_cuda_reducers.py
+++ b/tests-cuda/test_3136_cuda_reducers.py
@@ -267,10 +267,12 @@ def test_2020_reduce_axis_none_sum():
         ak.sum(array, axis=None, keepdims=True),
         ak.to_regular(ak.Array([[63.0]], backend="cuda")),
     )
+
+    arr = ak.Array([[63.0]], backend="cuda")
     assert ak.almost_equal(
         ak.sum(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[63.0]], backend="cuda").mask[ak.Array([[True]], backend="cuda")]
+            arr.mask[ak.Array([[True]], backend="cuda")]
         ),
     )
     assert ak.sum(array[2], axis=None, mask_identity=True) is None
@@ -291,10 +293,12 @@ def test_2020_reduce_axis_none_prod():
         ak.prod(array[1:], axis=None, keepdims=True),
         ak.to_regular(ak.Array([[4838400.0]], backend="cuda")),
     )
+
+    arr = ak.Array([[4838400.0]], backend="cuda")
     assert ak.almost_equal(
         ak.prod(array[1:], axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[4838400.0]], backend="cuda").mask[
+            arr.mask[
                 ak.Array([[True]], backend="cuda")
             ]
         ),
@@ -316,16 +320,20 @@ def test_2020_reduce_axis_none_min():
         ak.min(array, axis=None, keepdims=True, initial=-100.0, mask_identity=False),
         ak.to_regular(ak.Array([[-100.0]], backend="cuda")),
     )
+
+    arr = ak.Array([[0.0]], backend="cuda")
     assert ak.almost_equal(
         ak.min(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[0.0]], backend="cuda").mask[ak.Array([[True]], backend="cuda")]
+            arr.mask[ak.Array([[True]], backend="cuda")]
         ),
     )
+
+    arr = ak.Array(ak.Array([[np.inf]], backend="cuda"))
     assert ak.almost_equal(
         ak.min(array[-1:], axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array(ak.Array([[np.inf]], backend="cuda")).mask[
+            arr.mask[
                 ak.Array([[False]], backend="cuda")
             ]
         ),
@@ -347,16 +355,20 @@ def test_2020_reduce_axis_none_max():
         ak.max(array, axis=None, keepdims=True, initial=100.0, mask_identity=False),
         ak.to_regular(ak.Array([[100.0]], backend="cuda")),
     )
+
+    arr = ak.Array([[10.0]], backend="cuda")
     assert ak.almost_equal(
         ak.max(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[10.0]], backend="cuda").mask[ak.Array([[True]], backend="cuda")]
+            arr.mask[ak.Array([[True]], backend="cuda")]
         ),
     )
+
+    arr = ak.Array(ak.Array([[np.inf]], backend="cuda"))
     assert ak.almost_equal(
         ak.max(array[-1:], axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array(ak.Array([[np.inf]], backend="cuda")).mask[
+            arr.mask[
                 ak.Array([[False]], backend="cuda")
             ]
         ),
@@ -374,16 +386,20 @@ def test_2020_reduce_axis_none_count():
         ak.count(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular(ak.Array([[12]], backend="cuda")),
     )
+
+    arr = ak.Array([[12]], backend="cuda")
     assert ak.almost_equal(
         ak.count(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[12]], backend="cuda").mask[ak.Array([[True]], backend="cuda")]
+            arr.mask[ak.Array([[True]], backend="cuda")]
         ),
     )
+
+    arr = ak.Array([[0]], backend="cuda")
     assert ak.almost_equal(
         ak.count(array[-1:], axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[0]], backend="cuda").mask[ak.Array([[False]], backend="cuda")]
+            arr.mask[ak.Array([[False]], backend="cuda")]
         ),
     )
     assert ak.count(array[2], axis=None, mask_identity=True) is None
@@ -400,16 +416,20 @@ def test_2020_reduce_axis_none_count_nonzero():
         ak.count_nonzero(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular(ak.Array([[11]], backend="cuda")),
     )
+
+    arr = ak.Array([[11]], backend="cuda")
     assert ak.almost_equal(
         ak.count_nonzero(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[11]], backend="cuda").mask[ak.Array([[True]], backend="cuda")]
+            arr.mask[ak.Array([[True]], backend="cuda")]
         ),
     )
+
+    arr = ak.Array([[0]], backend="cuda")
     assert ak.almost_equal(
         ak.count_nonzero(array[-1:], axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[0]], backend="cuda").mask[ak.Array([[False]], backend="cuda")]
+            arr.mask[ak.Array([[False]], backend="cuda")]
         ),
     )
     assert ak.count_nonzero(array[2], axis=None, mask_identity=True) is None
@@ -422,8 +442,10 @@ def test_2020_reduce_axis_none_std_no_mask_axis_none():
         [[0, 2, 3.0], [4, 5, 6, 7, 8], [], [9, 8, None], [10, 1], []], backend="cuda"
     )
     out1 = ak.std(array[-1:], axis=None, keepdims=True, mask_identity=True)
+
+    arr = ak.Array([[0.0]], backend="cuda")
     out2 = ak.to_regular(
-        ak.Array([[0.0]], backend="cuda").mask[ak.Array([[False]], backend="cuda")]
+        arr.mask[ak.Array([[False]], backend="cuda")]
     )
     assert ak.almost_equal(out1, out2)
 
@@ -442,10 +464,12 @@ def test_2020_reduce_axis_none_std():
         ak.std(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[3.139134700306227]]),
     )
+
+    arr = ak.Array([[3.139134700306227]], backend="cuda")
     cpt.assert_allclose(
         ak.std(array, axis=None, keepdims=True, mask_identity=True),
         ak.to_regular(
-            ak.Array([[3.139134700306227]], backend="cuda").mask[
+            arr.mask[
                 ak.Array([[True]], backend="cuda")
             ]
         ),

--- a/tests/test_2020_reduce_axis_none.py
+++ b/tests/test_2020_reduce_axis_none.py
@@ -15,9 +15,11 @@ def test_sum():
     assert ak.almost_equal(
         ak.sum(array, axis=None, keepdims=True), ak.to_regular([[63.0]])
     )
+
+    arr = ak.Array([[63.0]])
     assert ak.almost_equal(
         ak.sum(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[63.0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert ak.sum(array[2], axis=None, mask_identity=True) is None
 
@@ -31,9 +33,10 @@ def test_prod():
     assert ak.almost_equal(
         ak.prod(array[1:], axis=None, keepdims=True), ak.to_regular([[4838400.0]])
     )
+    arr = ak.Array([[4838400.0]])
     assert ak.almost_equal(
         ak.prod(array[1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[4838400.0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert ak.prod(array[2], axis=None, mask_identity=True) is None
 
@@ -49,13 +52,16 @@ def test_min():
         ak.to_regular([[-100.0]]),
     )
 
+    arr = ak.Array([[0.0]])
     assert ak.almost_equal(
         ak.min(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0.0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[np.inf]])
     assert ak.almost_equal(
         ak.min(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[np.inf]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.min(array[2], axis=None, mask_identity=True) is None
 
@@ -70,13 +76,17 @@ def test_max():
         ak.max(array, axis=None, keepdims=True, initial=100, mask_identity=False),
         ak.to_regular([[100.0]]),
     )
+
+    arr = ak.Array([[10.0]])
     assert ak.almost_equal(
         ak.max(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[10.0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[-np.inf]])
     assert ak.almost_equal(
         ak.max(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[np.inf]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.max(array[2], axis=None, mask_identity=True) is None
 
@@ -87,13 +97,17 @@ def test_count():
         ak.count(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[12]]),
     )
+
+    arr = ak.Array([[12]])
     assert ak.almost_equal(
         ak.count(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[12]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[0]])
     assert ak.almost_equal(
         ak.count(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.count(array[2], axis=None, mask_identity=True) is None
     assert ak.count(array[2], axis=None, mask_identity=False) == 0
@@ -105,13 +119,17 @@ def test_count_nonzero():
         ak.count_nonzero(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[11]]),
     )
+
+    arr = ak.Array([[11]])
     assert ak.almost_equal(
         ak.count_nonzero(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[11]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[0]])
     assert ak.almost_equal(
         ak.count_nonzero(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.count_nonzero(array[2], axis=None, mask_identity=True) is None
     assert ak.count_nonzero(array[2], axis=None, mask_identity=False) == 0
@@ -123,17 +141,20 @@ def test_std():
         ak.std(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[3.139134700306227]]),
     )
+
+    arr = ak.Array([[3.139134700306227]])
     assert ak.almost_equal(
         ak.std(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[3.139134700306227]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert np.isnan(ak.std(array[2], axis=None, mask_identity=False))
 
 
 def test_std_no_mask_axis_none():
+    arr = ak.Array([[0.0]])
     assert ak.almost_equal(
         ak.std(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0.0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.std(array[2], axis=None, mask_identity=True) is None
 
@@ -144,17 +165,20 @@ def test_var():
         ak.var(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[9.854166666666666]]),
     )
+
+    arr = ak.Array([[9.854166666666666]])
     assert ak.almost_equal(
         ak.var(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[9.854166666666666]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert np.isnan(ak.var(array[2], axis=None, mask_identity=False))
 
 
 def test_var_no_mask_axis_none():
+    arr = ak.Array([[0.0]])
     assert ak.almost_equal(
         ak.var(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0.0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.var(array[2], axis=None, mask_identity=True) is None
 
@@ -165,17 +189,20 @@ def test_mean():
         ak.mean(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[5.25]]),
     )
+
+    arr = ak.Array([[5.25]])
     assert ak.almost_equal(
         ak.mean(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[5.25]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert np.isnan(ak.mean(array[2], axis=None, mask_identity=False))
 
 
 def test_mean_no_mask_axis_none():
+    arr = ak.Array([[0.0]])
     assert ak.almost_equal(
         ak.mean(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0.0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.mean(array[2], axis=None, mask_identity=True) is None
 
@@ -186,17 +213,20 @@ def test_ptp():
         ak.ptp(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[10.0]]),
     )
+
+    arr = ak.Array([[10.0]])
     assert ak.almost_equal(
         ak.ptp(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[10.0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
     assert ak.ptp(array[2], axis=None, mask_identity=False) == pytest.approx(0.0)
 
 
 def test_ptp_no_mask_axis_none():
+    arr = ak.Array([[0.0]])
     assert ak.almost_equal(
         ak.ptp(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0.0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.ptp(array[2], axis=None, mask_identity=True) is None
 
@@ -207,13 +237,17 @@ def test_argmax():
         ak.argmax(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[11]]),
     )
+
+    arr = ak.Array([[11]])
     assert ak.almost_equal(
         ak.argmax(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[11]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[0]])
     assert ak.almost_equal(
         ak.argmax(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.argmax(array[2], axis=None, mask_identity=True) is None
     assert ak.argmax(array[2], axis=None, mask_identity=False) == -1
@@ -225,13 +259,17 @@ def test_argmin():
         ak.argmin(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[0]]),
     )
+
+    arr = ak.Array([[0]])
     assert ak.almost_equal(
         ak.argmin(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[0]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[999]])
     assert ak.almost_equal(
         ak.argmin(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[999]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.argmin(array[2], axis=None, mask_identity=True) is None
     assert ak.argmin(array[2], axis=None, mask_identity=False) == -1
@@ -243,13 +281,17 @@ def test_any():
         ak.any(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[True]]),
     )
+
+    arr = ak.Array([[True]])
     assert ak.almost_equal(
         ak.any(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[True]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[True]])
     assert ak.almost_equal(
         ak.any(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[True]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.any(array[2], axis=None, mask_identity=True) is None
     assert not ak.any(array[2], axis=None, mask_identity=False)
@@ -261,13 +303,17 @@ def test_all():
         ak.all(array, axis=None, keepdims=True, mask_identity=False),
         ak.to_regular([[False]]),
     )
+
+    arr = ak.Array([[False]])
     assert ak.almost_equal(
         ak.all(array, axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[False]]).mask[[[True]]]),
+        ak.to_regular(arr.mask[[[True]]]),
     )
+
+    arr = ak.Array([[False]])
     assert ak.almost_equal(
         ak.all(array[-1:], axis=None, keepdims=True, mask_identity=True),
-        ak.to_regular(ak.Array([[False]]).mask[[[False]]]),
+        ak.to_regular(arr.mask[[[False]]]),
     )
     assert ak.all(array[2], axis=None, mask_identity=True) is None
     assert ak.all(array[2], axis=None, mask_identity=False)

--- a/tests/test_2064_fill_none_record.py
+++ b/tests/test_2064_fill_none_record.py
@@ -24,5 +24,6 @@ def test_axis_last():
 
 
 def test_option_outside_record():
-    record = ak.zip({"x": [1, 4], "y": [2, 3]}).mask[[True, False]]
+    record = ak.zip({"x": [1, 4], "y": [2, 3]})
+    record = record.mask[[True, False]]
     assert ak.fill_none(record, 0, axis=-1).to_list() == [{"x": 1, "y": 2}, 0]

--- a/tests/test_3347_weakref_mask_highlevel_array.py
+++ b/tests/test_3347_weakref_mask_highlevel_array.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import platform
+
 import pytest
 
 import awkward as ak
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="PyPy has a different GC strategy than CPython and thus weakrefs may stay alive a little bit longer than expected, see: https://doc.pypy.org/en/latest/cpython_differences.html#differences-related-to-garbage-collection-strategies",
+)
 def test_Array_mask_weakref():
     arr = ak.Array([1])
     m = arr.mask

--- a/tests/test_3347_weakref_mask_highlevel_array.py
+++ b/tests/test_3347_weakref_mask_highlevel_array.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+
+def test_Array_mask_weakref():
+    arr = ak.Array([1])
+    m = arr.mask
+
+    assert ak.all(m[[True]] == arr)
+
+    del arr
+    with pytest.raises(
+        ValueError,
+        match="The array to mask was deleted before it could be masked. If you want to construct this mask, you must either keep the array alive or use 'ak.mask' explicitly.",
+    ):
+        _ = m[[True]]


### PR DESCRIPTION
This PR makes the reference array (that is to be masked) weakly referenced in `ak.Array.mask` as suggested by @jpivarski in https://github.com/scikit-hep/awkward/pull/3344#pullrequestreview-2506946032