### PR TITLE
fix: resulting __setitem__ layout type for ak.Record

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2144,8 +2144,8 @@ class Record(NDArrayOperatorsMixin):
             ):
                 raise TypeError("only fields may be assigned in-place (by field name)")
 
-            self._layout = ak.operations.ak_with_field._impl(
-                self._layout,
+            self._layout._array = ak.operations.ak_with_field._impl(
+                self._layout.array,
                 what,
                 where,
                 highlevel=False,

--- a/tests/test_3372_akRecord_setitem.py
+++ b/tests/test_3372_akRecord_setitem.py
@@ -1,0 +1,14 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test():
+    rec = ak.Record({"a": 1})
+    assert isinstance(rec.layout, ak.record.Record)
+
+    rec["b"] = 2
+    assert isinstance(rec.layout, ak.record.Record)


### PR DESCRIPTION
Fixes: https://github.com/scikit-hep/awkward/issues/3370

`ak.Record`'s `.layout` property is expected to be an instance of `ak.record.Record`. `ak.with_field` returns a `ak.content.RecordArray` though. A `ak.record.Record`'s `.array` property points to this content class, thus we need to set `.array` and not `.layout` to the return value of `ak.with_field`.