### PR TITLE
fix: `_getitem_at_placeholder` checks

### DIFF
--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -289,7 +289,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._index, PlaceholderArray):
+        if isinstance(self._index.data, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -310,7 +310,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        if isinstance(self._index, PlaceholderArray):
+        if isinstance(self._index.data, PlaceholderArray):
             return True
         return self._content._is_getitem_at_placeholder()
 

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -311,8 +311,8 @@ class ListArray(ListMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        return isinstance(self._starts, PlaceholderArray) or isinstance(
-            self._stops, PlaceholderArray
+        return isinstance(self._starts.data, PlaceholderArray) or isinstance(
+            self._stops.data, PlaceholderArray
         )
 
     def _getitem_at(self, where: IndexType):

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -310,7 +310,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         return self._content._getitem_range(0, 0)
 
     def _is_getitem_at_placeholder(self) -> bool:
-        return isinstance(self._offsets, PlaceholderArray)
+        return (
+            isinstance(self._offsets.data, PlaceholderArray)
+            or self._content._is_getitem_at_placeholder()
+        )
 
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length


### PR DESCRIPTION
Some implementations of `_getitem_at_placeholder` have been wrong, e.g. `Index` classes can't be instances of `PlaceholderArrays` - only their `.data` can be.

Also a `ListoffsetArray` should return true if either its offsets or its contents contain PlaceholderArrays. Now that I think about it, that may be wrong from my side and the check should be only for the offsets (as originally intended). Let me know if this is the case, then I update this PR. 