### PR TITLE
chore: check if 32bit right broadcasting test pass again

### DIFF
--- a/tests/test_2596_named_axis.py
+++ b/tests/test_2596_named_axis.py
@@ -373,11 +373,6 @@ def test_negative_named_axis_indexing():
     )
 
 
-# @pytest.mark.xfail(
-#     sys.platform == "win32",
-#     reason="right-broadcasting (NumPy-style) behaves differently for 32-bit windows",
-#     strict=False,
-# )
 def test_named_axis_right_broadcasting():
     # [NumPy-style] rightbroadcasting: (n, m) -> (1, n, m)
     a = ak.Array([1])  # (1,)

--- a/tests/test_2596_named_axis.py
+++ b/tests/test_2596_named_axis.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 
@@ -375,11 +373,11 @@ def test_negative_named_axis_indexing():
     )
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="right-broadcasting (NumPy-style) behaves differently for 32-bit windows",
-    strict=False,
-)
+# @pytest.mark.xfail(
+#     sys.platform == "win32",
+#     reason="right-broadcasting (NumPy-style) behaves differently for 32-bit windows",
+#     strict=False,
+# )
 def test_named_axis_right_broadcasting():
     # [NumPy-style] rightbroadcasting: (n, m) -> (1, n, m)
     a = ak.Array([1])  # (1,)


### PR DESCRIPTION
This PR is only opened to see if the 32bit fix in https://github.com/scikit-hep/awkward/pull/3270 is related in any way to the marked test failure for 32bit windows for right broadcasting.

~If the tests pass now, I'll update this PR, so please don't merge!~

PR  https://github.com/scikit-hep/awkward/pull/3270 fixed it! 