### PR TITLE
fix: add arm64

### DIFF
--- a/awkward-cpp/CMakeLists.txt
+++ b/awkward-cpp/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT DEFINED SKBUILD)
   set(SKBUILD_PROJECT_VERSION 0.0.0)
 endif()
 
+if(APPLE_CLASSIC)
+  set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+endif()
+
 # Project must be near the top
 project(
   ${SKBUILD_PROJECT_NAME}


### PR DESCRIPTION
Builds native arm64 awkward-cpp libraries needed for:
```
% python
Python 3.9.6 (default, Nov 11 2024, 03:15:38) 
[Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform; print(platform.machine())
arm64

```