### PR TITLE
fix: an `Index`'s `data` should be passed into `array_equal`, not the `Index` itself

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -164,7 +164,7 @@ def _impl(
             # Check that indexes are equal
             left_index = left.to_ListOffsetArray64(True).offsets
             right_index = right.to_ListOffsetArray64(True).offsets
-            if not backend.index_nplike.array_equal(left_index, right_index):
+            if not backend.index_nplike.array_equal(left_index.data, right_index.data):
                 return False
             # Mixed regular-var
             if left.is_regular and not right.is_regular:


### PR DESCRIPTION
A subtle bug was introduced in https://github.com/scikit-hep/awkward/pull/3425. `array_equal` should see the `Index`'s `data`, not the `Index` itself. The ci didn't catch it but the offline cuda tests did because they request for the `.shape` property which doesn't exist for an `Index`.