### PR TITLE
feat: Add a parquet uuid calculation

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -202,11 +202,20 @@ def metadata(
             row_group_info = metadata.row_group(row_group_index).to_dict()
             for k, v in row_group_info.items():
                 if k in ["sorting_columns", "num_rows", "num_columns"]:
-                    uuids.append(repr({k:v}))
+                    uuids.append(repr({k: v}))
                 if k == "columns":
                     for subitem in v:
                         for subkey in subitem:
-                            if subkey not in ["file_offset", "file_path", "physical_type", "path_in_schema", "compression", "encodings", "total_compressed_size", "statistics"]:
+                            if subkey not in [
+                                "file_offset",
+                                "file_path",
+                                "physical_type",
+                                "path_in_schema",
+                                "compression",
+                                "encodings",
+                                "total_compressed_size",
+                                "statistics",
+                            ]:
                                 continue
                             uuids.append(repr({subkey: subitem[subkey]}))
         uuid = hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest()

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -199,8 +199,16 @@ def metadata(
     if calculate_uuid:
         uuids = [str(col_counts)]
         for row_group_index in (0, metadata.num_row_groups - 1):
-            row_group_info = metadata.row_group(row_group_index)
-            uuids.append(repr(row_group_info.to_dict()))
+            row_group_info = metadata.row_group(row_group_index).to_dict()
+            for k, v in row_group_info.items():
+                if k in ["sorting_columns", "num_rows", "num_columns"]:
+                    uuids.append(repr({k:v}))
+                if k == "columns":
+                    for subitem in v:
+                        for subkey in subitem:
+                            if subkey not in ["file_offset", "file_path", "physical_type", "path_in_schema", "compression", "encodings", "total_compressed_size", "statistics"]:
+                                continue
+                            uuids.append(repr({subkey: subitem[subkey]}))
         uuid = hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest()
         return (
             parquet_columns,

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -201,7 +201,9 @@ def metadata(
         for row_group_index in (0, metadata.num_row_groups - 1):
             row_group_info = metadata.row_group(row_group_index).to_dict()
             for k, v in row_group_info.items():
-                if k in ["sorting_columns", "num_rows", "num_columns"]:
+                # sorting columns, and columns::statistics have some version skew in underlying library
+                # with latter's 'distinct_counts' showing None vs 0 for example, so they're not used
+                if k in ["num_rows", "num_columns"]:
                     uuids.append(repr({k: v}))
                 if k == "columns":
                     for subitem in v:
@@ -214,7 +216,6 @@ def metadata(
                                 "compression",
                                 "encodings",
                                 "total_compressed_size",
-                                "statistics",
                             ]:
                                 continue
                             uuids.append(repr({subkey: subitem[subkey]}))

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import fsspec.parquet
 import hashlib
 import json
+
+import fsspec.parquet
 
 import awkward as ak
 import awkward._connect.pyarrow
@@ -67,12 +68,8 @@ def from_parquet(
     See also #ak.to_parquet, #ak.metadata_from_parquet.
     """
 
-    parquet_columns, subform, actual_paths, fs, subrg, row_counts, meta, uuid = metadata(
-        path,
-        storage_options,
-        row_groups,
-        columns,
-        calculate_uuid=True
+    parquet_columns, subform, actual_paths, fs, subrg, row_counts, meta, uuid = (
+        metadata(path, storage_options, row_groups, columns, calculate_uuid=True)
     )
     return _load(
         actual_paths,
@@ -197,7 +194,7 @@ def metadata(
         list_indicator=list_indicator, column_prefix=column_prefix
     )
 
-    #generate hash from the col_counts, first row_group and last row_group to calculate approximate parquet uuid
+    # generate hash from the col_counts, first row_group and last row_group to calculate approximate parquet uuid
     uuid = None
     if calculate_uuid:
         uuids = [str(col_counts)]
@@ -205,7 +202,16 @@ def metadata(
             row_group_info = metadata.row_group(row_group_index)
             uuids.append(repr(row_group_info.to_dict()))
         uuid = hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest()
-        return parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata, uuid
+        return (
+            parquet_columns,
+            subform,
+            actual_paths,
+            fs,
+            subrg,
+            col_counts,
+            metadata,
+            uuid,
+        )
 
     return parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata
 

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -219,12 +219,6 @@ def metadata(
                             ]:
                                 continue
                             uuids.append(repr({subkey: subitem[subkey]}))
-        for testing in uuids:
-            print("key-value pair:", testing)
-        print("concatenate:", ",".join(uuids))
-        print("json:", json.dumps(",".join(uuids)))
-        print("encode:", json.dumps(",".join(uuids)).encode())
-        print("hash:", hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest())
         uuid = hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest()
         return (
             parquet_columns,

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -197,7 +197,7 @@ def metadata(
     # generate hash from the col_counts, first row_group and last row_group to calculate approximate parquet uuid
     uuid = None
     if calculate_uuid:
-        uuids = [str(col_counts)]
+        uuids = [repr({"col_counts": col_counts})]
         for row_group_index in (0, metadata.num_row_groups - 1):
             row_group_info = metadata.row_group(row_group_index).to_dict()
             for k, v in row_group_info.items():
@@ -218,6 +218,12 @@ def metadata(
                             ]:
                                 continue
                             uuids.append(repr({subkey: subitem[subkey]}))
+        for testing in uuids:
+            print("key-value pair:", testing)
+        print("concatenate:", ",".join(uuids))
+        print("json:", json.dumps(",".join(uuids)))
+        print("encode:", json.dumps(",".join(uuids)).encode())
+        print("hash:", hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest())
         uuid = hashlib.sha256(json.dumps(",".join(uuids)).encode()).hexdigest()
         return (
             parquet_columns,

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -76,9 +76,17 @@ def _impl(
     path, storage_options, row_groups=None, ignore_metadata=False, scan_files=True
 ):
     results = ak.operations.ak_from_parquet.metadata(
-        path, storage_options, row_groups, None, ignore_metadata, scan_files, calculate_uuid=True
+        path,
+        storage_options,
+        row_groups,
+        None,
+        ignore_metadata,
+        scan_files,
+        calculate_uuid=True,
     )
-    parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata, uuid = results
+    parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata, uuid = (
+        results
+    )
 
     out = {
         "form": subform,

--- a/src/awkward/operations/ak_metadata_from_parquet.py
+++ b/src/awkward/operations/ak_metadata_from_parquet.py
@@ -76,9 +76,9 @@ def _impl(
     path, storage_options, row_groups=None, ignore_metadata=False, scan_files=True
 ):
     results = ak.operations.ak_from_parquet.metadata(
-        path, storage_options, row_groups, None, ignore_metadata, scan_files
+        path, storage_options, row_groups, None, ignore_metadata, scan_files, calculate_uuid=True
     )
-    parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata = results
+    parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata, uuid = results
 
     out = {
         "form": subform,
@@ -86,6 +86,7 @@ def _impl(
         "paths": actual_paths,
         "col_counts": col_counts,
         "columns": parquet_columns,
+        "uuid": uuid,
     }
     if col_counts:
         out["num_rows"] = sum(col_counts)

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -21,7 +21,10 @@ input = SAMPLES_DIR / "nullable-record-primitives.parquet"
 
 def test_parquet_uuid():
     meta = metadata_from_parquet(input)
-    assert meta["uuid"] == "582dabdb8c87bfa17bc930676ed26b8d4ab22a900f92357751dc380c41acb593"
+    assert (
+        meta["uuid"]
+        == "582dabdb8c87bfa17bc930676ed26b8d4ab22a900f92357751dc380c41acb593"
+    )
 
 
 @pytest.mark.parametrize("calculate_uuid", [True, False])

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -8,6 +8,8 @@ import pytest
 
 import awkward
 
+pytest.importorskip("pyarrow.parquet")
+
 metadata_from_parquet_submodule = pytest.importorskip(
     "awkward.operations.ak_metadata_from_parquet"
 )

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -23,7 +23,7 @@ def test_parquet_uuid():
     meta = metadata_from_parquet(input)
     assert (
         meta["uuid"]
-        == "37f505d95053fdd40fbc572b13fbc054d3b737ff85890990204c7e9cded13f87"
+        == "DEBUG"
     )
 
 

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -1,0 +1,56 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import awkward
+
+metadata_from_parquet_submodule = pytest.importorskip(
+    "awkward.operations.ak_metadata_from_parquet"
+)
+metadata_from_parquet = metadata_from_parquet_submodule.metadata_from_parquet
+
+SAMPLES_DIR = pathlib.Path(__file__).parent / "samples"
+input = SAMPLES_DIR / "nullable-record-primitives.parquet"
+
+
+def test_parquet_uuid():
+    meta = metadata_from_parquet(input)
+    assert (
+        meta["uuid"]
+        == "93fd596534251b1ac750f359d9d55418b02bcddcc79cd5ab1e3d9735941fbcae"
+    )
+
+
+@pytest.mark.parametrize("calculate_uuid", [True, False])
+def test_return_tuple_with_or_without_uuid(calculate_uuid):
+    results = awkward.operations.ak_from_parquet.metadata(
+        input,
+        {},
+        None,
+        None,
+        False,
+        True,
+        calculate_uuid=calculate_uuid,
+    )
+    if calculate_uuid:
+        assert len(results) == 8, "Expected 8 items in the result tuple"
+        (
+            parquet_columns,
+            subform,
+            actual_paths,
+            fs,
+            subrg,
+            col_counts,
+            metadata,
+            uuid,
+        ) = results
+        assert uuid is not None, "UUID should be present when calculate_uuid is True"
+    else:
+        assert len(results) == 7, "Expected 7 items in the result tuple"
+        parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata = (
+            results
+        )

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -21,7 +21,7 @@ def test_parquet_uuid():
     meta = metadata_from_parquet(input)
     assert (
         meta["uuid"]
-        == "93fd596534251b1ac750f359d9d55418b02bcddcc79cd5ab1e3d9735941fbcae"
+        == "37f505d95053fdd40fbc572b13fbc054d3b737ff85890990204c7e9cded13f87"
     )
 
 
@@ -49,6 +49,7 @@ def test_return_tuple_with_or_without_uuid(calculate_uuid):
             uuid,
         ) = results
         assert uuid is not None, "UUID should be present when calculate_uuid is True"
+        print("uuid:", uuid)
     else:
         assert len(results) == 7, "Expected 7 items in the result tuple"
         parquet_columns, subform, actual_paths, fs, subrg, col_counts, metadata = (

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -21,7 +21,7 @@ input = SAMPLES_DIR / "nullable-record-primitives.parquet"
 
 def test_parquet_uuid():
     meta = metadata_from_parquet(input)
-    assert meta["uuid"] == "DEBUG"
+    assert meta["uuid"] == "582dabdb8c87bfa17bc930676ed26b8d4ab22a900f92357751dc380c41acb593"
 
 
 @pytest.mark.parametrize("calculate_uuid", [True, False])

--- a/tests/test_3440_calculate_parquet_uuid.py
+++ b/tests/test_3440_calculate_parquet_uuid.py
@@ -21,10 +21,7 @@ input = SAMPLES_DIR / "nullable-record-primitives.parquet"
 
 def test_parquet_uuid():
     meta = metadata_from_parquet(input)
-    assert (
-        meta["uuid"]
-        == "DEBUG"
-    )
+    assert meta["uuid"] == "DEBUG"
 
 
 @pytest.mark.parametrize("calculate_uuid", [True, False])


### PR DESCRIPTION
Calculate a uuid from parquet metadata, utilizing detailed info of the first and last row_groups plus the col_counts of all row_groups of the file or dataset. At the column-page level, parquet should have a checksum AFAIK, but an approximate calculation that would catch differences in numbers of rows, row groups, columns, compression, etc. that deterministically uses two row groups should be sufficient for the equivalent of what coffea does with root files (which is flag them for changes to recalculate the form, steps, etc.).

https://github.com/scikit-hep/coffea/blob/master/src/coffea/dataset_tools/preprocess.py#L46-L48

Also, the ParquetMetadata namedtuple doesn't appear to be used, at least in this file that's touched. Given there's an extra line to handle not changing the length of returned tuple to try and avoid breaking compatibility with outside users, maybe this should be deprecated and the namedtuple should be used instead?