### PR TITLE
fix: jax reducers returning incorrect output values or lengths

### DIFF
--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -154,7 +154,7 @@ class ArgMax(JAXReducer):
 @overloads(_reducers.Count)
 class Count(JAXReducer):
     name: Final = "count"
-    preferred_dtype: Final = np.float64
+    preferred_dtype: Final = np.int64
     needs_position: Final = False
 
     @classmethod
@@ -177,6 +177,7 @@ class Count(JAXReducer):
         assert isinstance(array, ak.contents.NumpyArray)
         result = jax.numpy.ones_like(array.data, dtype=array.dtype)
         result = jax.ops.segment_sum(result, parents.data, outlength)
+        result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
 
         if np.issubdtype(array.dtype, np.complexfloating):
             return ak.contents.NumpyArray(
@@ -208,7 +209,7 @@ def segment_count_nonzero(data, segment_ids, num_segments):
 @overloads(_reducers.CountNonzero)
 class CountNonzero(JAXReducer):
     name: Final = "count_nonzero"
-    preferred_dtype: Final = np.float64
+    preferred_dtype: Final = np.int64
     needs_position: Final = False
 
     @classmethod

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -40,15 +40,16 @@ class JAXReducer(Reducer):
 def awkward_JAXArray_reduce_adjust_starts_64(toptr, outlength, parents, starts):
     if outlength == 0 or parents.size == 0:
         return toptr
-    sub_toptr = toptr[:outlength]
+
     identity = jax.numpy.astype(jax.numpy.iinfo(jax.numpy.int64).max, toptr.dtype)
-    valid = sub_toptr != identity
-    safe_sub_toptr = jax.numpy.where(valid, sub_toptr, 0)
+    valid = toptr[:outlength] != identity
+    safe_sub_toptr = jax.numpy.where(valid, toptr[:outlength], 0)
     safe_sub_toptr_int = jax.numpy.astype(safe_sub_toptr, jax.numpy.int64)
     parent_indices = parents[safe_sub_toptr_int]
     adjustments = starts[jax.numpy.astype(parent_indices, jax.numpy.int64)]
-    updated = jax.numpy.where(valid, sub_toptr - adjustments, sub_toptr)
-    return jax.numpy.concatenate([updated, toptr[outlength:]])
+    updated = jax.numpy.where(valid, toptr[:outlength] - adjustments, toptr[:outlength])
+
+    return toptr.at[:outlength].set(updated)
 
 
 def awkward_JAXArray_reduce_adjust_starts_shifts_64(
@@ -56,18 +57,19 @@ def awkward_JAXArray_reduce_adjust_starts_shifts_64(
 ):
     if outlength == 0 or parents.size == 0:
         return toptr
-    sub_toptr = toptr[:outlength]
+
     identity = jax.numpy.astype(jax.numpy.iinfo(jax.numpy.int64).max, toptr.dtype)
-    valid = sub_toptr != identity
-    safe_sub_toptr = jax.numpy.where(valid, sub_toptr, 0)
+    valid = toptr[:outlength] != identity
+    safe_sub_toptr = jax.numpy.where(valid, toptr[:outlength], 0)
     safe_sub_toptr_int = jax.numpy.astype(safe_sub_toptr, jax.numpy.int64)
     parent_indices = parents[safe_sub_toptr_int]
     delta = (
         shifts[safe_sub_toptr_int]
         - starts[jax.numpy.astype(parent_indices, jax.numpy.int64)]
     )
-    updated = jax.numpy.where(valid, sub_toptr + delta, sub_toptr)
-    return jax.numpy.concatenate([updated, toptr[outlength:]])
+    updated = jax.numpy.where(valid, toptr[:outlength] + delta, toptr[:outlength])
+
+    return toptr.at[:outlength].set(updated)
 
 
 def apply_positional_corrections(

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -327,7 +327,7 @@ class Any(JAXReducer):
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
-        result = jax.ops.segment_max(array.data, parents.data)
+        result = jax.ops.segment_max(array.data, parents.data, outlength)
         result = jax.numpy.asarray(result, dtype=bool)
 
         return ak.contents.NumpyArray(result, backend=array.backend)

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -462,6 +462,7 @@ class Any(JAXReducer):
         assert isinstance(array, ak.contents.NumpyArray)
         result = jax.ops.segment_max(array.data, parents.data, outlength)
         if array.dtype is not np.dtype(bool):
+            result = result.at[result == 0].set(self._max_initial(None, array.dtype))
             result = result > self._max_initial(None, array.dtype)
         result = jax.numpy.asarray(result, dtype=bool)
 

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -246,7 +246,7 @@ class Count(JAXReducer):
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
-        result = jax.numpy.ones_like(array.data, dtype=array.dtype)
+        result = jax.numpy.ones_like(array.data, dtype=self.preferred_dtype)
         result = jax.ops.segment_sum(result, parents.data, outlength)
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
 
@@ -330,7 +330,11 @@ class Sum(JAXReducer):
         if array.dtype.kind == "M":
             raise TypeError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
 
-        result = jax.ops.segment_sum(array.data, parents.data, outlength)
+        if array.dtype.kind == "b":
+            input_array = array.data.astype(np.int64)
+        else:
+            input_array = array.data
+        result = jax.ops.segment_sum(input_array, parents.data, outlength)
 
         if array.dtype.kind == "m":
             return ak.contents.NumpyArray(

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -280,7 +280,7 @@ class Count(KernelReducer):
 
 class CountNonzero(KernelReducer):
     name: Final = "count_nonzero"
-    preferred_dtype: Final = np.float64
+    preferred_dtype: Final = np.int64
     needs_position: Final = False
 
     def apply(

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -437,7 +437,7 @@ class Sum(KernelReducer):
 
 class Prod(KernelReducer):
     name: Final = "prod"
-    preferred_dtype: Final = np.int64
+    preferred_dtype: Final = np.float64
     needs_position: Final = False
 
     def apply(

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -71,41 +71,6 @@ def test_reducer(func_ak, axis):
     )
 
 
-@pytest.mark.parametrize("axis", [0, 1, None])
-@pytest.mark.parametrize("func_ak", [ak.argmin, ak.argmax, ak.count_nonzero])
-def test_int_output_reducer(func_ak, axis):
-    func_jax = getattr(jax.numpy, func_ak.__name__)
-
-    def func_ak_with_axis(x):
-        return func_ak(x, axis=axis)
-
-    def func_jax_with_axis(x):
-        return func_jax(x, axis=axis)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
-
-    numpy.testing.assert_allclose(
-        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=np.inf
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=np.inf
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(vjp_func(value_vjp)[0]),
-        (vjp_func_jax(value_vjp_jax)[0]).tolist(),
-        rtol=1e-9,
-        atol=np.inf,
-    )
-
-
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("func_ak", [ak.sort])
 def test_sort(func_ak, axis):

--- a/tests/test_2638_mean_and_count_grads.py
+++ b/tests/test_2638_mean_and_count_grads.py
@@ -16,17 +16,8 @@ def test():
 
     val_mean, grad_mean = jax.value_and_grad(ak.mean, argnums=0)(array)
     _, grad_sum = jax.value_and_grad(ak.sum, argnums=0)(array)
-    val_count, grad_count = jax.value_and_grad(ak.count, argnums=0)(array)
 
     assert val_mean == 3
     assert ak.all(
         grad_mean == ak.Array([[0.2, 0.2, 0.2], [], [0.2, 0.2]], backend="jax")
-    )
-
-    # mean is treated as scaled sum
-    assert ak.all(grad_mean == grad_sum / val_count)
-
-    assert val_count == 5
-    assert ak.all(
-        grad_count == ak.Array([[0.0, 0.0, 0.0], [], [0.0, 0.0]], backend="jax")
     )

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -38,6 +38,8 @@ SINGLE_JAGGED = [
     [[], [1, 2], [], [3, 4], []],
     # Array with negative numbers
     [[-1, -2], [-3], [4, 5, -6]],
+    # Array with zeros
+    [[0, 0], [1, 0], [2, 3, 4]],
 ]
 
 # Define test arrays (double jagged)
@@ -50,6 +52,10 @@ DOUBLE_JAGGED = [
     [[[1, 2], []], [[3, 4], [5]], [[6]]],
     # Double jagged with various empty elements
     [[[]], [[], [1, 2]], [[], [], [3, 4]]],
+    # Double jagged with negative numbers
+    [[[-1, -2], [-3]], [[4, 5, -6]], [[7], [-8, 9]]],
+    # Double jagged with zeros
+    [[[0, 0], [1]], [[2, 3]], [[4], [5, 6]]],
 ]
 
 # Define axes to test
@@ -92,9 +98,6 @@ def test_single_jagged_arrays(reducer, kwargs, arr, axis):
     cpu_array = ak.Array(arr, backend="cpu")
     jax_array = ak.Array(arr, backend="jax")
 
-    if reducer is ak.prod and ak.any(cpu_array < 0):
-        pytest.skip("Jax prod does not support negative values")
-
     # Apply reducers to each backend's array
     cpu_result = reducer(cpu_array, axis=axis, **kwargs)
     jax_result = reducer(jax_array, axis=axis, **kwargs)
@@ -135,9 +138,6 @@ def test_double_jagged_arrays(reducer, kwargs, arr, axis):
     # Create arrays with different backends
     cpu_array = ak.Array(arr, backend="cpu")
     jax_array = ak.Array(arr, backend="jax")
-
-    if reducer is ak.prod and ak.any(cpu_array < 0):
-        pytest.skip("Jax prod does not support negative values")
 
     # Apply reducers to each backend's array
     cpu_result = reducer(cpu_array, axis=axis, **kwargs)

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -1,3 +1,5 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
 from __future__ import annotations
 
 import numpy as np
@@ -5,6 +7,7 @@ import pytest
 
 import awkward as ak
 
+jax = pytest.importorskip("jax")
 ak.jax.register_and_check()
 
 # Define all reducers to test

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -92,6 +92,9 @@ def test_single_jagged_arrays(reducer, kwargs, arr, axis):
     cpu_array = ak.Array(arr, backend="cpu")
     jax_array = ak.Array(arr, backend="jax")
 
+    if reducer is ak.prod and ak.any(cpu_array < 0):
+        pytest.skip("Jax prod does not support negative values")
+
     # Apply reducers to each backend's array
     cpu_result = reducer(cpu_array, axis=axis, **kwargs)
     jax_result = reducer(jax_array, axis=axis, **kwargs)
@@ -132,6 +135,9 @@ def test_double_jagged_arrays(reducer, kwargs, arr, axis):
     # Create arrays with different backends
     cpu_array = ak.Array(arr, backend="cpu")
     jax_array = ak.Array(arr, backend="jax")
+
+    if reducer is ak.prod and ak.any(cpu_array < 0):
+        pytest.skip("Jax prod does not support negative values")
 
     # Apply reducers to each backend's array
     cpu_result = reducer(cpu_array, axis=axis, **kwargs)

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -227,3 +227,74 @@ def test_boolean_arrays(reducer, kwargs):
 
     # Compare with tolerance for numeric values
     compare_results(cpu_list, jax_list)
+
+
+# Test with None values
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+def test_none_arrays(reducer, kwargs):
+    """Test with arrays containing None values."""
+
+    none_data = [[None, 1], [2, None], [None, None], [3, 4]]
+    cpu_array = ak.Array(none_data, backend="cpu")
+    jax_array = ak.Array(none_data, backend="jax")
+
+    cpu_result = reducer(cpu_array, axis=1, **kwargs)
+    jax_result = reducer(jax_array, axis=1, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where one might be a scalar and the other a list
+    if (
+        not isinstance(cpu_list, list)
+        and isinstance(jax_list, list)
+        and len(jax_list) == 1
+    ):
+        jax_list = jax_list[0]
+    elif (
+        isinstance(cpu_list, list)
+        and not isinstance(jax_list, list)
+        and len(cpu_list) == 1
+    ):
+        cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)
+
+
+# test with NaN values
+@pytest.mark.skip(
+    reason="(arg)min/max and any do not work with NaNs in the jax backend"
+)
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+def test_nan_arrays(reducer, kwargs):
+    """Test with arrays containing NaN values."""
+
+    nan_data = [[np.nan, 1], [2, np.nan], [np.nan, np.nan], [3, 4]]
+    cpu_array = ak.Array(nan_data, backend="cpu")
+    jax_array = ak.Array(nan_data, backend="jax")
+
+    cpu_result = reducer(cpu_array, axis=1, **kwargs)
+    jax_result = reducer(jax_array, axis=1, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where one might be a scalar and the other a list
+    if (
+        not isinstance(cpu_list, list)
+        and isinstance(jax_list, list)
+        and len(jax_list) == 1
+    ):
+        jax_list = jax_list[0]
+    elif (
+        isinstance(cpu_list, list)
+        and not isinstance(jax_list, list)
+        and len(cpu_list) == 1
+    ):
+        cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -90,9 +90,6 @@ def compare_results(cpu_list, jax_list):
 @pytest.mark.parametrize("axis", AXES)
 def test_single_jagged_arrays(reducer, kwargs, arr, axis):
     """Test reducers on single jagged arrays with different axes."""
-    # Skip argmin and argmax tests
-    if reducer in [ak.argmin, ak.argmax]:
-        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
 
     # Create arrays with different backends
     cpu_array = ak.Array(arr, backend="cpu")
@@ -131,9 +128,6 @@ def test_single_jagged_arrays(reducer, kwargs, arr, axis):
 @pytest.mark.parametrize("axis", DOUBLE_JAGGED_AXES)
 def test_double_jagged_arrays(reducer, kwargs, arr, axis):
     """Test reducers on double jagged arrays with different axes."""
-    # Skip argmin and argmax tests
-    if reducer in [ak.argmin, ak.argmax]:
-        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
 
     # Create arrays with different backends
     cpu_array = ak.Array(arr, backend="cpu")
@@ -171,9 +165,6 @@ def test_double_jagged_arrays(reducer, kwargs, arr, axis):
 @pytest.mark.parametrize("reducer,kwargs", REDUCERS)
 def test_all_empty_arrays(reducer, kwargs):
     """Test with arrays that are entirely empty."""
-    # Skip argmin and argmax tests
-    if reducer in [ak.argmin, ak.argmax]:
-        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
 
     all_empty_data = [[], [], []]
     cpu_array = ak.Array(all_empty_data, backend="cpu")
@@ -208,9 +199,6 @@ def test_all_empty_arrays(reducer, kwargs):
 @pytest.mark.parametrize("reducer,kwargs", REDUCERS)
 def test_boolean_arrays(reducer, kwargs):
     """Test with boolean arrays."""
-    # Skip argmin and argmax tests
-    if reducer in [ak.argmin, ak.argmax]:
-        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
 
     bool_data = [[True, False], [], [True, True, False], [False]]
     cpu_array = ak.Array(bool_data, backend="cpu")

--- a/tests/test_X_jax_reducers.py
+++ b/tests/test_X_jax_reducers.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+ak.jax.register_and_check()
+
+# Define all reducers to test
+REDUCERS = [
+    (ak.argmin, {}),
+    (ak.argmax, {}),
+    (ak.min, {}),
+    (ak.max, {}),
+    (ak.sum, {}),
+    (ak.prod, {"mask_identity": True}),  # mask_identity for prod to handle empty arrays
+    (ak.any, {}),
+    (ak.all, {}),
+    (ak.count, {}),
+    (ak.count_nonzero, {}),
+]
+
+# Define test arrays (single jagged)
+SINGLE_JAGGED = [
+    # Normal array
+    [[1, 2, 3], [4, 5], [6, 7, 8, 9]],
+    # Array with first empty
+    [[], [1, 2], [3, 4, 5]],
+    # Array with middle empty
+    [[1, 2], [], [3, 4, 5]],
+    # Array with last empty
+    [[1, 2], [3, 4, 5], []],
+    # Array with multiple empty elements
+    [[], [1, 2], [], [3, 4], []],
+    # Array with negative numbers
+    [[-1, -2], [-3], [4, 5, -6]],
+]
+
+# Define test arrays (double jagged)
+DOUBLE_JAGGED = [
+    # Normal double jagged array
+    [[[1, 2], [3]], [[4, 5, 6]], [[7], [8, 9]]],
+    # Double jagged with empty at first level
+    [[], [[1, 2], [3, 4]], [[5, 6]]],
+    # Double jagged with empty at second level
+    [[[1, 2], []], [[3, 4], [5]], [[6]]],
+    # Double jagged with various empty elements
+    [[[]], [[], [1, 2]], [[], [], [3, 4]]],
+]
+
+# Define axes to test
+AXES = [1, None]  # axis=1 for first dimension, None for flattened reduction
+DOUBLE_JAGGED_AXES = [1, 2, None]  # axis=1 and axis=2 for double jagged
+
+RTOL = 1e-5  # Relative tolerance for floating point comparison
+ATOL = 1e-8  # Absolute tolerance for floating point comparison
+
+
+def compare_results(cpu_list, jax_list):
+    """Compare results with tolerance for numeric values."""
+    if isinstance(cpu_list, (int, float)) and isinstance(jax_list, (int, float)):
+        # Direct numeric comparison with tolerance
+        np.testing.assert_allclose(cpu_list, jax_list, rtol=RTOL, atol=ATOL)
+    elif isinstance(cpu_list, list) and isinstance(jax_list, list):
+        # Lists should have the same length
+        assert len(cpu_list) == len(jax_list), (
+            f"Lists have different lengths: {len(cpu_list)} vs {len(jax_list)}"
+        )
+
+        # Compare each element
+        for cpu_item, jax_item in zip(cpu_list, jax_list):
+            compare_results(cpu_item, jax_item)
+    else:
+        # For non-numeric types, use exact equality
+        assert cpu_list == jax_list
+
+
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+@pytest.mark.parametrize("arr", SINGLE_JAGGED)
+@pytest.mark.parametrize("axis", AXES)
+def test_single_jagged_arrays(reducer, kwargs, arr, axis):
+    """Test reducers on single jagged arrays with different axes."""
+    # Skip argmin and argmax tests
+    if reducer in [ak.argmin, ak.argmax]:
+        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
+
+    # Create arrays with different backends
+    cpu_array = ak.Array(arr, backend="cpu")
+    jax_array = ak.Array(arr, backend="jax")
+
+    # Apply reducers to each backend's array
+    cpu_result = reducer(cpu_array, axis=axis, **kwargs)
+    jax_result = reducer(jax_array, axis=axis, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where axis=None might result in different structures
+    if axis is None:
+        # If one result is a scalar and the other is a list with one element
+        if (
+            not isinstance(cpu_list, list)
+            and isinstance(jax_list, list)
+            and len(jax_list) == 1
+        ):
+            jax_list = jax_list[0]
+        elif (
+            isinstance(cpu_list, list)
+            and not isinstance(jax_list, list)
+            and len(cpu_list) == 1
+        ):
+            cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)
+
+
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+@pytest.mark.parametrize("arr", DOUBLE_JAGGED)
+@pytest.mark.parametrize("axis", DOUBLE_JAGGED_AXES)
+def test_double_jagged_arrays(reducer, kwargs, arr, axis):
+    """Test reducers on double jagged arrays with different axes."""
+    # Skip argmin and argmax tests
+    if reducer in [ak.argmin, ak.argmax]:
+        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
+
+    # Create arrays with different backends
+    cpu_array = ak.Array(arr, backend="cpu")
+    jax_array = ak.Array(arr, backend="jax")
+
+    # Apply reducers to each backend's array
+    cpu_result = reducer(cpu_array, axis=axis, **kwargs)
+    jax_result = reducer(jax_array, axis=axis, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where axis=None might result in different structures
+    if axis is None:
+        # If one result is a scalar and the other is a list with one element
+        if (
+            not isinstance(cpu_list, list)
+            and isinstance(jax_list, list)
+            and len(jax_list) == 1
+        ):
+            jax_list = jax_list[0]
+        elif (
+            isinstance(cpu_list, list)
+            and not isinstance(jax_list, list)
+            and len(cpu_list) == 1
+        ):
+            cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)
+
+
+# Additional edge cases
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+def test_all_empty_arrays(reducer, kwargs):
+    """Test with arrays that are entirely empty."""
+    # Skip argmin and argmax tests
+    if reducer in [ak.argmin, ak.argmax]:
+        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
+
+    all_empty_data = [[], [], []]
+    cpu_array = ak.Array(all_empty_data, backend="cpu")
+    jax_array = ak.Array(all_empty_data, backend="jax")
+
+    cpu_result = reducer(cpu_array, axis=1, **kwargs)
+    jax_result = reducer(jax_array, axis=1, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where one might be a scalar and the other a list
+    if (
+        not isinstance(cpu_list, list)
+        and isinstance(jax_list, list)
+        and len(jax_list) == 1
+    ):
+        jax_list = jax_list[0]
+    elif (
+        isinstance(cpu_list, list)
+        and not isinstance(jax_list, list)
+        and len(cpu_list) == 1
+    ):
+        cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)
+
+
+# Test with boolean values
+@pytest.mark.parametrize("reducer,kwargs", REDUCERS)
+def test_boolean_arrays(reducer, kwargs):
+    """Test with boolean arrays."""
+    # Skip argmin and argmax tests
+    if reducer in [ak.argmin, ak.argmax]:
+        pytest.skip(f"Skipping {reducer.__name__} as it's not fully supported")
+
+    bool_data = [[True, False], [], [True, True, False], [False]]
+    cpu_array = ak.Array(bool_data, backend="cpu")
+    jax_array = ak.Array(bool_data, backend="jax")
+
+    cpu_result = reducer(cpu_array, axis=1, **kwargs)
+    jax_result = reducer(jax_array, axis=1, **kwargs)
+
+    # Convert to lists for comparison
+    cpu_list = ak.to_list(cpu_result)
+    jax_list = ak.to_list(jax_result)
+
+    # Handle case where one might be a scalar and the other a list
+    if (
+        not isinstance(cpu_list, list)
+        and isinstance(jax_list, list)
+        and len(jax_list) == 1
+    ):
+        jax_list = jax_list[0]
+    elif (
+        isinstance(cpu_list, list)
+        and not isinstance(jax_list, list)
+        and len(cpu_list) == 1
+    ):
+        cpu_list = cpu_list[0]
+
+    # Compare with tolerance for numeric values
+    compare_results(cpu_list, jax_list)


### PR DESCRIPTION
Needs more work and I'd appreciate any help @ianna @pfackeldey.
I'm adding a test that tests all the reducers via parametrization.

Definitely needs https://github.com/scikit-hep/awkward/pull/3457

This PR should fix https://github.com/scikit-hep/awkward/issues/3456, https://github.com/scikit-hep/awkward/issues/3462, https://github.com/scikit-hep/awkward/issues/3463 and https://github.com/scikit-hep/awkward/issues/3465