### PR TITLE
feat: add pretty nbytes repr to .show and jupyter repr

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -45,7 +45,7 @@ from awkward._pickle import (
 from awkward._regularize import is_non_string_like_iterable
 from awkward._typing import Any, TypeVar
 from awkward._util import STDOUT
-from awkward.prettyprint import Formatter, bytes_repr, highlevel_array_show_rows
+from awkward.prettyprint import Formatter, highlevel_array_show_rows
 from awkward.prettyprint import valuestr as prettyprint_valuestr
 
 __all__ = ("Array", "ArrayBuilder", "Record")

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -469,9 +469,7 @@ def highlevel_array_show_rows(
     rows = []
     formatter_impl = Formatter(formatter, precision=precision)
 
-    array_line = valuestr(
-        array, limit_rows, limit_cols, formatter=formatter_impl
-    )
+    array_line = valuestr(array, limit_rows, limit_cols, formatter=formatter_impl)
     rows.append(array_line)
 
     if type:
@@ -484,7 +482,9 @@ def highlevel_array_show_rows(
     # other info
     if named_axis and array.named_axis:
         named_axis_line = "named axis: "
-        named_axis_line += _prettify_named_axes(array.named_axis, delimiter=", ", maxlen=None)
+        named_axis_line += _prettify_named_axes(
+            array.named_axis, delimiter=", ", maxlen=None
+        )
         rows.append(named_axis_line)
     if nbytes:
         nbytes_line = f"nbytes: {bytes_repr(array.nbytes)}"

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -441,7 +441,7 @@ def bytes_repr(nbytes: int) -> str:
         if nbytes > 1e9
         else (f"{nbytes / 1e6 :,.1f}", "MB")
         if nbytes > 1e6
-        else (f"{nbytes / 1e3 :,.1f}", "KB")
+        else (f"{nbytes / 1e3 :,.1f}", "kB")
         if nbytes > 1e3
         else (f"{nbytes:,}", "B")
     )

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -433,3 +433,17 @@ def valuestr(
 
     else:
         raise AssertionError(type(data))
+
+
+def bytes_repr(nbytes: int) -> str:
+    count, unit = (
+        (f"{nbytes / 1e9 :,.1f}", "GB")
+        if nbytes > 1e9
+        else (f"{nbytes / 1e6 :,.1f}", "MB")
+        if nbytes > 1e6
+        else (f"{nbytes / 1e3 :,.1f}", "KB")
+        if nbytes > 1e3
+        else (f"{nbytes:,}", "B")
+    )
+
+    return f"{count} {unit}"


### PR DESCRIPTION
This is a little PR that adds (optionally, default is False) a new line to `.show(nbytes=True)` and the jupyter repr of high-level ak.Arrays and ak.Records. It's for the lazy (like me) who don't want to do the calculation in their head...

Preview (`.show()`):

<img width="432" alt="Screenshot 2024-12-16 at 8 40 21 PM" src="https://github.com/user-attachments/assets/70ffc1e6-941b-43af-8fb0-3b679c6c0b1d" />

Preview (Jupyter repr):
<img width="302" alt="Screenshot 2024-12-16 at 8 44 03 PM" src="https://github.com/user-attachments/assets/1e347c9a-c128-436d-9dde-28543e71f07b" />

What do you think?