### PR TITLE
fix: enforce string-only keys in `.attrs`

### DIFF
--- a/src/awkward/_attrs.py
+++ b/src/awkward/_attrs.py
@@ -76,10 +76,10 @@ class Attrs(Mapping):
         return _unfreeze_attrs(self._data)
 
 
-def _enforce_str_key(attr: Any) -> str:
-    if not isinstance(attr, str):
-        raise TypeError(f"'attrs' keys must be strings: {attr!r}")
-    return attr
+def _enforce_str_key(key: Any) -> str:
+    if not isinstance(key, str):
+        raise TypeError(f"'attrs' keys must be strings, got: {key!r}")
+    return key
 
 
 def _freeze_attrs(attrs: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/tests/test_3350_enforce_attrs_string_keys.py
+++ b/tests/test_3350_enforce_attrs_string_keys.py
@@ -1,0 +1,17 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import pytest
+import awkward as ak
+
+
+def test():
+    arr = ak.Array([1])
+
+    with pytest.raises(
+        TypeError,
+        match="'attrs' keys must be strings, got: 1",
+    ):
+        arr.attrs[1] = "foo"

--- a/tests/test_3350_enforce_attrs_string_keys.py
+++ b/tests/test_3350_enforce_attrs_string_keys.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pytest
+
 import awkward as ak
 
 


### PR DESCRIPTION
As @agoose77 suggested (in https://github.com/scikit-hep/awkward/pull/3344) we should restrict keys of `.attrs` to str only.