### PR TITLE
fix: pyarrow 19.0 support

### DIFF
--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1095,8 +1095,7 @@ class RecordArray(RecordMeta[Content], Content):
                 pyarrow.field(
                     self.index_to_field(i),
                     values[i].type,
-                    (mask_node is not None and mask_node._arrow_needs_option_type())
-                    or x._arrow_needs_option_type(),
+                    x._arrow_needs_option_type(),
                 )
                 for i, x in enumerate(self._contents)
             ]

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1092,8 +1092,13 @@ class RecordArray(RecordMeta[Content], Content):
 
         types = pyarrow.struct(
             [
-                pyarrow.field(self.index_to_field(i), values[i].type).with_nullable(
-                    x._arrow_needs_option_type()
+                pyarrow.field(
+                    self.index_to_field(i),
+                    values[i].type,
+                    ak._connect.pyarrow.to_null_count(
+                        validbytes, options["count_nulls"]
+                    )
+                    or x._arrow_needs_option_type(),
                 )
                 for i, x in enumerate(self._contents)
             ]

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1089,8 +1089,13 @@ class RecordArray(RecordMeta[Content], Content):
 
         types = pyarrow.struct(
             [
-                pyarrow.field(self.index_to_field(i), values[i].type).with_nullable(
-                    x._arrow_needs_option_type()
+                pyarrow.field(
+                    self.index_to_field(i),
+                    values[i].type,
+                    ak._connect.pyarrow.to_null_count(
+                        validbytes, options["count_nulls"]
+                    )
+                    or x._arrow_needs_option_type(),
                 )
                 for i, x in enumerate(self._contents)
             ]

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1095,9 +1095,7 @@ class RecordArray(RecordMeta[Content], Content):
                 pyarrow.field(
                     self.index_to_field(i),
                     values[i].type,
-                    ak._connect.pyarrow.to_null_count(
-                        validbytes, options["count_nulls"]
-                    )
+                    (mask_node is not None and mask_node._arrow_needs_option_type())
                     or x._arrow_needs_option_type(),
                 )
                 for i, x in enumerate(self._contents)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1095,13 +1095,7 @@ class RecordArray(RecordMeta[Content], Content):
                 pyarrow.field(
                     self.index_to_field(i),
                     values[i].type,
-<<<<<<< HEAD
                     (mask_node is not None and mask_node._arrow_needs_option_type())
-=======
-                    ak._connect.pyarrow.to_null_count(
-                        validbytes, options["count_nulls"]
-                    )
->>>>>>> origin/ianna/parquet_190_support
                     or x._arrow_needs_option_type(),
                 )
                 for i, x in enumerate(self._contents)

--- a/tests/test_1125_to_arrow_from_arrow.py
+++ b/tests/test_1125_to_arrow_from_arrow.py
@@ -447,7 +447,7 @@ def test_unmaskedarray_numpyarray(tmp_path, extensionarray):
 
 @pytest.mark.parametrize("is_tuple", [False, True])
 @pytest.mark.parametrize("extensionarray", [False, True])
-def test_recordarray(tmp_path, is_tuple, extensionarray):
+def test_recordarray_numpy_listoffset(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.RecordArray(
         [
             ak.contents.NumpyArray(
@@ -463,11 +463,17 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
         None if is_tuple else ["x", "y"],
         parameters={"which": "outer"},
     )
+
     paarray = akarray.to_arrow(extensionarray=extensionarray)
+
     if not is_tuple or extensionarray:
         arrow_round_trip(akarray, paarray, extensionarray)
         parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_bytemased_listoffset(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.RecordArray(
         [
             ak.contents.ByteMaskedArray(
@@ -492,6 +498,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
         arrow_round_trip(akarray, paarray, extensionarray)
         parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_bytemasked_unmasked(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.RecordArray(
         [
             ak.contents.ByteMaskedArray(
@@ -519,6 +529,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
         arrow_round_trip(akarray, paarray, extensionarray)
         parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_indexedoption_recordarray_numpy_listoffset(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.IndexedOptionArray(
         ak.index.Index64(np.array([2, 0, -1, 0, 1], dtype=np.int64)),
         ak.contents.RecordArray(
@@ -543,6 +557,12 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
         arrow_round_trip(akarray, paarray, extensionarray)
         parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_indexedoption_recordarray_bytemasked_listoffset(
+    tmp_path, is_tuple, extensionarray
+):
     akarray = ak.contents.IndexedOptionArray(
         ak.index.Index64(np.array([2, 0, -1, 0, 1], dtype=np.int64)),
         ak.contents.RecordArray(
@@ -578,9 +598,6 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
 )
 @pytest.mark.parametrize("extensionarray", [False, True])
 def test_numpyarray_datetime(tmp_path, extensionarray):
-    # pyarrow doesn't yet support datetime/duration conversions to Parquet.
-    # (FIXME: find or create a JIRA ticket.)
-
     akarray = ak.contents.NumpyArray(
         np.array(
             ["2020-07-27T10:41:11", "2019-01-01", "2020-01-01"], dtype="datetime64[s]"
@@ -588,14 +605,14 @@ def test_numpyarray_datetime(tmp_path, extensionarray):
     )
     paarray = akarray.to_arrow(extensionarray=extensionarray)
     arrow_round_trip(akarray, paarray, extensionarray)
-    # parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
+    parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
     akarray = ak.contents.NumpyArray(
         np.array(["41", "1", "20"], dtype="timedelta64[s]")
     )
     paarray = akarray.to_arrow(extensionarray=extensionarray)
     arrow_round_trip(akarray, paarray, extensionarray)
-    # parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
+    parquet_round_trip(akarray, paarray, extensionarray, tmp_path)
 
 
 @pytest.mark.parametrize("extensionarray", [False, True])


### PR DESCRIPTION
also enable `datetime` tests 