### PR TITLE
fix: `nbytes` property of `ak.Record`

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2032,7 +2032,7 @@ class Record(NDArrayOperatorsMixin):
         the (small) Python objects that reference the (large)
         array buffers.
         """
-        return self._layout.nbytes
+        return self._layout.array.nbytes
 
     @property
     def fields(self):


### PR DESCRIPTION
This was uncovered by #3348 . (This bug is 3 years old, I suppose `.nbytes` was never accessed in that time on a `ak.Record` 😅)

Before:
```python
>>> ak.Record({"foo": [1,2,3]}).nbytes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../awkward/highlevel.py", line 2200, in __getattr__
    return super().__getattribute__(where)
  File ".../awkward/highlevel.py", line 2012, in nbytes
    return self._layout.nbytes
AttributeError: 'Record' object has no attribute 'nbytes'
```
Now: 
```python
>>> ak.Record({"foo": [1,2,3]}).nbytes
>>> 24
```