### PR TITLE
fix: remove mixed numpy<->jax arrays in Jax backend

### DIFF
--- a/src/awkward/_backends/backend.py
+++ b/src/awkward/_backends/backend.py
@@ -29,11 +29,6 @@ class Backend(PublicSingleton, ABC):
     def nplike(self) -> NumpyLike:
         raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def index_nplike(self) -> NumpyLike:
-        raise NotImplementedError
-
     def __getitem__(self, key: KernelKeyType) -> KernelType:
         raise NotImplementedError
 

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -24,10 +24,6 @@ class CupyBackend(Backend):
     def nplike(self) -> Cupy:
         return self._cupy
 
-    @property
-    def index_nplike(self) -> Cupy:
-        return self._cupy
-
     def __init__(self):
         self._cupy = Cupy.instance()
 

--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -22,20 +22,13 @@ class JaxBackend(Backend):
     name: Final[str] = "jax"
 
     _jax: Jax
-    _numpy: Numpy
 
     @property
     def nplike(self) -> Jax:
         return self._jax
 
-    @property
-    def index_nplike(self) -> Numpy:
-        # we need to ensure Numpy like here for our awkward-cpp kernels (they don't work with Jax arrays)
-        return self._numpy
-
     def __init__(self):
         self._jax = Jax.instance()
-        self._numpy = Numpy.instance()
 
     def __getitem__(self, index: KernelKeyType) -> JaxKernel:
         # JAX uses Awkward's C++ kernels for index-only operations

--- a/src/awkward/_backends/numpy.py
+++ b/src/awkward/_backends/numpy.py
@@ -25,10 +25,6 @@ class NumpyBackend(Backend):
     def nplike(self) -> Numpy:
         return self._numpy
 
-    @property
-    def index_nplike(self) -> Numpy:
-        return self._numpy
-
     def __init__(self):
         self._numpy = Numpy.instance()
 

--- a/src/awkward/_backends/typetracer.py
+++ b/src/awkward/_backends/typetracer.py
@@ -24,10 +24,6 @@ class TypeTracerBackend(Backend):
     def nplike(self) -> TypeTracer:
         return self._typetracer
 
-    @property
-    def index_nplike(self) -> TypeTracer:
-        return self._typetracer
-
     def __init__(self):
         self._typetracer = TypeTracer.instance()
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -144,8 +144,8 @@ def combinations(
 
 def is_unique(layout, axis: Integral | None = None) -> bool:
     negaxis = axis if axis is None else -axis
-    starts = ak.index.Index64.zeros(1, nplike=layout._backend.index_nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.index_nplike)
+    starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
+    parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.nplike)
     return layout._is_unique(negaxis, starts, parents, 1)
 
 
@@ -174,10 +174,8 @@ def unique(layout: Content, axis=None):
                         f"axis={axis} exceeds the depth of this array ({depth})"
                     )
 
-        starts = ak.index.Index64.zeros(1, nplike=layout._backend.index_nplike)
-        parents = ak.index.Index64.zeros(
-            layout.length, nplike=layout._backend.index_nplike
-        )
+        starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
+        parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.nplike)
 
         return layout._unique(negaxis, starts, parents, 1)
 
@@ -249,8 +247,8 @@ def reduce(
         else:
             (layout,) = parts
 
-        starts = ak.index.Index64.zeros(1, layout.backend.index_nplike)
-        parents = ak.index.Index64.zeros(layout.length, layout.backend.index_nplike)
+        starts = ak.index.Index64.zeros(1, layout.backend.nplike)
+        parents = ak.index.Index64.zeros(layout.length, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -290,8 +288,8 @@ def reduce(
                     f"(which is {depth})"
                 )
 
-        starts = ak.index.Index64.zeros(1, layout.backend.index_nplike)
-        parents = ak.index.Index64.zeros(layout.length, layout.backend.index_nplike)
+        starts = ak.index.Index64.zeros(1, layout.backend.nplike)
+        parents = ak.index.Index64.zeros(layout.length, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -341,8 +339,8 @@ def argsort(
                 f"(which is {depth})"
             )
 
-    starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.index_nplike)
+    starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
+    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.nplike)
     return layout._argsort_next(
         negaxis,
         starts,
@@ -380,8 +378,8 @@ def sort(
                 f"(which is {depth})"
             )
 
-    starts = ak.index.Index64.zeros(1, nplike=layout.backend.index_nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.index_nplike)
+    starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
+    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.nplike)
     return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
 
 

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -7,6 +7,8 @@ from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpy_like import UfuncLike
+from awkward._nplikes.placeholder import PlaceholderArray
+from awkward._nplikes.virtual import materialize_if_virtual
 from awkward._typing import Final, cast
 
 
@@ -65,6 +67,10 @@ class Jax(ArrayModuleNumpyLike):
         module, _, suffix = type_.__module__.partition(".")
         return module == "jaxlib"
 
+    def is_currently_tracing(self) -> bool:
+        jax = ak.jax.import_jax()
+        return isinstance(self._module.array(1) + 1, jax.core.Tracer)
+
     @classmethod
     def is_tracer_type(cls, type_: type) -> bool:
         """
@@ -88,3 +94,61 @@ class Jax(ArrayModuleNumpyLike):
         for item in cast(tuple[int, ...], x.shape[-1:0:-1]):
             out = (item * out[0], *out)
         return out
+
+    ############################ ufuncs, need to overwrite those because JAX doesn't support `out=` for ufuncs
+
+    def add(
+        self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
+    ) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x1, PlaceholderArray)
+        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = materialize_if_virtual(x1, x2)
+        return self._module.add(x1, x2)
+
+    def logical_or(
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
+    ) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x1, PlaceholderArray)
+        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = materialize_if_virtual(x1, x2)
+        return self._module.logical_or(x1, x2)
+
+    def logical_and(
+        self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
+    ) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x1, PlaceholderArray)
+        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = materialize_if_virtual(x1, x2)
+        return self._module.logical_and(x1, x2)
+
+    def logical_not(
+        self, x: ArrayLike, maybe_out: ArrayLike | None = None
+    ) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x, PlaceholderArray)
+        (x,) = materialize_if_virtual(x)
+        return self._module.logical_not(x)
+
+    def sqrt(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x, PlaceholderArray)
+        (x,) = materialize_if_virtual(x)
+        return self._module.sqrt(x)
+
+    def exp(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x, PlaceholderArray)
+        (x,) = materialize_if_virtual(x)
+        return self._module.exp(x)
+
+    def divide(
+        self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
+    ) -> ArrayLike:
+        del maybe_out
+        assert not isinstance(x1, PlaceholderArray)
+        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = materialize_if_virtual(x1, x2)
+        return self._module.divide(x1, x2)

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -86,8 +86,8 @@ def apply_positional_corrections(
 ):
     if shifts is None:
         assert (
-            parents.nplike is reduced.backend.index_nplike
-            and starts.nplike is reduced.backend.index_nplike
+            parents.nplike is reduced.backend.nplike
+            and starts.nplike is reduced.backend.nplike
         )
         reduced.backend.maybe_kernel_error(
             reduced.backend[
@@ -104,9 +104,9 @@ def apply_positional_corrections(
         )
     else:
         assert (
-            parents.nplike is reduced.backend.index_nplike
-            and starts.nplike is reduced.backend.index_nplike
-            and shifts.nplike is reduced.backend.index_nplike
+            parents.nplike is reduced.backend.nplike
+            and starts.nplike is reduced.backend.nplike
+            and shifts.nplike is reduced.backend.nplike
         )
         reduced.backend.maybe_kernel_error(
             reduced._backend[
@@ -151,7 +151,7 @@ class ArgMin(KernelReducer):
         kernel_array_data = array.data.view(self._dtype_for_kernel(array.dtype))
         result = array.backend.nplike.empty(outlength, dtype=np.int64)
         if array.dtype.type in (np.complex128, np.complex64):
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_argmin_complex",
@@ -167,7 +167,7 @@ class ArgMin(KernelReducer):
                 )
             )
         else:
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_argmin",
@@ -213,7 +213,7 @@ class ArgMax(KernelReducer):
         kernel_array_data = array.data.view(self._dtype_for_kernel(array.dtype))
         result = array.backend.nplike.empty(outlength, dtype=np.int64)
         if array.dtype.type in (np.complex128, np.complex64):
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_argmax_complex",
@@ -229,7 +229,7 @@ class ArgMax(KernelReducer):
                 )
             )
         else:
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_argmax",
@@ -264,7 +264,7 @@ class Count(KernelReducer):
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
         result = array.backend.nplike.empty(outlength, dtype=np.int64)
-        assert parents.nplike is array.backend.index_nplike
+        assert parents.nplike is array.backend.nplike
         array.backend.maybe_kernel_error(
             array.backend[
                 "awkward_reduce_count_64", result.dtype.type, parents.dtype.type
@@ -297,7 +297,7 @@ class CountNonzero(KernelReducer):
 
         result = array.backend.nplike.empty(outlength, dtype=np.int64)
         if np.issubdtype(array.dtype, np.complexfloating):
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_countnonzero_complex",
@@ -313,7 +313,7 @@ class CountNonzero(KernelReducer):
                 )
             )
         else:
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_countnonzero",
@@ -355,7 +355,7 @@ class Sum(KernelReducer):
                 dtype=self._promote_integer_rank(np.bool_),
             )
             if result.dtype in (np.int64, np.uint64):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_sum_int64_bool_64",
@@ -371,7 +371,7 @@ class Sum(KernelReducer):
                     )
                 )
             elif result.dtype in (np.int32, np.uint32):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_sum_int32_bool_64",
@@ -397,7 +397,7 @@ class Sum(KernelReducer):
                 dtype=self._promote_integer_rank(kernel_array_data.dtype),
             )
             if array.dtype.type in (np.complex128, np.complex64):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_sum_complex",
@@ -413,7 +413,7 @@ class Sum(KernelReducer):
                     )
                 )
             else:
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_sum",
@@ -459,7 +459,7 @@ class Prod(KernelReducer):
                 # This kernel, unlike sum, returns bools!
                 dtype=np.bool_,
             )
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_prod_bool",
@@ -488,7 +488,7 @@ class Prod(KernelReducer):
                 dtype=self._promote_integer_rank(kernel_array_data.dtype),
             )
             if array.dtype.type in (np.complex128, np.complex64):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_prod_complex",
@@ -504,7 +504,7 @@ class Prod(KernelReducer):
                     )
                 )
             else:
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_prod",
@@ -545,7 +545,7 @@ class Any(KernelReducer):
         result = array.backend.nplike.empty(outlength, dtype=np.bool_)
 
         if array.dtype.type in (np.complex128, np.complex64):
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_sum_bool_complex",
@@ -561,7 +561,7 @@ class Any(KernelReducer):
                 )
             )
         else:
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_sum_bool",
@@ -598,7 +598,7 @@ class All(KernelReducer):
         result = array.backend.nplike.empty(outlength, dtype=np.bool_)
 
         if array.dtype.type in (np.complex128, np.complex64):
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_prod_bool_complex",
@@ -614,7 +614,7 @@ class All(KernelReducer):
                 )
             )
         else:
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_prod_bool",
@@ -678,7 +678,7 @@ class Min(KernelReducer):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype == np.bool_:
             result = array.backend.nplike.empty(outlength, dtype=np.bool_)
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_prod_bool",
@@ -702,7 +702,7 @@ class Min(KernelReducer):
                 dtype=kernel_array_data.dtype,
             )
             if array.dtype.type in (np.complex128, np.complex64):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_min_complex",
@@ -719,7 +719,7 @@ class Min(KernelReducer):
                     )
                 )
             else:
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_min",
@@ -786,7 +786,7 @@ class Max(KernelReducer):
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype == np.bool_:
             result = array.backend.nplike.empty(outlength, dtype=np.bool_)
-            assert parents.nplike is array.backend.index_nplike
+            assert parents.nplike is array.backend.nplike
             array.backend.maybe_kernel_error(
                 array.backend[
                     "awkward_reduce_sum_bool",
@@ -810,7 +810,7 @@ class Max(KernelReducer):
                 dtype=kernel_array_data.dtype,
             )
             if array.dtype.type in (np.complex128, np.complex64):
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_max_complex",
@@ -827,7 +827,7 @@ class Max(KernelReducer):
                     )
                 )
             else:
-                assert parents.nplike is array.backend.index_nplike
+                assert parents.nplike is array.backend.nplike
                 array.backend.maybe_kernel_error(
                     array.backend[
                         "awkward_reduce_max",

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -165,7 +165,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 f"{type(self).__name__} 'lsb_order' must be boolean, not {lsb_order!r}"
             )
         if (
-            content.backend.index_nplike.known_data
+            content.backend.nplike.known_data
             and length is not unknown_length
             and mask.length is not unknown_length
             and length > mask.length * 8
@@ -174,7 +174,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 f"{type(self).__name__} 'length' ({length}) must be <= len(mask) * 8 ({mask.length * 8})"
             )
         if (
-            content.backend.index_nplike.known_data
+            content.backend.nplike.known_data
             and length is not unknown_length
             and mask.length is not unknown_length
             and length > content.length * 8
@@ -183,7 +183,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 f"{type(self).__name__} 'length' ({length}) must be <= len(content) ({content.length})"
             )
 
-        assert mask.nplike is content.backend.index_nplike
+        assert mask.nplike is content.backend.nplike
 
         self._mask = mask
         self._content = content
@@ -248,7 +248,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
     ):
         if content.is_union or content.is_indexed or content.is_option:
             backend = content.backend
-            index = ak.index.Index64.empty(mask.length * 8, backend.index_nplike)
+            index = ak.index.Index64.empty(mask.length * 8, backend.nplike)
             backend.maybe_kernel_error(
                 backend[
                     "awkward_BitMaskedArray_to_IndexedOptionArray",
@@ -310,7 +310,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         assert isinstance(form, self.form_cls)
         key = getkey(self, form, "mask")
         container[key] = ak._util.native_to_byteorder(
-            self._mask.raw(backend.index_nplike), byteorder
+            self._mask.raw(backend.nplike), byteorder
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
@@ -359,9 +359,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         return "".join(out)
 
     def to_IndexedOptionArray64(self) -> IndexedOptionArray:
-        index = ak.index.Index64.empty(
-            self._mask.length * 8, self._backend.index_nplike
-        )
+        index = ak.index.Index64.empty(self._mask.length * 8, self._backend.nplike)
         assert (
             index.nplike is self._backend.nplike
             and self._mask.nplike is self._backend.nplike
@@ -384,9 +382,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         )
 
     def to_ByteMaskedArray(self):
-        bytemask = ak.index.Index8.empty(
-            self._mask.length * 8, self._backend.index_nplike
-        )
+        bytemask = ak.index.Index8.empty(self._mask.length * 8, self._backend.nplike)
         assert (
             bytemask.nplike is self._backend.nplike
             and self._mask.nplike is self._backend.nplike
@@ -417,9 +413,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 return self
             else:
                 return BitMaskedArray(
-                    ak.index.IndexU8(
-                        self._backend.index_nplike.logical_not(self._mask.data)
-                    ),
+                    ak.index.IndexU8(self._backend.nplike.logical_not(self._mask.data)),
                     self._content,
                     valid_when,
                     self._length,
@@ -429,10 +423,10 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
 
         else:
             bit_order = "little" if lsb_order else "big"
-            bytemask = self.backend.index_nplike.unpackbits(
+            bytemask = self.backend.nplike.unpackbits(
                 self._mask.data, bitorder=bit_order
             )
-            bitmask = self.backend.index_nplike.packbits(bytemask, bitorder=bit_order)
+            bitmask = self.backend.nplike.packbits(bytemask, bitorder=bit_order)
 
             if valid_when != self._valid_when:
                 bitmask = ~bitmask
@@ -450,9 +444,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         if valid_when is None:
             valid_when = self._valid_when
 
-        bytemask = ak.index.Index8.empty(
-            self._mask.length * 8, self._backend.index_nplike
-        )
+        bytemask = ak.index.Index8.empty(self._mask.length * 8, self._backend.nplike)
         assert (
             bytemask.nplike is self._backend.nplike
             and self._mask.nplike is self._backend.nplike
@@ -471,7 +463,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             )
         )
         return bytemask.data[
-            : self._backend.index_nplike.shape_item_as_index(self._length)
+            : self._backend.nplike.shape_item_as_index(self._length)
         ].view(np.bool_)
 
     def _getitem_nothing(self):
@@ -863,7 +855,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
 
     def _to_backend(self, backend: Backend) -> Self:
         content = self._content.to_backend(backend)
-        mask = self._mask.to_nplike(backend.index_nplike)
+        mask = self._mask.to_nplike(backend.nplike)
         return BitMaskedArray(
             mask,
             content,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -132,7 +132,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 f"{type(self).__name__} 'valid_when' must be boolean, not {valid_when!r}"
             )
         if (
-            content.backend.index_nplike.known_data
+            content.backend.nplike.known_data
             and mask.length is not unknown_length
             and content.length is not unknown_length
             and mask.length > content.length
@@ -141,7 +141,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 f"{type(self).__name__} len(mask) ({mask.length}) must be <= len(content) ({content.length})"
             )
 
-        assert mask.nplike is content.backend.index_nplike
+        assert mask.nplike is content.backend.nplike
 
         self._mask = mask
         self._content = content
@@ -187,7 +187,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
     ):
         if content.is_union or content.is_indexed or content.is_option:
             backend = content.backend
-            index = ak.index.Index64.empty(mask.length, nplike=backend.index_nplike)
+            index = ak.index.Index64.empty(mask.length, nplike=backend.nplike)
             backend.maybe_kernel_error(
                 backend[
                     "awkward_ByteMaskedArray_toIndexedOptionArray",
@@ -239,7 +239,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         assert isinstance(form, self.form_cls)
         key = getkey(self, form, "mask")
         container[key] = ak._util.native_to_byteorder(
-            self._mask.raw(backend.index_nplike), byteorder
+            self._mask.raw(backend.nplike), byteorder
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
@@ -293,12 +293,10 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         return "".join(out)
 
     def to_IndexedOptionArray64(self) -> IndexedOptionArray:
-        index = ak.index.Index64.empty(
-            self._mask.length, nplike=self._backend.index_nplike
-        )
+        index = ak.index.Index64.empty(self._mask.length, nplike=self._backend.nplike)
         assert (
-            index.nplike is self._backend.index_nplike
-            and self._mask.nplike is self._backend.index_nplike
+            index.nplike is self._backend.nplike
+            and self._mask.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -322,11 +320,9 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         else:
             return ByteMaskedArray(
                 ak.index.Index8(
-                    self._backend.index_nplike.astype(
-                        self._backend.index_nplike.logical_not(
-                            self._backend.index_nplike.astype(
-                                self._mask.data, dtype=np.bool_
-                            )
+                    self._backend.nplike.astype(
+                        self._backend.nplike.logical_not(
+                            self._backend.nplike.astype(self._mask.data, dtype=np.bool_)
                         ),
                         dtype=np.int8,
                     )
@@ -357,7 +353,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         else:
             bit_order = "little" if lsb_order else "big"
             bytemask = self.mask_as_bool(valid_when).view(np.uint8)
-            bitmask = self.backend.index_nplike.packbits(bytemask, bitorder=bit_order)
+            bitmask = self.backend.nplike.packbits(bytemask, bitorder=bit_order)
 
             return ak.contents.BitMaskedArray(
                 ak.index.IndexU8(bitmask),
@@ -373,9 +369,9 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             valid_when = self._valid_when
 
         if valid_when == self._valid_when:
-            return self._mask.raw(self._backend.index_nplike) != 0
+            return self._mask.raw(self._backend.nplike) != 0
         else:
-            return self._mask.raw(self._backend.index_nplike) != 1
+            return self._mask.raw(self._backend.nplike) != 1
 
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
@@ -456,11 +452,11 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         )
 
     def _nextcarry_outindex(self) -> tuple[int, ak.index.Index64, ak.index.Index64]:
-        _numnull = ak.index.Index64.empty(1, nplike=self._backend.index_nplike)
+        _numnull = ak.index.Index64.empty(1, nplike=self._backend.nplike)
 
         assert (
-            _numnull.nplike is self._backend.index_nplike
-            and self._mask.nplike is self._backend.index_nplike
+            _numnull.nplike is self._backend.nplike
+            and self._mask.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -474,18 +470,16 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 self._valid_when,
             )
         )
-        numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
+        numnull = self._backend.nplike.index_as_shape_item(_numnull[0])
         nextcarry = ak.index.Index64.empty(
             self.length - numnull,
-            nplike=self._backend.index_nplike,
+            nplike=self._backend.nplike,
         )
-        outindex = ak.index.Index64.empty(
-            self.length, nplike=self._backend.index_nplike
-        )
+        outindex = ak.index.Index64.empty(self.length, nplike=self._backend.nplike)
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and outindex.nplike is self._backend.index_nplike
-            and self._mask.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and outindex.nplike is self._backend.nplike
+            and self._mask.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -521,17 +515,17 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
         reducedstarts = ak.index.Index64.empty(
             self.length - numnull,
-            nplike=self._backend.index_nplike,
+            nplike=self._backend.nplike,
         )
         reducedstops = ak.index.Index64.empty(
             self.length - numnull,
-            nplike=self._backend.index_nplike,
+            nplike=self._backend.nplike,
         )
 
         assert (
-            outindex.nplike is self._backend.index_nplike
-            and slicestarts.nplike is self._backend.index_nplike
-            and slicestops.nplike is self._backend.index_nplike
+            outindex.nplike is self._backend.nplike
+            and slicestarts.nplike is self._backend.nplike
+            and slicestops.nplike is self._backend.nplike
             and reducedstarts.nplike is self._backend.nplike
             and reducedstops.nplike is self._backend.nplike
         )
@@ -607,7 +601,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
     def project(self, mask=None):
         mask_length = self._mask.length
-        _numnull = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
+        _numnull = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
 
         if mask is not None:
             if self._backend.nplike.known_data and mask_length != mask.length:
@@ -615,13 +609,11 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                     f"mask length ({mask.length}) is not equal to {type(self).__name__} length ({mask_length})"
                 )
 
-            nextmask = ak.index.Index8.empty(
-                mask_length, nplike=self._backend.index_nplike
-            )
+            nextmask = ak.index.Index8.empty(mask_length, nplike=self._backend.nplike)
             assert (
-                nextmask.nplike is self._backend.index_nplike
-                and mask.nplike is self._backend.index_nplike
-                and self._mask.nplike is self._backend.index_nplike
+                nextmask.nplike is self._backend.nplike
+                and mask.nplike is self._backend.nplike
+                and self._mask.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -645,8 +637,8 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
         else:
             assert (
-                _numnull.nplike is self._backend.index_nplike
-                and self._mask.nplike is self._backend.index_nplike
+                _numnull.nplike is self._backend.nplike
+                and self._mask.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -660,13 +652,13 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                     self._valid_when,
                 )
             )
-            numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
+            numnull = self._backend.nplike.index_as_shape_item(_numnull[0])
             nextcarry = ak.index.Index64.empty(
-                mask_length - numnull, nplike=self._backend.index_nplike
+                mask_length - numnull, nplike=self._backend.nplike
             )
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and self._mask.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and self._mask.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -705,14 +697,14 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             else:
                 outoffsets = ak.index.Index64.empty(
                     offsets.length + numnull,
-                    nplike=self._backend.index_nplike,
+                    nplike=self._backend.nplike,
                     dtype=np.int64,
                 )
 
                 assert (
-                    outoffsets.nplike is self._backend.index_nplike
-                    and outindex.nplike is self._backend.index_nplike
-                    and offsets.nplike is self._backend.index_nplike
+                    outoffsets.nplike is self._backend.nplike
+                    and outindex.nplike is self._backend.nplike
+                    and offsets.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -752,14 +744,12 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             for x in others
         ):
             parameters = self._parameters
-            self_length_scalar = self._backend.index_nplike.shape_item_as_index(
-                self.length
-            )
+            self_length_scalar = self._backend.nplike.shape_item_as_index(self.length)
             masks = [self._mask.data[:self_length_scalar]]
             tail_contents = []
             length = 0
             for x in others:
-                length_scalar = self._backend.index_nplike.shape_item_as_index(x.length)
+                length_scalar = self._backend.nplike.shape_item_as_index(x.length)
                 parameters = parameters_intersect(parameters, x._parameters)
                 masks.append(x._mask.data[:length_scalar])
                 tail_contents.append(x._content[:length_scalar])
@@ -856,10 +846,10 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
     ):
         mask_length = self._mask.length
 
-        _numnull = ak.index.Index64.empty(1, nplike=self._backend.index_nplike)
+        _numnull = ak.index.Index64.empty(1, nplike=self._backend.nplike)
         assert (
-            _numnull.nplike is self._backend.index_nplike
-            and self._mask.nplike is self._backend.index_nplike
+            _numnull.nplike is self._backend.nplike
+            and self._mask.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -873,24 +863,18 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 self._valid_when,
             )
         )
-        numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
+        numnull = self._backend.nplike.index_as_shape_item(_numnull[0])
 
         next_length = mask_length - numnull
-        nextcarry = ak.index.Index64.empty(
-            next_length, nplike=self._backend.index_nplike
-        )
-        nextparents = ak.index.Index64.empty(
-            next_length, nplike=self._backend.index_nplike
-        )
-        outindex = ak.index.Index64.empty(
-            mask_length, nplike=self._backend.index_nplike
-        )
+        nextcarry = ak.index.Index64.empty(next_length, nplike=self._backend.nplike)
+        nextparents = ak.index.Index64.empty(next_length, nplike=self._backend.nplike)
+        outindex = ak.index.Index64.empty(mask_length, nplike=self._backend.nplike)
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and nextparents.nplike is self._backend.index_nplike
-            and outindex.nplike is self._backend.index_nplike
-            and self._mask.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and nextparents.nplike is self._backend.nplike
+            and outindex.nplike is self._backend.nplike
+            and self._mask.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -915,12 +899,12 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
         if reducer.needs_position and (not branch and negaxis == depth):
             nextshifts = ak.index.Index64.empty(
-                next_length, nplike=self._backend.index_nplike
+                next_length, nplike=self._backend.nplike
             )
             if shifts is None:
                 assert (
-                    nextshifts.nplike is self._backend.index_nplike
-                    and self._mask.nplike is self._backend.index_nplike
+                    nextshifts.nplike is self._backend.nplike
+                    and self._mask.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -936,8 +920,8 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 )
             else:
                 assert (
-                    nextshifts.nplike is self._backend.index_nplike
-                    and self._mask.nplike is self._backend.index_nplike
+                    nextshifts.nplike is self._backend.nplike
+                    and self._mask.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -987,7 +971,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
                 )
 
             outoffsets = ak.index.Index64.empty(
-                starts.length + 1, nplike=self._backend.index_nplike
+                starts.length + 1, nplike=self._backend.nplike
             )
             assert outoffsets.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
@@ -1023,12 +1007,10 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
-            index = ak.index.Index64.empty(
-                mask.length, nplike=self._backend.index_nplike
-            )
+            index = ak.index.Index64.empty(mask.length, nplike=self._backend.nplike)
             assert (
-                index.nplike is self._backend.index_nplike
-                and self._mask.nplike is self._backend.index_nplike
+                index.nplike is self._backend.nplike
+                and self._mask.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1207,7 +1189,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
     def _to_backend(self, backend: Backend) -> Self:
         content = self._content.to_backend(backend)
-        mask = self._mask.to_nplike(backend.index_nplike)
+        mask = self._mask.to_nplike(backend.nplike)
         return ByteMaskedArray(
             mask, content, valid_when=self._valid_when, parameters=self._parameters
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -383,15 +383,15 @@ class Content(Meta):
         length = 1 if length is not unknown_length and length == 0 else length
         index = head.index
         indexlength = index.length
-        index = index.to_nplike(self._backend.index_nplike)
+        index = index.to_nplike(self._backend.nplike)
         outindex = Index64.empty(
             index.length * length,
-            self._backend.index_nplike,
+            self._backend.nplike,
         )
 
         assert (
-            outindex.nplike is self._backend.index_nplike
-            and index.nplike is self._backend.index_nplike
+            outindex.nplike is self._backend.nplike
+            and index.nplike is self._backend.nplike
         )
         self._maybe_index_error(
             self._backend[
@@ -427,16 +427,16 @@ class Content(Meta):
                 f"cannot fit masked jagged slice with length {index.length} into {type(that).__name__} of size {content.length}",
             )
 
-        outputmask = Index64.empty(index.length, self._backend.index_nplike)
-        starts = Index64.empty(index.length, self._backend.index_nplike)
-        stops = Index64.empty(index.length, self._backend.index_nplike)
+        outputmask = Index64.empty(index.length, self._backend.nplike)
+        starts = Index64.empty(index.length, self._backend.nplike)
+        stops = Index64.empty(index.length, self._backend.nplike)
 
         assert (
-            index.nplike is self._backend.index_nplike
-            and jagged._offsets.nplike is self._backend.index_nplike
-            and outputmask.nplike is self._backend.index_nplike
-            and starts.nplike is self._backend.index_nplike
-            and stops.nplike is self._backend.index_nplike
+            index.nplike is self._backend.nplike
+            and jagged._offsets.nplike is self._backend.nplike
+            and outputmask.nplike is self._backend.nplike
+            and starts.nplike is self._backend.nplike
+            and stops.nplike is self._backend.nplike
         )
         self._maybe_index_error(
             self._backend[
@@ -539,8 +539,8 @@ class Content(Meta):
 
         elif isinstance(where, slice) and where.step is None:
             # Ensure that start, stop are non-negative!
-            start, stop, _, _ = self._backend.index_nplike.derive_slice_for_length(
-                normalize_slice(where, nplike=self._backend.index_nplike), self.length
+            start, stop, _, _ = self._backend.nplike.derive_slice_for_length(
+                normalize_slice(where, nplike=self._backend.nplike), self.length
             )
             return self._getitem_range(start, stop)
 
@@ -669,33 +669,33 @@ class Content(Meta):
         elif isinstance(where, ak.contents.NumpyArray):
             data_as_index = to_nplike(
                 where.data,
-                self._backend.index_nplike,
+                self._backend.nplike,
                 from_nplike=self._backend.nplike,
             )
             if np.issubdtype(where.dtype, np.int64):
                 allow_lazy = True
                 carry = Index64(
-                    self._backend.index_nplike.reshape(data_as_index, (-1,)),
-                    nplike=self._backend.index_nplike,
+                    self._backend.nplike.reshape(data_as_index, (-1,)),
+                    nplike=self._backend.nplike,
                 )
             elif np.issubdtype(where.dtype, np.integer):
                 allow_lazy = "copied"  # True, but also can be modified in-place
                 carry = Index64(
-                    self._backend.index_nplike.reshape(
-                        self._backend.index_nplike.astype(
+                    self._backend.nplike.reshape(
+                        self._backend.nplike.astype(
                             data_as_index, dtype=np.int64, copy=True
                         ),
                         (-1,),
                     ),
-                    nplike=self._backend.index_nplike,
+                    nplike=self._backend.nplike,
                 )
             elif np.issubdtype(where.dtype, np.bool_):
                 if len(where.data.shape) == 1:
-                    where = self._backend.index_nplike.nonzero(data_as_index)[0]
-                    carry = Index64(where, nplike=self._backend.index_nplike)
+                    where = self._backend.nplike.nonzero(data_as_index)[0]
+                    carry = Index64(where, nplike=self._backend.nplike)
                     allow_lazy = "copied"  # True, but also can be modified in-place
                 else:
-                    wheres = self._backend.index_nplike.nonzero(data_as_index)
+                    wheres = self._backend.nplike.nonzero(data_as_index)
                     return self._getitem(wheres, named_axis)
             else:
                 raise TypeError(
@@ -752,7 +752,7 @@ class Content(Meta):
 
             elif len(where) == 0:
                 return self._carry(
-                    Index64.empty(0, self._backend.index_nplike),
+                    Index64.empty(0, self._backend.nplike),
                     allow_lazy=True,
                 )
             # Normally we would be worried about np.array et al. being treated
@@ -830,7 +830,7 @@ class Content(Meta):
         raise NotImplementedError
 
     def _local_index_axis0(self) -> NumpyArray:
-        localindex = Index64.empty(self.length, self._backend.index_nplike)
+        localindex = Index64.empty(self.length, self._backend.nplike)
         self._backend.maybe_kernel_error(
             self._backend["awkward_localindex", np.int64](
                 localindex.data,
@@ -940,24 +940,24 @@ class Content(Meta):
                     combinationslen = combinationslen * (size - j + 1)
                     combinationslen = combinationslen // j
 
-        tocarryraw = self._backend.index_nplike.empty(n, dtype=np.intp)
+        tocarryraw = self._backend.nplike.empty(n, dtype=np.intp)
         tocarry = []
         for i in range(n):
             ptr = Index64.empty(
                 combinationslen,
-                nplike=self._backend.index_nplike,
+                nplike=self._backend.nplike,
                 dtype=np.int64,
             )
             tocarry.append(ptr)
             if self._backend.nplike.known_data:
                 tocarryraw[i] = ptr.ptr
 
-        toindex = Index64.empty(n, self._backend.index_nplike, dtype=np.int64)
-        fromindex = Index64.empty(n, self._backend.index_nplike, dtype=np.int64)
+        toindex = Index64.empty(n, self._backend.nplike, dtype=np.int64)
+        fromindex = Index64.empty(n, self._backend.nplike, dtype=np.int64)
 
         assert (
-            toindex.nplike is self._backend.index_nplike
-            and fromindex.nplike is self._backend.index_nplike
+            toindex.nplike is self._backend.nplike
+            and fromindex.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -1046,14 +1046,14 @@ class Content(Meta):
     def _pad_none_axis0(self, target: int, clip: bool) -> Content:
         if not clip and (self.length is unknown_length or (target < self.length)):
             index = Index64(
-                self._backend.index_nplike.arange(self.length, dtype=np.int64),
-                nplike=self._backend.index_nplike,
+                self._backend.nplike.arange(self.length, dtype=np.int64),
+                nplike=self._backend.nplike,
             )
 
         else:
-            index = Index64.empty(target, self._backend.index_nplike)
+            index = Index64.empty(target, self._backend.nplike)
 
-            assert index.nplike is self._backend.index_nplike
+            assert index.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_index_rpad_and_clip_axis0",

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -264,7 +264,7 @@ class EmptyArray(EmptyMeta, Content):
         if posaxis is not None and posaxis + 1 == depth:
             raise AxisError(self, "axis=0 not allowed for flatten")
         else:
-            offsets = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
+            offsets = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
             return (
                 offsets,
                 EmptyArray(backend=self._backend),

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -130,7 +130,7 @@ class IndexedArray(IndexedMeta[Content], Content):
                 )
             )
 
-        assert index.nplike is content.backend.index_nplike
+        assert index.nplike is content.backend.nplike
 
         self._index = index
         self._content = content
@@ -174,7 +174,7 @@ class IndexedArray(IndexedMeta[Content], Content):
                 inner = content.index
             else:
                 inner = content.to_IndexedOptionArray64().index
-            result = ak.index.Index64.empty(index.length, nplike=backend.index_nplike)
+            result = ak.index.Index64.empty(index.length, nplike=backend.nplike)
 
             backend.maybe_kernel_error(
                 backend[
@@ -234,7 +234,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         assert isinstance(form, self.form_cls)
         key = getkey(self, form, "index")
         container[key] = ak._util.native_to_byteorder(
-            self._index.raw(backend.index_nplike), byteorder
+            self._index.raw(backend.nplike), byteorder
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
@@ -361,10 +361,10 @@ class IndexedArray(IndexedMeta[Content], Content):
                 f"cannot fit jagged slice with length {slicestarts.length} into {type(self).__name__} of size {self.length}",
             )
 
-        nextcarry = ak.index.Index64.empty(self.length, self._backend.index_nplike)
+        nextcarry = ak.index.Index64.empty(self.length, self._backend.nplike)
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and self._index.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and self._index.nplike is self._backend.nplike
         )
         self._maybe_index_error(
             self._backend[
@@ -404,12 +404,10 @@ class IndexedArray(IndexedMeta[Content], Content):
         ):
             nexthead, nexttail = ak._slicing.head_tail(tail)
 
-            nextcarry = ak.index.Index64.empty(
-                self._index.length, self._backend.index_nplike
-            )
+            nextcarry = ak.index.Index64.empty(self._index.length, self._backend.nplike)
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -452,13 +450,11 @@ class IndexedArray(IndexedMeta[Content], Content):
                 raise ValueError(
                     f"mask length ({mask.length()}) is not equal to {type(self).__name__} length ({self._index.length})"
                 )
-            nextindex = ak.index.Index64.empty(
-                self._index.length, self._backend.index_nplike
-            )
+            nextindex = ak.index.Index64.empty(self._index.length, self._backend.nplike)
             assert (
-                nextindex.nplike is self._backend.index_nplike
-                and mask.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextindex.nplike is self._backend.nplike
+                and mask.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -479,10 +475,10 @@ class IndexedArray(IndexedMeta[Content], Content):
             return next.project()
 
         else:
-            nextcarry = ak.index.Index64.empty(self.length, self._backend.index_nplike)
+            nextcarry = ak.index.Index64.empty(self.length, self._backend.nplike)
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -566,14 +562,12 @@ class IndexedArray(IndexedMeta[Content], Content):
 
         theirlength = other.length
         mylength = self.length
-        index = ak.index.Index64.empty(
-            (theirlength + mylength), self._backend.index_nplike
-        )
+        index = ak.index.Index64.empty((theirlength + mylength), self._backend.nplike)
 
         content = other._mergemany([self._content])
 
         # Fill `index` with a range starting at zero, up to `theirlength`
-        assert index.nplike is self._backend.index_nplike
+        assert index.nplike is self._backend.nplike
         self._backend.maybe_kernel_error(
             self._backend["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -584,7 +578,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         )
 
         # Fill remaining indices
-        assert index.nplike is self._backend.index_nplike
+        assert index.nplike is self._backend.nplike
         self._backend.maybe_kernel_error(
             self._backend[
                 "awkward_IndexedArray_fill",
@@ -622,9 +616,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         contents = []
         contentlength_so_far = 0
         length_so_far = 0
-        nextindex = ak.index.Index64.empty(
-            total_length, nplike=self._backend.index_nplike
-        )
+        nextindex = ak.index.Index64.empty(total_length, nplike=self._backend.nplike)
 
         parameters = self._parameters
         for array in head:
@@ -650,8 +642,8 @@ class IndexedArray(IndexedMeta[Content], Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.nplike is self._backend.index_nplike
-                    and array_index.nplike is self._backend.index_nplike
+                    nextindex.nplike is self._backend.nplike
+                    and array_index.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -670,7 +662,7 @@ class IndexedArray(IndexedMeta[Content], Content):
                 length_so_far += array.length
             else:
                 contents.append(array)
-                assert nextindex.nplike is self._backend.index_nplike
+                assert nextindex.nplike is self._backend.nplike
                 self._backend.maybe_kernel_error(
                     self._backend[
                         "awkward_IndexedArray_fill_count",
@@ -739,17 +731,17 @@ class IndexedArray(IndexedMeta[Content], Content):
             return self.project()._local_index(axis, depth)
 
     def _unique_index(self, index, sorted=True):
-        next = ak.index.Index64.zeros(self.length, nplike=self._backend.index_nplike)
-        length = ak.index.Index64.zeros(1, nplike=self._backend.index_nplike)
+        next = ak.index.Index64.zeros(self.length, nplike=self._backend.nplike)
+        length = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
 
         if not sorted:
             next = self._index
-            offsets = ak.index.Index64.empty(2, self._backend.index_nplike)
+            offsets = ak.index.Index64.empty(2, self._backend.nplike)
             offsets[0] = 0
             offsets[1] = next.length
             assert (
-                next.nplike is self._backend.index_nplike
-                and offsets.nplike is self._backend.index_nplike
+                next.nplike is self._backend.nplike
+                and offsets.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -770,14 +762,14 @@ class IndexedArray(IndexedMeta[Content], Content):
             )
 
         assert (
-            self._index.nplike is self._backend.index_nplike
-            and next.nplike is self._backend.index_nplike
-            and length.nplike is self._backend.index_nplike
+            self._index.nplike is self._backend.nplike
+            and next.nplike is self._backend.nplike
+            and length.nplike is self._backend.nplike
         )
 
         next = ak.index.Index64(
-            self._backend.index_nplike.unique_values(self._index),
-            nplike=self._backend.index_nplike,
+            self._backend.nplike.unique_values(self._index),
+            nplike=self._backend.nplike,
         )
         length[0] = next.data.size
 
@@ -812,15 +804,15 @@ class IndexedArray(IndexedMeta[Content], Content):
         parents_length = parents.length
         next_length = index_length
 
-        nextcarry = ak.index.Index64.empty(index_length, self._backend.index_nplike)
-        nextparents = ak.index.Index64.empty(index_length, self._backend.index_nplike)
-        outindex = ak.index.Index64.empty(index_length, self._backend.index_nplike)
+        nextcarry = ak.index.Index64.empty(index_length, self._backend.nplike)
+        nextparents = ak.index.Index64.empty(index_length, self._backend.nplike)
+        outindex = ak.index.Index64.empty(index_length, self._backend.nplike)
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and nextparents.nplike is self._backend.index_nplike
-            and outindex.nplike is self._backend.index_nplike
-            and self._index.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and nextparents.nplike is self._backend.nplike
+            and outindex.nplike is self._backend.nplike
+            and self._index.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -848,14 +840,12 @@ class IndexedArray(IndexedMeta[Content], Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
-            nextoutindex = ak.index.Index64.empty(
-                parents_length, self._backend.index_nplike
-            )
+            nextoutindex = ak.index.Index64.empty(parents_length, self._backend.nplike)
             assert (
-                nextoutindex.nplike is self._backend.index_nplike
-                and starts.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
-                and nextparents.nplike is self._backend.index_nplike
+                nextoutindex.nplike is self._backend.nplike
+                and starts.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
+                and nextparents.nplike is self._backend.nplike
             )
 
             self._backend.maybe_kernel_error(
@@ -893,11 +883,11 @@ class IndexedArray(IndexedMeta[Content], Content):
                     )
 
                 outoffsets = ak.index.Index64.empty(
-                    starts.length + 1, self._backend.index_nplike
+                    starts.length + 1, self._backend.nplike
                 )
                 assert (
-                    outoffsets.nplike is self._backend.index_nplike
-                    and starts.nplike is self._backend.index_nplike
+                    outoffsets.nplike is self._backend.nplike
+                    and starts.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -920,8 +910,8 @@ class IndexedArray(IndexedMeta[Content], Content):
 
             elif isinstance(unique, ak.contents.NumpyArray):
                 nextoutindex = ak.index.Index64(
-                    self._backend.index_nplike.arange(unique.length, dtype=np.int64),
-                    nplike=self._backend.index_nplike,
+                    self._backend.nplike.arange(unique.length, dtype=np.int64),
+                    nplike=self._backend.nplike,
                 )
                 return ak.contents.IndexedOptionArray.simplified(
                     nextoutindex, unique, parameters=self._parameters
@@ -1099,11 +1089,9 @@ class IndexedArray(IndexedMeta[Content], Content):
             and self._index.length != 0
         ):
             npindex = self._index.data
-            indexmin = self._backend.index_nplike.min(npindex)
-            indexmax = self._backend.index_nplike.max(npindex)
-            index = ak.index.Index(
-                npindex - indexmin, nplike=self._backend.index_nplike
-            )
+            indexmin = self._backend.nplike.min(npindex)
+            indexmax = self._backend.nplike.max(npindex)
+            index = ak.index.Index(npindex - indexmin, nplike=self._backend.nplike)
             content = self._content[indexmin : indexmax + 1]
         else:
             if not self._backend.nplike.known_data:
@@ -1179,7 +1167,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
     def _to_backend(self, backend: Backend) -> Self:
         content = self._content.to_backend(backend)
-        index = self._index.to_nplike(backend.index_nplike)
+        index = self._index.to_nplike(backend.nplike)
         return IndexedArray(index, content, parameters=self._parameters)
 
     def _materialize(self) -> Self:
@@ -1222,7 +1210,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         )
 
     def _trim(self) -> Self:
-        nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
 
         if not nplike.known_data or self._index.length == 0:
             return self

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -10,6 +10,7 @@ from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.indexedoptionmeta import IndexedOptionMeta
 from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
@@ -1722,11 +1723,21 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             is_none = original_index < 0
             num_none = nplike.count_nonzero(is_none)
             new_index = nplike.empty(self._index.length, dtype=self._index.dtype)
-            new_index[is_none] = -1
-            new_index[~is_none] = nplike.arange(
-                nplike.shape_item_as_index(new_index.size - num_none),
-                dtype=self._index.dtype,
-            )
+            if isinstance(nplike, Jax):
+                num_none = num_none.item()
+                new_index = new_index.at[is_none].set(-1)
+                new_index = new_index.at[~is_none].set(
+                    nplike.arange(
+                        nplike.shape_item_as_index(new_index.size - num_none),
+                        dtype=self._index.dtype,
+                    )
+                )
+            else:
+                new_index[is_none] = -1
+                new_index[~is_none] = nplike.arange(
+                    nplike.shape_item_as_index(new_index.size - num_none),
+                    dtype=self._index.dtype,
+                )
             projected = self.project()
             return ak.contents.IndexedOptionArray(
                 ak.index.Index(new_index, nplike=self._backend.nplike),

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -125,7 +125,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 )
             )
 
-        assert index.nplike is content.backend.index_nplike
+        assert index.nplike is content.backend.nplike
 
         self._index = index
         self._content = content
@@ -167,7 +167,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 inner = content.index
             else:
                 inner = content.to_IndexedOptionArray64().index
-            result = ak.index.Index64.empty(index.length, nplike=backend.index_nplike)
+            result = ak.index.Index64.empty(index.length, nplike=backend.nplike)
 
             backend.maybe_kernel_error(
                 backend[
@@ -222,7 +222,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         assert isinstance(form, self.form_cls)
         key = getkey(self, form, "index")
         container[key] = ak._util.native_to_byteorder(
-            self._index.raw(backend.index_nplike), byteorder
+            self._index.raw(backend.nplike), byteorder
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
@@ -268,7 +268,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return self
         else:
             return IndexedOptionArray(
-                self._backend.index_nplike.astype(self._index, dtype=np.int64),
+                self._backend.nplike.astype(self._index, dtype=np.int64),
                 self._content,
                 parameters=self._parameters,
             )
@@ -278,9 +278,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
         carry = self._index.data
         too_negative = carry < -1
-        if self._backend.index_nplike.known_data and self._backend.index_nplike.any(
-            too_negative
-        ):
+        if self._backend.nplike.known_data and self._backend.nplike.any(too_negative):
             carry = carry.copy()
             carry[too_negative] = -1
         carry = ak.index.Index(carry)
@@ -303,9 +301,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def mask_as_bool(self, valid_when: bool = True) -> ArrayLike:
         if valid_when:
-            return self._index.raw(self._backend.index_nplike) >= 0
+            return self._index.raw(self._backend.nplike) >= 0
         else:
-            return self._index.raw(self._backend.index_nplike) < 0
+            return self._index.raw(self._backend.nplike) < 0
 
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
@@ -377,10 +375,10 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _nextcarry_outindex(self):
         backend = self._backend
-        index_nplike = backend.index_nplike
+        nplike = backend.nplike
 
-        _numnull = ak.index.Index64.empty(1, nplike=backend.index_nplike)
-        assert _numnull.nplike is index_nplike and self._index.nplike is index_nplike
+        _numnull = ak.index.Index64.empty(1, nplike=backend.nplike)
+        assert _numnull.nplike is nplike and self._index.nplike is nplike
         self._backend.maybe_kernel_error(
             backend[
                 "awkward_IndexedArray_numnull",
@@ -392,21 +390,21 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 self._index.length,
             )
         )
-        numnull = index_nplike.index_as_shape_item(_numnull[0])
+        numnull = nplike.index_as_shape_item(_numnull[0])
         nextcarry = ak.index.Index64.empty(
             self._index.length - numnull,
-            index_nplike,
+            nplike,
         )
         outindex = ak.index.Index.empty(
             self._index.length,
-            index_nplike,
+            nplike,
             dtype=self._index.dtype,
         )
 
         assert (
-            nextcarry.nplike is index_nplike
-            and outindex.nplike is index_nplike
-            and self._index.nplike is index_nplike
+            nextcarry.nplike is nplike
+            and outindex.nplike is nplike
+            and self._index.nplike is nplike
         )
         self._backend.maybe_kernel_error(
             backend[
@@ -426,8 +424,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return numnull, nextcarry, outindex
 
     def _getitem_next_jagged_generic(self, slicestarts, slicestops, slicecontent, tail):
-        slicestarts = slicestarts.to_nplike(self._backend.index_nplike)
-        slicestops = slicestops.to_nplike(self._backend.index_nplike)
+        slicestarts = slicestarts.to_nplike(self._backend.nplike)
+        slicestops = slicestops.to_nplike(self._backend.nplike)
 
         if self._backend.nplike.known_data and slicestarts.length != self.length:
             raise ak._errors.index_error(
@@ -442,18 +440,18 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
         reducedstarts = ak.index.Index64.empty(
             self.length - numnull,
-            nplike=self._backend.index_nplike,
+            nplike=self._backend.nplike,
         )
         reducedstops = ak.index.Index64.empty(
             self.length - numnull,
-            nplike=self._backend.index_nplike,
+            nplike=self._backend.nplike,
         )
         assert (
-            outindex.nplike is self._backend.index_nplike
-            and slicestarts.nplike is self._backend.index_nplike
-            and slicestops.nplike is self._backend.index_nplike
-            and reducedstarts.nplike is self._backend.index_nplike
-            and reducedstops.nplike is self._backend.index_nplike
+            outindex.nplike is self._backend.nplike
+            and slicestarts.nplike is self._backend.nplike
+            and slicestops.nplike is self._backend.nplike
+            and reducedstarts.nplike is self._backend.nplike
+            and reducedstops.nplike is self._backend.nplike
         )
         self._maybe_index_error(
             self._backend[
@@ -533,13 +531,11 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 raise ValueError(
                     f"mask length ({mask.length()}) is not equal to {type(self).__name__} length ({self._index.length})"
                 )
-            nextindex = ak.index.Index64.empty(
-                self._index.length, self._backend.index_nplike
-            )
+            nextindex = ak.index.Index64.empty(self._index.length, self._backend.nplike)
             assert (
-                nextindex.nplike is self._backend.index_nplike
-                and mask.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextindex.nplike is self._backend.nplike
+                and mask.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -559,10 +555,10 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             )
             return next.project()
         else:
-            _numnull = ak.index.Index64.empty(1, self._backend.index_nplike)
+            _numnull = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                _numnull.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                _numnull.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -575,15 +571,15 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                     self._index.length,
                 )
             )
-            numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
+            numnull = self._backend.nplike.index_as_shape_item(_numnull[0])
             nextcarry = ak.index.Index64.empty(
                 self.length - numnull,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
 
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -621,14 +617,14 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             else:
                 outoffsets = ak.index.Index64.empty(
                     offsets.length + numnull,
-                    self._backend.index_nplike,
+                    self._backend.nplike,
                     dtype=np.int64,
                 )
 
                 assert (
-                    outoffsets.nplike is self._backend.index_nplike
-                    and outindex.nplike is self._backend.index_nplike
-                    and offsets.nplike is self._backend.index_nplike
+                    outoffsets.nplike is self._backend.nplike
+                    and outindex.nplike is self._backend.nplike
+                    and offsets.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -701,13 +697,13 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         mylength = self.length
         index = ak.index.Index64.empty(
             theirlength + mylength,
-            self._backend.index_nplike,
+            self._backend.nplike,
         )
 
         content = other._mergemany([self._content])
 
         # Fill index::0→theirlength with arange(theirlength)
-        assert index.nplike is self._backend.index_nplike
+        assert index.nplike is self._backend.nplike
         self._backend.maybe_kernel_error(
             self._backend["awkward_IndexedArray_fill_count", index.dtype.type](
                 index.data,
@@ -719,8 +715,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
         # Fill index::theirlength->end with self.index[:mylength]+theirlength
         assert (
-            index.nplike is self._backend.index_nplike
-            and self.index.nplike is self._backend.index_nplike
+            index.nplike is self._backend.nplike
+            and self.index.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -759,7 +755,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         contents = []
         contentlength_so_far = 0
         length_so_far = 0
-        nextindex = ak.index.Index64.empty(total_length, self._backend.index_nplike)
+        nextindex = ak.index.Index64.empty(total_length, self._backend.nplike)
         parameters = self._parameters
 
         for array in head:
@@ -785,8 +781,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 contents.append(array.content)
                 array_index = array.index
                 assert (
-                    nextindex.nplike is self._backend.index_nplike
-                    and array_index.nplike is self._backend.index_nplike
+                    nextindex.nplike is self._backend.nplike
+                    and array_index.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -807,7 +803,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
             else:
                 contents.append(array)
-                assert nextindex.nplike is self._backend.index_nplike
+                assert nextindex.nplike is self._backend.nplike
                 self._backend.maybe_kernel_error(
                     self._backend[
                         "awkward_IndexedArray_fill_count",
@@ -861,11 +857,11 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
         contents = [self._content, value]
         tags = ak.index.Index8(self.mask_as_bool(valid_when=False))
-        index = ak.index.Index64.empty(tags.length, self._backend.index_nplike)
+        index = ak.index.Index64.empty(tags.length, self._backend.nplike)
 
         assert (
-            index.nplike is self._backend.index_nplike
-            and self._index.nplike is self._backend.index_nplike
+            index.nplike is self._backend.nplike
+            and self._index.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -895,17 +891,17 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return out2
 
     def _is_subrange_equal(self, starts, stops, length, sorted=True):
-        nextstarts = ak.index.Index64.empty(length, self._backend.index_nplike)
-        nextstops = ak.index.Index64.empty(length, self._backend.index_nplike)
+        nextstarts = ak.index.Index64.empty(length, self._backend.nplike)
+        nextstops = ak.index.Index64.empty(length, self._backend.nplike)
 
-        subranges_length = ak.index.Index64.empty(1, self._backend.index_nplike)
+        subranges_length = ak.index.Index64.empty(1, self._backend.nplike)
         assert (
-            self._index.nplike is self._backend.index_nplike
-            and starts.nplike is self._backend.index_nplike
-            and stops.nplike is self._backend.index_nplike
-            and nextstarts.nplike is self._backend.index_nplike
-            and nextstops.nplike is self._backend.index_nplike
-            and subranges_length.nplike is self._backend.index_nplike
+            self._index.nplike is self._backend.nplike
+            and starts.nplike is self._backend.nplike
+            and stops.nplike is self._backend.nplike
+            and nextstarts.nplike is self._backend.nplike
+            and nextstops.nplike is self._backend.nplike
+            and subranges_length.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -927,14 +923,12 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             )
         )
 
-        nextcarry = ak.index.Index64.empty(
-            subranges_length[0], self._backend.index_nplike
-        )
+        nextcarry = ak.index.Index64.empty(subranges_length[0], self._backend.nplike)
         assert (
-            self._index.nplike is self._backend.index_nplike
-            and starts.nplike is self._backend.index_nplike
-            and stops.nplike is self._backend.index_nplike
-            and nextcarry.nplike is self._backend.index_nplike
+            self._index.nplike is self._backend.nplike
+            and starts.nplike is self._backend.nplike
+            and stops.nplike is self._backend.nplike
+            and nextcarry.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -993,14 +987,12 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
-            nextoutindex = ak.index.Index64.empty(
-                parents.length, self._backend.index_nplike
-            )
+            nextoutindex = ak.index.Index64.empty(parents.length, self._backend.nplike)
             assert (
-                nextoutindex.nplike is self._backend.index_nplike
-                and starts.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
-                and nextparents.nplike is self._backend.index_nplike
+                nextoutindex.nplike is self._backend.nplike
+                and starts.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
+                and nextparents.nplike is self._backend.nplike
             )
 
             self._backend.maybe_kernel_error(
@@ -1025,14 +1017,12 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             )
 
         if isinstance(out, ak.contents.ListOffsetArray):
-            newnulls = ak.index.Index64.empty(
-                self._index.length, self._backend.index_nplike
-            )
-            _len_newnulls = ak.index.Index64.empty(1, self._backend.index_nplike)
+            newnulls = ak.index.Index64.empty(self._index.length, self._backend.nplike)
+            _len_newnulls = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                newnulls.nplike is self._backend.index_nplike
-                and _len_newnulls.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                newnulls.nplike is self._backend.nplike
+                and _len_newnulls.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1047,23 +1037,21 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                     index_length,
                 )
             )
-            len_newnulls = self._backend.index_nplike.index_as_shape_item(
-                _len_newnulls[0]
-            )
+            len_newnulls = self._backend.nplike.index_as_shape_item(_len_newnulls[0])
 
             newindex = ak.index.Index64.empty(
-                self._backend.index_nplike.index_as_shape_item(out._offsets[-1])
+                self._backend.nplike.index_as_shape_item(out._offsets[-1])
                 + len_newnulls,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
             newoffsets = ak.index.Index64.empty(
-                out._offsets.length, self._backend.index_nplike
+                out._offsets.length, self._backend.nplike
             )
             assert (
-                newindex.nplike is self._backend.index_nplike
-                and newoffsets.nplike is self._backend.index_nplike
-                and out._offsets.nplike is self._backend.index_nplike
-                and newnulls.nplike is self._backend.index_nplike
+                newindex.nplike is self._backend.nplike
+                and newoffsets.nplike is self._backend.nplike
+                and out._offsets.nplike is self._backend.nplike
+                and newnulls.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1095,9 +1083,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             # and tacking the index -1 onto the end
             nextoutindex = ak.index.Index64.empty(
                 out.length + 1,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
-            assert nextoutindex.nplike is self._backend.index_nplike
+            assert nextoutindex.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_IndexedArray_numnull_unique_64",
@@ -1120,15 +1108,13 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return out
 
     def _rearrange_nextshifts(self, nextparents, shifts):
-        nextshifts = ak.index.Index64.empty(
-            nextparents.length, self._backend.index_nplike
-        )
-        assert nextshifts.nplike is self._backend.index_nplike
+        nextshifts = ak.index.Index64.empty(nextparents.length, self._backend.nplike)
+        assert nextshifts.nplike is self._backend.nplike
 
         if shifts is None:
             assert (
-                nextshifts.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
+                nextshifts.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1143,9 +1129,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             )
         else:
             assert (
-                nextshifts.nplike is self._backend.index_nplike
-                and self._index.nplike is self._backend.index_nplike
-                and shifts.nplike is self._backend.index_nplike
+                nextshifts.nplike is self._backend.nplike
+                and self._index.nplike is self._backend.nplike
+                and shifts.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1164,12 +1150,12 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _rearrange_prepare_next(self, parents):
         assert (
-            self._index.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
+            self._index.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
         )
         index_length = self._index.length
-        _numnull = ak.index.Index64.empty(1, self._backend.index_nplike)
-        assert _numnull.nplike is self._backend.index_nplike
+        _numnull = ak.index.Index64.empty(1, self._backend.nplike)
+        assert _numnull.nplike is self._backend.nplike
 
         self._backend.maybe_kernel_error(
             self._backend[
@@ -1182,16 +1168,16 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
                 index_length,
             )
         )
-        numnull = self._backend.index_nplike.index_as_shape_item(_numnull[0])
+        numnull = self._backend.nplike.index_as_shape_item(_numnull[0])
 
         next_length = index_length - numnull
-        nextparents = ak.index.Index64.empty(next_length, self._backend.index_nplike)
-        nextcarry = ak.index.Index64.empty(next_length, self._backend.index_nplike)
-        outindex = ak.index.Index64.empty(index_length, self._backend.index_nplike)
+        nextparents = ak.index.Index64.empty(next_length, self._backend.nplike)
+        nextcarry = ak.index.Index64.empty(next_length, self._backend.nplike)
+        outindex = ak.index.Index64.empty(index_length, self._backend.nplike)
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and nextparents.nplike is self._backend.index_nplike
-            and outindex.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and nextparents.nplike is self._backend.nplike
+            and outindex.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -1217,9 +1203,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         self, negaxis, starts, shifts, parents, outlength, ascending, stable
     ):
         assert (
-            starts.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
-            and self._index.nplike is self._backend.index_nplike
+            starts.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
+            and self._index.nplike is self._backend.nplike
         )
 
         branch, depth = self.branch_depth
@@ -1240,8 +1226,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         # to account for these None values. First, we locate these nones within
         # their sublists
         nulls_merged = False
-        nulls_index = ak.index.Index64.empty(numnull, self._backend.index_nplike)
-        assert nulls_index.nplike is self._backend.index_nplike
+        nulls_index = ak.index.Index64.empty(numnull, self._backend.nplike)
+        assert nulls_index.nplike is self._backend.nplike
         self._backend.maybe_kernel_error(
             self._backend[
                 "awkward_IndexedArray_index_of_nulls",
@@ -1269,14 +1255,12 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             out = out._mergemany([nulls_index_content])
             nulls_merged = True
 
-        nextoutindex = ak.index.Index64.empty(
-            parents.length, self._backend.index_nplike
-        )
+        nextoutindex = ak.index.Index64.empty(parents.length, self._backend.nplike)
         assert (
-            nextoutindex.nplike is self._backend.index_nplike
-            and starts.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
-            and nextparents.nplike is self._backend.index_nplike
+            nextoutindex.nplike is self._backend.nplike
+            and starts.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
+            and nextparents.nplike is self._backend.nplike
         )
 
         self._backend.maybe_kernel_error(
@@ -1302,7 +1286,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             # only when the `None` value indices are explicitly stored in out,
             # we need to mapping the -1 values to their corresponding indices
             # in `out`
-            assert nextoutindex.nplike is self._backend.index_nplike
+            assert nextoutindex.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend["awkward_Index_nones_as_index", nextoutindex.dtype.type](
                     nextoutindex.data,
@@ -1345,8 +1329,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
         assert (
-            starts.nplike is self._backend.index_nplike
-            and parents.nplike is self._backend.index_nplike
+            starts.nplike is self._backend.nplike
+            and parents.nplike is self._backend.nplike
         )
         branch, depth = self.branch_depth
 
@@ -1356,10 +1340,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             negaxis, starts, nextparents, outlength, ascending, stable
         )
 
-        nextoutindex = ak.index.Index64.empty(
-            parents.length, self._backend.index_nplike
-        )
-        assert nextoutindex.nplike is self._backend.index_nplike
+        nextoutindex = ak.index.Index64.empty(parents.length, self._backend.nplike)
+        assert nextoutindex.nplike is self._backend.nplike
 
         self._backend.maybe_kernel_error(
             self._backend[
@@ -1464,16 +1446,16 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             # re-wrapping the result to have the length and starts requested by the caller.
             if starts.length is unknown_length:
                 outoffsets = ak.index.Index64.empty(
-                    unknown_length, self._backend.index_nplike
+                    unknown_length, self._backend.nplike
                 )
             else:
                 outoffsets = ak.index.Index64.empty(
                     starts.length + 1,
-                    self._backend.index_nplike,
+                    self._backend.nplike,
                 )
             assert (
-                outoffsets.nplike is self._backend.index_nplike
-                and starts.nplike is self._backend.index_nplike
+                outoffsets.nplike is self._backend.nplike
+                and starts.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1515,7 +1497,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             if not ak._do.is_unique(self._content):
                 return f'at {path} ("{type(self)}"): __array__ = "categorical" requires contents to be unique'
 
-        assert self.index.nplike is self._backend.index_nplike
+        assert self.index.nplike is self._backend.nplike
         error = self._backend["awkward_IndexedArray_validity", self.index.dtype.type](
             self.index.data, self.index.length, self._content.length, True
         )
@@ -1541,10 +1523,10 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return self._pad_none_axis0(target, clip)
         elif posaxis is not None and posaxis + 1 == depth + 1:
             mask = ak.index.Index8(self.mask_as_bool(valid_when=False))
-            index = ak.index.Index64.empty(mask.length, self._backend.index_nplike)
+            index = ak.index.Index64.empty(mask.length, self._backend.nplike)
             assert (
-                index.nplike is self._backend.index_nplike
-                and mask.nplike is self._backend.index_nplike
+                index.nplike is self._backend.nplike
+                and mask.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1599,24 +1581,24 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _to_backend_array(self, allow_missing, backend):
         nplike = backend.nplike
-        index_nplike = backend.index_nplike
+        nplike = backend.nplike
 
         content = self.project()._to_backend_array(allow_missing, backend)
         shape = (self.length, *content.shape[1:])
         data = nplike.empty(shape, dtype=content.dtype)
-        mask0 = index_nplike.asarray(self.mask_as_bool(valid_when=False)).view(np.bool_)
-        if index_nplike.any(mask0):
+        mask0 = nplike.asarray(self.mask_as_bool(valid_when=False)).view(np.bool_)
+        if nplike.any(mask0):
             if allow_missing:
-                mask = index_nplike.broadcast_to(
-                    index_nplike.reshape(mask0, (shape[0],) + (1,) * (len(shape) - 1)),
+                mask = nplike.broadcast_to(
+                    nplike.reshape(mask0, (shape[0],) + (1,) * (len(shape) - 1)),
                     shape,
                 )
                 if isinstance(content, nplike.ma.MaskedArray):
-                    mask1 = index_nplike.ma.getmaskarray(content)
-                    mask = index_nplike.asarray(mask, copy=True)
-                    mask[index_nplike.logical_not(mask0)] |= mask1
+                    mask1 = nplike.ma.getmaskarray(content)
+                    mask = nplike.asarray(mask, copy=True)
+                    mask[nplike.logical_not(mask0)] |= mask1
 
-                data[index_nplike.logical_not(mask0)] = content
+                data[nplike.logical_not(mask0)] = content
 
                 if content.dtype.names is not None:
                     missing_data = tuple(
@@ -1668,12 +1650,10 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         ):
             npindex = self._index.data
             npselect = npindex >= 0
-            if self._backend.index_nplike.any(npselect):
-                indexmin = self._backend.index_nplike.min(npindex[npselect])
-                indexmax = self._backend.index_nplike.max(npindex)
-                index = ak.index.Index(
-                    npindex - indexmin, nplike=self._backend.index_nplike
-                )
+            if self._backend.nplike.any(npselect):
+                indexmin = self._backend.nplike.min(npindex[npselect])
+                indexmax = self._backend.nplike.max(npindex)
+                index = ak.index.Index(npindex - indexmin, nplike=self._backend.nplike)
                 content = self._content[indexmin : indexmax + 1]
             else:
                 index, content = self._index, self._content
@@ -1737,19 +1717,19 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             )
 
         else:
-            index_nplike = self._backend.index_nplike
+            nplike = self._backend.nplike
             original_index = self._index.data
             is_none = original_index < 0
-            num_none = index_nplike.count_nonzero(is_none)
-            new_index = index_nplike.empty(self._index.length, dtype=self._index.dtype)
+            num_none = nplike.count_nonzero(is_none)
+            new_index = nplike.empty(self._index.length, dtype=self._index.dtype)
             new_index[is_none] = -1
-            new_index[~is_none] = index_nplike.arange(
-                index_nplike.shape_item_as_index(new_index.size - num_none),
+            new_index[~is_none] = nplike.arange(
+                nplike.shape_item_as_index(new_index.size - num_none),
                 dtype=self._index.dtype,
             )
             projected = self.project()
             return ak.contents.IndexedOptionArray(
-                ak.index.Index(new_index, nplike=self._backend.index_nplike),
+                ak.index.Index(new_index, nplike=self._backend.nplike),
                 projected.to_packed(True) if recursive else projected,
                 parameters=self._parameters,
             )
@@ -1776,7 +1756,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _to_backend(self, backend: Backend) -> Self:
         content = self._content.to_backend(backend)
-        index = self._index.to_nplike(backend.index_nplike)
+        index = self._index.to_nplike(backend.nplike)
         return IndexedOptionArray(index, content, parameters=self._parameters)
 
     def _materialize(self) -> Self:
@@ -1804,7 +1784,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         )
 
     def _trim(self) -> Self:
-        nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
 
         if not nplike.known_data or self._index.length == 0:
             return self

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -141,7 +141,7 @@ class ListArray(ListMeta[Content], Content):
             raise TypeError(
                 f"{type(self).__name__} 'content' must be a Content subtype, not {content!r}"
             )
-        if content.backend.index_nplike.known_data and starts.length > stops.length:
+        if content.backend.nplike.known_data and starts.length > stops.length:
             raise ValueError(
                 f"{type(self).__name__} len(starts) ({starts.length}) must be <= len(stops) ({stops.length})"
             )
@@ -157,8 +157,8 @@ class ListArray(ListMeta[Content], Content):
                     f"{type(self).__name__} is a bytestring, so its 'content' must be uint8 NumpyArray of byte, not {content!r}"
                 )
 
-        assert starts.nplike is content.backend.index_nplike
-        assert stops.nplike is content.backend.index_nplike
+        assert starts.nplike is content.backend.nplike
+        assert stops.nplike is content.backend.nplike
 
         self._starts = starts
         self._stops = stops
@@ -229,10 +229,10 @@ class ListArray(ListMeta[Content], Content):
         key1 = getkey(self, form, "starts")
         key2 = getkey(self, form, "stops")
         container[key1] = ak._util.native_to_byteorder(
-            self._starts.raw(backend.index_nplike), byteorder
+            self._starts.raw(backend.nplike), byteorder
         )
         container[key2] = ak._util.native_to_byteorder(
-            self._stops.raw(backend.index_nplike), byteorder
+            self._stops.raw(backend.nplike), byteorder
         )
         self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
@@ -279,23 +279,21 @@ class ListArray(ListMeta[Content], Content):
         return "".join(out)
 
     def to_ListOffsetArray64(self, start_at_zero: bool = False) -> ListOffsetArray:
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
 
         starts = self._starts.data
         stops = self._stops.data
 
         lenoffsets = self._starts.length + 1
-        if (not index_nplike.known_data) or index_nplike.array_equal(
-            starts[1:], stops[:-1]
-        ):
-            offsets = index_nplike.empty(lenoffsets, dtype=starts.dtype)
+        if (not nplike.known_data) or nplike.array_equal(starts[1:], stops[:-1]):
+            offsets = nplike.empty(lenoffsets, dtype=starts.dtype)
             if lenoffsets is not unknown_length and lenoffsets == 1:
                 offsets[0] = 0
             else:
                 offsets[:-1] = starts
                 offsets[-1] = stops[-1]
             return ListOffsetArray(
-                ak.index.Index(offsets, nplike=self._backend.index_nplike),
+                ak.index.Index(offsets, nplike=self._backend.nplike),
                 self._content,
                 parameters=self._parameters,
             ).to_ListOffsetArray64(start_at_zero=start_at_zero)
@@ -389,12 +387,12 @@ class ListArray(ListMeta[Content], Content):
         starts_len = self._starts.length
         out = ak.index.Index64.empty(
             starts_len + 1,
-            self._backend.index_nplike,
+            self._backend.nplike,
         )
         assert (
-            out.nplike is self._backend.index_nplike
-            and self._starts.nplike is self._backend.index_nplike
-            and self._stops.nplike is self._backend.index_nplike
+            out.nplike is self._backend.nplike
+            and self._starts.nplike is self._backend.nplike
+            and self._stops.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -415,13 +413,13 @@ class ListArray(ListMeta[Content], Content):
         self._touch_data(recursive=False)
         offsets._touch_data()
 
-        index_nplike = self._backend.index_nplike
-        assert offsets.nplike is index_nplike
+        nplike = self._backend.nplike
+        assert offsets.nplike is nplike
         if offsets.length is not unknown_length and offsets.length == 0:
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with non-empty offsets"
             )
-        elif index_nplike.known_data and offsets[0] != 0:
+        elif nplike.known_data and offsets[0] != 0:
             raise AssertionError(
                 f"broadcast_tooffsets64 can only be used with offsets that start at 0, not {offsets[0]}"
             )
@@ -435,14 +433,14 @@ class ListArray(ListMeta[Content], Content):
             )
 
         nextcarry = ak.index.Index64.empty(
-            self._backend.index_nplike.index_as_shape_item(offsets[-1]),
-            self._backend.index_nplike,
+            self._backend.nplike.index_as_shape_item(offsets[-1]),
+            self._backend.nplike,
         )
         assert (
-            nextcarry.nplike is self._backend.index_nplike
-            and offsets.nplike is self._backend.index_nplike
-            and self._starts.nplike is self._backend.index_nplike
-            and self._stops.nplike is self._backend.index_nplike
+            nextcarry.nplike is self._backend.nplike
+            and offsets.nplike is self._backend.nplike
+            and self._starts.nplike is self._backend.nplike
+            and self._stops.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -468,8 +466,8 @@ class ListArray(ListMeta[Content], Content):
     def _getitem_next_jagged(
         self, slicestarts: Index, slicestops: Index, slicecontent: Content, tail
     ) -> Content:
-        slicestarts = slicestarts.to_nplike(self._backend.index_nplike)
-        slicestops = slicestops.to_nplike(self._backend.index_nplike)
+        slicestarts = slicestarts.to_nplike(self._backend.nplike)
+        slicestops = slicestops.to_nplike(self._backend.nplike)
         if self._backend.nplike.known_data and slicestarts.length != self.length:
             raise ak._errors.index_error(
                 self,
@@ -482,14 +480,14 @@ class ListArray(ListMeta[Content], Content):
         if isinstance(slicecontent, ak.contents.ListOffsetArray):
             outoffsets = ak.index.Index64.empty(
                 slicestarts.length + 1,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
             assert (
-                outoffsets.nplike is self._backend.index_nplike
-                and slicestarts.nplike is self._backend.index_nplike
-                and slicestops.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
+                outoffsets.nplike is self._backend.nplike
+                and slicestarts.nplike is self._backend.nplike
+                and slicestops.nplike is self._backend.nplike
+                and self._starts.nplike is self._backend.nplike
+                and self._stops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -526,11 +524,11 @@ class ListArray(ListMeta[Content], Content):
             )
 
         elif isinstance(slicecontent, ak.contents.NumpyArray):
-            _carrylen = ak.index.Index64.empty(1, self._backend.index_nplike)
+            _carrylen = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                _carrylen.nplike is self._backend.index_nplike
-                and slicestarts.nplike is self._backend.index_nplike
-                and slicestops.nplike is self._backend.index_nplike
+                _carrylen.nplike is self._backend.nplike
+                and slicestarts.nplike is self._backend.nplike
+                and slicestops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -546,23 +544,23 @@ class ListArray(ListMeta[Content], Content):
                 ),
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
-            carrylen = self._backend.index_nplike.index_as_shape_item(_carrylen[0])
+            carrylen = self._backend.nplike.index_as_shape_item(_carrylen[0])
 
             sliceindex = ak.index.Index64(slicecontent._data)
             outoffsets = ak.index.Index64.empty(
                 slicestarts.length + 1,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
-            nextcarry = ak.index.Index64.empty(carrylen, self._backend.index_nplike)
+            nextcarry = ak.index.Index64.empty(carrylen, self._backend.nplike)
 
             assert (
-                outoffsets.nplike is self._backend.index_nplike
-                and nextcarry.nplike is self._backend.index_nplike
-                and slicestarts.nplike is self._backend.index_nplike
-                and slicestops.nplike is self._backend.index_nplike
-                and sliceindex.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
+                outoffsets.nplike is self._backend.nplike
+                and nextcarry.nplike is self._backend.nplike
+                and slicestarts.nplike is self._backend.nplike
+                and slicestops.nplike is self._backend.nplike
+                and sliceindex.nplike is self._backend.nplike
+                and self._starts.nplike is self._backend.nplike
+                and self._stops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -608,12 +606,12 @@ class ListArray(ListMeta[Content], Content):
                 )
 
             missing = slicecontent._index
-            _numvalid = ak.index.Index64.empty(1, self._backend.index_nplike)
+            _numvalid = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                _numvalid.nplike is self._backend.index_nplike
-                and slicestarts.nplike is self._backend.index_nplike
-                and slicestops.nplike is self._backend.index_nplike
-                and missing.nplike is self._backend.index_nplike
+                _numvalid.nplike is self._backend.nplike
+                and slicestarts.nplike is self._backend.nplike
+                and slicestops.nplike is self._backend.nplike
+                and missing.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -632,26 +630,26 @@ class ListArray(ListMeta[Content], Content):
                 ),
                 slicer=ak.contents.ListArray(slicestarts, slicestops, slicecontent),
             )
-            numvalid = self._backend.index_nplike.index_as_shape_item(_numvalid[0])
+            numvalid = self._backend.nplike.index_as_shape_item(_numvalid[0])
 
-            nextcarry = ak.index.Index64.empty(numvalid, self._backend.index_nplike)
+            nextcarry = ak.index.Index64.empty(numvalid, self._backend.nplike)
 
             smalloffsets = ak.index.Index64.empty(
                 slicestarts.length + 1,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
             largeoffsets = ak.index.Index64.empty(
                 slicestarts.length + 1,
-                self._backend.index_nplike,
+                self._backend.nplike,
             )
 
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and smalloffsets.nplike is self._backend.index_nplike
-                and largeoffsets.nplike is self._backend.index_nplike
-                and slicestarts.nplike is self._backend.index_nplike
-                and slicestops.nplike is self._backend.index_nplike
-                and missing.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and smalloffsets.nplike is self._backend.nplike
+                and largeoffsets.nplike is self._backend.nplike
+                and slicestarts.nplike is self._backend.nplike
+                and slicestops.nplike is self._backend.nplike
+                and missing.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -733,12 +731,12 @@ class ListArray(ListMeta[Content], Content):
             assert advanced is None
             nexthead, nexttail = ak._slicing.head_tail(tail)
             lenstarts = self._starts.length
-            nextcarry = ak.index.Index64.empty(lenstarts, self._backend.index_nplike)
+            nextcarry = ak.index.Index64.empty(lenstarts, self._backend.nplike)
             head = ak._slicing.normalize_integer_like(head)
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and self._starts.nplike is self._backend.nplike
+                and self._stops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -770,11 +768,11 @@ class ListArray(ListMeta[Content], Content):
             stop = ak._util.kSliceNone if stop is None else stop
 
             if self._backend.nplike.known_data:
-                carrylength = ak.index.Index64.empty(1, self._backend.index_nplike)
+                carrylength = ak.index.Index64.empty(1, self._backend.nplike)
                 assert (
-                    carrylength.nplike is self._backend.index_nplike
-                    and self._starts.nplike is self._backend.index_nplike
-                    and self._stops.nplike is self._backend.index_nplike
+                    carrylength.nplike is self._backend.nplike
+                    and self._starts.nplike is self._backend.nplike
+                    and self._stops.nplike is self._backend.nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -793,34 +791,30 @@ class ListArray(ListMeta[Content], Content):
                     ),
                     slicer=head,
                 )
-                nextcarry = ak.index.Index64.empty(
-                    carrylength[0], self._backend.index_nplike
-                )
+                nextcarry = ak.index.Index64.empty(carrylength[0], self._backend.nplike)
             else:
                 self._touch_data(recursive=False)
-                nextcarry = ak.index.Index64.empty(
-                    unknown_length, self._backend.index_nplike
-                )
+                nextcarry = ak.index.Index64.empty(unknown_length, self._backend.nplike)
 
             lennextoffsets = lenstarts + 1
             if self._starts.dtype == "int64":
                 nextoffsets = ak.index.Index64.empty(
-                    lennextoffsets, self._backend.index_nplike
+                    lennextoffsets, self._backend.nplike
                 )
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
-                    lennextoffsets, self._backend.index_nplike
+                    lennextoffsets, self._backend.nplike
                 )
             elif self._starts.dtype == "uint32":
                 nextoffsets = ak.index.IndexU32.empty(
-                    lennextoffsets, self._backend.index_nplike
+                    lennextoffsets, self._backend.nplike
                 )
 
             assert (
-                nextoffsets.nplike is self._backend.index_nplike
-                and nextcarry.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
+                nextoffsets.nplike is self._backend.nplike
+                and nextcarry.nplike is self._backend.nplike
+                and self._starts.nplike is self._backend.nplike
+                and self._stops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -854,10 +848,10 @@ class ListArray(ListMeta[Content], Content):
                 )
             else:
                 if self._backend.nplike.known_data:
-                    total = ak.index.Index64.empty(1, self._backend.index_nplike)
+                    total = ak.index.Index64.empty(1, self._backend.nplike)
                     assert (
-                        total.nplike is self._backend.index_nplike
-                        and nextoffsets.nplike is self._backend.index_nplike
+                        total.nplike is self._backend.nplike
+                        and nextoffsets.nplike is self._backend.nplike
                     )
                     self._maybe_index_error(
                         self._backend[
@@ -872,18 +866,18 @@ class ListArray(ListMeta[Content], Content):
                         slicer=head,
                     )
                     nextadvanced = ak.index.Index64.empty(
-                        total[0], self._backend.index_nplike
+                        total[0], self._backend.nplike
                     )
                 else:
                     self._touch_data(recursive=False)
                     nextadvanced = ak.index.Index64.empty(
-                        unknown_length, self._backend.index_nplike
+                        unknown_length, self._backend.nplike
                     )
-                advanced = advanced.to_nplike(self._backend.index_nplike)
+                advanced = advanced.to_nplike(self._backend.nplike)
                 assert (
-                    nextadvanced.nplike is self._backend.index_nplike
-                    and advanced.nplike is self._backend.index_nplike
-                    and nextoffsets.nplike is self._backend.index_nplike
+                    nextadvanced.nplike is self._backend.nplike
+                    and advanced.nplike is self._backend.nplike
+                    and nextoffsets.nplike is self._backend.nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -921,29 +915,27 @@ class ListArray(ListMeta[Content], Content):
             lenstarts = self._starts.length
 
             nexthead, nexttail = ak._slicing.head_tail(tail)
-            flathead = self._backend.index_nplike.reshape(
-                self._backend.index_nplike.asarray(head.data), (-1,)
+            flathead = self._backend.nplike.reshape(
+                self._backend.nplike.asarray(head.data), (-1,)
             )
-            regular_flathead = ak.index.Index64(
-                flathead, nplike=self._backend.index_nplike
-            )
+            regular_flathead = ak.index.Index64(flathead, nplike=self._backend.nplike)
             if advanced is None or (
                 advanced.length is not unknown_length and advanced.length == 0
             ):
                 nextcarry = ak.index.Index64.empty(
                     lenstarts * flathead.shape[0],
-                    self._backend.index_nplike,
+                    self._backend.nplike,
                 )
                 nextadvanced = ak.index.Index64.empty(
                     lenstarts * flathead.shape[0],
-                    self._backend.index_nplike,
+                    self._backend.nplike,
                 )
                 assert (
-                    nextcarry.nplike is self._backend.index_nplike
-                    and nextadvanced.nplike is self._backend.index_nplike
-                    and self._starts.nplike is self._backend.index_nplike
-                    and self._stops.nplike is self._backend.index_nplike
-                    and regular_flathead.nplike is self._backend.index_nplike
+                    nextcarry.nplike is self._backend.nplike
+                    and nextadvanced.nplike is self._backend.nplike
+                    and self._starts.nplike is self._backend.nplike
+                    and self._stops.nplike is self._backend.nplike
+                    and regular_flathead.nplike is self._backend.nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -976,20 +968,16 @@ class ListArray(ListMeta[Content], Content):
                     return out
 
             else:
-                nextcarry = ak.index.Index64.empty(
-                    lenstarts, self._backend.index_nplike
-                )
-                nextadvanced = ak.index.Index64.empty(
-                    lenstarts, self._backend.index_nplike
-                )
-                advanced = advanced.to_nplike(self._backend.index_nplike)
+                nextcarry = ak.index.Index64.empty(lenstarts, self._backend.nplike)
+                nextadvanced = ak.index.Index64.empty(lenstarts, self._backend.nplike)
+                advanced = advanced.to_nplike(self._backend.nplike)
                 assert (
-                    nextcarry.nplike is self._backend.index_nplike
-                    and nextadvanced.nplike is self._backend.index_nplike
-                    and self._starts.nplike is self._backend.index_nplike
-                    and self._stops.nplike is self._backend.index_nplike
-                    and regular_flathead.nplike is self._backend.index_nplike
-                    and advanced.nplike is self._backend.index_nplike
+                    nextcarry.nplike is self._backend.nplike
+                    and nextadvanced.nplike is self._backend.nplike
+                    and self._starts.nplike is self._backend.nplike
+                    and self._stops.nplike is self._backend.nplike
+                    and regular_flathead.nplike is self._backend.nplike
+                    and advanced.nplike is self._backend.nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -1028,22 +1016,22 @@ class ListArray(ListMeta[Content], Content):
             length = self.length
             singleoffsets = ak.index.Index64(head.offsets.data)
             multistarts = ak.index.Index64.empty(
-                head.length * length, self._backend.index_nplike
+                head.length * length, self._backend.nplike
             )
             multistops = ak.index.Index64.empty(
-                head.length * length, self._backend.index_nplike
+                head.length * length, self._backend.nplike
             )
             nextcarry = ak.index.Index64.empty(
-                head.length * length, self._backend.index_nplike
+                head.length * length, self._backend.nplike
             )
 
             assert (
-                multistarts.nplike is self._backend.index_nplike
-                and multistops.nplike is self._backend.index_nplike
-                and singleoffsets.nplike is self._backend.index_nplike
-                and nextcarry.nplike is self._backend.index_nplike
-                and self._starts.nplike is self._backend.index_nplike
-                and self._stops.nplike is self._backend.index_nplike
+                multistarts.nplike is self._backend.nplike
+                and multistops.nplike is self._backend.nplike
+                and singleoffsets.nplike is self._backend.nplike
+                and nextcarry.nplike is self._backend.nplike
+                and self._starts.nplike is self._backend.nplike
+                and self._stops.nplike is self._backend.nplike
             )
             self._maybe_index_error(
                 self._backend[
@@ -1150,8 +1138,8 @@ class ListArray(ListMeta[Content], Content):
         tail_contents = contents[1:]
         nextcontent = contents[0]._mergemany(tail_contents)
 
-        nextstarts = ak.index.Index64.empty(total_length, self._backend.index_nplike)
-        nextstops = ak.index.Index64.empty(total_length, self._backend.index_nplike)
+        nextstarts = ak.index.Index64.empty(total_length, self._backend.nplike)
+        nextstops = ak.index.Index64.empty(total_length, self._backend.nplike)
 
         contentlength_so_far = 0
         length_so_far = 0
@@ -1173,10 +1161,10 @@ class ListArray(ListMeta[Content], Content):
                 array_stops = array.stops
 
                 assert (
-                    nextstarts.nplike is self._backend.index_nplike
-                    and nextstops.nplike is self._backend.index_nplike
-                    and array_starts.nplike is self._backend.index_nplike
-                    and array_stops.nplike is self._backend.index_nplike
+                    nextstarts.nplike is self._backend.nplike
+                    and nextstops.nplike is self._backend.nplike
+                    and array_starts.nplike is self._backend.nplike
+                    and array_stops.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -1207,10 +1195,10 @@ class ListArray(ListMeta[Content], Content):
                 array_stops = listoffsetarray.stops
 
                 assert (
-                    nextstarts.nplike is self._backend.index_nplike
-                    and nextstops.nplike is self._backend.index_nplike
-                    and array_starts.nplike is self._backend.index_nplike
-                    and array_stops.nplike is self._backend.index_nplike
+                    nextstarts.nplike is self._backend.nplike
+                    and nextstops.nplike is self._backend.nplike
+                    and array_starts.nplike is self._backend.nplike
+                    and array_stops.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -1267,13 +1255,13 @@ class ListArray(ListMeta[Content], Content):
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
             offsets = self._compact_offsets64(True)
-            innerlength = self._backend.index_nplike.index_as_shape_item(
+            innerlength = self._backend.nplike.index_as_shape_item(
                 offsets[-1]
             )  # todo: removed touch_data?
-            localindex = ak.index.Index64.empty(innerlength, self._backend.index_nplike)
+            localindex = ak.index.Index64.empty(innerlength, self._backend.nplike)
             assert (
-                localindex.nplike is self._backend.index_nplike
-                and offsets.nplike is self._backend.index_nplike
+                localindex.nplike is self._backend.nplike
+                and offsets.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1367,8 +1355,8 @@ class ListArray(ListMeta[Content], Content):
         if self._backend.nplike.known_data and self.stops.length < self.starts.length:
             return f"at {path} ({type(self)!r}): len(stops) < len(starts)"
         assert (
-            self.starts.nplike is self._backend.index_nplike
-            and self.stops.nplike is self._backend.index_nplike
+            self.starts.nplike is self._backend.nplike
+            and self.stops.nplike is self._backend.nplike
         )
         error = self._backend[
             "awkward_ListArray_validity", self.starts.dtype.type, self.stops.dtype.type
@@ -1403,11 +1391,11 @@ class ListArray(ListMeta[Content], Content):
             if posaxis is not None and posaxis + 1 == depth:
                 return self._pad_none_axis0(target, clip)
             elif posaxis is not None and posaxis + 1 == depth + 1:
-                _min = ak.index.Index64.empty(1, self._backend.index_nplike)
+                _min = ak.index.Index64.empty(1, self._backend.nplike)
                 assert (
-                    _min.nplike is self._backend.index_nplike
-                    and self._starts.nplike is self._backend.index_nplike
-                    and self._stops.nplike is self._backend.index_nplike
+                    _min.nplike is self._backend.nplike
+                    and self._starts.nplike is self._backend.nplike
+                    and self._stops.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -1422,17 +1410,17 @@ class ListArray(ListMeta[Content], Content):
                         self._starts.length,
                     )
                 )
-                min_ = self._backend.index_nplike.index_as_shape_item(_min[0])
+                min_ = self._backend.nplike.index_as_shape_item(_min[0])
                 # TODO: Replace the kernel call with below code once typtracer supports '-'
                 # min_ = self._backend.nplike.min(self._stops.data - self._starts.data)
                 if min_ is not unknown_length and target < min_:
                     return self
                 else:
-                    _tolength = ak.index.Index64.empty(1, self._backend.index_nplike)
+                    _tolength = ak.index.Index64.empty(1, self._backend.nplike)
                     assert (
-                        _tolength.nplike is self._backend.index_nplike
-                        and self._starts.nplike is self._backend.index_nplike
-                        and self._stops.nplike is self._backend.index_nplike
+                        _tolength.nplike is self._backend.nplike
+                        and self._starts.nplike is self._backend.nplike
+                        and self._stops.nplike is self._backend.nplike
                     )
                     self._backend.maybe_kernel_error(
                         self._backend[
@@ -1448,27 +1436,25 @@ class ListArray(ListMeta[Content], Content):
                             self._starts.length,
                         )
                     )
-                    tolength = self._backend.index_nplike.index_as_shape_item(
-                        _tolength[0]
-                    )
+                    tolength = self._backend.nplike.index_as_shape_item(_tolength[0])
 
-                    index = ak.index.Index64.empty(tolength, self._backend.index_nplike)
+                    index = ak.index.Index64.empty(tolength, self._backend.nplike)
                     starts_ = ak.index.Index.empty(
                         self._starts.length,
-                        self._backend.index_nplike,
+                        self._backend.nplike,
                         dtype=self._starts.dtype,
                     )
                     stops_ = ak.index.Index.empty(
                         self._stops.length,
-                        self._backend.index_nplike,
+                        self._backend.nplike,
                         dtype=self._stops.dtype,
                     )
                     assert (
-                        index.nplike is self._backend.index_nplike
-                        and self._starts.nplike is self._backend.index_nplike
-                        and self._stops.nplike is self._backend.index_nplike
-                        and starts_.nplike is self._backend.index_nplike
-                        and stops_.nplike is self._backend.index_nplike
+                        index.nplike is self._backend.nplike
+                        and self._starts.nplike is self._backend.nplike
+                        and self._stops.nplike is self._backend.nplike
+                        and starts_.nplike is self._backend.nplike
+                        and stops_.nplike is self._backend.nplike
                     )
                     self._backend.maybe_kernel_error(
                         self._backend[
@@ -1559,15 +1545,15 @@ class ListArray(ListMeta[Content], Content):
             and self._backend.nplike.known_data
             and self._starts.length != 0
         ):
-            startsmin = self._backend.index_nplike.min(self._starts.data)
+            startsmin = self._backend.nplike.min(self._starts.data)
             starts = ak.index.Index(
-                self._starts.data - startsmin, nplike=self._backend.index_nplike
+                self._starts.data - startsmin, nplike=self._backend.nplike
             )
             stops = ak.index.Index(
-                self._stops.data - startsmin, nplike=self._backend.index_nplike
+                self._stops.data - startsmin, nplike=self._backend.nplike
             )
             content = self._content[
-                startsmin : self._backend.index_nplike.max(self._stops.data)
+                startsmin : self._backend.nplike.max(self._stops.data)
             ]
         else:
             self._touch_data(recursive=False)
@@ -1628,8 +1614,8 @@ class ListArray(ListMeta[Content], Content):
 
     def _to_backend(self, backend: Backend) -> Self:
         content = self._content.to_backend(backend)
-        starts = self._starts.to_nplike(backend.index_nplike)
-        stops = self._stops.to_nplike(backend.index_nplike)
+        starts = self._starts.to_nplike(backend.nplike)
+        stops = self._stops.to_nplike(backend.nplike)
         return ListArray(starts, stops, content, parameters=self._parameters)
 
     def _materialize(self) -> Self:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -423,7 +423,7 @@ class NumpyArray(NumpyMeta, Content):
                 where = (slice(None), head.data, *tail)
             else:
                 where = (
-                    self._backend.index_nplike.asarray(advanced.data),
+                    self._backend.nplike.asarray(advanced.data),
                     head.data,
                     *tail,
                 )
@@ -584,8 +584,8 @@ class NumpyArray(NumpyMeta, Content):
         is_equal = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
 
         assert (
-            starts.nplike is self._backend.index_nplike
-            and stops.nplike is self._backend.index_nplike
+            starts.nplike is self._backend.nplike
+            and stops.nplike is self._backend.nplike
         )
         if self.dtype == np.bool_:
             self._backend.maybe_kernel_error(
@@ -628,14 +628,12 @@ class NumpyArray(NumpyMeta, Content):
 
     def _as_unique_strings(self, offsets):
         offsets = ak.index.Index64(offsets.data, nplike=offsets.nplike)
-        outoffsets = ak.index.Index64.empty(
-            offsets.length, nplike=self._backend.index_nplike
-        )
+        outoffsets = ak.index.Index64.empty(offsets.length, nplike=self._backend.nplike)
         out = self._backend.nplike.empty(self.shape[0], dtype=self.dtype)
 
         assert (
-            offsets.nplike is self._backend.index_nplike
-            and outoffsets.nplike is self._backend.index_nplike
+            offsets.nplike is self._backend.nplike
+            and outoffsets.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -655,12 +653,12 @@ class NumpyArray(NumpyMeta, Content):
             )
         )
 
-        outlength = ak.index.Index64.empty(1, self._backend.index_nplike)
-        nextoffsets = ak.index.Index64.empty(offsets.length, self._backend.index_nplike)
+        outlength = ak.index.Index64.empty(1, self._backend.nplike)
+        nextoffsets = ak.index.Index64.empty(offsets.length, self._backend.nplike)
         assert (
-            outoffsets.nplike is self._backend.index_nplike
-            and nextoffsets.nplike is self._backend.index_nplike
-            and outlength.nplike is self._backend.index_nplike
+            outoffsets.nplike is self._backend.nplike
+            and nextoffsets.nplike is self._backend.nplike
+            and outlength.nplike is self._backend.nplike
         )
         self._backend.maybe_kernel_error(
             self._backend[
@@ -732,7 +730,7 @@ class NumpyArray(NumpyMeta, Content):
         elif negaxis is None:
             contiguous_self = self.to_contiguous()
 
-            offsets = ak.index.Index64.zeros(2, self._backend.index_nplike)
+            offsets = ak.index.Index64.zeros(2, self._backend.nplike)
             offsets[1] = self._data.size
             dtype = (
                 np.dtype(np.int64)
@@ -740,7 +738,7 @@ class NumpyArray(NumpyMeta, Content):
                 else self._data.dtype
             )
             out = self._backend.nplike.empty(self._data.size, dtype=dtype)
-            assert offsets.nplike is self._backend.index_nplike
+            assert offsets.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_sort",
@@ -758,9 +756,9 @@ class NumpyArray(NumpyMeta, Content):
                     False,
                 )
             )
-            nextlength = ak.index.Index64.empty(1, self._backend.index_nplike)
-            assert nextlength.nplike is self._backend.index_nplike
-            out = self._backend.index_nplike.unique_values(out)
+            nextlength = ak.index.Index64.empty(1, self._backend.nplike)
+            assert nextlength.nplike is self._backend.nplike
+            out = self._backend.nplike.unique_values(out)
             nextlength[0] = out.size
 
             return ak.contents.NumpyArray(
@@ -779,10 +777,10 @@ class NumpyArray(NumpyMeta, Content):
             )
         else:
             parents_length = parents.length
-            offsets_length = ak.index.Index64.empty(1, self._backend.index_nplike)
+            offsets_length = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                offsets_length.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                offsets_length.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -796,12 +794,10 @@ class NumpyArray(NumpyMeta, Content):
                 )
             )
 
-            offsets = ak.index.Index64.empty(
-                offsets_length[0], self._backend.index_nplike
-            )
+            offsets = ak.index.Index64.empty(offsets_length[0], self._backend.nplike)
             assert (
-                offsets.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                offsets.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -817,7 +813,7 @@ class NumpyArray(NumpyMeta, Content):
             )
 
             out = self._backend.nplike.empty(self.length, dtype=self.dtype)
-            assert offsets.nplike is self._backend.index_nplike
+            assert offsets.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_sort",
@@ -836,12 +832,10 @@ class NumpyArray(NumpyMeta, Content):
                 )
             )
 
-            nextoffsets = ak.index.Index64.empty(
-                offsets.length, self._backend.index_nplike
-            )
+            nextoffsets = ak.index.Index64.empty(offsets.length, self._backend.nplike)
             assert (
-                offsets.nplike is self._backend.index_nplike
-                and nextoffsets.nplike is self._backend.index_nplike
+                offsets.nplike is self._backend.nplike
+                and nextoffsets.nplike is self._backend.nplike
             )
             if out.dtype == np.bool_:
                 self._backend.maybe_kernel_error(
@@ -872,14 +866,12 @@ class NumpyArray(NumpyMeta, Content):
                     )
                 )
 
-            outoffsets = ak.index.Index64.empty(
-                starts.length + 1, self._backend.index_nplike
-            )
+            outoffsets = ak.index.Index64.empty(starts.length + 1, self._backend.nplike)
 
             assert (
-                outoffsets.nplike is self._backend.index_nplike
-                and nextoffsets.nplike is self._backend.index_nplike
-                and starts.nplike is self._backend.index_nplike
+                outoffsets.nplike is self._backend.nplike
+                and nextoffsets.nplike is self._backend.nplike
+                and starts.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -913,10 +905,10 @@ class NumpyArray(NumpyMeta, Content):
             )
         else:
             parents_length = parents.length
-            _offsets_length = ak.index.Index64.empty(1, self._backend.index_nplike)
+            _offsets_length = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                _offsets_length.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                _offsets_length.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -929,14 +921,14 @@ class NumpyArray(NumpyMeta, Content):
                     parents_length,
                 )
             )
-            offsets_length = self._backend.index_nplike.index_as_shape_item(
+            offsets_length = self._backend.nplike.index_as_shape_item(
                 _offsets_length[0]
             )
 
-            offsets = ak.index.Index64.empty(offsets_length, self._backend.index_nplike)
+            offsets = ak.index.Index64.empty(offsets_length, self._backend.nplike)
             assert (
-                offsets.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                offsets.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -956,10 +948,10 @@ class NumpyArray(NumpyMeta, Content):
                 if self._data.dtype.kind.upper() == "M"
                 else self._data.dtype
             )
-            nextcarry = ak.index.Index64.empty(self.length, self._backend.index_nplike)
+            nextcarry = ak.index.Index64.empty(self.length, self._backend.nplike)
             assert (
-                nextcarry.nplike is self._backend.index_nplike
-                and offsets.nplike is self._backend.index_nplike
+                nextcarry.nplike is self._backend.nplike
+                and offsets.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -980,11 +972,11 @@ class NumpyArray(NumpyMeta, Content):
 
             if shifts is not None:
                 assert (
-                    nextcarry.nplike is self._backend.index_nplike
-                    and shifts.nplike is self._backend.index_nplike
-                    and offsets.nplike is self._backend.index_nplike
-                    and parents.nplike is self._backend.index_nplike
-                    and starts.nplike is self._backend.index_nplike
+                    nextcarry.nplike is self._backend.nplike
+                    and shifts.nplike is self._backend.nplike
+                    and offsets.nplike is self._backend.nplike
+                    and parents.nplike is self._backend.nplike
+                    and starts.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -1019,10 +1011,10 @@ class NumpyArray(NumpyMeta, Content):
 
         else:
             parents_length = parents.length
-            _offsets_length = ak.index.Index64.empty(1, self._backend.index_nplike)
+            _offsets_length = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
-                _offsets_length.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                _offsets_length.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1035,15 +1027,15 @@ class NumpyArray(NumpyMeta, Content):
                     parents_length,
                 )
             )
-            offsets_length = self._backend.index_nplike.index_as_shape_item(
+            offsets_length = self._backend.nplike.index_as_shape_item(
                 _offsets_length[0]
             )
 
-            offsets = ak.index.Index64.empty(offsets_length, self._backend.index_nplike)
+            offsets = ak.index.Index64.empty(offsets_length, self._backend.nplike)
 
             assert (
-                offsets.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                offsets.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1064,7 +1056,7 @@ class NumpyArray(NumpyMeta, Content):
                 else self._data.dtype
             )
             out = self._backend.nplike.empty(self.length, dtype=dtype)
-            assert offsets.nplike is self._backend.index_nplike
+            assert offsets.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_sort",
@@ -1143,10 +1135,10 @@ class NumpyArray(NumpyMeta, Content):
         out = reducer.apply(self, parents, starts, shifts, outlength)
 
         if mask:
-            outmask = ak.index.Index8.empty(outlength, self._backend.index_nplike)
+            outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
             assert (
-                outmask.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                outmask.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -219,7 +219,7 @@ class RecordArray(RecordMeta[Content], Content):
             # Ensure lengths are not smaller than given length.
             for content in contents:
                 if (
-                    backend.index_nplike.known_data
+                    backend.nplike.known_data
                     and content.length is not unknown_length
                     and content.length < length
                 ):
@@ -412,7 +412,7 @@ class RecordArray(RecordMeta[Content], Content):
         else:
             return ak.contents.IndexedOptionArray(
                 ak.index.Index64(
-                    self._backend.index_nplike.full(self.length, -1, dtype=np.int64)
+                    self._backend.nplike.full(self.length, -1, dtype=np.int64)
                 ),
                 ak.contents.EmptyArray(),
             )
@@ -438,7 +438,7 @@ class RecordArray(RecordMeta[Content], Content):
         if not self._backend.nplike.known_data:
             self._touch_shape(recursive=False)
 
-        start, stop, _, length = self._backend.index_nplike.derive_slice_for_length(
+        start, stop, _, length = self._backend.nplike.derive_slice_for_length(
             slice(start, stop), self._length
         )
 
@@ -507,14 +507,14 @@ class RecordArray(RecordMeta[Content], Content):
                 where = where.copy()
 
             negative = where < 0
-            if self._backend.index_nplike.known_data:
-                if self._backend.index_nplike.any(negative):
+            if self._backend.nplike.known_data:
+                if self._backend.nplike.any(negative):
                     where[negative] += self._length
 
-                if self._backend.index_nplike.any(where >= self._length):
+                if self._backend.nplike.any(where >= self._length):
                     raise ak._errors.index_error(self, where)
 
-            nextindex = ak.index.Index64(where, nplike=self._backend.index_nplike)
+            nextindex = ak.index.Index64(where, nplike=self._backend.nplike)
             return ak.contents.IndexedArray(nextindex, self, parameters=None)
 
         else:
@@ -621,7 +621,7 @@ class RecordArray(RecordMeta[Content], Content):
                 contents.append(flattened)
             offsets = ak.index.Index64.zeros(
                 1,
-                nplike=self._backend.index_nplike,
+                nplike=self._backend.nplike,
                 dtype=np.int64,
             )
             return (
@@ -907,19 +907,19 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(outlength + 1, self._backend.index_nplike)
+            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
             assert (
-                offsets.nplike is self._backend.index_nplike
-                and parents.nplike is self._backend.index_nplike
+                offsets.nplike is self._backend.nplike
+                and parents.nplike is self._backend.nplike
             )
             # `parents` are possibly non monotonic increasing, so we must re-order the result
             # This happens naturally for the `NumpyArray` reducers.
-            carry = ak.index.Index64.empty(outlength, self._backend.index_nplike)
+            carry = ak.index.Index64.empty(outlength, self._backend.nplike)
 
             # Note: if we knew that `negaxis == depth` exclusively for this layout, we could use
             # the simpler `ListOffsetArray_reduce_local_outoffsets_64`. However, if our parent was reduced,
             # we would still see `negaxis == depth`, so this kernel has to be used instead.
-            assert carry.nplike is self._backend.index_nplike
+            assert carry.nplike is self._backend.nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_RecordArray_reduce_nonlocal_outoffsets_64",
@@ -959,8 +959,8 @@ class RecordArray(RecordMeta[Content], Content):
                 if shifts is None:
                     assert (
                         out.backend is self._backend
-                        and parents.nplike is self._backend.index_nplike
-                        and starts.nplike is self._backend.index_nplike
+                        and parents.nplike is self._backend.nplike
+                        and starts.nplike is self._backend.nplike
                     )
                     self._backend.maybe_kernel_error(
                         self._backend[
@@ -978,9 +978,9 @@ class RecordArray(RecordMeta[Content], Content):
                 else:
                     assert (
                         out.backend is self._backend
-                        and parents.nplike is self._backend.index_nplike
-                        and starts.nplike is self._backend.index_nplike
-                        and shifts.nplike is self._backend.index_nplike
+                        and parents.nplike is self._backend.nplike
+                        and starts.nplike is self._backend.nplike
+                        and shifts.nplike is self._backend.nplike
                     )
                     self._backend.maybe_kernel_error(
                         self._backend[
@@ -999,10 +999,10 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(outlength, self._backend.index_nplike)
+                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
                 assert (
-                    outmask.nplike is self._backend.index_nplike
-                    and parents.nplike is self._backend.index_nplike
+                    outmask.nplike is self._backend.nplike
+                    and parents.nplike is self._backend.nplike
                 )
                 self._backend.maybe_kernel_error(
                     self._backend[
@@ -1152,7 +1152,7 @@ class RecordArray(RecordMeta[Content], Content):
         for n, x in zip(self.fields, contents):
             if allow_missing and isinstance(x, self._backend.nplike.ma.MaskedArray):
                 if mask is None:
-                    mask = backend.index_nplike.ma.zeros(
+                    mask = backend.nplike.ma.zeros(
                         self.length, [(n, np.bool_) for n in self.fields]
                     )
                 if x.mask is not None:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -127,7 +127,7 @@ class RegularArray(RegularMeta[Content], Content):
                 f"{type(self).__name__} 'content' must be a Content subtype, not {content!r}"
             )
         if size is unknown_length:
-            if content.backend.index_nplike.known_data:
+            if content.backend.nplike.known_data:
                 raise TypeError(
                     f"{type(self).__name__} 'size' must be a non-negative integer for backends with known shapes, not None"
                 )
@@ -297,22 +297,22 @@ class RegularArray(RegularMeta[Content], Content):
         return False
 
     def _getitem_at(self, where: IndexType):
-        index_nplike = self._backend.index_nplike
-        where = index_nplike.regularize_index_for_length(where, self._length)
-        size_scalar = index_nplike.shape_item_as_index(self._size)
+        nplike = self._backend.nplike
+        where = nplike.regularize_index_for_length(where, self._length)
+        size_scalar = nplike.shape_item_as_index(self._size)
         start, stop = where * size_scalar, (where + 1) * size_scalar
         return self._content._getitem_range(start, stop)
 
     def _getitem_range(self, start: IndexType, stop: IndexType) -> Content:
-        index_nplike = self._backend.index_nplike
-        if not index_nplike.known_data:
+        nplike = self._backend.nplike
+        if not nplike.known_data:
             self._touch_shape(recursive=False)
             return self
 
-        zeros_length = index_nplike.index_as_shape_item(stop - start)
+        zeros_length = nplike.index_as_shape_item(stop - start)
         substart, substop = (
-            start * index_nplike.shape_item_as_index(self._size),
-            stop * index_nplike.shape_item_as_index(self._size),
+            start * nplike.shape_item_as_index(self._size),
+            stop * nplike.shape_item_as_index(self._size),
         )
         return RegularArray(
             self._content._getitem_range(substart, substop),
@@ -348,29 +348,27 @@ class RegularArray(RegularMeta[Content], Content):
 
         copied = allow_lazy == "copied"
         if not issubclass(where.dtype.type, np.int64):
-            where = self._backend.index_nplike.astype(where, dtype=np.int64)
+            where = self._backend.nplike.astype(where, dtype=np.int64)
             copied = True
 
         negative = where < 0
-        if self._backend.index_nplike.known_data:
-            if self._backend.index_nplike.any(negative):
+        if self._backend.nplike.known_data:
+            if self._backend.nplike.any(negative):
                 if not copied:
                     where = where.copy()
                     copied = True
                 where[negative] += self._length
 
-            if self._backend.index_nplike.any(where >= self._length):
+            if self._backend.nplike.any(where >= self._length):
                 raise ak._errors.index_error(self, where)
 
         if where.shape[0] is unknown_length or self._size is unknown_length:
-            nextcarry = ak.index.Index64.empty(
-                unknown_length, self._backend.index_nplike
-            )
+            nextcarry = ak.index.Index64.empty(unknown_length, self._backend.nplike)
         else:
             nextcarry = ak.index.Index64.empty(
-                where.shape[0] * self._size, self._backend.index_nplike
+                where.shape[0] * self._size, self._backend.nplike
             )
-        assert nextcarry.nplike is self._backend.index_nplike
+        assert nextcarry.nplike is self._backend.nplike
         self._maybe_index_error(
             self._backend[
                 "awkward_RegularArray_getitem_carry",
@@ -393,31 +391,31 @@ class RegularArray(RegularMeta[Content], Content):
         )
 
     def _compact_offsets64(self, start_at_zero):
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
         if self._size is not unknown_length and self._size == 0:
-            return ak.index.Index64.zeros(self._length + 1, nplike=index_nplike)
+            return ak.index.Index64.zeros(self._length + 1, nplike=nplike)
         else:
             return ak.index.Index64(
-                index_nplike.arange(
+                nplike.arange(
                     0,
-                    index_nplike.shape_item_as_index(self._length * self._size) + 1,
-                    index_nplike.shape_item_as_index(self._size),
+                    nplike.shape_item_as_index(self._length * self._size) + 1,
+                    nplike.shape_item_as_index(self._size),
                     dtype=np.int64,
                 ),
-                nplike=index_nplike,
+                nplike=nplike,
             )
 
     def _broadcast_tooffsets64(self, offsets: Index) -> ListOffsetArray:
         self._touch_data(recursive=False)
         offsets._touch_data()
 
-        index_nplike = self._backend.index_nplike
-        assert offsets.nplike is index_nplike
+        nplike = self._backend.nplike
+        assert offsets.nplike is nplike
         if offsets.length is not unknown_length and offsets.length == 0:
             raise AssertionError(
                 "broadcast_tooffsets64 can only be used with non-empty offsets"
             )
-        elif index_nplike.known_data and offsets[0] != 0:
+        elif nplike.known_data and offsets[0] != 0:
             raise AssertionError(
                 f"broadcast_tooffsets64 can only be used with offsets that start at 0, not {offsets[0]}"
             )
@@ -434,25 +432,25 @@ class RegularArray(RegularMeta[Content], Content):
             count = offsets.data[1:] - offsets.data[:-1]
             # Sanity check that our kernel isn't losing values here
             assert (
-                not self._backend.index_nplike.known_data
+                not self._backend.nplike.known_data
                 or count.size is unknown_length
                 or count.size == 0
                 or count.dtype == np.intp
-                or self._backend.index_nplike.max(count) <= np.iinfo(np.intp).max
+                or self._backend.nplike.max(count) <= np.iinfo(np.intp).max
             )
             carry = ak.index.Index64(
-                index_nplike.repeat(
-                    index_nplike.arange(
-                        index_nplike.shape_item_as_index(self._length), dtype=np.int64
+                nplike.repeat(
+                    nplike.arange(
+                        nplike.shape_item_as_index(self._length), dtype=np.int64
                     ),
-                    index_nplike.astype(count, np.intp),
+                    nplike.astype(count, np.intp),
                 ),
-                nplike=index_nplike,
+                nplike=nplike,
             )
             next_content = self._content._carry(carry, True)
         else:
             this_offsets = self._compact_offsets64(True)
-            if index_nplike.known_data and not index_nplike.array_equal(
+            if nplike.known_data and not nplike.array_equal(
                 offsets.data, this_offsets.data
             ):
                 raise ValueError("cannot broadcast nested list")
@@ -474,15 +472,15 @@ class RegularArray(RegularMeta[Content], Content):
         tail: tuple[SliceItem, ...],
         advanced: Index | None,
     ) -> Content:
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
 
         if head is NO_HEAD:
             return self
 
         elif is_integer_like(head):
             nexthead, nexttail = ak._slicing.head_tail(tail)
-            nextcarry = ak.index.Index64.empty(self._length, index_nplike)
-            assert nextcarry.nplike is index_nplike
+            nextcarry = ak.index.Index64.empty(self._length, nplike)
+            assert nextcarry.nplike is nplike
             head = ak._slicing.normalize_integer_like(head)
             self._maybe_index_error(
                 self._backend[
@@ -500,12 +498,12 @@ class RegularArray(RegularMeta[Content], Content):
 
         elif isinstance(head, slice):
             nexthead, nexttail = ak._slicing.head_tail(tail)
-            start, stop, step, nextsize = index_nplike.derive_slice_for_length(
+            start, stop, step, nextsize = nplike.derive_slice_for_length(
                 head, length=self._size
             )
 
-            nextcarry = ak.index.Index64.empty(self._length * nextsize, index_nplike)
-            assert nextcarry.nplike is index_nplike
+            nextcarry = ak.index.Index64.empty(self._length * nextsize, nplike)
+            assert nextcarry.nplike is nplike
             self._maybe_index_error(
                 self._backend[
                     "awkward_RegularArray_getitem_next_range",
@@ -533,12 +531,9 @@ class RegularArray(RegularMeta[Content], Content):
                     parameters=self._parameters,
                 )
             else:
-                nextadvanced = ak.index.Index64.empty(nextcarry.length, index_nplike)
-                advanced = advanced.to_nplike(index_nplike)
-                assert (
-                    nextadvanced.nplike is index_nplike
-                    and advanced.nplike is index_nplike
-                )
+                nextadvanced = ak.index.Index64.empty(nextcarry.length, nplike)
+                advanced = advanced.to_nplike(nplike)
+                assert nextadvanced.nplike is nplike and advanced.nplike is nplike
                 self._maybe_index_error(
                     self._backend[
                         "awkward_RegularArray_getitem_next_range_spreadadvanced",
@@ -572,10 +567,10 @@ class RegularArray(RegularMeta[Content], Content):
             return self._getitem_next_ellipsis(tail, advanced)
 
         elif isinstance(head, ak.index.Index64):
-            head = head.to_nplike(index_nplike)
-            flathead = index_nplike.reshape(index_nplike.asarray(head.data), (-1,))
-            regular_flathead = ak.index.Index64.empty(flathead.shape[0], index_nplike)
-            assert regular_flathead.nplike is index_nplike
+            head = head.to_nplike(nplike)
+            flathead = nplike.reshape(nplike.asarray(head.data), (-1,))
+            regular_flathead = ak.index.Index64.empty(flathead.shape[0], nplike)
+            assert regular_flathead.nplike is nplike
             self._maybe_index_error(
                 self._backend[
                     "awkward_RegularArray_getitem_next_array_regularize",
@@ -596,13 +591,13 @@ class RegularArray(RegularMeta[Content], Content):
             ):
                 nextcarry = ak.index.Index64.empty(
                     self._length * flathead.shape[0],
-                    index_nplike,
+                    nplike,
                 )
-                nextadvanced = ak.index.Index64.empty(nextcarry.length, index_nplike)
+                nextadvanced = ak.index.Index64.empty(nextcarry.length, nplike)
                 assert (
-                    nextcarry.nplike is index_nplike
-                    and nextadvanced.nplike is index_nplike
-                    and regular_flathead.nplike is index_nplike
+                    nextcarry.nplike is nplike
+                    and nextadvanced.nplike is nplike
+                    and regular_flathead.nplike is nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -631,20 +626,20 @@ class RegularArray(RegularMeta[Content], Content):
                     return out
 
             elif self._size == 0:
-                nextcarry = ak.index.Index64.empty(0, nplike=index_nplike)
-                nextadvanced = ak.index.Index64.empty(0, nplike=index_nplike)
+                nextcarry = ak.index.Index64.empty(0, nplike=nplike)
+                nextadvanced = ak.index.Index64.empty(0, nplike=nplike)
                 nextcontent = self._content._carry(nextcarry, True)
                 return nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
 
             else:
-                nextcarry = ak.index.Index64.empty(self._length, index_nplike)
-                nextadvanced = ak.index.Index64.empty(self._length, index_nplike)
-                advanced = advanced.to_nplike(index_nplike)
+                nextcarry = ak.index.Index64.empty(self._length, nplike)
+                nextadvanced = ak.index.Index64.empty(self._length, nplike)
+                advanced = advanced.to_nplike(nplike)
                 assert (
-                    nextcarry.nplike is index_nplike
-                    and nextadvanced.nplike is index_nplike
-                    and advanced.nplike is index_nplike
-                    and regular_flathead.nplike is index_nplike
+                    nextcarry.nplike is nplike
+                    and nextadvanced.nplike is nplike
+                    and advanced.nplike is nplike
+                    and regular_flathead.nplike is nplike
                 )
                 self._maybe_index_error(
                     self._backend[
@@ -684,14 +679,10 @@ class RegularArray(RegularMeta[Content], Content):
                     f"cannot fit jagged slice with length {head.length} into {type(self).__name__} of size {self._size}",
                 )
 
-            multistarts = ak.index.Index64.empty(
-                head.length * self._length, index_nplike
-            )
-            multistops = ak.index.Index64.empty(
-                head.length * self._length, index_nplike
-            )
+            multistarts = ak.index.Index64.empty(head.length * self._length, nplike)
+            multistops = ak.index.Index64.empty(head.length * self._length, nplike)
 
-            assert head.offsets.nplike is index_nplike
+            assert head.offsets.nplike is nplike
             self._maybe_index_error(
                 self._backend[
                     "awkward_RegularArray_getitem_jagged_expand",
@@ -794,7 +785,7 @@ class RegularArray(RegularMeta[Content], Content):
             return self._local_index_axis0()
         elif posaxis is not None and posaxis + 1 == depth + 1:
             localindex = ak.index.Index64.empty(
-                self._length * self._size, nplike=self._backend.index_nplike
+                self._length * self._size, nplike=self._backend.nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend["awkward_RegularArray_localindex", np.int64](
@@ -890,7 +881,7 @@ class RegularArray(RegularMeta[Content], Content):
         return out
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
 
         posaxis = maybe_posaxis(self, axis, depth)
         if posaxis is not None and posaxis + 1 == depth:
@@ -921,25 +912,23 @@ class RegularArray(RegularMeta[Content], Content):
                     combinationslen = combinationslen // j
 
             totallen = combinationslen * self._length
-            tocarryraw = index_nplike.empty(n, dtype=np.intp)
+            tocarryraw = nplike.empty(n, dtype=np.intp)
             tocarry = []
             for i in range(n):
                 ptr = ak.index.Index64.empty(
                     totallen,
-                    nplike=index_nplike,
+                    nplike=nplike,
                     dtype=np.int64,
                 )
                 tocarry.append(ptr)
                 if self._backend.nplike.known_data:
                     tocarryraw[i] = ptr.ptr
 
-            toindex = ak.index.Index64.empty(n, index_nplike, dtype=np.int64)
-            fromindex = ak.index.Index64.empty(n, index_nplike, dtype=np.int64)
+            toindex = ak.index.Index64.empty(n, nplike, dtype=np.int64)
+            fromindex = ak.index.Index64.empty(n, nplike, dtype=np.int64)
 
             if self._size != 0:
-                assert (
-                    toindex.nplike is index_nplike and fromindex.nplike is index_nplike
-                )
+                assert toindex.nplike is nplike and fromindex.nplike is nplike
                 self._backend.maybe_kernel_error(
                     self._backend[
                         "awkward_RegularArray_combinations_64",
@@ -976,7 +965,7 @@ class RegularArray(RegularMeta[Content], Content):
         else:
             length = self._length * self._size
             next = self._content._getitem_range(
-                0, index_nplike.shape_item_as_index(length)
+                0, nplike.shape_item_as_index(length)
             )._combinations(n, replacement, recordlookup, parameters, axis, depth + 1)
             return ak.contents.RegularArray(
                 next, self._size, self._length, parameters=self._parameters
@@ -994,16 +983,16 @@ class RegularArray(RegularMeta[Content], Content):
         keepdims,
         behavior,
     ):
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
         branch, depth = self.branch_depth
         nextlen = self._length * self._size
         if not branch and negaxis == depth:
-            nextcarry = ak.index.Index64.empty(nextlen, nplike=index_nplike)
-            nextparents = ak.index.Index64.empty(nextlen, nplike=index_nplike)
+            nextcarry = ak.index.Index64.empty(nextlen, nplike=nplike)
+            nextparents = ak.index.Index64.empty(nextlen, nplike=nplike)
             assert (
-                parents.nplike is index_nplike
-                and nextcarry.nplike is index_nplike
-                and nextparents.nplike is index_nplike
+                parents.nplike is nplike
+                and nextcarry.nplike is nplike
+                and nextparents.nplike is nplike
             )
             self._backend.maybe_kernel_error(
                 self._backend[
@@ -1024,11 +1013,9 @@ class RegularArray(RegularMeta[Content], Content):
                 # The upper bound for this value is given by `nextlen` (each item in this list belonging
                 # to a distinct reduction), but the length of `starts` should equate to `maxnextparents - 1`.
                 starts.length * self._size,
-                nplike=index_nplike,
+                nplike=nplike,
             )
-            assert (
-                nextstarts.nplike is index_nplike and nextparents.nplike is index_nplike
-            )
+            assert nextstarts.nplike is nplike and nextparents.nplike is nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_ListOffsetArray_reduce_nonlocal_nextstarts_64",
@@ -1044,9 +1031,7 @@ class RegularArray(RegularMeta[Content], Content):
             if reducer.needs_position:
                 # Regular arrays have the same length rows, so there can be no "missing" values
                 # unlike ragged list types
-                nextshifts = ak.index.Index64.zeros(
-                    nextcarry.length, nplike=index_nplike
-                )
+                nextshifts = ak.index.Index64.zeros(nextcarry.length, nplike=nplike)
             else:
                 nextshifts = None
 
@@ -1073,9 +1058,9 @@ class RegularArray(RegularMeta[Content], Content):
                 out = ak.contents.RegularArray(out, 1, self._length, parameters=None)
             return out
         else:
-            nextparents = ak.index.Index64.empty(nextlen, index_nplike)
+            nextparents = ak.index.Index64.empty(nextlen, nplike)
 
-            assert nextparents.nplike is index_nplike
+            assert nextparents.nplike is nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_RegularArray_reduce_local_nextparents_64",
@@ -1089,14 +1074,14 @@ class RegularArray(RegularMeta[Content], Content):
 
             if self._size is not unknown_length and self._size > 0:
                 nextstarts = ak.index.Index64(
-                    index_nplike.arange(0, nextlen, self._size),
-                    nplike=index_nplike,
+                    nplike.arange(0, nextlen, self._size),
+                    nplike=nplike,
                 )
             else:
                 assert nextlen is unknown_length or nextlen == 0
                 nextstarts = ak.index.Index64(
-                    index_nplike.zeros(nextlen, dtype=np.int64),
-                    nplike=index_nplike,
+                    nplike.zeros(nextlen, dtype=np.int64),
+                    nplike=nplike,
                 )
 
             outcontent = self._content._reduce_next(
@@ -1167,8 +1152,8 @@ class RegularArray(RegularMeta[Content], Content):
                 else:
                     assert outcontent.is_regular
 
-            outoffsets = ak.index.Index64.empty(outlength + 1, index_nplike)
-            assert outoffsets.nplike is index_nplike and parents.nplike is index_nplike
+            outoffsets = ak.index.Index64.empty(outlength + 1, nplike)
+            assert outoffsets.nplike is nplike and parents.nplike is nplike
             self._backend.maybe_kernel_error(
                 self._backend[
                     "awkward_ListOffsetArray_reduce_local_outoffsets_64",
@@ -1208,9 +1193,9 @@ class RegularArray(RegularMeta[Content], Content):
             else:
                 index = ak.index.Index64.empty(
                     self._length * target,
-                    self._backend.index_nplike,
+                    self._backend.nplike,
                 )
-                assert index.nplike is self._backend.index_nplike
+                assert index.nplike is self._backend.nplike
                 self._backend.maybe_kernel_error(
                     self._backend[
                         "awkward_RegularArray_rpad_and_clip_axis1", index.dtype.type
@@ -1239,7 +1224,7 @@ class RegularArray(RegularMeta[Content], Content):
         if array_param == "string":
             offsets = self._compact_offsets64(True)
             # Determine the widest string (in code points)
-            _max_code_points = backend.index_nplike.empty(1, dtype=np.int64)
+            _max_code_points = backend.nplike.empty(1, dtype=np.int64)
             backend[
                 "awkward_NumpyArray_prepare_utf8_to_utf32_padded",
                 self._content.dtype.type,
@@ -1251,9 +1236,7 @@ class RegularArray(RegularMeta[Content], Content):
                 offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.index_nplike.index_as_shape_item(
-                _max_code_points[0]
-            )
+            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -1292,9 +1275,7 @@ class RegularArray(RegularMeta[Content], Content):
             # ShapeItem is a defined type, but some nplikes don't map onto the entire space; e.g.
             # NumPy never has `None` shape items. We require that if a shape-item is used between nplikes
             # they both be the same "known-shape-ness".
-            assert (
-                self._backend.index_nplike.known_data == self._backend.nplike.known_data
-            )
+            assert self._backend.nplike.known_data == self._backend.nplike.known_data
             return self._backend.nplike.reshape(
                 out[
                     : self._backend.nplike.shape_item_as_index(
@@ -1377,9 +1358,9 @@ class RegularArray(RegularMeta[Content], Content):
         ):
             return [self]
         else:
-            index_nplike = self._backend.index_nplike
+            nplike = self._backend.nplike
             content = self._content[
-                : index_nplike.shape_item_as_index(self._length * self._size)
+                : nplike.shape_item_as_index(self._length * self._size)
             ]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
@@ -1457,9 +1438,9 @@ class RegularArray(RegularMeta[Content], Content):
             raise AssertionError(result)
 
     def to_packed(self, recursive: bool = True) -> Self:
-        index_nplike = self._backend.index_nplike
+        nplike = self._backend.nplike
         length = self._length * self._size
-        content = self._content[: index_nplike.shape_item_as_index(length)]
+        content = self._content[: nplike.shape_item_as_index(length)]
 
         return RegularArray(
             content.to_packed(True) if recursive else content,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -189,9 +189,9 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         return "".join(out)
 
     def to_IndexedOptionArray64(self) -> IndexedOptionArray:
-        arange = self._backend.index_nplike.arange(self._content.length, dtype=np.int64)
+        arange = self._backend.nplike.arange(self._content.length, dtype=np.int64)
         return ak.contents.IndexedOptionArray(
-            ak.index.Index64(arange, nplike=self._backend.index_nplike),
+            ak.index.Index64(arange, nplike=self._backend.nplike),
             self._content,
             parameters=self._parameters,
         )
@@ -200,7 +200,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         return ak.contents.ByteMaskedArray(
             ak.index.Index8(
                 self.mask_as_bool(valid_when).view(np.int8),
-                nplike=self._backend.index_nplike,
+                nplike=self._backend.nplike,
             ),
             self._content,
             valid_when,
@@ -210,11 +210,11 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
     def to_BitMaskedArray(self, valid_when, lsb_order):
         bitlength = math.ceil(self._content.length / 8.0)
         if valid_when:
-            bitmask = self._backend.index_nplike.full(
+            bitmask = self._backend.nplike.full(
                 bitlength, np.uint8(255), dtype=np.uint8
             )
         else:
-            bitmask = self._backend.index_nplike.zeros(bitlength, dtype=np.uint8)
+            bitmask = self._backend.nplike.zeros(bitlength, dtype=np.uint8)
 
         return ak.contents.BitMaskedArray(
             ak.index.IndexU8(bitmask),
@@ -227,11 +227,9 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
     def mask_as_bool(self, valid_when: bool = True) -> ArrayLike:
         if valid_when:
-            return self._backend.index_nplike.ones(self._content.length, dtype=np.bool_)
+            return self._backend.nplike.ones(self._content.length, dtype=np.bool_)
         else:
-            return self._backend.index_nplike.zeros(
-                self._content.length, dtype=np.bool_
-            )
+            return self._backend.nplike.zeros(self._content.length, dtype=np.bool_)
 
     def _getitem_nothing(self):
         return self._content._getitem_range(0, 0)
@@ -279,9 +277,9 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         )
 
     def _nextcarry_outindex(self) -> tuple[int, ak.index.Index64, ak.index.Index64]:
-        counting = self._backend.index_nplike.arange(self._content.length)
-        nextcarry = ak.index.Index64(counting, nplike=self._backend.index_nplike)
-        outindex = ak.index.Index64(counting, nplike=self._backend.index_nplike)
+        counting = self._backend.nplike.arange(self._content.length)
+        nextcarry = ak.index.Index64(counting, nplike=self._backend.nplike)
+        outindex = ak.index.Index64(counting, nplike=self._backend.nplike)
         return 0, nextcarry, outindex
 
     def _getitem_next_jagged(

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -164,7 +164,7 @@ def _impl(
             # Check that indexes are equal
             left_index = left.to_ListOffsetArray64(True).offsets
             right_index = right.to_ListOffsetArray64(True).offsets
-            if not backend.index_nplike.array_equal(left_index.data, right_index.data):
+            if not backend.nplike.array_equal(left_index.data, right_index.data):
                 return False
             # Mixed regular-var
             if left.is_regular and not right.is_regular:
@@ -221,7 +221,7 @@ def _impl(
                     and left.shape == right.shape
                 )
         elif left.is_option and right.is_option:
-            return backend.index_nplike.array_equal(
+            return backend.nplike.array_equal(
                 left.mask_as_bool(True), right.mask_as_bool(True)
             ) and visitor(left.project(), right.project())
         elif left.is_union and right.is_union:
@@ -234,16 +234,16 @@ def _impl(
                     unique,
                     unique_index,
                     *_,
-                ) = backend.index_nplike.unique_all(values)
+                ) = backend.nplike.unique_all(values)
                 # Now re-order `unique` by order of appearance (`unique_index`)
-                return values[backend.index_nplike.sort(unique_index)]
+                return values[backend.nplike.sort(unique_index)]
 
             # Find order of appearance for each union tags, and assume these are one-to-one maps
             left_tag_order = ordered_unique_values(left.tags.data)
             right_tag_order = ordered_unique_values(right.tags.data)
 
             # Create map from left tags to right tags
-            left_tag_to_right_tag = backend.index_nplike.empty(
+            left_tag_to_right_tag = backend.nplike.empty(
                 left_tag_order.size, dtype=np.int64
             )
             left_tag_to_right_tag[left_tag_order] = right_tag_order
@@ -251,7 +251,7 @@ def _impl(
             # Map left tags onto right, such that the result should equal right.tags
             # if the two tag arrays are equivalent
             new_left_tag = left_tag_to_right_tag[left.tags.data]
-            if not backend.index_nplike.all(new_left_tag == right.tags.data):
+            if not backend.nplike.all(new_left_tag == right.tags.data):
                 return False
 
             # Now project out the contents, and check for equality

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -322,12 +322,9 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
             nested_as_index = nested
 
         indexes = [
-            ak.index.Index64(backend.index_nplike.reshape(x, (-1,)))
-            for x in backend.index_nplike.meshgrid(
-                *[
-                    backend.index_nplike.arange(x.length, dtype=np.int64)
-                    for x in layouts
-                ],
+            ak.index.Index64(backend.nplike.reshape(x, (-1,)))
+            for x in backend.nplike.meshgrid(
+                *[backend.nplike.arange(x.length, dtype=np.int64) for x in layouts],
                 indexing="ij",
             )
         ]

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -631,7 +631,7 @@ def _recurse_option_any(
         if isinstance(type_.content, ak.types.UnknownType):
             return ak.contents.IndexedOptionArray(
                 ak.index.Index64(
-                    layout.backend.index_nplike.full(layout.length, -1, dtype=np.int64)
+                    layout.backend.nplike.full(layout.length, -1, dtype=np.int64)
                 ),
                 ak.forms.from_type(type_.content).length_zero_array(
                     backend=layout.backend
@@ -644,19 +644,19 @@ def _recurse_option_any(
                 # If so, convert to packed so that any non-referenced content items are trimmed
                 # This is required so that unused union items are seen to be safe to project out later
                 # We don't use to_packed(), as it recurses
-                index_nplike = layout.backend.index_nplike
-                new_index = index_nplike.empty(layout.length, dtype=np.int64)
+                nplike = layout.backend.nplike
+                new_index = nplike.empty(layout.length, dtype=np.int64)
 
                 is_none = layout.mask_as_bool(False)
-                num_none = index_nplike.count_nonzero(is_none)
+                num_none = nplike.count_nonzero(is_none)
 
                 new_index[is_none] = -1
-                new_index[~is_none] = index_nplike.arange(
+                new_index[~is_none] = nplike.arange(
                     layout.length - num_none,
                     dtype=new_index.dtype,
                 )
                 return ak.contents.IndexedOptionArray(
-                    ak.index.Index64(new_index, nplike=index_nplike),
+                    ak.index.Index64(new_index, nplike=nplike),
                     _enforce_type(layout.project(), type_.content),
                     parameters=layout._parameters,
                 )
@@ -671,7 +671,7 @@ def _recurse_option_any(
         # Check that we can build the content
         content_enforceable = _type_is_enforceable(layout.content, type_)
 
-        if layout.backend.index_nplike.any(layout.mask_as_bool(False)):
+        if layout.backend.nplike.any(layout.mask_as_bool(False)):
             raise ValueError(
                 "option types can only be removed if there are no missing values"
             )
@@ -699,7 +699,7 @@ def _recurse_any_option(
     if isinstance(type_.content, ak.types.UnknownType):
         return ak.contents.IndexedOptionArray(
             ak.index.Index64(
-                layout.backend.index_nplike.full(layout.length, -1, dtype=np.int64)
+                layout.backend.nplike.full(layout.length, -1, dtype=np.int64)
             ),
             ak.forms.from_type(type_.content).length_zero_array(backend=layout.backend),
         )
@@ -806,7 +806,7 @@ def _recurse_union_union(
             layout_tags = layout.tags
         else:
             layout_tags = ak.index.Index8.empty(
-                layout.tags.length, layout.backend.index_nplike
+                layout.tags.length, layout.backend.nplike
             )
 
         # Ensure that the union references all of the tags of the permutation,
@@ -820,13 +820,9 @@ def _recurse_union_union(
                 layout_tags.data[layout_tag_is_i] = j
 
             # Keep track of the length of layout subcontent
-            _total_used_tags += layout.backend.index_nplike.count_nonzero(
-                layout_tag_is_i
-            )
+            _total_used_tags += layout.backend.nplike.count_nonzero(layout_tag_is_i)
         # Is the new union of the same length as the original?
-        total_used_tags = layout.backend.index_nplike.index_as_shape_item(
-            _total_used_tags
-        )
+        total_used_tags = layout.backend.nplike.index_as_shape_item(_total_used_tags)
         if not (
             total_used_tags is unknown_length
             or layout.length is unknown_length
@@ -890,11 +886,11 @@ def _recurse_union_union(
                             layout_content = layout.project(tag)
                             # Rebuild the index as an enumeration over the (dense) projection
                             # This ensures that it is packed!
-                            index_data = layout.backend.index_nplike.asarray(
+                            index_data = layout.backend.nplike.asarray(
                                 layout.index.data, copy=True
                             )
                             is_tag = layout.tags.data == tag
-                            index_data[is_tag] = layout.backend.index_nplike.arange(
+                            index_data[is_tag] = layout.backend.nplike.arange(
                                 layout_content.length, dtype=index_data.dtype
                             )
                             index = ak.index.Index(index_data)
@@ -922,19 +918,17 @@ def _recurse_union_union(
 def _recurse_union_non_union(
     layout: ak.contents.UnionArray, type_: ak.types.Type
 ) -> ak.contents.Content:
-    index_nplike = layout.backend.index_nplike
+    nplike = layout.backend.nplike
     if all(_type_is_enforceable(c, type_).is_enforceable for c in layout.contents):
         # Convert each projected content to the required type
         next_contents = []
-        index_data = index_nplike.empty(layout.length, dtype=np.int64)
+        index_data = nplike.empty(layout.length, dtype=np.int64)
         j = 0
         for tag in range(len(layout.contents)):
             tag_content = layout.project(tag)
             # Set the index of these tags to a simple range
-            i, j = j, j + index_nplike.shape_item_as_index(tag_content.length)
-            index_data[layout.tags.data == tag] = index_nplike.arange(
-                i, j, dtype=np.int64
-            )
+            i, j = j, j + nplike.shape_item_as_index(tag_content.length)
+            index_data[layout.tags.data == tag] = nplike.arange(i, j, dtype=np.int64)
             # Convert layout
             next_contents.append(_enforce_type(tag_content, type_))
 
@@ -959,7 +953,7 @@ def _recurse_union_non_union(
 
         # Require that we are the only content
         content_is_tag = layout.tags.data == tag
-        if index_nplike.known_data and not index_nplike.all(content_is_tag):
+        if nplike.known_data and not nplike.all(content_is_tag):
             raise ValueError(
                 f"UnionArray(s) can only be converted to {type_} if they are equivalent to their "
                 f"projections"
@@ -977,15 +971,15 @@ def _recurse_union_non_union(
 def _recurse_any_union(
     layout: ak.contents.Content, type_: ak.types.UnionType
 ) -> ak.contents.Content:
-    index_nplike = layout.backend.index_nplike
+    nplike = layout.backend.nplike
 
     for i, content_type in enumerate(type_.contents):
         if not _layout_has_type(layout, content_type):
             continue
 
         # Build zero-length contents from the new types
-        tags = index_nplike.zeros(layout.length, dtype=np.int8)
-        index = index_nplike.arange(layout.length, dtype=np.int64)
+        tags = nplike.zeros(layout.length, dtype=np.int8)
+        index = nplike.arange(layout.length, dtype=np.int64)
 
         other_contents = [
             ak.forms.from_type(t).length_zero_array(backend=layout.backend)
@@ -994,8 +988,8 @@ def _recurse_any_union(
         ]
 
         return ak.contents.UnionArray(
-            tags=ak.index.Index8(tags, nplike=index_nplike),
-            index=ak.index.Index64(index, nplike=index_nplike),
+            tags=ak.index.Index8(tags, nplike=nplike),
+            index=ak.index.Index64(index, nplike=nplike),
             contents=[
                 _enforce_type(layout, content_type),
                 *other_contents,
@@ -1129,7 +1123,7 @@ def _recurse_record_any(
                 next_contents.append(
                     ak.contents.IndexedOptionArray(
                         ak.index.Index64(
-                            layout.backend.index_nplike.full(
+                            layout.backend.nplike.full(
                                 layout.length, -1, dtype=np.int64
                             )
                         ),
@@ -1176,7 +1170,7 @@ def _recurse_record_any(
                 next_contents.append(
                     ak.contents.IndexedOptionArray(
                         ak.index.Index64(
-                            layout.backend.index_nplike.full(
+                            layout.backend.nplike.full(
                                 layout.length, -1, dtype=np.int64
                             )
                         ),

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -8,6 +8,7 @@ from itertools import permutations
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
+from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import unknown_length
 from awkward._parameters import type_parameters_equal
@@ -650,11 +651,20 @@ def _recurse_option_any(
                 is_none = layout.mask_as_bool(False)
                 num_none = nplike.count_nonzero(is_none)
 
-                new_index[is_none] = -1
-                new_index[~is_none] = nplike.arange(
-                    layout.length - num_none,
-                    dtype=new_index.dtype,
-                )
+                if isinstance(nplike, Jax):
+                    new_index = new_index.at[is_none].set(-1)
+                    new_index = new_index.at[~is_none].set(
+                        nplike.arange(
+                            layout.length - num_none,
+                            dtype=new_index.dtype,
+                        )
+                    )
+                else:
+                    new_index[is_none] = -1
+                    new_index[~is_none] = nplike.arange(
+                        layout.length - num_none,
+                        dtype=new_index.dtype,
+                    )
                 return ak.contents.IndexedOptionArray(
                     ak.index.Index64(new_index, nplike=nplike),
                     _enforce_type(layout.project(), type_.content),

--- a/src/awkward/operations/ak_firsts.py
+++ b/src/awkward/operations/ak_firsts.py
@@ -98,7 +98,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
 
             if posaxis == depth and layout.is_list:
                 # this is a copy of the raw array
-                index = starts = backend.index_nplike.asarray(
+                index = starts = backend.nplike.asarray(
                     layout.starts.data, dtype=np.int64, copy=True
                 )
 

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -223,10 +223,8 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     return layout
 
                 tags = layout.tags.data
-                index = layout.backend.index_nplike.asarray(
-                    layout.index.data, copy=True
-                )
-                big_mask = layout.backend.index_nplike.empty(
+                index = layout.backend.nplike.asarray(layout.index.data, copy=True)
+                big_mask = layout.backend.nplike.empty(
                     layout.index.length, dtype=np.bool_
                 )
                 for tag, content in enumerate(layout.contents):

--- a/src/awkward/operations/ak_full_like.py
+++ b/src/awkward/operations/ak_full_like.py
@@ -121,7 +121,7 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
 
     def action(layout, backend, **kwargs):
         nplike = backend.nplike
-        index_nplike = backend.index_nplike
+        nplike = backend.nplike
 
         if layout.is_numpy:
             original = nplike.asarray(layout.data)
@@ -166,12 +166,12 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
                 asbytes = nplike.frombuffer(b"", dtype=np.uint8)
                 result = ak.contents.ListArray(
                     ak.index.Index64(
-                        index_nplike.zeros(layout.length, dtype=np.int64),
-                        nplike=index_nplike,
+                        nplike.zeros(layout.length, dtype=np.int64),
+                        nplike=nplike,
                     ),
                     ak.index.Index64(
-                        index_nplike.zeros(layout.length, dtype=np.int64),
-                        nplike=index_nplike,
+                        nplike.zeros(layout.length, dtype=np.int64),
+                        nplike=nplike,
                     ),
                     ak.contents.NumpyArray(
                         asbytes,
@@ -197,11 +197,11 @@ def _impl(array, fill_value, highlevel, behavior, dtype, including_unknown, attr
                 asbytes = nplike.frombuffer(asbytes, dtype=np.uint8)
                 result = ak.contents.ListArray(
                     ak.index.Index64(
-                        index_nplike.zeros(layout.length, dtype=np.int64),
-                        nplike=index_nplike,
+                        nplike.zeros(layout.length, dtype=np.int64),
+                        nplike=nplike,
                     ),
                     ak.index.Index64(
-                        index_nplike.full(layout.length, len(asbytes), dtype=np.int64)
+                        nplike.full(layout.length, len(asbytes), dtype=np.int64)
                     ),
                     ak.contents.NumpyArray(
                         asbytes, parameters={"__array__": charlike_type}

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -75,7 +75,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
     def invert_record_union(
         tags: ArrayLike, index: ArrayLike, contents
     ) -> ak.contents.RecordArray:
-        index_nplike = layout.backend.index_nplike
+        nplike = layout.backend.nplike
         # First, create an ordered list containing the union of all fields
         seen_fields = set()
         all_fields = []
@@ -89,8 +89,8 @@ def _impl(array, axis, highlevel, behavior, attrs):
         # Build unions for each field
         outer_field_contents = []
         for field in all_fields:
-            field_tags = index_nplike.asarray(tags.data, copy=True)
-            field_index = index_nplike.asarray(index.data, copy=True)
+            field_tags = nplike.asarray(tags.data, copy=True)
+            field_index = nplike.asarray(index.data, copy=True)
 
             # Build contents for union representing current field
             field_contents = [c.content(field) for c in contents if c.has_field(field)]
@@ -111,11 +111,11 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 # Make the tagged content an option, growing by one to ensure we
                 # have a known `None` value to index into
                 tagged_content = field_contents[tag_for_missing]
-                indexedoption_index = index_nplike.arange(
+                indexedoption_index = nplike.arange(
                     tagged_content.length + 1, dtype=np.int64
                 )
                 indexedoption_index[
-                    index_nplike.shape_item_as_index(tagged_content.length)
+                    nplike.shape_item_as_index(tagged_content.length)
                 ] = -1
                 field_contents[tag_for_missing] = (
                     ak.contents.IndexedOptionArray.simplified(
@@ -124,7 +124,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 )
 
             # Index of None values in tagged content (content with extra None item at end)
-            index_missing = index_nplike.shape_item_as_index(
+            index_missing = nplike.shape_item_as_index(
                 field_contents[tag_for_missing].length - 1
             )
             # Now build contents for union, by looping over outermost index
@@ -160,10 +160,10 @@ def _impl(array, axis, highlevel, behavior, attrs):
         # Find dense (outer) index into non-null items.
         # This is in trivial order: the re-arranging is done by the union (below)
         is_none = index < 0
-        num_none = layout.backend.index_nplike.count_nonzero(is_none)
-        dense_index = layout.backend.index_nplike.empty(index.size, dtype=index.dtype)
+        num_none = layout.backend.nplike.count_nonzero(is_none)
+        dense_index = layout.backend.nplike.empty(index.size, dtype=index.dtype)
         dense_index[is_none] = -1
-        dense_index[~is_none] = layout.backend.index_nplike.arange(
+        dense_index[~is_none] = layout.backend.nplike.arange(
             index.size - num_none,
             dtype=index.dtype,
         )
@@ -190,7 +190,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 # We'll rebuild the union to include only the non-null items.
                 inner_union_index_parts = []
                 next_contents = []
-                next_tags_data_sparse = backend.index_nplike.asarray(
+                next_tags_data_sparse = backend.nplike.asarray(
                     layout.tags.data, copy=True
                 )
                 for tag, content in enumerate(layout.contents):
@@ -214,7 +214,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
                         is_non_null = merged_index >= 0
                         inner_union_index_parts.append(merged_index[is_non_null])
                         # Mask out tags of items that are missing
-                        next_tags_data_sparse[is_this_tag] = backend.index_nplike.where(
+                        next_tags_data_sparse[is_this_tag] = backend.nplike.where(
                             is_non_null, tag, -1
                         )
 
@@ -234,7 +234,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 # Ignore missing items for inner union, creating a dense array of tags
                 next_tags_data = next_tags_data_sparse[next_tags_data_sparse >= 0]
                 # Build dense index from parts for each tag
-                next_index_data = backend.index_nplike.empty(
+                next_index_data = backend.nplike.empty(
                     next_tags_data.size, dtype=np.int64
                 )
                 for tag, content_index in enumerate(inner_union_index_parts):
@@ -249,7 +249,7 @@ def _impl(array, axis, highlevel, behavior, attrs):
             # Any index types need to be re-written
             elif any(x.is_indexed for x in layout.contents):
                 # We'll create an outermost indexed-option type, which re-instates the missing values
-                next_index_data = backend.index_nplike.empty(
+                next_index_data = backend.nplike.empty(
                     layout.index.length, dtype=np.int64
                 )
 

--- a/src/awkward/operations/ak_nan_to_none.py
+++ b/src/awkward/operations/ak_nan_to_none.py
@@ -47,7 +47,7 @@ def _impl(array, highlevel: bool, behavior: Mapping | None, attrs: Mapping | Non
         if layout.is_numpy and np.issubdtype(layout.dtype, np.floating):
             mask = backend.nplike.isnan(layout.data)
             return ak.contents.ByteMaskedArray(
-                ak.index.Index8(mask, nplike=backend.index_nplike),
+                ak.index.Index8(mask, nplike=backend.nplike),
                 layout,
                 valid_when=False,
             )

--- a/src/awkward/operations/ak_num.py
+++ b/src/awkward/operations/ak_num.py
@@ -117,11 +117,11 @@ def _impl(
     axis = regularize_axis(axis, none_allowed=False)
 
     if maybe_posaxis(layout, axis, 1) == 0:
-        index_nplike = layout.backend.index_nplike
+        nplike = layout.backend.nplike
         if isinstance(layout, ak.record.Record):
-            return index_nplike.asarray(index_nplike.shape_item_as_index(1))
+            return nplike.asarray(nplike.shape_item_as_index(1))
         else:
-            return index_nplike.asarray(index_nplike.shape_item_as_index(layout.length))
+            return nplike.asarray(nplike.shape_item_as_index(layout.length))
 
     def action(layout, depth, **kwargs):
         posaxis = maybe_posaxis(layout, axis, depth)

--- a/src/awkward/operations/ak_run_lengths.py
+++ b/src/awkward/operations/ak_run_lengths.py
@@ -110,7 +110,7 @@ def _impl(array, highlevel, behavior, attrs):
             size = ak.to_layout(data).length
 
         if size is not unknown_length and size == 0:
-            return backend.index_nplike.empty(0, dtype=np.int64), offsets
+            return backend.nplike.empty(0, dtype=np.int64), offsets
         else:
             diffs = backend.nplike.asarray(data[1:] != data[:-1])
             # Do we have list boundaries to consider?
@@ -125,25 +125,23 @@ def _impl(array, highlevel, behavior, attrs):
                 #                                      boundary diff ^
                 # To consider only the interior boundaries, we ignore the start and end
                 # offset values. These can be repeated with empty sublists, so we mask them out.
-                is_interior = backend.index_nplike.logical_and(
+                is_interior = backend.nplike.logical_and(
                     0 < offsets,
-                    offsets < backend.index_nplike.shape_item_as_index(size),
+                    offsets < backend.nplike.shape_item_as_index(size),
                 )
                 interior_offsets = offsets[is_interior]
                 diffs[interior_offsets - 1] = True
-            positions = backend.index_nplike.nonzero(diffs)[0]
-            full_positions = backend.index_nplike.empty(
-                positions.size + 2, dtype=np.int64
-            )
+            positions = backend.nplike.nonzero(diffs)[0]
+            full_positions = backend.nplike.empty(positions.size + 2, dtype=np.int64)
             full_positions[0] = 0
-            full_positions[-1] = backend.index_nplike.shape_item_as_index(size)
+            full_positions[-1] = backend.nplike.shape_item_as_index(size)
             full_positions[1:-1] = positions + 1
 
             nextcontent = full_positions[1:] - full_positions[:-1]
             if offsets is None:
                 nextoffsets = None
             else:
-                nextoffsets = backend.index_nplike.searchsorted(
+                nextoffsets = backend.nplike.searchsorted(
                     full_positions, offsets, side="left"
                 )
             return nextcontent, nextoffsets

--- a/src/awkward/operations/ak_singletons.py
+++ b/src/awkward/operations/ak_singletons.py
@@ -85,10 +85,10 @@ def _impl(array, axis, highlevel, behavior, attrs):
                 return None
 
             elif layout.is_option:
-                offsets = backend.index_nplike.empty(layout.length + 1, dtype=np.int64)
+                offsets = backend.nplike.empty(layout.length + 1, dtype=np.int64)
                 offsets[0] = 0
 
-                backend.index_nplike.cumsum(
+                backend.nplike.cumsum(
                     layout.mask_as_bool(valid_when=True), maybe_out=offsets[1:]
                 )
 

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -178,7 +178,7 @@ or
             starts, stops = offsets.data[:-1], offsets.data[1:]
             counts = stops - starts
             if ak._util.win or ak._util.bits32:
-                counts = layout.backend.index_nplike.astype(counts, np.int32)
+                counts = layout.backend.nplike.astype(counts, np.int32)
             if len(row_arrays) == 0:
                 newrows = [
                     numpy.repeat(numpy.arange(len(counts), dtype=counts.dtype), counts)
@@ -325,9 +325,7 @@ def _union_to_record(unionarray, anonymous):
 
         missingarray = ak.contents.IndexedOptionArray(
             ak.index.Index64(
-                unionarray.backend.index_nplike.full(
-                    unionarray.length, -1, dtype=np.int64
-                )
+                unionarray.backend.nplike.full(unionarray.length, -1, dtype=np.int64)
             ),
             ak.contents.EmptyArray(),
         )

--- a/src/awkward/operations/ak_where.py
+++ b/src/awkward/operations/ak_where.py
@@ -93,11 +93,11 @@ def _impl3(condition, x, y, mergebool, highlevel, behavior, attrs):
     def action(inputs, backend, **kwargs):
         x, y, condition = inputs
         if isinstance(condition, ak.contents.NumpyArray):
-            npcondition = backend.index_nplike.asarray(condition.data)
+            npcondition = backend.nplike.asarray(condition.data)
             tags = ak.index.Index8((npcondition == 0).view(np.int8))
             index = ak.index.Index64(
-                backend.index_nplike.arange(tags.length, dtype=np.int64),
-                nplike=backend.index_nplike,
+                backend.nplike.arange(tags.length, dtype=np.int64),
+                nplike=backend.nplike,
             )
             if not isinstance(x, ak.contents.Content):
                 x = ak.contents.NumpyArray(

--- a/src/awkward/operations/ak_with_field.py
+++ b/src/awkward/operations/ak_with_field.py
@@ -129,8 +129,8 @@ def _impl(base, what, where, highlevel, behavior, attrs):
                 if what is None:
                     what = ak.contents.IndexedOptionArray(
                         ak.index.Index64(
-                            backend.index_nplike.full(base.length, -1, dtype=np.int64),
-                            nplike=backend.index_nplike,
+                            backend.nplike.full(base.length, -1, dtype=np.int64),
+                            nplike=backend.nplike,
                         ),
                         ak.contents.EmptyArray(),
                     )

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -96,11 +96,11 @@ def _drop_option_preserving_form(layout, ensure_empty_mask: bool = False):
         elif isinstance(this, UnmaskedArray):
             return this.content
         else:
-            index_nplike = this.backend.index_nplike
+            nplike = this.backend.nplike
             assert not (
                 ensure_empty_mask
-                and index_nplike.known_data
-                and index_nplike.any(this.mask_as_bool(valid_when=False))
+                and nplike.known_data
+                and nplike.any(this.mask_as_bool(valid_when=False))
             ), "did not expect option type, but arrow returned a non-erasable option"
             # Re-write indexed options as indexed
             if isinstance(this, IndexedOptionArray):

--- a/tests/test_1850_bytemasked_array_to_bytemaskedarray.py
+++ b/tests/test_1850_bytemasked_array_to_bytemaskedarray.py
@@ -17,7 +17,7 @@ def test():
     result = layout.to_ByteMaskedArray(False)
     assert layout.to_list() == [None, 1, None, 3, None]
     assert result.to_list() == [None, 1, None, 3, None]
-    assert layout.backend.index_nplike.asarray(result.mask.data).tolist() == [
+    assert layout.backend.nplike.asarray(result.mask.data).tolist() == [
         1,
         0,
         1,

--- a/tests/test_2263_to_packed_list.py
+++ b/tests/test_2263_to_packed_list.py
@@ -12,9 +12,7 @@ from awkward._backends.typetracer import TypeTracerBackend
 def test():
     backend = TypeTracerBackend.instance()
     layout = ak.contents.ListOffsetArray(
-        ak.index.Index64(
-            backend.index_nplike.asarray([0, 1, 3, 7], dtype=np.dtype("int64"))
-        ),
+        ak.index.Index64(backend.nplike.asarray([0, 1, 3, 7], dtype=np.dtype("int64"))),
         ak.contents.NumpyArray(backend.nplike.asarray([1, 2, 3, 4, 5, 6, 7])),
     )
     assert layout.to_packed().length == 3

--- a/tests/test_2656_unflatten_axis_typetracer.py
+++ b/tests/test_2656_unflatten_axis_typetracer.py
@@ -91,13 +91,9 @@ def test():
     result = ak.unflatten(ttarray.muon.pt, ttarray.anindex, axis=1)
     assert result.layout.is_equal_to(
         ak.contents.ListOffsetArray(
-            ak.index.Index64(
-                backend.index_nplike.empty(unknown_length, dtype=np.int64)
-            ),
+            ak.index.Index64(backend.nplike.empty(unknown_length, dtype=np.int64)),
             ak.contents.ListOffsetArray(
-                ak.index.Index64(
-                    backend.index_nplike.empty(unknown_length, dtype=np.int64)
-                ),
+                ak.index.Index64(backend.nplike.empty(unknown_length, dtype=np.int64)),
                 ak.contents.NumpyArray(
                     backend.nplike.empty(unknown_length, dtype=np.int64)
                 ),


### PR DESCRIPTION
This PR makes the jax backend _only_ use jax arrays (no more mixing with numpy arrays). This was the only motivation to split `nplike` and `index_nplike` so far, which is why `index_nplike` is now entirely dropped. 

In addition, this PR enables (fancier) slicing with the jax backend (I had to introduce Jax's set/getitem syntax where needed), such as:
```python
import awkward as ak

ak.jax.register_and_check()

array = ak.Array({"foo": [[1], [], [3]]}, backend="jax")
array.foo[array.foo>2]
>> <Array [[], [], [3]] type='3 * var * int64'> 

# and
array[array.foo>2]
>> <Array [{foo: []}, {...}, {foo: [3]}] type='3 * {foo: var * int64}'>

# or
array = ak.Array([[1.0, 2.0, 3.0], [], [4.0, 5.0]], backend="jax")
array[array>2.0]
>> <Array [[3.0], [], [4.0, 5.0]] type='3 * var * float64'>
```
None of these cuts are possible with the current jax backend.