### PR TITLE
chore: reducing warnings

### DIFF
--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 cmake_minimum_required(VERSION 3.15...3.30)
 
+if(NOT DEFINED SKBUILD)
+  set(SKBUILD_PROJECT_NAME awkward_cpp)
+  set(SKBUILD_PROJECT_VERSION 0.0.0)
+endif()
+
 # Project must be near the top
 project(
   ${SKBUILD_PROJECT_NAME}

--- a/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
+++ b/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
@@ -1684,13 +1684,11 @@ namespace awkward {
           throw std::invalid_argument(
             std::string("unclosed string after .\" or s\" word") + FILENAME(__LINE__));
         }
-        int64_t nextline = line;
         current = source_[stop];
         start = stop;
         colstart = colstop;
         while (current != '\"'  ||  source_[stop - 1] == '\\') {
           if (current == '\n') {
-            nextline++;
             colstart = 0;
             colstop = 0;
           }


### PR DESCRIPTION
Reducing a few more warnings:

* Updated rapidjson to the latest commit, which removes all the "deprecated in C++17" warnings. There hasn't been a release of rapidjson in many, many years.
* Dropped a useless variable. If it was supposed to be used, then that should probably be fixed instead.
* Made it possible to compile directly, without scikit-build-core. Makes it easier to run clang-tidy, for example.


There are a bunch of signed -> unsigned conversions happening in one file which I did not fix yet.
