### PR TITLE
fix: maintain tupleness of RecordForms when using _select_columns and _prune_columns

### DIFF
--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -127,7 +127,9 @@ class RecordForm(RecordMeta[Form], Form):
         if not fields and is_inside_record_or_union:
             return None
         else:
-            return self.copy(contents=contents, fields=fields)
+            return self.copy(
+                contents=contents, fields=None if self.is_tuple else fields
+            )
 
     def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
         contents = []
@@ -145,7 +147,7 @@ class RecordForm(RecordMeta[Form], Form):
             contents.append(next_content)
             fields.append(field)
 
-        return self.copy(contents=contents, fields=fields)
+        return self.copy(contents=contents, fields=None if self.is_tuple else fields)
 
     def _column_types(self):
         return sum((x._column_types() for x in self._contents), ())

--- a/tests/test_3410_select_columns_keep_tuples.py
+++ b/tests/test_3410_select_columns_keep_tuples.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_select_columns():
+    (records, records_tuple) = (
+        ak.forms.RecordForm(
+            [
+                ak.forms.NumpyForm("int64"),
+                ak.forms.NumpyForm("int64"),
+            ],
+            None if is_tuple else ["x", "y"],
+        )
+        for is_tuple in (False, True)
+    )
+
+    assert not records.is_tuple
+    assert records_tuple.is_tuple
+
+    assert not records.select_columns("*").is_tuple
+    assert records_tuple.select_columns("*").is_tuple


### PR DESCRIPTION
Currently, if you take some form that contains a tuple `RecordForm` and apply `select_columns` it is converted into a non-tuple one by adding field names "1", "2", "3", ... . This PR fixes that, since it doesn't really make sense to do so.