### PR TITLE
refactor: simplify attrs & fix its pickability (for e.g. dask.distributed)

### DIFF
--- a/src/awkward/_attrs.py
+++ b/src/awkward/_attrs.py
@@ -1,9 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
 from __future__ import annotations
 
-import weakref
 from collections.abc import Mapping
-from types import MappingProxyType
 
 from awkward._typing import Any, JSONMapping
 
@@ -47,21 +45,14 @@ def without_transient_attrs(attrs: dict[str, Any]) -> JSONMapping:
 
 
 class Attrs(Mapping):
-    def __init__(self, ref, data: Mapping[str, Any]):
-        self._ref = weakref.ref(ref)
-        self._data = _freeze_attrs(
-            {_enforce_str_key(k): v for k, v in _unfreeze_attrs(data).items()}
-        )
+    def __init__(self, data: Mapping[str, Any]):
+        self._data = {_enforce_str_key(k): v for k, v in data.items()}
 
     def __getitem__(self, key: str):
         return self._data[key]
 
     def __setitem__(self, key: str, value: Any):
-        ref = self._ref()
-        if ref is None:
-            msg = "The reference array has been deleted. If you still need to set attributes, convert this 'Attrs' instance to a dict with '.to_dict()'."
-            raise ValueError(msg)
-        ref._attrs = _unfreeze_attrs(self._data) | {_enforce_str_key(key): value}
+        self._data[_enforce_str_key(key)] = value
 
     def __iter__(self):
         return iter(self._data)
@@ -70,21 +61,13 @@ class Attrs(Mapping):
         return len(self._data)
 
     def __repr__(self):
-        return f"Attrs({_unfreeze_attrs(self._data)!r})"
+        return f"Attrs({self._data!r})"
 
     def to_dict(self):
-        return _unfreeze_attrs(self._data)
+        return dict(self._data)
 
 
 def _enforce_str_key(key: Any) -> str:
     if not isinstance(key, str):
         raise TypeError(f"'attrs' keys must be strings, got: {key!r}")
     return key
-
-
-def _freeze_attrs(attrs: Mapping[str, Any]) -> Mapping[str, Any]:
-    return MappingProxyType(attrs)
-
-
-def _unfreeze_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
-    return dict(attrs)

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -393,13 +393,13 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         non-pickleable types.
         """
         if self._attrs is None:
-            self._attrs = {}
-        return Attrs(self, self._attrs)
+            self._attrs = Attrs({})
+        return self._attrs
 
     @attrs.setter
     def attrs(self, value: Mapping[str, Any]):
         if isinstance(value, Mapping):
-            self._attrs = dict(value)
+            self._attrs = Attrs(value)
         else:
             raise TypeError("attrs must be a 'Attrs' mapping")
 
@@ -1919,13 +1919,13 @@ class Record(NDArrayOperatorsMixin):
         non-pickleable types.
         """
         if self._attrs is None:
-            self._attrs = {}
-        return Attrs(self, self._attrs)
+            self._attrs = Attrs({})
+        return self._attrs
 
     @attrs.setter
     def attrs(self, value: Mapping[str, Any]):
         if isinstance(value, Mapping):
-            self._attrs = dict(value)
+            self._attrs = Attrs(value)
         else:
             raise TypeError("attrs must be a mapping")
 
@@ -2726,13 +2726,13 @@ class ArrayBuilder(Sized):
         non-pickleable types.
         """
         if self._attrs is None:
-            self._attrs = {}
-        return Attrs(self, self._attrs)
+            self._attrs = Attrs({})
+        return self._attrs
 
     @attrs.setter
     def attrs(self, value: Mapping[str, Any]):
         if isinstance(value, Mapping):
-            self._attrs = dict(value)
+            self._attrs = Attrs(value)
         else:
             raise TypeError("attrs must be a mapping")
 


### PR DESCRIPTION
This PR makes `.attrs` properly pickable again by getting rid of the weak reference (without loosing the intended behavior introduced in https://github.com/scikit-hep/awkward/pull/3344).

Without this PR we'll break any usage with dask.distributed as it needs to pickle all objects (including `.attrs`) for scheduling.
Thus, we should get this PR in before a new awkward-array release.

(and also I think it's much cleaner now :-) )

