### PR TITLE
feat: add `tobytes` to `VirtualArray`

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -191,6 +191,12 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
             lambda: self.materialize().byteswap(inplace=inplace),
         )
 
+    def tobytes(self, order="C") -> bytes:
+        return self.materialize().tobytes(order) # type: ignore[attr-defined]
+
+    def tostring(self, order="C") -> bytes:
+        return self.materialize().tostring(order) # type: ignore[attr-defined]
+
     def __copy__(self) -> VirtualArray:
         new_virtual = type(self)(
             self._nplike,

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -194,9 +194,6 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     def tobytes(self, order="C") -> bytes:
         return self.materialize().tobytes(order)  # type: ignore[attr-defined]
 
-    def tostring(self, order="C") -> bytes:
-        return self.materialize().tostring(order)  # type: ignore[attr-defined]
-
     def __copy__(self) -> VirtualArray:
         new_virtual = type(self)(
             self._nplike,

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -192,10 +192,10 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     def tobytes(self, order="C") -> bytes:
-        return self.materialize().tobytes(order) # type: ignore[attr-defined]
+        return self.materialize().tobytes(order)  # type: ignore[attr-defined]
 
     def tostring(self, order="C") -> bytes:
-        return self.materialize().tostring(order) # type: ignore[attr-defined]
+        return self.materialize().tostring(order)  # type: ignore[attr-defined]
 
     def __copy__(self) -> VirtualArray:
         new_virtual = type(self)(

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -439,10 +439,15 @@ def test_copy(virtual_array):
 def test_tolist(virtual_array):
     assert virtual_array.tolist() == [1, 2, 3, 4, 5]
 
+
 # Test tobytes
 def test_tobytes(virtual_array):
-    assert virtual_array.tobytes(order="C") == np.array([1, 2, 3, 4, 5], dtype=np.int64).tobytes(order="C")
-    assert virtual_array.tobytes(order="F") == np.array([1, 2, 3, 4, 5], dtype=np.int64).tobytes(order="F")
+    assert virtual_array.tobytes(order="C") == np.array(
+        [1, 2, 3, 4, 5], dtype=np.int64
+    ).tobytes(order="C")
+    assert virtual_array.tobytes(order="F") == np.array(
+        [1, 2, 3, 4, 5], dtype=np.int64
+    ).tobytes(order="F")
     assert virtual_array.is_materialized
 
 

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -439,6 +439,12 @@ def test_copy(virtual_array):
 def test_tolist(virtual_array):
     assert virtual_array.tolist() == [1, 2, 3, 4, 5]
 
+# Test tobytes
+def test_tobytes(virtual_array):
+    assert virtual_array.tobytes(order="C") == np.array([1, 2, 3, 4, 5], dtype=np.int64).tobytes(order="C")
+    assert virtual_array.tobytes(order="F") == np.array([1, 2, 3, 4, 5], dtype=np.int64).tobytes(order="F")
+    assert virtual_array.is_materialized
+
 
 # Test ctypes
 def test_ctypes(virtual_array):


### PR DESCRIPTION
Discovered via a failing test in `coffea`, we need it to make `ak._util.tobytes` work.