### PR TITLE
chore: make the 'field_path' argument of placeholder arrays more robust

### DIFF
--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -22,13 +22,13 @@ class PlaceholderArray(ArrayLike):
         nplike: NumpyLike,
         shape: tuple[ShapeItem, ...],
         dtype: DType,
-        field_path: tuple[str, ...] = (),
+        field_path: tuple = (),
     ):
         self._nplike = nplike
         self._shape = shape
         self._dtype = np.dtype(dtype)
         if not isinstance(field_path, tuple):
-            raise TypeError(f"field_path must be a tuple of strings, not {field_path}")
+            raise TypeError(f"field_path must be a tuple, not {field_path}")
         self._field_path = field_path
 
     @property

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -27,11 +27,13 @@ class PlaceholderArray(ArrayLike):
         self._nplike = nplike
         self._shape = shape
         self._dtype = np.dtype(dtype)
+        if not isinstance(field_path, tuple):
+            raise TypeError(f"field_path must be a tuple of strings, not {field_path}")
         self._field_path = field_path
 
     @property
     def field_path(self) -> str:
-        return ".".join(self._field_path)
+        return ".".join(map(str, self._field_path))
 
     @property
     def dtype(self) -> DType:


### PR DESCRIPTION
This improves the robustness of the `field_path` argument of a `PlaceholderArray`, by 
1. ensuring it's a tuple (this makes sure that explicit usage of this feature has the correct type, e.g. when used in dask-awkward in the future)
2. ensuring all elements are strings before they're joined (otherwise this causes issues if e.g. `None` or an `int` is encountered)