### PR TITLE
fix: jax backend tracer leaks

### DIFF
--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -30,6 +30,7 @@ class JaxBackend(Backend):
 
     @property
     def index_nplike(self) -> Numpy:
+        # we need to ensure Numpy like here for our awkward-cpp kernels (they don't work with Jax arrays)
         return self._numpy
 
     def __init__(self):

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -59,7 +59,7 @@ class ArgMin(JAXReducer):
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
-        raise RuntimeError("Cannot differentiate through argmin")
+        raise NotImplementedError()
 
 
 @overloads(_reducers.ArgMax)
@@ -85,7 +85,7 @@ class ArgMax(JAXReducer):
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
-        raise RuntimeError("Cannot differentiate through argmax")
+        raise NotImplementedError()
 
 
 @overloads(_reducers.Count)
@@ -146,7 +146,7 @@ class CountNonzero(JAXReducer):
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
-        raise RuntimeError("Cannot differentiate through count_nonzero")
+        raise NotImplementedError()
 
 
 @overloads(_reducers.Sum)

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -102,7 +102,11 @@ class AuxData(Generic[T]):
 
         # reconstruct layout
         layout = ak.operations.from_buffers(
-            self._form, self._length, buffers, backend="jax"
+            self._form,
+            self._length,
+            buffers,
+            backend="jax",
+            highlevel=False,  # we will wrap it later
         )
 
         # wrap layout

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -6,162 +6,114 @@ import jax
 
 import awkward as ak
 from awkward import contents, highlevel, record
-from awkward._backends.backend import Backend
 from awkward._backends.jax import JaxBackend
-from awkward._behavior import behavior_of
-from awkward._layout import wrap_layout
-from awkward._nplikes.jax import Jax
-from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.numpy_like import NumpyMetadata
+from awkward._layout import HighLevelContext
 from awkward._typing import Generic, TypeVar, Union
 from awkward.contents import Content
-from awkward.record import Record
-
-numpy = Numpy.instance()
-np = NumpyMetadata.instance()
-
-
-def find_all_buffers(
-    layout: Content | Record,
-) -> list[numpy.ndarray]:
-    data_ptrs = []
-
-    def action(node, **kwargs):
-        if isinstance(node, ak.contents.NumpyArray):
-            data_ptrs.append(node.data)
-
-    ak._do.recursively_apply(
-        layout, action=action, return_array=False, numpy_to_regular=False
-    )
-
-    return data_ptrs
-
-
-def replace_all_buffers(
-    layout: contents.Content | record.Record,
-    buffers: list,
-    backend: Backend,
-):
-    def action(node, **kwargs):
-        jaxlike = Jax.instance()
-        if isinstance(node, ak.contents.NumpyArray):
-            buffer = buffers.pop(0)
-            # JAX might give us non-buffers, so ignore them
-            if not (numpy.is_own_array(buffer) or jaxlike.is_own_array(buffer)):
-                return
-            else:
-                return ak.contents.NumpyArray(
-                    buffer, parameters=node.parameters, backend=backend
-                )
-
-    return ak._do.recursively_apply(layout, action=action, numpy_to_regular=False)
-
 
 T = TypeVar(
     "T", bound=Union[highlevel.Array, highlevel.Record, contents.Content, record.Record]
 )
 
 
+def split_buffers(buffers: dict) -> tuple[dict, dict]:
+    data_buffers, other_buffers = {}, {}
+    for key, buf in buffers.items():
+        _, attr = key.rsplit("-", 1)
+        if attr == "data":
+            data_buffers[key] = buf
+        else:
+            other_buffers[key] = buf
+    return data_buffers, other_buffers
+
+
 class AuxData(Generic[T]):
+    """
+    This class is used to store the auxiliary data needed to reconstruct an Awkward Array from its buffers.
+
+    AuxData deliberately can not use the layout, because the layout has a reference to the buffers which are replaced
+    by JAX with tracers - this leads to tracer leaks!
+
+    Instead, this class holds the form, length, and other numpy buffers needed to reconstruct it.
+    """
+
     def __init__(
         self,
-        layout: contents.Content | record.Record,
-        is_highlevel: bool,
-        behavior: dict | None = None,
+        data_buffer_keys: tuple[str],
+        other_buffers: dict,
+        form: ak.forms.Form,
+        length: int,
+        ctx: HighLevelContext,
+        highlevel: bool = True,
     ):
-        self._layout = layout
-        self._behavior = behavior
-        self._is_highlevel = is_highlevel
+        self._data_buffer_keys = data_buffer_keys
+        self._other_buffers = other_buffers
+        self._form = form
+        self._length = length
+        self._ctx = ctx
+        self._highlevel = highlevel
 
     @classmethod
     def from_array_or_layout(cls, obj: T):
-        is_highlevel = isinstance(obj, (highlevel.Array, highlevel.Record))
-        if is_highlevel:
-            layout = obj.layout
-        elif isinstance(obj, (contents.Content, record.Record)):
-            layout = obj
-        else:
-            raise TypeError
+        with HighLevelContext() as ctx:
+            layout = ctx.unwrap(obj, allow_record=True, primitive_policy="error")
 
-        # First, make sure we're all JAX
+        # change backend
         jax_backend = JaxBackend.instance()
         layout = layout.to_backend(jax_backend)
 
-        # Now pull out the Jax tracers / arrays
-        buffers = find_all_buffers(layout)
+        # decompose
+        form, length, buffers = ak.operations.to_buffers(layout)
 
-        # # Drop the references to the existing buffers by replacing them with empty buffers
-        # # FIXME: This works-around the fact that AuxData should probably contain only a form and length,
-        # # rather than the actual layout (which holds references to the buffers that we're returning)
-        # # We use NumPy buffers here to ensure that we don't create any new tracers (they're just placeholders)
-        # # This is particularly unpleasant, because we're mixing nplikes here (deliberately)
-        # # We should use `to_buffers`.
-        # import numpy as _numpy
-        #
-        # def create_placeholder_like(array) -> _numpy.ndarray:
-        #     data = _numpy.empty(1, dtype=array.dtype)
-        #     strides = tuple(0 for _ in array.shape)
-        #     return _numpy.lib.stride_tricks.as_strided(
-        #         data, array.shape, strides=strides, writeable=False
-        #     )
-        # layout = replace_all_buffers(
-        #     layout,
-        #     [create_placeholder_like(n) for n in buffers],
-        #     nplike=Numpy.instance(),
-        # )
+        # we need to split buffers into all "data" buffers and all others (e.g. index, offsets, etc.)
+        data_buffers, other_buffers = split_buffers(buffers)
 
-        return buffers, AuxData(
-            layout=layout,
-            is_highlevel=is_highlevel,
-            behavior=behavior_of(obj),
+        # now we need to flatten the data buffers
+        data_buffer_keys, data_flat_buffers = zip(*data_buffers.items())
+        return data_flat_buffers, AuxData(
+            data_buffer_keys=data_buffer_keys,
+            other_buffers=other_buffers,
+            form=form,
+            length=length,
+            ctx=ctx,
+            highlevel=not isinstance(obj, Content),
         )
 
-    @property
-    def layout(self) -> contents.Content | record.Record:
-        return self._layout
+    def unflatten(self, data_buffers: tuple) -> T:
+        # reconstitute data buffers
+        data_buffers = dict(zip(self._data_buffer_keys, data_buffers))
 
-    @property
-    def behavior(self) -> dict | None:
-        return self._behavior
+        # combine data buffers with other buffers
+        buffers = {**self._other_buffers, **data_buffers}
 
-    @property
-    def is_highlevel(self) -> bool:
-        return self._is_highlevel
-
-    def unflatten(self, buffers: tuple) -> T:
-        for buffer in buffers:
-            # Check that JAX isn't trying to give us float0 types
-            dtype = getattr(buffer, "dtype", None)
-            if dtype == np.dtype([("float0", "V")]):
-                raise TypeError(
-                    f"a buffer with the dtype {buffer.dtype} was encountered during unflattening. "
-                    "JAX uses this dtype for the tangents of integer/boolean outputs; these cannot "
-                    "reasonably be differentiated. Make sure that you are not computing the derivative "
-                    "of a boolean/integer (array) valued function."
-                )
-
-        # Replace the mixed NumPy-JAX layout leaves with the given buffers (and use the JAX nplike)
-        layout = replace_all_buffers(
-            self._layout, list(buffers), backend=JaxBackend.instance()
+        # reconstruct layout
+        layout = ak.operations.from_buffers(
+            self._form, self._length, buffers, backend="jax"
         )
-        return wrap_layout(
-            layout, behavior=self._behavior, highlevel=self._is_highlevel
+
+        # wrap layout
+        return self._ctx.wrap(
+            layout,
+            highlevel=self._highlevel,
+            allow_other=True,
         )
 
     def __eq__(self, other: AuxData) -> bool:
-        return self.layout.is_equal_to(
-            other.layout, index_dtype=False, numpyarray=False
-        )
+        # should this test for more?
+        return self._form == other._form and self._length == other._length
+
+    def __ne__(self, other: AuxData) -> bool:
+        return not self == other
 
 
 def jax_flatten(
     array: T,
-) -> tuple[list[numpy.ndarray], AuxData]:
+) -> tuple[tuple, AuxData]:
     result = AuxData.from_array_or_layout(array)
     return result
 
 
-def jax_unflatten(aux_data: AuxData, children: list[numpy.ndarray]) -> T | None:
+def jax_unflatten(aux_data: AuxData, children: tuple) -> T | None:
     return aux_data.unflatten(children)
 
 

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -99,8 +99,12 @@ class AuxData(Generic[T]):
         )
 
     def __eq__(self, other: AuxData) -> bool:
-        # should this test for more?
-        return self._form == other._form and self._length == other._length
+        return (
+            self._form.is_equal_to(
+                other=other._form, all_parameters=True, form_key=True
+            )
+            and self._length == other._length
+        )
 
     def __ne__(self, other: AuxData) -> bool:
         return not self == other

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -33,7 +33,10 @@ def register_and_check():
     Register Awkward Array node types with JAX's tree mechanism.
     """
     try:
-        import jax  # noqa: TID251, F401
+        import jax  # noqa: TID251
+
+        # ak.from_buffers needs this
+        jax.config.update("jax_enable_x64", True)
 
     except ModuleNotFoundError:
         raise ModuleNotFoundError(

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -9,6 +9,7 @@ from awkward._backends.dispatch import regularize_backend
 from awkward._dispatch import high_level_function
 from awkward._layout import wrap_layout
 from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
@@ -176,7 +177,8 @@ def _from_buffer(
         return PlaceholderArray(nplike, (count,), dtype, field_path)
     elif isinstance(buffer, PlaceholderArray) or nplike.is_own_array(buffer):
         # Require 1D buffers
-        array = nplike.reshape(buffer.view(dtype), shape=(-1,), copy=False)
+        copy = None if isinstance(nplike, Jax) else False  # Jax can not avoid this
+        array = nplike.reshape(buffer.view(dtype), shape=(-1,), copy=copy)
 
         if array.size < count:
             raise TypeError(

--- a/tests/test_1399_from_jax.py
+++ b/tests/test_1399_from_jax.py
@@ -8,7 +8,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_enable_x64", True)
 
 ak.jax.register_and_check()
 

--- a/tests/test_1399_to_jax.py
+++ b/tests/test_1399_to_jax.py
@@ -8,7 +8,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_enable_x64", True)
 
 ak.jax.register_and_check()
 

--- a/tests/test_1447_jax_autodiff_slices_ufuncs.py
+++ b/tests/test_1447_jax_autodiff_slices_ufuncs.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from packaging.version import parse as parse_version
 
 import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
-jax.config.update("jax_enable_x64", True)
-if parse_version(jax.__version__) >= parse_version("0.4.36"):
-    jax.config.update("jax_data_dependent_tracing_fallback", True)
 
 ak.jax.register_and_check()
 

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -10,7 +10,6 @@ import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
-jax.config.update("jax_enable_x64", True)
 
 ak.jax.register_and_check()
 
@@ -110,7 +109,5 @@ def test_bool_raises(func_ak, axis):
     def func_with_axis(x):
         return func_ak(x, axis=axis)
 
-    with pytest.raises(
-        TypeError, match=".*Make sure that you are not computing the derivative.*"
-    ):
+    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
         jax.jvp(func_with_axis, (test_regulararray,), (test_regulararray_tangent,))

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -109,5 +109,7 @@ def test_bool_raises(func_ak, axis):
     def func_with_axis(x):
         return func_ak(x, axis=axis)
 
-    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+    with pytest.raises(
+        TypeError, match=".*Make sure that you are not computing the derivative.*"
+    ):
         jax.jvp(func_with_axis, (test_regulararray,), (test_regulararray_tangent,))

--- a/tests/test_1762_jax_behavior_support.py
+++ b/tests/test_1762_jax_behavior_support.py
@@ -9,7 +9,6 @@ import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
-jax.config.update("jax_enable_x64", True)
 
 ak.jax.register_and_check()
 

--- a/tests/test_1764_jax_jacobian.py
+++ b/tests/test_1764_jax_jacobian.py
@@ -8,7 +8,6 @@ import awkward as ak
 
 jax = pytest.importorskip("jax")
 jax.config.update("jax_platform_name", "cpu")
-jax.config.update("jax_enable_x64", True)
 
 ak.jax.register_and_check()
 


### PR DESCRIPTION
This fixes https://github.com/scikit-hep/awkward/pull/3340 properly. 

The issue was: we were using the `layout` as part of the tree definition of a `PyTree`. The `layout` holds a reference to _all_ arrays, also the ones that will be replace by tracers by Jax. To fix this, the (un-)flattening can not make use of `layouts` anymore, instead I'm using all other metadata to (de-)construct an awkward array. We had these tracer leaks all the time, just the newer Jax version (from 0.4.36 onwards) uncovered it.

In addition, `ak.form.Form` is much closer to a `PyTree`-definition than a layout is. 

This was really a hard bug to identify, tracer leaks are no fun!