### PR TITLE
fix: set allow_lazy to True to avoid touching potential placeholders

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -588,7 +588,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 )
             )
 
-            return self._content._carry(nextcarry, False)
+            return self._content._carry(nextcarry, True)
 
     def _offsets_and_flattened(self, axis: int, depth: int) -> tuple[Index, Content]:
         posaxis = maybe_posaxis(self, axis, depth)


### PR DESCRIPTION
(Finally) fixes: https://github.com/scikit-hep/coffea/issues/1231. This issue has causing me multiple headaches.

This PR is a follow-up of https://github.com/scikit-hep/awkward/pull/2524 for `IndexedOptionArrays`. The problem here is that a `RecordArray` may be wrapped in a `IndexedOptionArray` after a `ak.with_field/__setitem__` operation. This has been fixed for `IndexedArrays` in https://github.com/scikit-hep/awkward/pull/2524, but not for option types.

By setting `allow_lazy=True` in the `_carry` function we don't apply a slice to each content of a `RecordArray`, which causes errors for `PlaceholderArrays`. Instead this wraps them in an `IndexedArray` and thus follows the fix provided in https://github.com/scikit-hep/awkward/pull/2524 by "pushing" the `IndexedArray` down into each field of the `RecordArray` in the next recursion during broadcasting.

Adding the same "pushing" fix to `IndexedOptionArrays` led to multiple issues, which is why I gave up on it. If you have an idea how to implement this, I can give it another try. I'm not 100% sure if my/this solution is what we want.

(PS: I _think_, setting `allow_lazy=True` here should also benefit in the scope of the current `VirtualArray` implementation (https://github.com/scikit-hep/awkward/pull/3364) as it delays materialization of slicing `RecordArrays`. The same is likely true for `IndexedArrays`?)