### PR TITLE
fix: typo/bug in `to_nplike`

### DIFF
--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -24,7 +24,7 @@ def to_nplike(
                 f"internal error: expected an array supported by an existing nplike, got {type(array).__name__!r}"
             )
 
-    if from_nplike is to_nplike:
+    if from_nplike is nplike:
         return array
 
     if nplike.known_data and not from_nplike.known_data:


### PR DESCRIPTION
`to_nplike` is the function itself. `nplike` is the target nplike.