### PR TITLE
docs: minor fixes to JAX guide + add VJP example

### DIFF
--- a/docs/user-guide/how-to-specialize-differentiate-jax.md
+++ b/docs/user-guide/how-to-specialize-differentiate-jax.md
@@ -14,7 +14,7 @@ kernelspec:
 Differentiation using JAX
 =========================
 
-JAX, amongst other things, is a powerful tool for computing derivatives of native Python and NumPy code. Awkward Array implements support for the {func}`jax.jvp` and {func}`jax.vjp` JAX functions for computing forward/reverse-mode Jacobian-vector/vector-Jacobian products of functions that operate upon Awkard Arrays. Only a subset of Awkward Array operations can be differentiated through, including:
+JAX, amongst other things, is a powerful tool for computing derivatives of native Python and NumPy code. Awkward Array implements support for the {func}`jax.grad`, {func}`jax.jvp` and {func}`jax.vjp` JAX functions for computing gradients and forward/reverse-mode Jacobian-vector/vector-Jacobian products of functions that operate upon Awkward Arrays. Only a subset of Awkward Array operations can be differentiated through, including:
 - ufunc operations like `x + y`
 - reducers like {func}`ak.sum`
 - slices like `x[1:]`
@@ -45,7 +45,8 @@ def reverse_sum(array):
     return ak.sum(array[::-1], axis=0)
 ```
 
-We can then create an array with which to evaluate `reverse_sum`. The `backend` argument ensures that we build an Awkward Array that is backed by {class}`jaxlib.xla_extension.DeviceArray` buffers, which power JAX's automatic differentiation and JIT compiling features.
+We can then create an array with which to evaluate `reverse_sum`. The `backend` argument ensures that we build an Awkward Array that is backed by {class}`jax.Array` ({class}`jaxlib.xla_extension.ArrayImpl`) buffers, which power JAX's automatic differentiation and JIT compiling features. However, Awkward Array's JAX backend does not support JIT compilation on reducers as XLA requires array sizes to not be
+dependent on data values at compile-time.
 
 ```{code-cell}
 array = ak.Array([[1.0, 2.0, 3.0], [], [4.0, 5.0]], backend="jax")
@@ -55,7 +56,7 @@ array = ak.Array([[1.0, 2.0, 3.0], [], [4.0, 5.0]], backend="jax")
 reverse_sum(array)
 ```
 
-To compute the JVP of `reverse_sum` requires a _tangent_ vector, which can also be defined as an Awkward Array:
+Computing the JVP of `reverse_sum` requires a _tangent_ vector, which can also be defined as an Awkward Array:
 
 ```{code-cell}
 tangent = ak.Array([[0.0, 0.0, 0.0], [], [0.0, 1.0]], backend="jax")
@@ -79,6 +80,28 @@ and the JVP evaluted at `array` for the given `tangent`:
 
 ```{code-cell}
 jvp_grad
+```
+
+Similarly, VJP of `reverse_sum` can be computed as:
+
+```{code-cell}
+value_vjp, func_vjp = jax.vjp(reverse_sum, array)
+```
+
+where `value_vjp` is the function (`reverse_sum`) evaluated at `array` (forward pass):
+
+```{code-cell}
+assert value_vjp.to_list() == reverse_sum(array).to_list()
+```
+
+and `func_vjp` is a function that takes a _cotangent_ vector as an argument and returns the VJP (backward pass):
+
+```{code-cell}
+cotanget = ak.Array([0., 1., 0.], backend="jax")
+```
+
+```{code-cell}
+func_vjp(value_vjp)
 ```
 
 JAX's own documentation encourages the user to use {mod}`jax.numpy` instead of the canonical {mod}`numpy` module when operating upon JAX arrays. However, {mod}`jax.numpy` does not understand Awkward Arrays, so for {class}`ak.Array`s you should use the normal {mod}`ak` and {mod}`numpy` functions instead.

--- a/docs/user-guide/how-to-specialize-differentiate-jax.md
+++ b/docs/user-guide/how-to-specialize-differentiate-jax.md
@@ -45,8 +45,7 @@ def reverse_sum(array):
     return ak.sum(array[::-1], axis=0)
 ```
 
-We can then create an array with which to evaluate `reverse_sum`. The `backend` argument ensures that we build an Awkward Array that is backed by {class}`jax.Array` ({class}`jaxlib.xla_extension.ArrayImpl`) buffers, which power JAX's automatic differentiation and JIT compiling features. However, Awkward Array's JAX backend does not support JIT compilation on reducers as XLA requires array sizes to not be
-dependent on data values at compile-time.
+We can then create an array with which to evaluate `reverse_sum`. The `backend` argument ensures that we build an Awkward Array that is backed by {class}`jax.Array` ({class}`jaxlib.xla_extension.ArrayImpl`) buffers, which power JAX's automatic differentiation and JIT compiling features. However, Awkward Array's JAX backend does not support JIT compilation on reducers as XLA requires array sizes to not be dependent on data values at compile-time.
 
 ```{code-cell}
 array = ak.Array([[1.0, 2.0, 3.0], [], [4.0, 5.0]], backend="jax")


### PR DESCRIPTION
- explicitly tell users that `jax.jit` won't work on reducers
- `jax.grad` is supported
- add an example for `jax.vjp` (reverse mode AD)