### PR TITLE
fix: `ak.almost_equal` and `ak.array_equal` should check that jagged arrays have the same offsets

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -162,8 +162,8 @@ def _impl(
         # List-list
         elif left.is_list and right.is_list:
             # Check that indexes are equal
-            left_index = left.to_ListOffsetArray64(False).offsets
-            right_index = right.to_ListOffsetArray64(False).offsets
+            left_index = left.to_ListOffsetArray64(True).offsets
+            right_index = right.to_ListOffsetArray64(True).offsets
             if not backend.index_nplike.array_equal(left_index, right_index):
                 return False
             # Mixed regular-var

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -161,6 +161,11 @@ def _impl(
             return (left.size == right.size) and visitor(left.content, right.content)
         # List-list
         elif left.is_list and right.is_list:
+            # Check that indexes are equal
+            left_index = left.to_ListOffsetArray64(False).offsets
+            right_index = right.to_ListOffsetArray64(False).offsets
+            if not backend.index_nplike.array_equal(left_index, right_index):
+                return False
             # Mixed regular-var
             if left.is_regular and not right.is_regular:
                 return (not check_regular) and visitor(

--- a/tests/test_1105_ak_aray_equal.py
+++ b/tests/test_1105_ak_aray_equal.py
@@ -52,6 +52,16 @@ def test_array_equal_on_listoffsets():
     b = ak.Array([[[], [1], []], [[0]]])
     assert not ak.array_equal(a, b)
 
+    # same outer index, different inner index
+    a = ak.Array([[[0, 1], [1]], [[0], []]])
+    b = ak.Array([[[0], [1, 1]], [[], [0]]])
+    assert not ak.array_equal(a, b)
+
+    # nested
+    a = ak.Array([[[[]], [[0, 1], [1]]], [[[0]], [[]]]])
+    b = ak.Array([[[[0]], [[1], [1]]], [[[]], [[0]]]])
+    assert not ak.array_equal(a, b)
+
 
 def test_array_equal_mixed_content_type():
     a1 = ak.Array([[1, 2, 3], [4, 5, 6], [7, 8]])

--- a/tests/test_1105_ak_aray_equal.py
+++ b/tests/test_1105_ak_aray_equal.py
@@ -38,18 +38,19 @@ def test_array_equal_on_listoffsets():
     )
     assert ak.array_equal(a1, a2)
 
-
-def test_array_equal_on_doubly_jagged():
     # double jagged array
     a = ak.Array([[[1], [2, 3]], [[4, 5], [6]]])
     assert ak.array_equal(a, a)
 
+    # different index same content
+    a = ak.Array([[1], [2, 3]])
+    b = ak.Array([[1, 2], [3]])
+    assert not ak.array_equal(a, b)
+
     # different outer index, same inner index
-    a1 = ak.Array([[[], [1]], [[], [0]]])
-    a2 = ak.Array([[[], [1], []], [[0]]])
-    assert not ak.array_equal(a1, a2)
-    assert ak.array_equal(a1, a1)
-    assert ak.array_equal(a2, a2)
+    a = ak.Array([[[], [1]], [[], [0]]])
+    b = ak.Array([[[], [1], []], [[0]]])
+    assert not ak.array_equal(a, b)
 
 
 def test_array_equal_mixed_content_type():

--- a/tests/test_1105_ak_aray_equal.py
+++ b/tests/test_1105_ak_aray_equal.py
@@ -39,6 +39,19 @@ def test_array_equal_on_listoffsets():
     assert ak.array_equal(a1, a2)
 
 
+def test_array_equal_on_doubly_jagged():
+    # double jagged array
+    a = ak.Array([[[1], [2, 3]], [[4, 5], [6]]])
+    assert ak.array_equal(a, a)
+
+    # different outer index, same inner index
+    a1 = ak.Array([[[], [1]], [[], [0]]])
+    a2 = ak.Array([[[], [1], []], [[0]]])
+    assert not ak.array_equal(a1, a2)
+    assert ak.array_equal(a1, a1)
+    assert ak.array_equal(a2, a2)
+
+
 def test_array_equal_mixed_content_type():
     a1 = ak.Array([[1, 2, 3], [4, 5, 6], [7, 8]])
     a1r = ak.to_regular(a1[:2])

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -133,6 +133,25 @@ def test_behavior():
     assert not ak.almost_equal(other_array, another_array)
 
 
+def test_ragged():
+    # single jagged array
+    a = ak.Array([[1], [2, 3]])
+    b = ak.Array([[1], [2, 3]])
+    assert ak.almost_equal(a, b)
+
+    # double jagged array
+    a = ak.Array([[[1], [2, 3]], [[4, 5], [6]]])
+    b = ak.Array([[[1], [2, 3]], [[4, 5], [6]]])
+    assert ak.almost_equal(a, b)
+
+    # different outer index, same inner index
+    a = ak.Array([[[], [1]], [[], [0]]])
+    b = ak.Array([[[], [1], []], [[0]]])
+    assert not ak.almost_equal(a, b)
+    assert ak.almost_equal(a, a)
+    assert ak.almost_equal(b, b)
+
+
 def test_empty_outer_ragged():
     array = ak.Array([[1]])[0:0]
     assert not ak.almost_equal(array, [])

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -154,6 +154,16 @@ def test_ragged():
     b = ak.Array([[[], [1], []], [[0]]])
     assert not ak.almost_equal(a, b)
 
+    # same outer index, different inner index
+    a = ak.Array([[[0, 1], [1]], [[0], []]])
+    b = ak.Array([[[0], [1, 1]], [[], [0]]])
+    assert not ak.almost_equal(a, b)
+
+    # nested
+    a = ak.Array([[[[]], [[0, 1], [1]]], [[[0]], [[]]]])
+    b = ak.Array([[[[0]], [[1], [1]]], [[[]], [[0]]]])
+    assert not ak.almost_equal(a, b)
+
 
 def test_empty_outer_ragged():
     array = ak.Array([[1]])[0:0]

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -144,12 +144,15 @@ def test_ragged():
     b = ak.Array([[[1], [2, 3]], [[4, 5], [6]]])
     assert ak.almost_equal(a, b)
 
+    # different index same content
+    a = ak.Array([[1], [2, 3]])
+    b = ak.Array([[1, 2], [3]])
+    assert not ak.almost_equal(a, b)
+
     # different outer index, same inner index
     a = ak.Array([[[], [1]], [[], [0]]])
     b = ak.Array([[[], [1], []], [[0]]])
     assert not ak.almost_equal(a, b)
-    assert ak.almost_equal(a, a)
-    assert ak.almost_equal(b, b)
 
 
 def test_empty_outer_ragged():


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/3426
Addresses https://github.com/scikit-hep/awkward/discussions/3418

Jagged arrays can have the same content but different offsets. `ak.almost_equal` and `ak.array_equal` do not check for that and only check whether the contents are equal. Example:
```python
In [15]: a = ak.Array([[1, 2], [3]])

In [16]: b = ak.Array([[1], [2, 3]])

In [17]: ak.almost_equal(a, b)
Out[17]: True

In [18]: ak.array_equal(a,b)
Out[18]: True
```
This isn't proper behavior in my opinion.