### PR TITLE
fix: single int slicing for named axis

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -533,7 +533,7 @@ class Content(Meta):
         if is_integer_like(where):
             # propagate named_axis to output
             named_axis.mapping = _remove_named_axis(
-                named_axis.mapping, where, self.purelist_depth
+                named_axis.mapping, 0, self.purelist_depth
             )
             return self._getitem_at(ak._slicing.normalize_integer_like(where))
 

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1121,10 +1121,10 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                     attrs=self._attrs,
                 )
             else:
-                return wrap_layout(
+                return ak.operations.ak_without_named_axis._impl(
                     indexed_layout,
-                    self._behavior,
-                    allow_other=True,
+                    highlevel=True,
+                    behavior=self._behavior,
                     attrs=self._attrs,
                 )
 

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -13,6 +13,7 @@ from awkward._layout import (
     maybe_posaxis,
 )
 from awkward._namedaxis import (
+    NAMED_AXIS_KEY,
     _get_named_axis,
     _named_axis_to_positional_axis,
 )
@@ -263,7 +264,7 @@ def _impl(x, weight, axis, keepdims, mask_identity, highlevel, behavior, attrs):
                 posaxis = maybe_posaxis(out.layout, axis, 1)
                 out = out[(slice(None, None),) * posaxis + (0,)]
 
-        wrapped = ctx.wrap(
+        wrapped = ctx.without_attr(NAMED_AXIS_KEY).wrap(
             maybe_highlevel_to_lowlevel(out),
             highlevel=highlevel,
             allow_other=True,

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -12,6 +12,7 @@ from awkward._layout import (
     maybe_posaxis,
 )
 from awkward._namedaxis import (
+    NAMED_AXIS_KEY,
     _get_named_axis,
     _named_axis_to_positional_axis,
 )
@@ -137,7 +138,7 @@ def _impl(array, axis, keepdims, mask_identity, highlevel, behavior, attrs):
                 posaxis = maybe_posaxis(out.layout, axis, 1)
                 out = out[(slice(None, None),) * posaxis + (0,)]
 
-        wrapped = ctx.wrap(
+        wrapped = ctx.without_attr(NAMED_AXIS_KEY).wrap(
             maybe_highlevel_to_lowlevel(out),
             highlevel=highlevel,
             allow_other=True,

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -13,6 +13,7 @@ from awkward._layout import (
     maybe_posaxis,
 )
 from awkward._namedaxis import (
+    NAMED_AXIS_KEY,
     _get_named_axis,
     _named_axis_to_positional_axis,
 )
@@ -225,7 +226,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, highlevel, behavior, a
                 posaxis = maybe_posaxis(out.layout, axis, 1)
                 out = out[(slice(None, None),) * posaxis + (0,)]
 
-        wrapped = ctx.wrap(
+        wrapped = ctx.without_attr(NAMED_AXIS_KEY).wrap(
             maybe_highlevel_to_lowlevel(out),
             highlevel=highlevel,
             allow_other=True,

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -208,7 +208,14 @@ def _impl(
         backend = TypeTracerBackend.instance()
 
         if obj.ndim == 0:
-            obj = backend.nplike.reshape(obj, (1,))
+            if primitive_policy == "pass-through":
+                return obj
+            elif primitive_policy == "error":
+                raise TypeError(
+                    f"Encountered a scalar ({type(obj).__name__}), but scalar conversion/promotion is disabled"
+                )
+            else:
+                obj = backend.nplike.reshape(obj, (1,))
 
         if obj.dtype.kind in {"S", "U"}:
             raise NotImplementedError(

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -13,6 +13,7 @@ from awkward._layout import (
     maybe_posaxis,
 )
 from awkward._namedaxis import (
+    NAMED_AXIS_KEY,
     _get_named_axis,
     _named_axis_to_positional_axis,
 )
@@ -276,7 +277,7 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, highlevel, behavior, a
                 posaxis = maybe_posaxis(out.layout, axis, 1)
                 out = out[(slice(None, None),) * posaxis + (0,)]
 
-        wrapped = ctx.wrap(
+        wrapped = ctx.without_attr(NAMED_AXIS_KEY).wrap(
             maybe_highlevel_to_lowlevel(out),
             highlevel=highlevel,
             allow_other=True,

--- a/src/awkward/operations/ak_without_named_axis.py
+++ b/src/awkward/operations/ak_without_named_axis.py
@@ -45,7 +45,13 @@ def without_named_axis(
 
 def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
-        layout = ctx.unwrap(array, allow_record=True, primitive_policy="pass-through")
+        layout = ctx.unwrap(
+            array,
+            allow_record=True,
+            primitive_policy="pass-through",
+            none_policy="pass-through",
+            string_policy="pass-through",
+        )
 
     return ctx.without_attr(key=NAMED_AXIS_KEY).wrap(
         layout,

--- a/src/awkward/operations/ak_without_named_axis.py
+++ b/src/awkward/operations/ak_without_named_axis.py
@@ -45,7 +45,7 @@ def without_named_axis(
 
 def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
-        layout = ctx.unwrap(array, allow_record=True)
+        layout = ctx.unwrap(array, allow_record=True, primitive_policy="pass-through")
 
     return ctx.without_attr(key=NAMED_AXIS_KEY).wrap(
         layout,

--- a/tests/test_2596_named_axis.py
+++ b/tests/test_2596_named_axis.py
@@ -123,6 +123,12 @@ def test_named_axis_indexing():
         named_array[()].named_axis == named_array.named_axis == {"x": 0, "y": 1, "z": 2}
     )
 
+    # single int as index slices always only first dim
+    assert named_array[0].named_axis == {"y": 0, "z": 1}
+    assert named_array[1].named_axis == {"y": 0, "z": 1}
+    assert named_array[2].named_axis == {"y": 0, "z": 1}
+    assert named_array[3].named_axis == {"y": 0, "z": 1}
+
     assert named_array[None, :, :, :].named_axis == {"x": 1, "y": 2, "z": 3}
     assert named_array[:, None, :, :].named_axis == {"x": 0, "y": 2, "z": 3}
     assert named_array[:, :, None, :].named_axis == {"x": 0, "y": 1, "z": 3}


### PR DESCRIPTION
Fixes single int slicing with named axis, and improves robustness of named axis attachment in case all named axes are gone.