### PR TITLE
fix: nbytes repr for typetracers with nbytes=unknown_length

### DIFF
--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -11,6 +11,7 @@ import awkward as ak
 from awkward._layout import wrap_layout
 from awkward._namedaxis import _prettify_named_axes
 from awkward._nplikes.numpy import Numpy, NumpyMetadata
+from awkward._nplikes.shape import unknown_length
 from awkward._typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
@@ -486,7 +487,7 @@ def highlevel_array_show_rows(
             array.named_axis, delimiter=", ", maxlen=None
         )
         rows.append(named_axis_line)
-    if nbytes:
+    if nbytes and array.nbytes is not unknown_length:
         nbytes_line = f"nbytes: {bytes_repr(array.nbytes)}"
         rows.append(nbytes_line)
     if backend:

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -487,8 +487,11 @@ def highlevel_array_show_rows(
             array.named_axis, delimiter=", ", maxlen=None
         )
         rows.append(named_axis_line)
-    if nbytes and array.nbytes is not unknown_length:
-        nbytes_line = f"nbytes: {bytes_repr(array.nbytes)}"
+    if nbytes:
+        if array.nbytes is unknown_length:
+            nbytes_line = "nbytes: unknown"
+        else:
+            nbytes_line = f"nbytes: {bytes_repr(array.nbytes)}"
         rows.append(nbytes_line)
     if backend:
         backend_line = f"backend: {array.layout.backend.name}"


### PR DESCRIPTION
This was an oversight from https://github.com/scikit-hep/awkward/pull/3348

The `nbytes` property of a typetracer can be the `unknown_length` sentinel, which doesn't tell us anything about the number of bytes of the array. Thus, we can't add it to the repr.