### PR TITLE
fix: placeholder array repr with extra info

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -677,7 +677,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         precision: int | None = None,
         suppress_small: bool | None = None,
     ):
-        assert not isinstance(x, PlaceholderArray)
+        if isinstance(x, PlaceholderArray):
+            return "[## ... ##]"
         return self._module.array_str(
             x,
             max_line_width=max_line_width,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -258,12 +258,9 @@ class NumpyArray(NumpyMeta, Content):
 
         extra = self._repr_extra(indent + "    ")
 
-        if isinstance(self._data, (TypeTracerArray, PlaceholderArray)):
-            arraystr_lines = ["[## ... ##]"]
-        else:
-            arraystr_lines = self._backend.nplike.array_str(
-                self._data, max_line_width=30
-            ).split("\n")
+        arraystr_lines = self._backend.nplike.array_str(
+            self._data, max_line_width=30
+        ).split("\n")
 
         if len(extra) != 0 or len(arraystr_lines) > 1:
             arraystr_lines = self._backend.nplike.array_str(

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -11,9 +11,8 @@ from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
-from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem
-from awkward._nplikes.typetracer import TypeTracer, TypeTracerArray
+from awkward._nplikes.typetracer import TypeTracer
 from awkward._slicing import normalize_slice
 from awkward._typing import Any, DType, Final, Self, cast
 
@@ -193,12 +192,9 @@ class Index:
         out.append(" len=")
         out.append(repr(str(self._data.shape[0])))
 
-        if isinstance(self._data, (TypeTracerArray, PlaceholderArray)):
-            arraystr_lines = ["[## ... ##]"]
-        else:
-            arraystr_lines = self._nplike.array_str(
-                self._data, max_line_width=30
-            ).split("\n")
+        arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
+            "\n"
+        )
 
         if len(arraystr_lines) > 1 or self._metadata is not None:
             arraystr_lines = self._nplike.array_str(


### PR DESCRIPTION
This PR fixes the repr of PlaceholderArrays for good by moving the `array_str` into the array module (nplike).

Currently the repr could be printed if no extra information is present, however, when a `parameter` exists (which is typically the case for e.g. `coffea.NanoEvents` that includes the `__doc__` of a TBranch as a parameter) the repr was broken.

This should also be a more cleaner approach as it avoids runtime type dependent if conditions in certain parts of the codebase. 