### PR TITLE
fix: `ruff` linting

### DIFF
--- a/src/awkward/_connect/numba/growablebuffer.py
+++ b/src/awkward/_connect/numba/growablebuffer.py
@@ -231,7 +231,7 @@ def GrowableBufferType_len(growablebuffer):
 def GrowableBuffer_add_panel(growablebuffer):
     def add_panel(growablebuffer):
         first_panel = growablebuffer._panels[0]
-        panel_length = int(math.ceil(len(first_panel) * growablebuffer._resize))
+        panel_length = math.ceil(len(first_panel) * growablebuffer._resize)
 
         growablebuffer._panels.append(numpy.empty((panel_length,), first_panel.dtype))
         growablebuffer._pos_set(0)
@@ -262,8 +262,8 @@ def GrowableBuffer_extend(growablebuffer, data):
         remaining = len(data)
 
         if remaining > available:
-            panel_length = int(
-                math.ceil(len(growablebuffer._panels[0]) * growablebuffer._resize)
+            panel_length = math.ceil(
+                len(growablebuffer._panels[0]) * growablebuffer._resize
             )
 
             growablebuffer._panels.append(

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -809,7 +809,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             )
 
         else:
-            excess_length = int(math.ceil(self._length / 8.0))
+            excess_length = math.ceil(self._length / 8.0)
             if (
                 self._mask.length is not unknown_length
                 and self._mask.length == excess_length

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -339,7 +339,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         if not self._backend.nplike.known_data:
             self._touch_data(recursive=False)
             if self._backend.nplike.known_data:
-                excess_length = int(math.ceil(self.length / 8.0))
+                excess_length = math.ceil(self.length / 8.0)
             else:
                 excess_length = unknown_length
             return ak.contents.BitMaskedArray(

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -208,7 +208,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         )
 
     def to_BitMaskedArray(self, valid_when, lsb_order):
-        bitlength = int(math.ceil(self._content.length / 8.0))
+        bitlength = math.ceil(self._content.length / 8.0)
         if valid_when:
             bitmask = self._backend.index_nplike.full(
                 bitlength, np.uint8(255), dtype=np.uint8

--- a/src/awkward/numba/__init__.py
+++ b/src/awkward/numba/__init__.py
@@ -111,7 +111,7 @@ class GrowableBuffer:
         remaining = len(data)
 
         if remaining > available:
-            panel_length = int(math.ceil(len(self._panels[0]) * self._resize))
+            panel_length = math.ceil(len(self._panels[0]) * self._resize)
 
             self._panels.append(
                 numpy.empty((max(remaining, panel_length),), dtype=self.dtype)

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -240,7 +240,7 @@ def _reconstitute(
         if length is unknown_length:
             next_length = unknown_length
         else:
-            next_length = int(math.ceil(length / 8.0))
+            next_length = math.ceil(length / 8.0)
         mask = _from_buffer(
             backend.index_nplike,
             raw_array,

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -46,7 +46,7 @@ numpy = Numpy.instance()
 
 
 def half(integer: int) -> int:
-    return int(math.ceil(integer / 2))
+    return math.ceil(integer / 2)
 
 
 def alternate(length: int):

--- a/src/awkward/types/_awkward_datashape_parser.py
+++ b/src/awkward/types/_awkward_datashape_parser.py
@@ -1,3 +1,4 @@
+# ruff: ignore
 # flake8: noqa
 # fmt: off
 # pylint: skip-file


### PR DESCRIPTION
Remove unnecessary casts reported by `ruff` linting,
disable `ruff` liniting for `src/awkward/types/_awkward_datashape_parser.py`.