### PR TITLE
fix: index with int in unionarray.py

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1586,7 +1586,7 @@ class UnionArray(UnionMeta[Content], Content):
         # backends with concrete data
         for i in range(self._tags.length):
             content = (
-                self._contents[self._tags.data[i]]
+                self._contents[int(self._tags.data[i])]
                 ._carry(ak.index.Index(self._index.data[i]), False)
                 ._remove_structure(backend, options)
             )

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1586,7 +1586,7 @@ class UnionArray(UnionMeta[Content], Content):
         # backends with concrete data
         for i in range(self._tags.length):
             content = (
-                self._contents[int(self._tags.data[i])]
+                self._contents[self._tags[i]]
                 ._carry(ak.index.Index(self._index.data[i]), False)
                 ._remove_structure(backend, options)
             )


### PR DESCRIPTION
fix` TypeError:` list indices must be integers or slices, not `ndarray` for `cuda` backend.