### PR TITLE
chore: use ubuntu-latest for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Run Codecov
 
     env:


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image began deprecation on 2025-02-01 and is fully unsupported by 2025-04-15.