### PR TITLE
fix: typo in `UnionArray` combinations

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1323,7 +1323,7 @@ class UnionArray(UnionMeta[Content], Content):
                         n, replacement, recordlookup, parameters, axis, depth
                     )
                 )
-            return ak.unionarray.UnionArray(
+            return ak.contents.UnionArray(
                 self._tags,
                 self._index,
                 contents,

--- a/tests/test_1074_combinations.py
+++ b/tests/test_1074_combinations.py
@@ -1401,6 +1401,61 @@ def test_UnionArray():
         == ak._do.combinations(v2_array, 2, axis=-1).form
     )
 
+    v2_array = ak.contents.unionarray.UnionArray(
+        ak.index.Index(np.array([1, 1, 0, 0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index(np.array([4, 3, 0, 1, 2, 2, 4, 100])),
+        [
+            ak.highlevel.Array(
+                [[0, 1, 2, 3], [], [4, 5, 6], [7], [8, 9, 10, 11, 12]]
+            ).layout,
+            ak.highlevel.Array(
+                [
+                    [0.0, 1.1, 2.2, 3.3],
+                    [],
+                    [4.4, 5.5, 6.6],
+                    [7.7],
+                    [8.8, 9.9, 10.0, 11.1, 12.2],
+                ]
+            ).layout,
+        ],
+    )
+
+    assert to_list(ak._do.combinations(v2_array, 2, axis=1)) == [
+        [
+            (8.8, 9.9),
+            (8.8, 10.0),
+            (8.8, 11.1),
+            (8.8, 12.2),
+            (9.9, 10.0),
+            (9.9, 11.1),
+            (9.9, 12.2),
+            (10.0, 11.1),
+            (10.0, 12.2),
+            (11.1, 12.2),
+        ],
+        [],
+        [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+        [],
+        [(4.4, 5.5), (4.4, 6.6), (5.5, 6.6)],
+        [(4, 5), (4, 6), (5, 6)],
+        [
+            (8.8, 9.9),
+            (8.8, 10.0),
+            (8.8, 11.1),
+            (8.8, 12.2),
+            (9.9, 10.0),
+            (9.9, 11.1),
+            (9.9, 12.2),
+            (10.0, 11.1),
+            (10.0, 12.2),
+            (11.1, 12.2),
+        ],
+    ]
+    assert (
+        ak._do.combinations(v2_array.to_typetracer(), 2, axis=1).form
+        == ak._do.combinations(v2_array, 2, axis=1).form
+    )
+
 
 def test_UnmaskedArray():
     v2_array = ak.contents.unmaskedarray.UnmaskedArray(


### PR DESCRIPTION
`UnionArray` combinations try to call `ak.unionarray.UnionArray` which doesn't exist. It should be `ak.contents.UnionArray`. Looking at the blame, it's there for at least 3 years 🤣 . Apparently no-one ever tried to using combinations with union arrays.

Discovered through coffea by:
```python
In [13]: leptons = ak.concatenate([events.Electron, events.Muon], axis=0)

In [14]: zcands = ak.combinations(leptons, 2)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[14], line 1
----> 1 zcands = ak.combinations(leptons, 2)

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/_dispatch.py:38, in named_high_level_function.<locals>.dispatch(*args, **kwargs)
     35 @wraps(func)
     36 def dispatch(*args, **kwargs):
     37     # NOTE: this decorator assumes that the operation is exposed under `ak.`
---> 38     with OperationErrorContext(name, args, kwargs):
     39         gen_or_result = func(*args, **kwargs)
     40         if isgenerator(gen_or_result):

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/_errors.py:80, in ErrorContext.__exit__(self, exception_type, exception_value, traceback)
     78     self._slate.__dict__.clear()
     79     # Handle caught exception
---> 80     raise self.decorate_exception(exception_type, exception_value)
     81 else:
     82     # Step out of the way so that another ErrorContext can become primary.
     83     if self.primary() is self:

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/_dispatch.py:64, in named_high_level_function.<locals>.dispatch(*args, **kwargs)
     62 # Failed to find a custom overload, so resume the original function
     63 try:
---> 64     next(gen_or_result)
     65 except StopIteration as err:
     66     return err.value

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/operations/ak_combinations.py:195, in combinations(array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior, attrs)
    192 yield (array,)
    194 # Implementation
--> 195 return _impl(
    196     array,
    197     n,
    198     replacement,
    199     axis,
    200     fields,
    201     parameters,
    202     with_name,
    203     highlevel,
    204     behavior,
    205     attrs,
    206 )

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/operations/ak_combinations.py:238, in _impl(array, n, replacement, axis, fields, parameters, with_name, highlevel, behavior, attrs)
    235 else:
    236     parameters = {**parameters, "__record__": with_name}
--> 238 out = ak._do.combinations(
    239     layout,
    240     n,
    241     replacement=replacement,
    242     axis=axis,
    243     fields=fields,
    244     parameters=parameters,
    245 )
    246 return ctx.wrap(out, highlevel=highlevel)

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/_do.py:142, in combinations(layout, n, replacement, axis, fields, parameters)
    140     if len(recordlookup) != n:
    141         raise ValueError("if provided, the length of 'fields' must be 'n'")
--> 142 return layout._combinations(n, replacement, recordlookup, parameters, axis, 1)

File ~/Dropbox/work/coffea_dev/awkward/src/awkward/contents/unionarray.py:1326, in UnionArray._combinations(self, n, replacement, recordlookup, parameters, axis, depth)
   1320 for content in self._contents:
   1321     contents.append(
   1322         content._combinations(
   1323             n, replacement, recordlookup, parameters, axis, depth
   1324         )
   1325     )
-> 1326 return ak.unionarray.UnionArray(
   1327     self._tags,
   1328     self._index,
   1329     contents,
   1330     parameters=self._parameters,
   1331 )

AttributeError: module 'awkward' has no attribute 'unionarray'

This error occurred while calling

    ak.combinations(
        <Array [[], [{...}], [...], ..., [], []] type='80 * union[var * Ele...'>
        2
    )
```