### PR TITLE
chore: use `_util.native_to_byteorder` function in `ak.from_buffers`

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -186,10 +186,7 @@ def _from_buffer(
         return array[:count]
     else:
         array = nplike.frombuffer(buffer, dtype=dtype, count=count)
-        if byteorder != ak._util.native_byteorder:
-            return array.byteswap(inplace=False)
-        else:
-            return array
+        return ak._util.native_to_byteorder(array, byteorder)
 
 
 def _reconstitute(


### PR DESCRIPTION
Directly use an existing utility function for byte ordering. Stumbled over this while working on #3353.