### PR TITLE
refactor: propagate attrs & behavior with dict-like `ak.Array` input data

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -302,19 +302,22 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         elif isinstance(data, dict):
             fields = []
-            contents = []
+            _arrays = []
             length = None
             for k, v in data.items():
                 fields.append(k)
-                contents.append(Array(v).layout)
+                _arrays.append(Array(v))
                 if length is None:
-                    length = contents[-1].length
-                elif length != contents[-1].length:
+                    length = _arrays[-1].layout.length
+                elif length != _arrays[-1].layout.length:
                     raise ValueError(
                         "dict of arrays in ak.Array constructor must have arrays "
-                        f"of equal length ({length} vs {contents[-1].length})"
+                        f"of equal length ({length} vs {_arrays[-1].layout.length}). "
+                        "For automatic broadcasting use 'ak.zip' instead. "
                     )
-            layout = ak.contents.RecordArray(contents, fields)
+            layout = ak.contents.RecordArray([arr.layout for arr in _arrays], fields)
+            attrs = attrs_of(*_arrays, attrs=attrs)
+            behavior = behavior_of(*_arrays, behavior=behavior)
 
         elif isinstance(data, str):
             layout = ak.operations.from_json(data, highlevel=False)

--- a/tests/test_3374_propagate_metadata_akArray_dictlike_data.py
+++ b/tests/test_3374_propagate_metadata_akArray_dictlike_data.py
@@ -1,0 +1,32 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_attrs():
+    x = ak.Array([1], attrs={"me": "ta"})
+    y = ak.Array([1], attrs={"da": "ta"})
+
+    rec = ak.Array({"x": x, "y": y})
+    assert rec.attrs == {"me": "ta", "da": "ta"}
+
+    # overwrite attrs:
+    rec = ak.Array({"x": x, "y": y}, attrs={"foo": "bar"})
+    assert rec.attrs == {"foo": "bar"}
+
+
+def test_behaviors():
+    behavior = {"foo": object()}
+    x = ak.Array([1], behavior=behavior)
+    y = ak.Array([1], behavior=behavior)
+
+    rec = ak.Array({"x": x, "y": y})
+    assert rec.behavior == behavior
+
+    # overwrite behavior:
+    behavior2 = {"bar": object()}
+    rec = ak.Array({"x": x, "y": y}, behavior=behavior2)
+    assert rec.behavior == behavior2


### PR DESCRIPTION
Currently `ak.Array` (with `dict` input data) and `ak.zip` differ in the following ways:
1. `ak.zip` does broadcasting, `ak.Array` does not (it errors instead)
2. `ak.zip` does propagate `attrs` and `behavior` from all (nested) arrays in the given dictionary, `ak.Array` does not

For `1.` this PR improves the error message for `ak.Array` if it encounters different length inputs to give a hint to try `ak.zip` instead (if broadcasting is a suitable solution).

The second difference does not exist anymore with this PR, `ak.Array` will now also propagate `attrs` and `behavior` in the same way `ak.zip` does. I think it is a bit unintuitive that `ak.zip` and `ak.Array` currently behave different for propagating `attrs` and `behavior`.

I'll add a `policy` label, because it might be good to hear some input/feedback from @ianna, @jpivarski and @agoose77 about this change. 

(Closes: https://github.com/scikit-hep/awkward/issues/3346)