### PR TITLE
chore: update ROOT test platform to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,7 +164,7 @@ jobs:
         uses: codecov/codecov-action@v5
 
   Linux-ROOT:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr


### PR DESCRIPTION
As of February 2024, GitHub has deprecated `ubuntu-20.04` from GitHub-hosted runners. We'll try to update to `ubuntu-latest`.