### PR TITLE
feat: support `unknown_length` for virtual arrays in order to read without any materialization

### DIFF
--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -38,7 +38,7 @@ def to_nplike(
             )
         else:
             if nplike.supports_virtual_arrays:
-                array = array.materialize_data()
+                array = array.materialize()
             elif not nplike.known_data:
                 pass
             else:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -38,7 +38,7 @@ def to_nplike(
             )
         else:
             if nplike.supports_virtual_arrays:
-                array = array.materialize()
+                array = array.materialize_data()
             elif not nplike.known_data:
                 pass
             else:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -66,7 +66,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return obj
         if isinstance(obj, VirtualArray):
             if obj.is_materialized:
-                obj = obj.materialize()
+                obj = obj.materialize_data()
             else:
                 if obj.dtype == dtype or dtype is None:
                     return obj
@@ -75,7 +75,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                         obj.nplike,
                         obj.shape,
                         dtype,
-                        lambda: self.asarray(obj.materialize(), dtype=dtype),
+                        lambda: self.asarray(obj.materialize_data(), dtype=dtype),
                     )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
@@ -96,13 +96,13 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return x
         elif isinstance(x, VirtualArray):
             if x.is_materialized:
-                return self._module.ascontiguousarray(x.materialize())
+                return self._module.ascontiguousarray(x.materialize_data())
             else:
                 return VirtualArray(
                     x.nplike,
                     x.shape,
                     x.dtype,
-                    lambda: self._module.ascontiguousarray(x.materialize()),
+                    lambda: self._module.ascontiguousarray(x.materialize_data()),
                 )
         else:
             return self._module.ascontiguousarray(x)
@@ -354,10 +354,10 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[union-attr]
+                    lambda: self.reshape(x.materialize_data(), next_shape),  # type: ignore[union-attr]
                 )
             else:
-                x = x.materialize()  # type: ignore[assignment]
+                x = x.materialize_data()  # type: ignore[assignment]
 
         if copy is None:
             return self._module.reshape(x, shape)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -66,16 +66,17 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return obj
         if isinstance(obj, VirtualArray):
             if obj.is_materialized:
-                obj = obj.materialize_data()
+                obj = obj.materialize()
             else:
                 if obj.dtype == dtype or dtype is None:
                     return obj
                 else:
                     return VirtualArray(
-                        obj.nplike,
-                        obj.shape,
+                        obj._nplike,
+                        obj._shape,
                         dtype,
-                        lambda: self.asarray(obj.materialize_data(), dtype=dtype),
+                        lambda: self.asarray(obj.materialize(), dtype=dtype),
+                        lambda: obj.shape,
                     )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
@@ -96,13 +97,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return x
         elif isinstance(x, VirtualArray):
             if x.is_materialized:
-                return self._module.ascontiguousarray(x.materialize_data())
+                return self.ascontiguousarray(x.materialize())  #  type: ignore[arg-type]
             else:
                 return VirtualArray(
-                    x.nplike,
-                    x.shape,
-                    x.dtype,
-                    lambda: self._module.ascontiguousarray(x.materialize_data()),
+                    x._nplike,
+                    x._shape,
+                    x._dtype,
+                    lambda: self.ascontiguousarray(x.materialize()),  # type: ignore[arg-type]
+                    lambda: x.shape,
                 )
         else:
             return self._module.ascontiguousarray(x)
@@ -354,10 +356,11 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize_data(), next_shape),  # type: ignore[union-attr]
+                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[union-attr]
+                    lambda: next_shape,
                 )
             else:
-                x = x.materialize_data()  # type: ignore[assignment]
+                x = x.materialize()  # type: ignore[assignment]
 
         if copy is None:
             return self._module.reshape(x, shape)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -794,9 +794,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
                         "asarray was called with copy=False for an array of a different dtype"
                     )
                 else:
-                    return TypeTracerArray._new(
-                        obj.dtype, ak._util.non_materializing_shape_of(obj)
-                    )
+                    return TypeTracerArray._new(obj.dtype, ak._util.maybe_shape_of(obj))
             # Python objects
             elif isinstance(obj, (Number, bool)):
                 as_array = numpy.asarray(obj)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -276,7 +276,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         if cls.runtime_typechecks:
             if not isinstance(shape, tuple):
                 raise TypeError("typetracer shape must be a tuple")
-            if not all(isinstance(x, int) or x is unknown_length for x in shape):
+            if not all(is_integer(x) or x is unknown_length for x in shape):
                 raise TypeError("typetracer shape must be integers or unknown-length")
             if not isinstance(dtype, np.dtype):
                 raise TypeError("typetracer dtype must be an instance of np.dtype")

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -783,7 +783,10 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
                 obj = numpy.asarray(obj)
 
             # Support array-like objects
-            if hasattr(obj, "shape") and hasattr(obj, "dtype"):
+            # Check for ._shape first because .shape might materialize
+            if (hasattr(obj, "_shape") or hasattr(obj, "shape")) and hasattr(
+                obj, "dtype"
+            ):
                 if obj.dtype.kind == "S":
                     raise TypeError("TypeTracerArray cannot be created from strings")
                 elif copy is False and dtype != obj.dtype:
@@ -791,7 +794,9 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
                         "asarray was called with copy=False for an array of a different dtype"
                     )
                 else:
-                    return TypeTracerArray._new(obj.dtype, obj.shape)
+                    return TypeTracerArray._new(
+                        obj.dtype, ak._util.non_materializing_shape_of(obj)
+                    )
             # Python objects
             elif isinstance(obj, (Number, bool)):
                 as_array = numpy.asarray(obj)

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -91,6 +91,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     @property
     def size(self) -> ShapeItem:
         size: ShapeItem = 1
+        self.get_shape()
         for item in self._shape:
             size *= item
         return size
@@ -103,7 +104,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     def strides(self) -> tuple[ShapeItem, ...]:
         return self.materialize().strides  # type: ignore[attr-defined]
 
-    def get_shape(self) -> Self:
+    def get_shape(self) -> None:
         if any(dim is unknown_length for dim in self._shape):
             if self._shape_generator is not None:
                 shape = self._shape_generator()
@@ -119,7 +120,6 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
                     )
             self._shape = shape
-        return self
 
     def materialize(self) -> ArrayLike:
         if self._array is UNMATERIALIZED:
@@ -167,6 +167,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
 
     def view(self, dtype: DTypeLike) -> Self:
         dtype = np.dtype(dtype)
+        self.get_shape()
 
         if self._array is not UNMATERIALIZED:
             return self.materialize().view(dtype)  # type: ignore[return-value]
@@ -195,6 +196,10 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     @property
     def generator(self) -> Callable:
         return self._generator
+
+    @property
+    def shape_generator(self) -> Callable | None:
+        return self._shape_generator
 
     @property
     def nplike(self) -> NumpyLike:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -58,7 +58,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
             raise TypeError(
                 f"Only numpy and cupy nplikes are supported for {type(self).__name__}. Received {type(nplike)}"
             )
-        if any(not (is_integer(dim) or dim is unknown_length) for dim in shape):
+        if not all(is_integer(dim) or dim is unknown_length for dim in shape):
             raise TypeError(
                 f"Only shapes of integer dimensions or unknown_length are supported for {type(self).__name__}. Received shape {shape}"
             )

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
 
-UNMATERIALIZED = Sentinel("<UNMATERIALIZED>", None)
+UNMATERIALIZED = Sentinel("UNMATERIALIZED", None)
 
 
 def materialize_if_virtual(*args: Any) -> tuple[Any, ...]:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -99,7 +99,10 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
 
     @property
     def nbytes(self) -> ShapeItem:
-        return self.size * self._dtype.itemsize
+        size: ShapeItem = 1
+        for item in self._shape:
+            size *= item
+        return size * self._dtype.itemsize
 
     @property
     def strides(self) -> tuple[ShapeItem, ...]:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -337,7 +337,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     def __len__(self) -> int:
         if len(self._shape) == 0:
             raise TypeError("len() of unsized object")
-        return int(self._shape[0])
+        return int(self.shape[0])
 
     def __iter__(self):
         array = self.materialize()

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -123,7 +123,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                     raise TypeError(
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
                     )
-            self._shape = shape
+            self._shape = tuple(map(int, shape))
 
     def materialize(self) -> ArrayLike:
         if self._array is UNMATERIALIZED:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -120,7 +120,7 @@ def copy_behaviors(from_name: str, to_name: str, behavior: dict):
     return output
 
 
-def non_materializing_shape_of(
+def maybe_shape_of(
     obj: ak._nplikes.ArrayLike,
 ) -> tuple[ak._nplikes.shape.ShapeItem, ...]:
     if isinstance(obj, ak._nplikes.virtual.VirtualArray):
@@ -129,28 +129,28 @@ def non_materializing_shape_of(
         return obj.shape
 
 
-def non_materializing_length_of(
+def maybe_length_of(
     obj: ak.contents.Content | ak.index.Index,
 ) -> ak._nplikes.shape.ShapeItem:
     if isinstance(obj, (ak.contents.NumpyArray, ak.index.Index)):
-        return non_materializing_shape_of(obj._data)[0]
+        return maybe_shape_of(obj._data)[0]
     elif isinstance(obj, ak.contents.ListOffsetArray):
-        return non_materializing_length_of(obj._offsets) - 1
+        return maybe_length_of(obj._offsets) - 1
     elif isinstance(obj, ak.contents.ListArray):
-        return non_materializing_length_of(obj._starts)
+        return maybe_length_of(obj._starts)
     elif isinstance(
         obj,
         (ak.contents.RecordArray, ak.contents.RegularArray, ak.contents.BitMaskedArray),
     ):
         return obj._length
     elif isinstance(obj, ak.contents.ByteMaskedArray):
-        return non_materializing_length_of(obj._mask)
+        return maybe_length_of(obj._mask)
     elif isinstance(obj, (ak.contents.IndexedArray, ak.contents.IndexedOptionArray)):
-        return non_materializing_length_of(obj._index)
+        return maybe_length_of(obj._index)
     elif isinstance(obj, ak.contents.UnionArray):
-        return non_materializing_length_of(obj._tags)
+        return maybe_length_of(obj._tags)
     elif isinstance(obj, ak.contents.UnmaskedArray):
-        return non_materializing_length_of(obj._content)
+        return maybe_length_of(obj._content)
     elif isinstance(obj, ak.contents.EmptyArray):
         return 0
     else:

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -121,37 +121,37 @@ def copy_behaviors(from_name: str, to_name: str, behavior: dict):
 
 
 def non_materializing_shape_of(
-    item: ak._nplikes.ArrayLike,
+    obj: ak._nplikes.ArrayLike,
 ) -> tuple[ak._nplikes.shape.ShapeItem, ...]:
-    if isinstance(item, ak._nplikes.virtual.VirtualArray):
-        return item._shape
+    if isinstance(obj, ak._nplikes.virtual.VirtualArray):
+        return obj._shape
     else:
-        return item.shape
+        return obj.shape
 
 
 def non_materializing_length_of(
-    item: ak.contents.Content | ak.index.Index,
+    obj: ak.contents.Content | ak.index.Index,
 ) -> ak._nplikes.shape.ShapeItem:
-    if isinstance(item, (ak.contents.NumpyArray, ak.index.Index)):
-        return non_materializing_shape_of(item._data)[0]
-    elif isinstance(item, ak.contents.ListOffsetArray):
-        return non_materializing_length_of(item._offsets) - 1
-    elif isinstance(item, ak.contents.ListArray):
-        return non_materializing_length_of(item._starts)
+    if isinstance(obj, (ak.contents.NumpyArray, ak.index.Index)):
+        return non_materializing_shape_of(obj._data)[0]
+    elif isinstance(obj, ak.contents.ListOffsetArray):
+        return non_materializing_length_of(obj._offsets) - 1
+    elif isinstance(obj, ak.contents.ListArray):
+        return non_materializing_length_of(obj._starts)
     elif isinstance(
-        item,
+        obj,
         (ak.contents.RecordArray, ak.contents.RegularArray, ak.contents.BitMaskedArray),
     ):
-        return item._length
-    elif isinstance(item, ak.contents.ByteMaskedArray):
-        return non_materializing_length_of(item._mask)
-    elif isinstance(item, (ak.contents.IndexedArray, ak.contents.IndexedOptionArray)):
-        return non_materializing_length_of(item._index)
-    elif isinstance(item, ak.contents.UnionArray):
-        return non_materializing_length_of(item._tags)
-    elif isinstance(item, ak.contents.UnmaskedArray):
-        return non_materializing_length_of(item._content)
-    elif isinstance(item, ak.contents.EmptyArray):
+        return obj._length
+    elif isinstance(obj, ak.contents.ByteMaskedArray):
+        return non_materializing_length_of(obj._mask)
+    elif isinstance(obj, (ak.contents.IndexedArray, ak.contents.IndexedOptionArray)):
+        return non_materializing_length_of(obj._index)
+    elif isinstance(obj, ak.contents.UnionArray):
+        return non_materializing_length_of(obj._tags)
+    elif isinstance(obj, ak.contents.UnmaskedArray):
+        return non_materializing_length_of(obj._content)
+    elif isinstance(obj, ak.contents.EmptyArray):
         return 0
     else:
-        raise TypeError(f"Invalid type {type(item)} for length calculation")
+        raise TypeError(f"Invalid type {type(obj)} for length calculation")

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -123,6 +123,12 @@ def copy_behaviors(from_name: str, to_name: str, behavior: dict):
 def maybe_shape_of(
     obj: ak._nplikes.ArrayLike,
 ) -> tuple[ak._nplikes.shape.ShapeItem, ...]:
+    """
+    Gets the shape of an object while keeping `unknown_length` in the shape tuple.
+    Virtual arrays `.shape` property materializes the shape so we use this function
+    to get the shape of objects without materializing it in the case of virtual arrays.
+    Unknown dimensions will be represted as `unknown_length`.
+    """
     if isinstance(obj, ak._nplikes.virtual.VirtualArray):
         return obj._shape
     else:
@@ -132,6 +138,13 @@ def maybe_shape_of(
 def maybe_length_of(
     obj: ak.contents.Content | ak.index.Index,
 ) -> ak._nplikes.shape.ShapeItem:
+    """
+    Gets the length of an object if it is known, otherwise returns `unknown_length`.
+    We use this function to get the length of objects without materializing the underlying
+    virtual array buffers' shape.
+    Useful for example in `__init__` methods and `__repr__` where we don't want to
+    materialize the virtual array shapes.
+    """
     if isinstance(obj, (ak.contents.NumpyArray, ak.index.Index)):
         return maybe_shape_of(obj._data)[0]
     elif isinstance(obj, ak.contents.ListOffsetArray):

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -120,10 +120,26 @@ def copy_behaviors(from_name: str, to_name: str, behavior: dict):
     return output
 
 
-def non_materializing_shape(
-    array: ak._nplikes.ArrayLike,
+def non_materializing_shape_of(
+    item: ak._nplikes.ArrayLike,
 ) -> tuple[ak._nplikes.shape.ShapeItem, ...]:
-    if isinstance(array, ak._nplikes.virtual.VirtualArray):
-        return array._shape
+    if isinstance(item, ak._nplikes.virtual.VirtualArray):
+        return item._shape
     else:
-        return array.shape
+        return item.shape
+
+
+def non_materializing_length_of(
+    item: ak.contents.Content | ak.index.Index,
+) -> ak._nplikes.shape.ShapeItem:
+    if isinstance(item, ak.contents.ListOffsetArray):
+        return non_materializing_length_of(item._offsets) - 1
+    elif isinstance(item, ak.contents.ListArray):
+        return non_materializing_length_of(item._starts)
+    elif isinstance(item, (ak.contents.NumpyArray, ak.index.Index)):
+        if isinstance(item._data, ak._nplikes.virtual.VirtualArray):
+            return item._data._shape[0]
+        else:
+            return item._data.shape[0]
+    else:
+        return item.length

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -11,6 +11,7 @@ from collections.abc import Collection
 import numpy as np  # noqa: TID251
 import packaging.version
 
+import awkward as ak
 from awkward._typing import TypeVar
 
 win = os.name == "nt"
@@ -117,3 +118,12 @@ def copy_behaviors(from_name: str, to_name: str, behavior: dict):
                 output[new_tuple] = value
 
     return output
+
+
+def non_materializing_shape(
+    array: ak._nplikes.ArrayLike,
+) -> tuple[ak._nplikes.shape.ShapeItem, ...]:
+    if isinstance(array, ak._nplikes.virtual.VirtualArray):
+        return array._shape
+    else:
+        return array.shape

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -348,7 +348,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         out.append(" lsb_order=")
         out.append(repr(json.dumps(self._lsb_order)))
         out.append(" len=")
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -348,7 +348,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         out.append(" lsb_order=")
         out.append(repr(json.dumps(self._lsb_order)))
         out.append(" len=")
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -282,7 +282,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         out = [indent, pre, "<ByteMaskedArray valid_when="]
         out.append(repr(json.dumps(self._valid_when)))
         out.append(" len=")
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -282,7 +282,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         out = [indent, pre, "<ByteMaskedArray valid_when="]
         out.append(repr(json.dumps(self._valid_when)))
         out.append(" len=")
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -265,7 +265,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<IndexedArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -265,7 +265,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<IndexedArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -254,7 +254,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<IndexedOptionArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -254,7 +254,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<IndexedOptionArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -142,7 +142,12 @@ class ListArray(ListMeta[Content], Content):
             raise TypeError(
                 f"{type(self).__name__} 'content' must be a Content subtype, not {content!r}"
             )
-        if content.backend.nplike.known_data and starts.length > stops.length:
+        if (
+            content.backend.nplike.known_data
+            and ak._util.non_materializing_length_of(starts) is not unknown_length
+            and ak._util.non_materializing_length_of(stops) is not unknown_length
+            and starts.length > stops.length
+        ):
             raise ValueError(
                 f"{type(self).__name__} len(starts) ({starts.length}) must be <= len(stops) ({stops.length})"
             )

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -273,7 +273,7 @@ class ListArray(ListMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<ListArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -144,8 +144,8 @@ class ListArray(ListMeta[Content], Content):
             )
         if (
             content.backend.nplike.known_data
-            and ak._util.non_materializing_length_of(starts) is not unknown_length
-            and ak._util.non_materializing_length_of(stops) is not unknown_length
+            and ak._util.maybe_length_of(starts) is not unknown_length
+            and ak._util.maybe_length_of(stops) is not unknown_length
             and starts.length > stops.length
         ):
             raise ValueError(
@@ -273,7 +273,7 @@ class ListArray(ListMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<ListArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -132,8 +132,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
         if (
             content.backend.nplike.known_data
-            and offsets.length is not unknown_length
-            and offsets.length == 0
+            and ak._util.non_materializing_length_of(offsets) is not unknown_length
+            and ak._util.non_materializing_length_of(offsets) == 0
         ):
             raise ValueError(
                 f"{type(self).__name__} len(offsets) ({offsets.length}) must be >= 1"

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -250,7 +250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<ListOffsetArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -132,8 +132,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
         if (
             content.backend.nplike.known_data
-            and ak._util.non_materializing_length_of(offsets) is not unknown_length
-            and ak._util.non_materializing_length_of(offsets) == 0
+            and ak._util.maybe_length_of(offsets) is not unknown_length
+            and ak._util.maybe_length_of(offsets) == 0
         ):
             raise ValueError(
                 f"{type(self).__name__} len(offsets) ({offsets.length}) must be >= 1"
@@ -250,7 +250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<ListOffsetArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -123,7 +123,7 @@ class NumpyArray(NumpyMeta, Content):
         if not isinstance(backend.nplike, Jax):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
 
-        if len(ak._util.non_materializing_shape(self._data)) == 0:
+        if len(ak._util.non_materializing_shape_of(self._data)) == 0:
             raise TypeError(
                 f"{type(self).__name__} 'data' must be an array, not a scalar: {data!r}"
             )
@@ -131,7 +131,7 @@ class NumpyArray(NumpyMeta, Content):
         if parameters is not None and parameters.get("__array__") in ("char", "byte"):
             if (
                 data.dtype != np.dtype(np.uint8)
-                or len(ak._util.non_materializing_shape(data)) != 1
+                or len(ak._util.non_materializing_shape_of(data)) != 1
             ):
                 raise ValueError(
                     "{} is a {}, so its 'data' must be 1-dimensional and uint8, not {}".format(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -253,12 +253,11 @@ class NumpyArray(NumpyMeta, Content):
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<NumpyArray dtype="]
         out.append(repr(str(self.dtype)))
-        if len(self._data.shape) == 1:
-            out.append(" len=" + repr(str(self._data.shape[0])))
+        shape = ak._util.non_materializing_shape_of(self._data)
+        if len(shape) == 1:
+            out.append(" len=" + repr(str(shape[0])))
         else:
-            out.append(
-                " shape='({})'".format(", ".join(str(x) for x in self._data.shape))
-            )
+            out.append(" shape='({})'".format(", ".join(str(x) for x in shape)))
 
         extra = self._repr_extra(indent + "    ")
 

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -123,13 +123,16 @@ class NumpyArray(NumpyMeta, Content):
         if not isinstance(backend.nplike, Jax):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
 
-        if len(self._data.shape) == 0:
+        if len(ak._util.non_materializing_shape(self._data)) == 0:
             raise TypeError(
                 f"{type(self).__name__} 'data' must be an array, not a scalar: {data!r}"
             )
 
         if parameters is not None and parameters.get("__array__") in ("char", "byte"):
-            if data.dtype != np.dtype(np.uint8) or len(data.shape) != 1:
+            if (
+                data.dtype != np.dtype(np.uint8)
+                or len(ak._util.non_materializing_shape(data)) != 1
+            ):
                 raise ValueError(
                     "{} is a {}, so its 'data' must be 1-dimensional and uint8, not {}".format(
                         type(self).__name__, parameters["__array__"], repr(data)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -123,7 +123,7 @@ class NumpyArray(NumpyMeta, Content):
         if not isinstance(backend.nplike, Jax):
             ak.types.numpytype.dtype_to_primitive(self._data.dtype)
 
-        if len(ak._util.non_materializing_shape_of(self._data)) == 0:
+        if len(ak._util.maybe_shape_of(self._data)) == 0:
             raise TypeError(
                 f"{type(self).__name__} 'data' must be an array, not a scalar: {data!r}"
             )
@@ -131,7 +131,7 @@ class NumpyArray(NumpyMeta, Content):
         if parameters is not None and parameters.get("__array__") in ("char", "byte"):
             if (
                 data.dtype != np.dtype(np.uint8)
-                or len(ak._util.non_materializing_shape_of(data)) != 1
+                or len(ak._util.maybe_shape_of(data)) != 1
             ):
                 raise ValueError(
                     "{} is a {}, so its 'data' must be 1-dimensional and uint8, not {}".format(
@@ -253,7 +253,7 @@ class NumpyArray(NumpyMeta, Content):
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<NumpyArray dtype="]
         out.append(repr(str(self.dtype)))
-        shape = ak._util.non_materializing_shape_of(self._data)
+        shape = ak._util.maybe_shape_of(self._data)
         if len(shape) == 1:
             out.append(" len=" + repr(str(shape[0])))
         else:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -59,6 +59,51 @@ def _apply_record_reducer(reducer, layout: Content, mask: bool, behavior) -> Con
     return ak.to_layout(reducer(array, mask))
 
 
+def _calculate_recordarray_length(contents, length, backend):
+    if length is None:
+        # Require a length if we have no contents
+        if len(contents) == 0:
+            raise TypeError(
+                "RecordArray if len(contents) == 0, a 'length' must be specified"
+            )
+
+        # Take length as minimum length of contents. This will touch shapes
+        it_contents = iter(contents)
+        for content in it_contents:
+            # First time we're setting length, and content.length is not unknown_length
+            if length is None:
+                length = content.length
+                # Any unknown_length means all unknown_length
+                if length is unknown_length:
+                    break
+            # `length` is set, can't be unknown_length
+            elif content.length is unknown_length:
+                length = unknown_length
+                break
+            # `length` is set, can't be unknown_length
+            else:
+                length = min(length, content.length)
+
+        # Touch everything else
+        for content in it_contents:
+            content._touch_shape(False)
+
+    # Otherwise
+    elif length is not unknown_length:
+        # Ensure lengths are not smaller than given length.
+        for content in contents:
+            if (
+                backend.nplike.known_data
+                and ak._util.non_materializing_length_of(content) is not unknown_length
+                and content.length < length
+            ):
+                raise ValueError(
+                    f"RecordArray len(content) ({content.length}) must be >= length ({length}) for all 'contents'"
+                )
+
+    return length
+
+
 @final
 class RecordArray(RecordMeta[Content], Content):
     """
@@ -186,47 +231,7 @@ class RecordArray(RecordMeta[Content], Content):
         if backend is None:
             backend = NumpyBackend.instance()
 
-        if length is None:
-            # Require a length if we have no contents
-            if len(contents) == 0:
-                raise TypeError(
-                    f"{type(self).__name__} if len(contents) == 0, a 'length' must be specified"
-                )
-
-            # Take length as minimum length of contents. This will touch shapes
-            it_contents = iter(contents)
-            for content in it_contents:
-                # First time we're setting length, and content.length is not unknown_length
-                if length is None:
-                    length = content.length
-                    # Any unknown_length means all unknown_length
-                    if length is unknown_length:
-                        break
-                # `length` is set, can't be unknown_length
-                elif content.length is unknown_length:
-                    length = unknown_length
-                    break
-                # `length` is set, can't be unknown_length
-                else:
-                    length = min(length, content.length)
-
-            # Touch everything else
-            for content in it_contents:
-                content._touch_shape(False)
-
-        # Otherwise
-        elif length is not unknown_length:
-            # Ensure lengths are not smaller than given length.
-            for content in contents:
-                if (
-                    backend.nplike.known_data
-                    and ak._util.non_materializing_length_of(content)
-                    is not unknown_length
-                    and content.length < length
-                ):
-                    raise ValueError(
-                        f"{type(self).__name__} len(content) ({content.length}) must be >= length ({length}) for all 'contents'"
-                    )
+        length = _calculate_recordarray_length(contents, length, backend)
 
         if isinstance(fields, Iterable):
             if not isinstance(fields, list):
@@ -365,6 +370,10 @@ class RecordArray(RecordMeta[Content], Content):
 
     @property
     def length(self) -> ShapeItem:
+        if self._backend.nplike.known_data and self._length is unknown_length:
+            self._length = _calculate_recordarray_length(
+                self._contents, None, self._backend
+            )
         return self._length
 
     def __repr__(self):
@@ -374,7 +383,7 @@ class RecordArray(RecordMeta[Content], Content):
         out = [indent, pre, "<RecordArray is_tuple="]
         out.append(repr(json.dumps(self.is_tuple)))
         out.append(" len=")
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
@@ -399,13 +408,13 @@ class RecordArray(RecordMeta[Content], Content):
     def content(self, index_or_field: str | SupportsIndex) -> Content:
         out = super().content(index_or_field)
         if (
-            self._length is unknown_length
+            self.length is unknown_length
             or out.length is unknown_length
-            or out.length == self._length
+            or out.length == self.length
         ):
             return out
         else:
-            return out[: self._length]
+            return out[: self.length]
 
     def maybe_content(self, index_or_field) -> Content:
         if self.has_field(index_or_field):
@@ -431,7 +440,7 @@ class RecordArray(RecordMeta[Content], Content):
         if self._backend.nplike.known_data and where < 0:
             where += self.length
 
-        if not (self._length is unknown_length or (0 <= where < self._length)):
+        if not (self.length is unknown_length or (0 <= where < self.length)):
             raise ak._errors.index_error(self, where)
         return Record(self, where)
 
@@ -440,7 +449,7 @@ class RecordArray(RecordMeta[Content], Content):
             self._touch_shape(recursive=False)
 
         start, stop, _, length = self._backend.nplike.derive_slice_for_length(
-            slice(start, stop), self._length
+            slice(start, stop), self.length
         )
 
         if len(self._contents) == 0:
@@ -510,9 +519,9 @@ class RecordArray(RecordMeta[Content], Content):
             negative = where < 0
             if self._backend.nplike.known_data:
                 if self._backend.nplike.any(negative):
-                    where[negative] += self._length
+                    where[negative] += self.length
 
-                if self._backend.nplike.any(where >= self._length):
+                if self._backend.nplike.any(where >= self.length):
                     raise ak._errors.index_error(self, where)
 
             nextindex = ak.index.Index64(where, nplike=self._backend.nplike)
@@ -550,7 +559,7 @@ class RecordArray(RecordMeta[Content], Content):
                 )
             )
         return RecordArray(
-            contents, self._fields, self._length, parameters=None, backend=self._backend
+            contents, self._fields, self.length, parameters=None, backend=self._backend
         )
 
     def _getitem_next(
@@ -630,7 +639,7 @@ class RecordArray(RecordMeta[Content], Content):
                 RecordArray(
                     contents,
                     self._fields,
-                    self._length,
+                    self.length,
                     parameters=None,
                     backend=self._backend,
                 ),
@@ -793,7 +802,7 @@ class RecordArray(RecordMeta[Content], Content):
         return RecordArray(
             contents,
             self._fields,
-            self._length,
+            self.length,
             parameters=self._parameters,
             backend=self._backend,
         )
@@ -821,7 +830,7 @@ class RecordArray(RecordMeta[Content], Content):
         return ak.contents.RecordArray(
             contents,
             self._fields,
-            self._length,
+            self.length,
             parameters=self._parameters,
             backend=self._backend,
         )
@@ -858,7 +867,7 @@ class RecordArray(RecordMeta[Content], Content):
         return RecordArray(
             contents,
             self._fields,
-            self._length,
+            self.length,
             parameters=self._parameters,
             backend=self._backend,
         )
@@ -1063,7 +1072,7 @@ class RecordArray(RecordMeta[Content], Content):
                 return ak.contents.RecordArray(
                     contents,
                     self._fields,
-                    self._length,
+                    self.length,
                     parameters=self._parameters,
                     backend=self._backend,
                 )
@@ -1071,7 +1080,7 @@ class RecordArray(RecordMeta[Content], Content):
                 return ak.contents.RecordArray(
                     contents,
                     self._fields,
-                    self._length,
+                    self.length,
                     parameters=self._parameters,
                     backend=self._backend,
                 )
@@ -1171,7 +1180,7 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self._length]._remove_structure(backend, options))
+                out.extend(content[: self.length]._remove_structure(backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1194,7 +1203,7 @@ class RecordArray(RecordMeta[Content], Content):
         options: ApplyActionOptions,
     ) -> Content | None:
         if self._backend.nplike.known_data:
-            contents = [x[: self._length] for x in self._contents]
+            contents = [x[: self.length] for x in self._contents]
         else:
             self._touch_data(recursive=False)
             contents = self._contents
@@ -1218,7 +1227,7 @@ class RecordArray(RecordMeta[Content], Content):
                         for content in contents
                     ],
                     self._fields,
-                    self._length,
+                    self.length,
                     parameters=self._parameters if options["keep_parameters"] else None,
                     backend=self._backend,
                 )
@@ -1255,11 +1264,11 @@ class RecordArray(RecordMeta[Content], Content):
     def to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self._length].to_packed(True) if recursive else x[: self._length]
+                x[: self.length].to_packed(True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
-            self._length,
+            self.length,
             parameters=self._parameters,
             backend=self._backend,
         )
@@ -1274,8 +1283,8 @@ class RecordArray(RecordMeta[Content], Content):
 
         if self.is_tuple and json_conversions is None:
             contents = [x._to_list(behavior, json_conversions) for x in self._contents]
-            out = [None] * self._length
-            for i in range(self._length):
+            out = [None] * self.length
+            for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
             return out
 
@@ -1284,8 +1293,8 @@ class RecordArray(RecordMeta[Content], Content):
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
             contents = [x._to_list(behavior, json_conversions) for x in self._contents]
-            out = [None] * self._length
-            for i in range(self._length):
+            out = [None] * self.length
+            for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents]))
             return out
 
@@ -1294,7 +1303,7 @@ class RecordArray(RecordMeta[Content], Content):
         return RecordArray(
             contents,
             self._fields,
-            length=self._length,
+            length=self.length,
             parameters=self._parameters,
             backend=backend,
         )
@@ -1304,7 +1313,7 @@ class RecordArray(RecordMeta[Content], Content):
         return RecordArray(
             contents,
             self._fields,
-            length=self._length,
+            length=self.length,
             parameters=self._parameters,
             backend=self._backend,
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -220,7 +220,8 @@ class RecordArray(RecordMeta[Content], Content):
             for content in contents:
                 if (
                     backend.nplike.known_data
-                    and content.length is not unknown_length
+                    and ak._util.non_materializing_length_of(content)
+                    is not unknown_length
                     and content.length < length
                 ):
                     raise ValueError(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -99,7 +99,7 @@ def _calculate_recordarray_length(
         for content in contents:
             if (
                 backend.nplike.known_data
-                and ak._util.non_materializing_length_of(content) is not unknown_length
+                and ak._util.maybe_length_of(content) is not unknown_length
                 and content.length < length
             ):
                 raise ValueError(
@@ -389,7 +389,7 @@ class RecordArray(RecordMeta[Content], Content):
         out = [indent, pre, "<RecordArray is_tuple="]
         out.append(repr(json.dumps(self.is_tuple)))
         out.append(" len=")
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -21,6 +21,7 @@ from awkward._parameters import (
     parameters_intersect,
     type_parameters_equal,
 )
+from awkward._regularize import is_integer
 from awkward._slicing import NO_HEAD
 from awkward._typing import (
     TYPE_CHECKING,
@@ -378,6 +379,7 @@ class RecordArray(RecordMeta[Content], Content):
             self._length = _calculate_recordarray_length(
                 self._contents, None, self._backend
             )
+            assert is_integer(self._length)
         return self._length
 
     def __repr__(self):

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -59,7 +59,11 @@ def _apply_record_reducer(reducer, layout: Content, mask: bool, behavior) -> Con
     return ak.to_layout(reducer(array, mask))
 
 
-def _calculate_recordarray_length(contents, length, backend):
+def _calculate_recordarray_length(
+    contents: Iterable[Content],
+    length: int | type[unknown_length] | None,
+    backend: Backend,
+) -> int | type[unknown_length]:
     if length is None:
         # Require a length if we have no contents
         if len(contents) == 0:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -258,7 +258,7 @@ class RegularArray(RegularMeta[Content], Content):
         out = [indent, pre, "<RegularArray size="]
         out.append(repr(str(self._size)))
         out.append(" len=")
-        out.append(repr(str(self._length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -268,6 +268,7 @@ class RegularArray(RegularMeta[Content], Content):
             self._length = _calculate_regulararray_length(
                 self._content, self._size, self._length, materialize=True
             )
+            assert is_integer(self._length)
         return self._length
 
     def __repr__(self):

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -59,7 +59,7 @@ def _calculate_regulararray_length(
     if materialize:
         length_of_content = content.length
     else:
-        length_of_content = ak._util.non_materializing_length_of(content)
+        length_of_content = ak._util.maybe_length_of(content)
     if length_of_content is unknown_length or size is unknown_length:
         length = unknown_length
     elif size != 0:
@@ -278,7 +278,7 @@ class RegularArray(RegularMeta[Content], Content):
         out = [indent, pre, "<RegularArray size="]
         out.append(repr(str(self._size)))
         out.append(" len=")
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -537,7 +537,7 @@ class UnionArray(UnionMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<UnionArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -537,7 +537,7 @@ class UnionArray(UnionMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<UnionArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -179,7 +179,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<UnmaskedArray len="]
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -179,7 +179,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
     def _repr(self, indent, pre, post):
         out = [indent, pre, "<UnmaskedArray len="]
-        out.append(repr(str(self.length)))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -212,7 +212,7 @@ class Index:
         out = [indent, pre, "<Index dtype="]
         out.append(repr(str(self.dtype)))
         out.append(" len=")
-        out.append(repr(str(self._data.shape[0])))
+        out.append(repr(str(ak._util.non_materializing_length_of(self))))
 
         arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
             "\n"

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -68,7 +68,7 @@ class Index:
             self._nplike.asarray(data, dtype=self._expected_dtype)
         )
 
-        if len(ak._util.non_materializing_shape_of(self._data)) != 1:
+        if len(ak._util.maybe_shape_of(self._data)) != 1:
             raise TypeError("Index data must be one-dimensional")
 
         if np.issubdtype(self._data.dtype, np.longlong):
@@ -212,7 +212,7 @@ class Index:
         out = [indent, pre, "<Index dtype="]
         out.append(repr(str(self.dtype)))
         out.append(" len=")
-        out.append(repr(str(ak._util.non_materializing_length_of(self))))
+        out.append(repr(str(ak._util.maybe_length_of(self))))
 
         arraystr_lines = self._nplike.array_str(self._data, max_line_width=30).split(
             "\n"

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 
+import awkward as ak
 from awkward._nplikes import to_nplike
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.cupy import Cupy
@@ -67,7 +68,7 @@ class Index:
             self._nplike.asarray(data, dtype=self._expected_dtype)
         )
 
-        if len(self._data.shape) != 1:
+        if len(ak._util.non_materializing_shape(self._data)) != 1:
             raise TypeError("Index data must be one-dimensional")
 
         if np.issubdtype(self._data.dtype, np.longlong):

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -68,7 +68,7 @@ class Index:
             self._nplike.asarray(data, dtype=self._expected_dtype)
         )
 
-        if len(ak._util.non_materializing_shape(self._data)) != 1:
+        if len(ak._util.non_materializing_shape_of(self._data)) != 1:
             raise TypeError("Index data must be one-dimensional")
 
         if np.issubdtype(self._data.dtype, np.longlong):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -180,7 +180,19 @@ def _from_buffer(
 ) -> ArrayLike:
     if isinstance(buffer, VirtualArray):
         # This is the case for VirtualArrays
-        # TODO: should we make sure that dtype, count, etc are correct?
+        # just some checks to make sure the VirtualArray is correctly constructed
+        if nplike != buffer.nplike:
+            raise ValueError(
+                f"Mismatch of nplikes. Got {nplike}, but VirtualArray has {buffer.nplike}."
+            )
+        if dtype != buffer.dtype:
+            raise ValueError(
+                f"Mismatch of dtypes. Got {dtype}, but VirtualArray has {buffer.dtype}."
+            )
+        if count != buffer._shape[0]:
+            raise ValueError(
+                f"Mismatch of lengths. Got {count}, but VirtualArray has {buffer._shape[0]}."
+            )
         return buffer
 
     elif callable(buffer):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -344,6 +344,9 @@ def _reconstitute(
             make = ak.contents.BitMaskedArray.simplified
         else:
             make = ak.contents.BitMaskedArray
+        # We need to know the length of a BitMaskedArray to initialize it
+        # as it is an argument in __init__ and is not calculated from the content
+        (length,) = shape_generator()
         return make(
             ak.index.Index(mask),
             content,

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -268,8 +268,8 @@ def _reconstitute(
         real_length = _adjust_length(length)
 
         def _shape_generator():
-            length, *rest = shape_generator()
-            return (_adjust_length(length), *rest)
+            (length,) = shape_generator()
+            return (_adjust_length(length),)
 
         data = _from_buffer(
             backend.nplike,
@@ -312,8 +312,8 @@ def _reconstitute(
             return math.ceil(length / 8.0)
 
         def _shape_generator():
-            length, *rest = shape_generator()
-            return (_adjust_length(length), *rest)
+            (length,) = shape_generator()
+            return (_adjust_length(length),)
 
         if length is unknown_length:
             next_length = unknown_length
@@ -402,8 +402,7 @@ def _reconstitute(
             return 0 if len(index) == 0 else max(0, backend.nplike.max(index) + 1)
 
         def _shape_generator():
-            _, *rest = shape_generator()
-            return (_adjust_length(index), *rest)
+            return (_adjust_length(index),)
 
         if isinstance(index, (PlaceholderArray, VirtualArray)):
             next_length = unknown_length
@@ -450,8 +449,7 @@ def _reconstitute(
             )
 
         def _shape_generator():
-            _, *rest = shape_generator
-            return (_adjust_length(index), *rest)
+            return (_adjust_length(index),)
 
         if isinstance(index, (PlaceholderArray, VirtualArray)):
             next_length = unknown_length
@@ -505,8 +503,7 @@ def _reconstitute(
             return 0 if len(starts) == 0 else backend.nplike.max(reduced_stops)
 
         def _shape_generator():
-            _, *rest = shape_generator()
-            return (_adjust_length(starts, stops), *rest)
+            return (_adjust_length(starts, stops),)
 
         if isinstance(starts, (PlaceholderArray, VirtualArray)) or isinstance(
             stops, (PlaceholderArray, VirtualArray)
@@ -536,8 +533,8 @@ def _reconstitute(
         raw_array = container[getkey(form, "offsets")]
 
         def _shape_generator():
-            first, *rest = shape_generator()
-            return (first + 1, *rest)
+            (first,) = shape_generator()
+            return (first + 1,)
 
         offsets = _from_buffer(
             backend.nplike,
@@ -554,8 +551,7 @@ def _reconstitute(
             return 0 if len(offsets) == 1 else offsets[-1]
 
         def _shape_generator():
-            _, *rest = shape_generator()
-            return (_adjust_length(offsets), *rest)
+            return (_adjust_length(offsets),)
 
         if isinstance(offsets, (PlaceholderArray, VirtualArray)):
             next_length = unknown_length
@@ -587,8 +583,8 @@ def _reconstitute(
         next_length = _adjust_length(length)
 
         def _shape_generator():
-            first, *rest = shape_generator()
-            return (_adjust_length(first), *rest)
+            (first,) = shape_generator()
+            return (_adjust_length(first),)
 
         content = _reconstitute(
             form.content,
@@ -663,8 +659,7 @@ def _reconstitute(
         for tag in range(len(form.contents)):
 
             def _shape_generator(tag):
-                first, *rest = shape_generator()
-                return (_adjust_length(index, tags, tag), *rest)
+                return (_adjust_length(index, tags, tag),)
 
             _shape_generators.append(partial(_shape_generator, tag=tag))
 

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from functools import partial
 
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
@@ -16,6 +17,7 @@ from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.virtual import VirtualArray
 from awkward._regularize import is_integer
+from awkward._typing import Callable
 from awkward.forms.form import index_to_dtype, regularize_buffer_key
 
 __all__ = ("from_buffers",)
@@ -153,7 +155,15 @@ def _impl(
     getkey = regularize_buffer_key(buffer_key)
 
     out = _reconstitute(
-        form, length, container, getkey, backend, byteorder, simplify, field_path=()
+        form,
+        length,
+        container,
+        getkey,
+        backend,
+        byteorder,
+        simplify,
+        field_path=(),
+        shape_generator=lambda: (length,),
     )
 
     return wrap_layout(out, highlevel=highlevel, attrs=attrs, behavior=behavior)
@@ -161,22 +171,33 @@ def _impl(
 
 def _from_buffer(
     nplike: NumpyLike,
-    buffer,
+    buffer: Callable | ArrayLike,
     dtype: np.dtype,
     count: ShapeItem,
     byteorder: str,
     field_path: tuple,
+    shape_generator: Callable | None = None,
 ) -> ArrayLike:
-    if callable(buffer):
+    if isinstance(buffer, VirtualArray):
         # This is the case for VirtualArrays
+        # TODO: should we make sure that dtype, count, etc are correct?
+        return buffer
+
+    elif callable(buffer):
+        # This is the case where we automatically create VirtualArrays
         # We use recursion here to pass down the from_buffer and byteorder transformations to the generator
+        def generator():
+            (length,) = shape_generator()
+            return _from_buffer(
+                nplike, buffer(), dtype, length, byteorder, field_path, None
+            )
+
         return VirtualArray(
             nplike=nplike,
             shape=(count,),
             dtype=dtype,
-            generator=lambda: _from_buffer(
-                nplike, buffer(), dtype, count, byteorder, field_path
-            ),
+            generator=generator,
+            shape_generator=shape_generator,
         )
     # Unknown-length information implies that we didn't load shape-buffers (offsets, etc)
     # for the parent of this node. Thus, this node and its children *must* only
@@ -210,7 +231,15 @@ def _from_buffer(
 
 
 def _reconstitute(
-    form, length, container, getkey, backend, byteorder, simplify, field_path
+    form,
+    length,
+    container,
+    getkey,
+    backend,
+    byteorder,
+    simplify,
+    field_path,
+    shape_generator,
 ):
     if isinstance(form, ak.forms.EmptyForm):
         if length != 0:
@@ -220,7 +249,16 @@ def _reconstitute(
     elif isinstance(form, ak.forms.NumpyForm):
         dtype = ak.types.numpytype.primitive_to_dtype(form.primitive)
         raw_array = container[getkey(form, "data")]
-        real_length = length * math.prod(form.inner_shape)
+
+        def _adjust_length(length):
+            return length * math.prod(form.inner_shape)
+
+        real_length = _adjust_length(length)
+
+        def _shape_generator():
+            length, *rest = shape_generator()
+            return (_adjust_length(length), *rest)
+
         data = _from_buffer(
             backend.nplike,
             raw_array,
@@ -228,6 +266,7 @@ def _reconstitute(
             count=real_length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=_shape_generator,
         )
         if form.inner_shape != ():
             data = backend.nplike.reshape(data, (length, *form.inner_shape))
@@ -246,6 +285,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            shape_generator,
         )
         if simplify:
             make = ak.contents.UnmaskedArray.simplified
@@ -255,10 +295,19 @@ def _reconstitute(
 
     elif isinstance(form, ak.forms.BitMaskedForm):
         raw_array = container[getkey(form, "mask")]
+
+        def _adjust_length(length):
+            return math.ceil(length / 8.0)
+
+        def _shape_generator():
+            length, *rest = shape_generator()
+            return (_adjust_length(length), *rest)
+
         if length is unknown_length:
             next_length = unknown_length
         else:
-            next_length = math.ceil(length / 8.0)
+            next_length = _adjust_length(length)
+
         mask = _from_buffer(
             backend.nplike,
             raw_array,
@@ -266,6 +315,7 @@ def _reconstitute(
             count=next_length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=_shape_generator,
         )
         content = _reconstitute(
             form.content,
@@ -276,6 +326,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         if simplify:
             make = ak.contents.BitMaskedArray.simplified
@@ -299,6 +350,7 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
         content = _reconstitute(
             form.content,
@@ -309,6 +361,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            shape_generator,
         )
         if simplify:
             make = ak.contents.ByteMaskedArray.simplified
@@ -330,16 +383,20 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
-        if isinstance(index, PlaceholderArray):
+
+        def _adjust_length(index):
+            return 0 if len(index) == 0 else max(0, backend.nplike.max(index) + 1)
+
+        def _shape_generator():
+            _, *rest = shape_generator()
+            return (_adjust_length(index), *rest)
+
+        if isinstance(index, (PlaceholderArray, VirtualArray)):
             next_length = unknown_length
         else:
-            next_length = (
-                0 if len(index) == 0 else max(0, backend.nplike.max(index) + 1)
-            )
-            # free memory
-            if isinstance(index, VirtualArray):
-                index.dematerialize()
+            next_length = _adjust_length(index)
         content = _reconstitute(
             form.content,
             next_length,
@@ -349,6 +406,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         if simplify:
             make = ak.contents.IndexedOptionArray.simplified
@@ -369,18 +427,24 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
-        if isinstance(index, PlaceholderArray):
-            next_length = unknown_length
-        else:
-            next_length = (
+
+        def _adjust_length(index):
+            return (
                 0
                 if len(index) == 0
                 else backend.nplike.index_as_shape_item(backend.nplike.max(index) + 1)
             )
-            # free memory
-            if isinstance(index, VirtualArray):
-                index.dematerialize()
+
+        def _shape_generator():
+            _, *rest = shape_generator
+            return (_adjust_length(index), *rest)
+
+        if isinstance(index, (PlaceholderArray, VirtualArray)):
+            next_length = unknown_length
+        else:
+            next_length = _adjust_length(index)
         content = _reconstitute(
             form.content,
             next_length,
@@ -390,6 +454,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         if simplify:
             make = ak.contents.IndexedArray.simplified
@@ -411,6 +476,7 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
         stops = _from_buffer(
             backend.nplike,
@@ -419,17 +485,23 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
-        if isinstance(stops, PlaceholderArray):
+
+        def _adjust_length(starts, stops):
+            reduced_stops = stops[starts != stops]
+            return 0 if len(starts) == 0 else backend.nplike.max(reduced_stops)
+
+        def _shape_generator():
+            _, *rest = shape_generator()
+            return (_adjust_length(starts, stops), *rest)
+
+        if isinstance(starts, (PlaceholderArray, VirtualArray)) or isinstance(
+            stops, (PlaceholderArray, VirtualArray)
+        ):
             next_length = unknown_length
         else:
-            reduced_stops = stops[starts != stops]
-            next_length = 0 if len(starts) == 0 else backend.nplike.max(reduced_stops)
-            # free memory
-            if isinstance(starts, VirtualArray):
-                starts.dematerialize()
-            if isinstance(stops, VirtualArray):
-                stops.dematerialize()
+            next_length = _adjust_length(starts, stops)
         content = _reconstitute(
             form.content,
             next_length,
@@ -439,6 +511,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         return ak.contents.ListArray(
             ak.index.Index(starts),
@@ -449,6 +522,11 @@ def _reconstitute(
 
     elif isinstance(form, ak.forms.ListOffsetForm):
         raw_array = container[getkey(form, "offsets")]
+
+        def _shape_generator():
+            first, *rest = shape_generator()
+            return (first + 1, *rest)
+
         offsets = _from_buffer(
             backend.nplike,
             raw_array,
@@ -456,15 +534,22 @@ def _reconstitute(
             count=length + 1,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=_shape_generator,
         )
 
-        if isinstance(offsets, PlaceholderArray):
+        # next length
+        def _adjust_length(offsets):
+            return 0 if len(offsets) == 1 else offsets[-1]
+
+        def _shape_generator():
+            _, *rest = shape_generator()
+            return (_adjust_length(offsets), *rest)
+
+        if isinstance(offsets, (PlaceholderArray, VirtualArray)):
             next_length = unknown_length
         else:
-            next_length = 0 if len(offsets) == 1 else offsets[-1]
-            # free memory
-            if isinstance(offsets, VirtualArray):
-                offsets.dematerialize()
+            next_length = _adjust_length(offsets)
+
         content = _reconstitute(
             form.content,
             next_length,
@@ -474,6 +559,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         return ak.contents.ListOffsetArray(
             ak.index.Index(offsets),
@@ -482,7 +568,16 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.RegularForm):
-        next_length = length * form.size
+
+        def _adjust_length(length):
+            return length * form.size
+
+        next_length = _adjust_length(length)
+
+        def _shape_generator():
+            first, *rest = shape_generator()
+            return (_adjust_length(first), *rest)
+
         content = _reconstitute(
             form.content,
             next_length,
@@ -492,6 +587,7 @@ def _reconstitute(
             byteorder,
             simplify,
             field_path,
+            _shape_generator,
         )
         return ak.contents.RegularArray(
             content,
@@ -511,6 +607,7 @@ def _reconstitute(
                 byteorder,
                 simplify,
                 (*field_path, field),
+                shape_generator,
             )
             for content, field in zip(form.contents, form.fields)
         ]
@@ -531,6 +628,7 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
         index = _from_buffer(
             backend.nplike,
@@ -539,22 +637,34 @@ def _reconstitute(
             count=length,
             byteorder=byteorder,
             field_path=field_path,
+            shape_generator=shape_generator,
         )
-        if isinstance(index, PlaceholderArray) or isinstance(tags, PlaceholderArray):
+
+        def _adjust_length(index, tags, tag):
+            selected_index = index[tags == tag]
+            if len(selected_index) == 0:
+                return 0
+            else:
+                return backend.nplike.max(selected_index) + 1
+
+        _shape_generators = []
+        for tag in range(len(form.contents)):
+
+            def _shape_generator(tag):
+                first, *rest = shape_generator()
+                return (_adjust_length(index, tags, tag), *rest)
+
+            _shape_generators.append(partial(_shape_generator, tag=tag))
+
+        if isinstance(index, (PlaceholderArray, VirtualArray)) or isinstance(
+            tags, (PlaceholderArray, VirtualArray)
+        ):
             lengths = [unknown_length] * len(form.contents)
         else:
             lengths = []
             for tag in range(len(form.contents)):
-                selected_index = index[tags == tag]
-                if len(selected_index) == 0:
-                    lengths.append(0)
-                else:
-                    lengths.append(backend.nplike.max(selected_index) + 1)
-            # free memory
-            if isinstance(index, VirtualArray):
-                index.dematerialize()
-            if isinstance(tags, VirtualArray):
-                tags.dematerialize()
+                lengths.append(_adjust_length(index, tags, tag))
+
         contents = [
             _reconstitute(
                 content,
@@ -565,6 +675,7 @@ def _reconstitute(
                 byteorder,
                 simplify,
                 field_path,
+                _shape_generators[i],
             )
             for i, content in enumerate(form.contents)
         ]

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -284,7 +284,8 @@ def test_init_valid(numpy_like, simple_array_generator):
 def test_init_invalid_shape():
     nplike = Numpy.instance()
     with pytest.raises(
-        TypeError, match=r"Only shapes of integer dimensions are supported"
+        TypeError,
+        match=r"Only shapes of integer dimensions or unknown_length are supported",
     ):
         VirtualArray(
             nplike,

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -28,7 +28,7 @@ def virtual_array(numpy_like, simple_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=simple_array_generator,
+        data_generator=simple_array_generator,
     )
 
 
@@ -43,7 +43,7 @@ def two_dim_virtual_array(numpy_like, two_dim_array_generator):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=two_dim_array_generator,
+        data_generator=two_dim_array_generator,
     )
 
 
@@ -55,7 +55,10 @@ def scalar_array_generator():
 @pytest.fixture
 def scalar_virtual_array(numpy_like, scalar_array_generator):
     return VirtualArray(
-        numpy_like, shape=(), dtype=np.dtype(np.int64), generator=scalar_array_generator
+        numpy_like,
+        shape=(),
+        dtype=np.dtype(np.int64),
+        data_generator=scalar_array_generator,
     )
 
 
@@ -70,7 +73,7 @@ def float_virtual_array(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=float_array_generator,
+        data_generator=float_array_generator,
     )
 
 
@@ -95,7 +98,7 @@ def virtual_offset_array(numpy_like, offset_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=offset_array_generator,
+        data_generator=offset_array_generator,
     )
 
 
@@ -129,7 +132,7 @@ def virtual_starts_array(numpy_like, starts_array_generator):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=starts_array_generator,
+        data_generator=starts_array_generator,
     )
 
 
@@ -144,7 +147,7 @@ def virtual_stops_array(numpy_like, stops_array_generator):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=stops_array_generator,
+        data_generator=stops_array_generator,
     )
 
 
@@ -161,7 +164,7 @@ def virtual_content_array(numpy_like, content_array_generator):
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=content_array_generator,
+        data_generator=content_array_generator,
     )
 
 
@@ -199,7 +202,7 @@ def virtual_offsets_array(numpy_like, offsets_array_generator):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=offsets_array_generator,
+        data_generator=offsets_array_generator,
     )
 
 
@@ -216,7 +219,7 @@ def virtual_x_content_array(numpy_like, x_content_array_generator):
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=x_content_array_generator,
+        data_generator=x_content_array_generator,
     )
 
 
@@ -231,7 +234,7 @@ def virtual_y_array(numpy_like, y_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=y_array_generator,
+        data_generator=y_array_generator,
     )
 
 
@@ -271,7 +274,7 @@ def virtual_recordarray(
 # Test initialization
 def test_init_valid(numpy_like, simple_array_generator):
     va = VirtualArray(
-        numpy_like, shape=(5,), dtype=np.int64, generator=simple_array_generator
+        numpy_like, shape=(5,), dtype=np.int64, data_generator=simple_array_generator
     )
     assert va.shape == (5,)
     assert va.dtype == np.dtype(np.int64)
@@ -287,7 +290,7 @@ def test_init_invalid_shape():
             nplike,
             shape=("not_an_integer", 5),
             dtype=np.int64,
-            generator=lambda: np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
+            data_generator=lambda: np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
         )
 
 
@@ -318,7 +321,7 @@ def test_nbytes_unmaterialized(virtual_array):
 
 
 def test_nbytes_materialized(virtual_array):
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     assert virtual_array.nbytes == np.array([1, 2, 3, 4, 5], dtype=np.int64).nbytes
 
 
@@ -329,7 +332,7 @@ def test_strides(virtual_array):
 
 # Test materialization
 def test_materialize(virtual_array):
-    result = virtual_array.materialize()
+    result = virtual_array.materialize_data()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
     assert virtual_array.is_materialized
@@ -337,7 +340,7 @@ def test_materialize(virtual_array):
 
 def test_is_materialized(virtual_array):
     assert not virtual_array.is_materialized
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     assert virtual_array.is_materialized
 
 
@@ -351,9 +354,9 @@ def test_materialize_shape_mismatch(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.int64,
-            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+            data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
         )
-        va.materialize()
+        va.materialize_data()
 
 
 def test_materialize_dtype_mismatch(numpy_like):
@@ -366,9 +369,9 @@ def test_materialize_dtype_mismatch(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.int64,
-            generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            data_generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
         )
-        va.materialize()
+        va.materialize_data()
 
 
 # Test transpose
@@ -380,7 +383,7 @@ def test_T_unmaterialized(two_dim_virtual_array):
 
 
 def test_T_materialized(two_dim_virtual_array):
-    two_dim_virtual_array.materialize()
+    two_dim_virtual_array.materialize_data()
     transposed = two_dim_virtual_array.T
     assert isinstance(transposed, np.ndarray)
     assert transposed.shape == (3, 2)
@@ -395,7 +398,7 @@ def test_view_unmaterialized(virtual_array):
 
 
 def test_view_materialized(virtual_array):
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     view = virtual_array.view(np.float64)
     assert isinstance(view, np.ndarray)
     assert view.dtype == np.dtype(np.float64)
@@ -407,7 +410,7 @@ def test_view_invalid_size():
         nplike,
         shape=(3,),
         dtype=np.int8,
-        generator=lambda: np.array([1, 2, 3], dtype=np.int8),
+        data_generator=lambda: np.array([1, 2, 3], dtype=np.int8),
     )
     with pytest.raises(
         ValueError, match=r"new size of array with larger dtype must be a divisor"
@@ -417,7 +420,7 @@ def test_view_invalid_size():
 
 # Test generator property
 def test_generator(virtual_array, simple_array_generator):
-    assert virtual_array.generator is simple_array_generator
+    assert virtual_array.data_generator is simple_array_generator
 
 
 # Test nplike property
@@ -490,14 +493,14 @@ def test_getitem_slice(virtual_array):
     sliced = virtual_array[1:4]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
-    np.testing.assert_array_equal(sliced.materialize(), np.array([2, 3, 4]))
+    np.testing.assert_array_equal(sliced.materialize_data(), np.array([2, 3, 4]))
 
 
 def test_getitem_slice_with_step(virtual_array):
     sliced = virtual_array[::2]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
-    np.testing.assert_array_equal(sliced.materialize(), np.array([1, 3, 5]))
+    np.testing.assert_array_equal(sliced.materialize_data(), np.array([1, 3, 5]))
 
 
 def test_getitem_slice_with_unknown_length():
@@ -506,7 +509,7 @@ def test_getitem_slice_with_unknown_length():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
     with pytest.raises(
         TypeError, match=r"does not support slicing with unknown_length"
@@ -519,7 +522,7 @@ def test_setitem(virtual_array):
     virtual_array[2] = 10
     assert virtual_array[2] == 10
     np.testing.assert_array_equal(
-        virtual_array.materialize(), np.array([1, 2, 10, 4, 5])
+        virtual_array.materialize_data(), np.array([1, 2, 10, 4, 5])
     )
 
 
@@ -530,7 +533,10 @@ def test_bool_scalar(scalar_virtual_array):
     # Test with zero value
     nplike = Numpy.instance()
     va_zero = VirtualArray(
-        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(0, dtype=np.int64)
+        nplike,
+        shape=(),
+        dtype=np.int64,
+        data_generator=lambda: np.array(0, dtype=np.int64),
     )
     assert bool(va_zero) is False
 
@@ -575,7 +581,10 @@ def test_len_scalar():
     # Scalar arrays don't have a length
     nplike = Numpy.instance()
     scalar_va = VirtualArray(
-        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(42, dtype=np.int64)
+        nplike,
+        shape=(),
+        dtype=np.int64,
+        data_generator=lambda: np.array(42, dtype=np.int64),
     )
     with pytest.raises(TypeError, match=r"len\(\) of unsized object"):
         len(scalar_va)
@@ -620,13 +629,13 @@ def test_materialize_if_virtual():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
     va2 = VirtualArray(
         nplike,
         shape=(2,),
         dtype=np.int64,
-        generator=lambda: np.array([4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([4, 5], dtype=np.int64),
     )
     regular_array = np.array([6, 7, 8])
 
@@ -644,7 +653,7 @@ def test_materialize_if_virtual():
 # Tests for float virtual array
 def test_float_array_init(numpy_like, float_array_generator):
     va = VirtualArray(
-        numpy_like, shape=(5,), dtype=np.float64, generator=float_array_generator
+        numpy_like, shape=(5,), dtype=np.float64, data_generator=float_array_generator
     )
     assert va.shape == (5,)
     assert va.dtype == np.dtype(np.float64)
@@ -652,7 +661,7 @@ def test_float_array_init(numpy_like, float_array_generator):
 
 
 def test_float_array_materialize(float_virtual_array):
-    result = float_virtual_array.materialize()
+    result = float_virtual_array.materialize_data()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
     assert float_virtual_array.is_materialized
@@ -664,13 +673,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=float_array_generator,
+        data_generator=float_array_generator,
     )
     sliced = float_virtual_array1[1:4]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
     np.testing.assert_array_almost_equal(
-        sliced.materialize(), np.array([2.2, 3.3, 4.4])
+        sliced.materialize_data(), np.array([2.2, 3.3, 4.4])
     )
 
     # Test step slice
@@ -678,13 +687,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=float_array_generator,
+        data_generator=float_array_generator,
     )
     sliced_step = float_virtual_array2[::2]
     assert isinstance(sliced_step, VirtualArray)
     assert sliced_step.shape == (3,)
     np.testing.assert_array_almost_equal(
-        sliced_step.materialize(), np.array([1.1, 3.3, 5.5])
+        sliced_step.materialize_data(), np.array([1.1, 3.3, 5.5])
     )
 
     # Test negative step
@@ -692,13 +701,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=float_array_generator,
+        data_generator=float_array_generator,
     )
     sliced_neg = float_virtual_array3[::-1]
     assert isinstance(sliced_neg, VirtualArray)
     assert sliced_neg.shape == (5,)
     np.testing.assert_array_almost_equal(
-        sliced_neg.materialize(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
+        sliced_neg.materialize_data(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
     )
 
     # Test complex slice
@@ -706,13 +715,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=float_array_generator,
+        data_generator=float_array_generator,
     )
     sliced_complex = float_virtual_array4[4:1:-2]
     assert isinstance(sliced_complex, VirtualArray)
     assert sliced_complex.shape == (2,)
     np.testing.assert_array_almost_equal(
-        sliced_complex.materialize(), np.array([5.5, 3.3])
+        sliced_complex.materialize_data(), np.array([5.5, 3.3])
     )
 
 
@@ -742,14 +751,14 @@ def test_float_array_view(float_virtual_array):
     assert view.dtype == np.dtype(np.float32)
 
     # Test materialization of view
-    materialized = view.materialize()
+    materialized = view.materialize_data()
     assert materialized.dtype == np.dtype(np.float32)
 
 
 def test_float_to_int_comparison(float_virtual_array, virtual_array):
     # Compare float and int arrays
-    float_data = float_virtual_array.materialize()
-    int_data = virtual_array.materialize()
+    float_data = float_virtual_array.materialize_data()
+    int_data = virtual_array.materialize_data()
 
     # Test basic properties
     assert float_virtual_array.shape == virtual_array.shape
@@ -773,7 +782,7 @@ def test_float_array_rounding():
         nplike,
         shape=(5,),
         dtype=np.float64,
-        generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
     )
 
     # Test floor
@@ -796,7 +805,9 @@ def test_float_array_nan():
         nplike,
         shape=(5,),
         dtype=np.float64,
-        generator=lambda: np.array([1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64
+        ),
     )
 
     # Test isnan
@@ -821,7 +832,7 @@ def test_multidim_slicing(two_dim_virtual_array):
         nplike,
         shape=(2, 3),
         dtype=np.int64,
-        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     # Test advanced indexing
@@ -838,13 +849,13 @@ def test_empty_array():
         nplike,
         shape=(0,),
         dtype=np.int64,
-        generator=lambda: np.array([], dtype=np.int64),
+        data_generator=lambda: np.array([], dtype=np.int64),
     )
 
     assert va.shape == (0,)
     assert va.size == 0
     assert len(va) == 0
-    materialized = va.materialize()
+    materialized = va.materialize_data()
     assert len(materialized) == 0
 
 
@@ -860,11 +871,11 @@ def test_structured_dtype():
         nplike,
         shape=(3,),
         dtype=dtype,
-        generator=lambda: data,
+        data_generator=lambda: data,
     )
 
     assert va.dtype == dtype
-    materialized = va.materialize()
+    materialized = va.materialize_data()
     assert materialized["name"][1] == "Bob"
     assert materialized["age"][2] == 35
     assert materialized["weight"][0] == 55.0
@@ -883,7 +894,7 @@ def test_large_array_memory():
         nplike,
         shape=(1000, 1000),
         dtype=np.float64,
-        generator=large_array_generator,
+        data_generator=large_array_generator,
     )
 
     assert va.nbytes == 1000 * 1000 * 8  # 8 bytes per float64 element
@@ -908,11 +919,11 @@ def test_generator_error():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        generator=failing_generator,
+        data_generator=failing_generator,
     )
 
     with pytest.raises(ValueError, match="Generator failure test"):
-        va.materialize()
+        va.materialize_data()
 
 
 # Test nested VirtualArrays (generator returns another VirtualArray)
@@ -924,7 +935,7 @@ def test_nested_virtual_arrays():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        generator=lambda: np.array([10, 20, 30], np.int64),
+        data_generator=lambda: np.array([10, 20, 30], np.int64),
     )
 
     # Outer virtual array, generator returns inner virtual array
@@ -932,11 +943,11 @@ def test_nested_virtual_arrays():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        generator=lambda: inner_va,
+        data_generator=lambda: inner_va,
     )
 
     # Should materialize both
-    result = outer_va.materialize()
+    result = outer_va.materialize_data()
     np.testing.assert_array_equal(result, np.array([10, 20, 30]))
     assert inner_va.is_materialized
     assert outer_va.is_materialized
@@ -949,11 +960,11 @@ def test_complex_numbers():
         nplike,
         shape=(3,),
         dtype=np.complex128,
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     assert va.dtype == np.dtype(np.complex128)
-    materialized = va.materialize()
+    materialized = va.materialize_data()
     np.testing.assert_array_equal(materialized, np.array([1 + 2j, 3 + 4j, 5 + 6j]))
 
     # Test complex operations
@@ -969,7 +980,7 @@ def test_slice_zero_step():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     with pytest.raises(ValueError):
@@ -1000,7 +1011,7 @@ def test_slice_length_calculation():
             nplike,
             shape=(array_length,),
             dtype=np.int64,
-            generator=create_generator(array_length),
+            data_generator=create_generator(array_length),
         )
 
         sliced = va[slice_obj]
@@ -1030,7 +1041,7 @@ def test_asarray_virtual_array_unmaterialized(numpy_like, virtual_array):
 
 def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
     # Test with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.asarray(virtual_array)
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
@@ -1042,12 +1053,12 @@ def test_asarray_virtual_array_with_dtype(numpy_like, virtual_array):
     assert isinstance(out, VirtualArray)
     assert out.dtype == np.dtype(np.float64)
     assert not out.is_materialized
-    assert out.materialize().dtype == np.dtype(np.float64)
+    assert out.materialize_data().dtype == np.dtype(np.float64)
 
 
 def test_asarray_virtual_array_with_copy(numpy_like, virtual_array):
     # Test with copy parameter
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     with pytest.raises(
         ValueError,
         match="asarray was called with copy=False for an array of a different dtype",
@@ -1067,7 +1078,7 @@ def test_ascontiguousarray_unmaterialized(numpy_like, virtual_array):
 
 def test_ascontiguousarray_materialized(numpy_like, virtual_array):
     # Test with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.ascontiguousarray(virtual_array)
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
@@ -1094,7 +1105,7 @@ def test_zeros_like_unmaterialized(numpy_like, virtual_array):
 
 def test_zeros_like_materialized(numpy_like, virtual_array):
     # Test zeros_like with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1114,7 +1125,7 @@ def test_ones_like_unmaterialized(numpy_like, virtual_array):
 
 def test_ones_like_materialized(numpy_like, virtual_array):
     # Test ones_like with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1134,7 +1145,7 @@ def test_full_like_unmaterialized(numpy_like, virtual_array):
 
 def test_full_like_materialized(numpy_like, virtual_array):
     # Test full_like with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1152,7 +1163,7 @@ def test_arange_with_virtual_array_start(numpy_like, scalar_virtual_array):
 
 def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
     # Test meshgrid with VirtualArray parameter
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.meshgrid(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
@@ -1166,7 +1177,7 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Test array_equal
@@ -1178,7 +1189,7 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1, 2, 3, 4, 6], dtype=np.int64
         ),  # Different last value
     )
@@ -1192,13 +1203,13 @@ def test_array_equal_with_equal_nan(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        data_generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
     )
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        data_generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
     )
 
     # Should be False by default (NaN != NaN)
@@ -1216,7 +1227,7 @@ def test_searchsorted_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+        data_generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
     result = numpy_like.searchsorted(virtual_array, values)
@@ -1236,7 +1247,7 @@ def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.apply_ufunc(np.multiply, "__call__", [virtual_array, va2])
@@ -1250,7 +1261,7 @@ def test_broadcast_arrays_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([10], dtype=np.int64),
+        data_generator=lambda: np.array([10], dtype=np.int64),
     )
 
     result = numpy_like.broadcast_arrays(virtual_array, va2)
@@ -1275,7 +1286,7 @@ def test_reshape_unmaterialized(numpy_like, virtual_array):
 
 def test_reshape_materialized(numpy_like, virtual_array):
     # Test reshape with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.reshape(virtual_array, (5, 1))
     assert isinstance(result, np.ndarray)
     assert result.shape == (5, 1)
@@ -1332,14 +1343,16 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, False, True, False, True], dtype=np.bool_),
+        data_generator=lambda: np.array(
+            [True, False, True, False, True], dtype=np.bool_
+        ),
     )
 
     x1 = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.where(condition, virtual_array, x1)
@@ -1352,7 +1365,7 @@ def test_unique_values_with_virtual_array(numpy_like):
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
     )
 
     result = numpy_like.unique_values(va)
@@ -1365,7 +1378,7 @@ def test_unique_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
     )
 
     result = numpy_like.unique_all(va)
@@ -1381,7 +1394,7 @@ def test_sort_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Sort ascending
@@ -1397,7 +1410,7 @@ def test_sort_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.sort(va2d, axis=1)
@@ -1410,7 +1423,7 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([6, 7, 8], dtype=np.int64),
+        data_generator=lambda: np.array([6, 7, 8], dtype=np.int64),
     )
 
     result = numpy_like.concat([virtual_array, va2])
@@ -1421,14 +1434,14 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
+        data_generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
     )
 
     va2d2 = VirtualArray(
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
+        data_generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
     )
 
     result = numpy_like.concat([va2d1, va2d2], axis=1)
@@ -1445,7 +1458,7 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     result = numpy_like.repeat(va2d, 2, axis=0)
@@ -1460,7 +1473,7 @@ def test_stack_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
+        data_generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
     )
 
     result = numpy_like.stack([virtual_array, va2])
@@ -1479,7 +1492,7 @@ def test_packbits_with_virtual_array(numpy_like):
         numpy_like,
         shape=(8,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
+        data_generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
     )
 
     result = numpy_like.packbits(va)
@@ -1494,7 +1507,7 @@ def test_unpackbits_with_virtual_array(numpy_like):
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.uint8),
-        generator=lambda: np.array([170], dtype=np.uint8),
+        data_generator=lambda: np.array([170], dtype=np.uint8),
     )
 
     result = numpy_like.unpackbits(va)
@@ -1520,7 +1533,7 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
     assert numpy_like.strides(virtual_array) == (8,)  # 8 bytes per int64
 
     # Then test after materializing
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     assert numpy_like.strides(virtual_array) == (8,)
 
 
@@ -1531,7 +1544,7 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.add(virtual_array, va2)
@@ -1544,14 +1557,14 @@ def test_logical_or_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        data_generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_or(va1, va2)
@@ -1564,14 +1577,14 @@ def test_logical_and_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        data_generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_and(va1, va2)
@@ -1584,7 +1597,7 @@ def test_logical_not_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_not(va)
@@ -1598,7 +1611,7 @@ def test_sqrt_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
+        data_generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
     )
 
     result = numpy_like.sqrt(va)
@@ -1611,7 +1624,7 @@ def test_exp_with_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
+        data_generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
     )
 
     result = numpy_like.exp(va)
@@ -1624,14 +1637,14 @@ def test_divide_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
+        data_generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
+        data_generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
     )
 
     result = numpy_like.divide(va1, va2)
@@ -1645,7 +1658,9 @@ def test_nan_to_num_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, np.nan, np.inf, -np.inf], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.0, np.nan, np.inf, -np.inf], dtype=np.float64
+        ),
     )
 
     result = numpy_like.nan_to_num(va)
@@ -1662,14 +1677,14 @@ def test_isclose_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
+        data_generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
+        data_generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
     )
 
     # Default tolerance
@@ -1691,7 +1706,7 @@ def test_isnan_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
+        data_generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
     )
 
     result = numpy_like.isnan(va)
@@ -1705,14 +1720,14 @@ def test_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
+        data_generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
     )
 
     va_mixed = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
+        data_generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
     )
 
     # Test all(all True)
@@ -1728,7 +1743,7 @@ def test_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [[True, True, False], [True, True, True]], dtype=np.bool_
         ),
     )
@@ -1747,14 +1762,14 @@ def test_any_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
+        data_generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
     )
 
     va_mixed = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
+        data_generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
     )
 
     # Test any(all False)
@@ -1770,7 +1785,7 @@ def test_any_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [[False, False, False], [False, True, False]], dtype=np.bool_
         ),
     )
@@ -1785,7 +1800,7 @@ def test_min_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Test overall min
@@ -1797,7 +1812,7 @@ def test_min_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.min(va_2d, axis=1)
@@ -1810,7 +1825,7 @@ def test_max_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Test overall max
@@ -1822,7 +1837,7 @@ def test_max_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.max(va_2d, axis=1)
@@ -1835,7 +1850,7 @@ def test_count_nonzero_with_virtual_array(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
+        data_generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
     )
 
     # Test overall count
@@ -1847,7 +1862,7 @@ def test_count_nonzero_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
+        data_generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
     )
 
     result = numpy_like.count_nonzero(va_2d, axis=1)
@@ -1860,7 +1875,7 @@ def test_cumsum_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Test cumsum
@@ -1872,7 +1887,7 @@ def test_cumsum_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     result = numpy_like.cumsum(va_2d, axis=1)
@@ -1885,7 +1900,7 @@ def test_real_imag_with_complex_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     # Test real
@@ -1903,7 +1918,7 @@ def test_angle_with_complex_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -1925,7 +1940,7 @@ def test_round_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     # Test round to nearest integer
@@ -1949,7 +1964,7 @@ def test_array_str_with_virtual_array_unmaterialized(numpy_like, virtual_array):
 
 def test_array_str_with_virtual_array_materialized(numpy_like, virtual_array):
     # Test array_str with materialized VirtualArray
-    virtual_array.materialize()
+    virtual_array.materialize_data()
     result = numpy_like.array_str(virtual_array)
     assert "[1 2 3 4 5]" in result
 
@@ -1984,14 +1999,14 @@ def test_materialize_if_virtual_function(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([4, 5, 6], dtype=np.int64),
+        data_generator=lambda: np.array([4, 5, 6], dtype=np.int64),
     )
 
     regular_array = np.array([7, 8, 9])
@@ -2012,9 +2027,9 @@ def test_materialize_if_virtual_function(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([10, 11], dtype=np.int64),
+        data_generator=lambda: np.array([10, 11], dtype=np.int64),
     )
-    va3.materialize()  # Pre-materialize
+    va3.materialize_data()  # Pre-materialize
 
     results = materialize_if_virtual(va3, regular_array)
     assert len(results) == 2
@@ -2028,21 +2043,21 @@ def test_operations_with_multiple_virtual_arrays(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        data_generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
+        data_generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
     )
 
     va3 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
+        data_generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
     )
 
     # Expression: (va1 + va2) * va3
@@ -2065,7 +2080,7 @@ def test_is_own_array_with_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
 
     # Before materialization
@@ -2073,7 +2088,7 @@ def test_is_own_array_with_virtual_array(numpy_like):
     assert result  # Should be True because VirtualArray.nplike.ndarray is numpy.ndarray
 
     # After materialization
-    va.materialize()
+    va.materialize_data()
     result = numpy_like.is_own_array(va)
     assert result
 
@@ -2086,7 +2101,7 @@ def test_virtual_array_with_structured_dtype(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=dtype,
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [("Alice", 25, 55.0), ("Bob", 30, 70.5)], dtype=dtype
         ),
     )
@@ -2096,7 +2111,7 @@ def test_virtual_array_with_structured_dtype(numpy_like):
     assert va.shape == (2,)
 
     # Test materialization
-    materialized = va.materialize()
+    materialized = va.materialize_data()
     assert materialized["name"][0] == "Alice"
     assert materialized["age"][1] == 30
     assert materialized["weight"][1] == 70.5
@@ -2108,7 +2123,7 @@ def test_virtual_array_with_empty_array(numpy_like):
         numpy_like,
         shape=(0,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([], dtype=np.int64),
+        data_generator=lambda: np.array([], dtype=np.int64),
     )
 
     # Test properties
@@ -2116,7 +2131,7 @@ def test_virtual_array_with_empty_array(numpy_like):
     assert va.size == 0
 
     # Test materialization
-    materialized = va.materialize()
+    materialized = va.materialize_data()
     assert len(materialized) == 0
 
 
@@ -2126,7 +2141,7 @@ def test_chained_operations_materialization(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Chain of operations
@@ -2388,7 +2403,7 @@ def test_numpyarray_drop_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2396,7 +2411,7 @@ def test_numpyarray_drop_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2413,7 +2428,7 @@ def test_numpy_array_pad_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2421,7 +2436,7 @@ def test_numpy_array_pad_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2440,7 +2455,7 @@ def test_numpyarray_fill_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2448,7 +2463,7 @@ def test_numpyarray_fill_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2475,7 +2490,7 @@ def test_numpyarray_singletons(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
+            data_generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2483,7 +2498,7 @@ def test_numpyarray_singletons(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedArray(virtual_index, virtual_content)
@@ -2558,7 +2573,7 @@ def test_numpyarray_nan_to_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
-            generator=lambda: np.array(
+            data_generator=lambda: np.array(
                 [1, np.nan, 2, 3, np.nan, 4, 5], dtype=np.float64
             ),
         )
@@ -2576,7 +2591,7 @@ def test_numpyarray_nan_to_num(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
-            generator=lambda: np.array(
+            data_generator=lambda: np.array(
                 [1, np.nan, 2, 3, np.nan, 4, 5], dtype=np.float64
             ),
         )
@@ -2603,7 +2618,7 @@ def test_numpyarray_run_lengths(numpy_like):
             numpy_like,
             shape=(8,),
             dtype=np.dtype(np.int64),
-            generator=lambda: np.array([1, 1, 2, 3, 3, 3, 4, 5], dtype=np.int64),
+            data_generator=lambda: np.array([1, 1, 2, 3, 3, 3, 4, 5], dtype=np.int64),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2619,7 +2634,9 @@ def test_numpyarray_round(numpy_like):
             numpy_like,
             shape=(4,),
             dtype=np.dtype(np.float64),
-            generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+            data_generator=lambda: np.array(
+                [1.234, 2.567, 3.499, 4.501], dtype=np.float64
+            ),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2655,7 +2672,9 @@ def test_numpyarray_real(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
-            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+            data_generator=lambda: np.array(
+                [1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128
+            ),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2671,7 +2690,9 @@ def test_numpyarray_imag(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
-            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+            data_generator=lambda: np.array(
+                [1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128
+            ),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2990,14 +3011,14 @@ def test_listoffsetarray_nanargmin(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3040,14 +3061,14 @@ def test_listoffsetarray_nanargmax(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3112,21 +3133,25 @@ def test_listoffsetarray_drop_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
+        data_generator=lambda: np.array(
+            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
+        ),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -3158,14 +3183,14 @@ def test_listoffsetarray_pad_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -3202,21 +3227,25 @@ def test_listoffsetarray_fill_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
+        data_generator=lambda: np.array(
+            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
+        ),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -3259,14 +3288,14 @@ def test_listoffsetarray_singletons(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3356,14 +3385,14 @@ def test_listoffsetarray_nan_to_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3394,14 +3423,14 @@ def test_listoffsetarray_nan_to_num(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3441,14 +3470,14 @@ def test_listoffsetarray_run_lengths(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+        data_generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3475,14 +3504,14 @@ def test_listoffsetarray_round(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3528,14 +3557,14 @@ def test_listoffsetarray_real(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3561,14 +3590,14 @@ def test_listoffsetarray_imag(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3594,14 +3623,14 @@ def test_listoffsetarray_angle(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -3958,21 +3987,21 @@ def test_listarray_nanargmin(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4016,21 +4045,21 @@ def test_listarray_nanargmax(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4100,28 +4129,32 @@ def test_listarray_drop_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
+        data_generator=lambda: np.array(
+            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
+        ),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -4156,21 +4189,21 @@ def test_listarray_pad_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -4212,28 +4245,32 @@ def test_listarray_fill_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
+        data_generator=lambda: np.array(
+            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
+        ),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -4279,21 +4316,21 @@ def test_listarray_singletons(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
+        data_generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4386,21 +4423,21 @@ def test_listarray_nan_to_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4434,21 +4471,21 @@ def test_listarray_nan_to_num(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4491,21 +4528,21 @@ def test_listarray_run_lengths(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 3], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([3, 6], dtype=np.int64),
+        data_generator=lambda: np.array([3, 6], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4535,21 +4572,21 @@ def test_listarray_round(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4598,21 +4635,21 @@ def test_listarray_real(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4641,21 +4678,21 @@ def test_listarray_imag(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 3], dtype=np.int64),
+        data_generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4684,21 +4721,21 @@ def test_listarray_angle(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([2, 4], dtype=np.int64),
+        data_generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -5272,14 +5309,14 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -5289,7 +5326,7 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5332,14 +5369,14 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -5348,7 +5385,9 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, np.nan, 0.3, np.nan, 0.5], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [0.1, np.nan, 0.3, np.nan, 0.5], dtype=np.float64
+        ),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5552,21 +5591,21 @@ def test_recordarray_run_lengths_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
+        data_generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5607,21 +5646,25 @@ def test_recordarray_run_lengths_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
+        data_generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.1, 0.2, 0.3, 0.3, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [0.1, 0.1, 0.2, 0.3, 0.3, 0.3], dtype=np.float64
+        ),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5662,21 +5705,21 @@ def test_recordarray_round_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5717,21 +5760,21 @@ def test_recordarray_round_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.234, 2.567, 3.499], dtype=np.float64),
+        data_generator=lambda: np.array([1.234, 2.567, 3.499], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5792,21 +5835,21 @@ def test_recordarray_real_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5847,20 +5890,20 @@ def test_recordarray_real_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5901,21 +5944,21 @@ def test_recordarray_imag_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5956,21 +5999,21 @@ def test_recordarray_imag_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6011,14 +6054,14 @@ def test_recordarray_angle_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array(
+        data_generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -6027,7 +6070,7 @@ def test_recordarray_angle_x_field(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6068,21 +6111,21 @@ def test_recordarray_angle_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        generator=lambda: np.array([1 + 0j, 0 + 1j, -1 + 0j], dtype=np.complex128),
+        data_generator=lambda: np.array([1 + 0j, 0 + 1j, -1 + 0j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6121,7 +6164,7 @@ def test_recordarray_with_field(recordarray, virtual_recordarray, numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64),
+        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64),
     )
 
     # Test with_field method which adds a new field
@@ -6180,21 +6223,21 @@ def test_recordarray_with_custom_generator(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=compute_offsets,
+        data_generator=compute_offsets,
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        generator=compute_content,
+        data_generator=compute_content,
     )
 
     virtual_y = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        generator=compute_y_values,
+        data_generator=compute_y_values,
     )
 
     # Create the RecordArray
@@ -6276,35 +6319,39 @@ def test_recordarray_with_none_values(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_x_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
+        data_generator=lambda: np.array(
+            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
+        ),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
+        data_generator=lambda: np.array(
+            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
+        ),
     )
 
     virtual_y_index = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
+        data_generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -2355,6 +2355,13 @@ def test_numpyarray_argmax(numpyarray, virtual_numpyarray):
     assert virtual_numpyarray.is_all_materialized
 
 
+def test_numpyarray_nanargmax(numpyarray, virtual_numpyarray):
+    assert not virtual_numpyarray.is_any_materialized
+    assert ak.nanargmax(virtual_numpyarray, axis=0) == ak.nanargmax(numpyarray, axis=0)
+    assert virtual_numpyarray.is_any_materialized
+    assert virtual_numpyarray.is_all_materialized
+
+
 def test_numpyarray_sort(numpyarray, virtual_numpyarray):
     assert not virtual_numpyarray.is_any_materialized
     assert ak.array_equal(

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -28,7 +28,7 @@ def virtual_array(numpy_like, simple_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=simple_array_generator,
+        generator=simple_array_generator,
     )
 
 
@@ -43,7 +43,7 @@ def two_dim_virtual_array(numpy_like, two_dim_array_generator):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=two_dim_array_generator,
+        generator=two_dim_array_generator,
     )
 
 
@@ -55,10 +55,7 @@ def scalar_array_generator():
 @pytest.fixture
 def scalar_virtual_array(numpy_like, scalar_array_generator):
     return VirtualArray(
-        numpy_like,
-        shape=(),
-        dtype=np.dtype(np.int64),
-        data_generator=scalar_array_generator,
+        numpy_like, shape=(), dtype=np.dtype(np.int64), generator=scalar_array_generator
     )
 
 
@@ -73,7 +70,7 @@ def float_virtual_array(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=float_array_generator,
+        generator=float_array_generator,
     )
 
 
@@ -98,7 +95,7 @@ def virtual_offset_array(numpy_like, offset_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=offset_array_generator,
+        generator=offset_array_generator,
     )
 
 
@@ -132,7 +129,7 @@ def virtual_starts_array(numpy_like, starts_array_generator):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=starts_array_generator,
+        generator=starts_array_generator,
     )
 
 
@@ -147,7 +144,7 @@ def virtual_stops_array(numpy_like, stops_array_generator):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=stops_array_generator,
+        generator=stops_array_generator,
     )
 
 
@@ -164,7 +161,7 @@ def virtual_content_array(numpy_like, content_array_generator):
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=content_array_generator,
+        generator=content_array_generator,
     )
 
 
@@ -202,7 +199,7 @@ def virtual_offsets_array(numpy_like, offsets_array_generator):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=offsets_array_generator,
+        generator=offsets_array_generator,
     )
 
 
@@ -219,7 +216,7 @@ def virtual_x_content_array(numpy_like, x_content_array_generator):
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=x_content_array_generator,
+        generator=x_content_array_generator,
     )
 
 
@@ -234,7 +231,7 @@ def virtual_y_array(numpy_like, y_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=y_array_generator,
+        generator=y_array_generator,
     )
 
 
@@ -274,7 +271,7 @@ def virtual_recordarray(
 # Test initialization
 def test_init_valid(numpy_like, simple_array_generator):
     va = VirtualArray(
-        numpy_like, shape=(5,), dtype=np.int64, data_generator=simple_array_generator
+        numpy_like, shape=(5,), dtype=np.int64, generator=simple_array_generator
     )
     assert va.shape == (5,)
     assert va.dtype == np.dtype(np.int64)
@@ -291,7 +288,7 @@ def test_init_invalid_shape():
             nplike,
             shape=("not_an_integer", 5),
             dtype=np.int64,
-            data_generator=lambda: np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
+            generator=lambda: np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
         )
 
 
@@ -322,7 +319,7 @@ def test_nbytes_unmaterialized(virtual_array):
 
 
 def test_nbytes_materialized(virtual_array):
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     assert virtual_array.nbytes == np.array([1, 2, 3, 4, 5], dtype=np.int64).nbytes
 
 
@@ -333,7 +330,7 @@ def test_strides(virtual_array):
 
 # Test materialization
 def test_materialize(virtual_array):
-    result = virtual_array.materialize_data()
+    result = virtual_array.materialize()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
     assert virtual_array.is_materialized
@@ -341,7 +338,7 @@ def test_materialize(virtual_array):
 
 def test_is_materialized(virtual_array):
     assert not virtual_array.is_materialized
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     assert virtual_array.is_materialized
 
 
@@ -355,9 +352,9 @@ def test_materialize_shape_mismatch(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.int64,
-            data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
         )
-        va.materialize_data()
+        va.materialize()
 
 
 def test_materialize_dtype_mismatch(numpy_like):
@@ -370,9 +367,9 @@ def test_materialize_dtype_mismatch(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.int64,
-            data_generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
         )
-        va.materialize_data()
+        va.materialize()
 
 
 # Test transpose
@@ -384,7 +381,7 @@ def test_T_unmaterialized(two_dim_virtual_array):
 
 
 def test_T_materialized(two_dim_virtual_array):
-    two_dim_virtual_array.materialize_data()
+    two_dim_virtual_array.materialize()
     transposed = two_dim_virtual_array.T
     assert isinstance(transposed, np.ndarray)
     assert transposed.shape == (3, 2)
@@ -399,7 +396,7 @@ def test_view_unmaterialized(virtual_array):
 
 
 def test_view_materialized(virtual_array):
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     view = virtual_array.view(np.float64)
     assert isinstance(view, np.ndarray)
     assert view.dtype == np.dtype(np.float64)
@@ -411,7 +408,7 @@ def test_view_invalid_size():
         nplike,
         shape=(3,),
         dtype=np.int8,
-        data_generator=lambda: np.array([1, 2, 3], dtype=np.int8),
+        generator=lambda: np.array([1, 2, 3], dtype=np.int8),
     )
     with pytest.raises(
         ValueError, match=r"new size of array with larger dtype must be a divisor"
@@ -421,7 +418,7 @@ def test_view_invalid_size():
 
 # Test generator property
 def test_generator(virtual_array, simple_array_generator):
-    assert virtual_array.data_generator is simple_array_generator
+    assert virtual_array.generator is simple_array_generator
 
 
 # Test nplike property
@@ -494,14 +491,14 @@ def test_getitem_slice(virtual_array):
     sliced = virtual_array[1:4]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
-    np.testing.assert_array_equal(sliced.materialize_data(), np.array([2, 3, 4]))
+    np.testing.assert_array_equal(sliced.materialize(), np.array([2, 3, 4]))
 
 
 def test_getitem_slice_with_step(virtual_array):
     sliced = virtual_array[::2]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
-    np.testing.assert_array_equal(sliced.materialize_data(), np.array([1, 3, 5]))
+    np.testing.assert_array_equal(sliced.materialize(), np.array([1, 3, 5]))
 
 
 def test_getitem_slice_with_unknown_length():
@@ -510,7 +507,7 @@ def test_getitem_slice_with_unknown_length():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
     with pytest.raises(
         TypeError, match=r"does not support slicing with unknown_length"
@@ -523,7 +520,7 @@ def test_setitem(virtual_array):
     virtual_array[2] = 10
     assert virtual_array[2] == 10
     np.testing.assert_array_equal(
-        virtual_array.materialize_data(), np.array([1, 2, 10, 4, 5])
+        virtual_array.materialize(), np.array([1, 2, 10, 4, 5])
     )
 
 
@@ -534,10 +531,7 @@ def test_bool_scalar(scalar_virtual_array):
     # Test with zero value
     nplike = Numpy.instance()
     va_zero = VirtualArray(
-        nplike,
-        shape=(),
-        dtype=np.int64,
-        data_generator=lambda: np.array(0, dtype=np.int64),
+        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(0, dtype=np.int64)
     )
     assert bool(va_zero) is False
 
@@ -582,10 +576,7 @@ def test_len_scalar():
     # Scalar arrays don't have a length
     nplike = Numpy.instance()
     scalar_va = VirtualArray(
-        nplike,
-        shape=(),
-        dtype=np.int64,
-        data_generator=lambda: np.array(42, dtype=np.int64),
+        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(42, dtype=np.int64)
     )
     with pytest.raises(TypeError, match=r"len\(\) of unsized object"):
         len(scalar_va)
@@ -630,13 +621,13 @@ def test_materialize_if_virtual():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
     va2 = VirtualArray(
         nplike,
         shape=(2,),
         dtype=np.int64,
-        data_generator=lambda: np.array([4, 5], dtype=np.int64),
+        generator=lambda: np.array([4, 5], dtype=np.int64),
     )
     regular_array = np.array([6, 7, 8])
 
@@ -654,7 +645,7 @@ def test_materialize_if_virtual():
 # Tests for float virtual array
 def test_float_array_init(numpy_like, float_array_generator):
     va = VirtualArray(
-        numpy_like, shape=(5,), dtype=np.float64, data_generator=float_array_generator
+        numpy_like, shape=(5,), dtype=np.float64, generator=float_array_generator
     )
     assert va.shape == (5,)
     assert va.dtype == np.dtype(np.float64)
@@ -662,7 +653,7 @@ def test_float_array_init(numpy_like, float_array_generator):
 
 
 def test_float_array_materialize(float_virtual_array):
-    result = float_virtual_array.materialize_data()
+    result = float_virtual_array.materialize()
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
     assert float_virtual_array.is_materialized
@@ -674,13 +665,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=float_array_generator,
+        generator=float_array_generator,
     )
     sliced = float_virtual_array1[1:4]
     assert isinstance(sliced, VirtualArray)
     assert sliced.shape == (3,)
     np.testing.assert_array_almost_equal(
-        sliced.materialize_data(), np.array([2.2, 3.3, 4.4])
+        sliced.materialize(), np.array([2.2, 3.3, 4.4])
     )
 
     # Test step slice
@@ -688,13 +679,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=float_array_generator,
+        generator=float_array_generator,
     )
     sliced_step = float_virtual_array2[::2]
     assert isinstance(sliced_step, VirtualArray)
     assert sliced_step.shape == (3,)
     np.testing.assert_array_almost_equal(
-        sliced_step.materialize_data(), np.array([1.1, 3.3, 5.5])
+        sliced_step.materialize(), np.array([1.1, 3.3, 5.5])
     )
 
     # Test negative step
@@ -702,13 +693,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=float_array_generator,
+        generator=float_array_generator,
     )
     sliced_neg = float_virtual_array3[::-1]
     assert isinstance(sliced_neg, VirtualArray)
     assert sliced_neg.shape == (5,)
     np.testing.assert_array_almost_equal(
-        sliced_neg.materialize_data(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
+        sliced_neg.materialize(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
     )
 
     # Test complex slice
@@ -716,13 +707,13 @@ def test_float_array_slicing(numpy_like, float_array_generator):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=float_array_generator,
+        generator=float_array_generator,
     )
     sliced_complex = float_virtual_array4[4:1:-2]
     assert isinstance(sliced_complex, VirtualArray)
     assert sliced_complex.shape == (2,)
     np.testing.assert_array_almost_equal(
-        sliced_complex.materialize_data(), np.array([5.5, 3.3])
+        sliced_complex.materialize(), np.array([5.5, 3.3])
     )
 
 
@@ -752,14 +743,14 @@ def test_float_array_view(float_virtual_array):
     assert view.dtype == np.dtype(np.float32)
 
     # Test materialization of view
-    materialized = view.materialize_data()
+    materialized = view.materialize()
     assert materialized.dtype == np.dtype(np.float32)
 
 
 def test_float_to_int_comparison(float_virtual_array, virtual_array):
     # Compare float and int arrays
-    float_data = float_virtual_array.materialize_data()
-    int_data = virtual_array.materialize_data()
+    float_data = float_virtual_array.materialize()
+    int_data = virtual_array.materialize()
 
     # Test basic properties
     assert float_virtual_array.shape == virtual_array.shape
@@ -783,7 +774,7 @@ def test_float_array_rounding():
         nplike,
         shape=(5,),
         dtype=np.float64,
-        data_generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
     )
 
     # Test floor
@@ -806,9 +797,7 @@ def test_float_array_nan():
         nplike,
         shape=(5,),
         dtype=np.float64,
-        data_generator=lambda: np.array(
-            [1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64),
     )
 
     # Test isnan
@@ -833,7 +822,7 @@ def test_multidim_slicing(two_dim_virtual_array):
         nplike,
         shape=(2, 3),
         dtype=np.int64,
-        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     # Test advanced indexing
@@ -850,13 +839,13 @@ def test_empty_array():
         nplike,
         shape=(0,),
         dtype=np.int64,
-        data_generator=lambda: np.array([], dtype=np.int64),
+        generator=lambda: np.array([], dtype=np.int64),
     )
 
     assert va.shape == (0,)
     assert va.size == 0
     assert len(va) == 0
-    materialized = va.materialize_data()
+    materialized = va.materialize()
     assert len(materialized) == 0
 
 
@@ -872,11 +861,11 @@ def test_structured_dtype():
         nplike,
         shape=(3,),
         dtype=dtype,
-        data_generator=lambda: data,
+        generator=lambda: data,
     )
 
     assert va.dtype == dtype
-    materialized = va.materialize_data()
+    materialized = va.materialize()
     assert materialized["name"][1] == "Bob"
     assert materialized["age"][2] == 35
     assert materialized["weight"][0] == 55.0
@@ -895,7 +884,7 @@ def test_large_array_memory():
         nplike,
         shape=(1000, 1000),
         dtype=np.float64,
-        data_generator=large_array_generator,
+        generator=large_array_generator,
     )
 
     assert va.nbytes == 1000 * 1000 * 8  # 8 bytes per float64 element
@@ -920,11 +909,11 @@ def test_generator_error():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        data_generator=failing_generator,
+        generator=failing_generator,
     )
 
     with pytest.raises(ValueError, match="Generator failure test"):
-        va.materialize_data()
+        va.materialize()
 
 
 # Test nested VirtualArrays (generator returns another VirtualArray)
@@ -936,7 +925,7 @@ def test_nested_virtual_arrays():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        data_generator=lambda: np.array([10, 20, 30], np.int64),
+        generator=lambda: np.array([10, 20, 30], np.int64),
     )
 
     # Outer virtual array, generator returns inner virtual array
@@ -944,11 +933,11 @@ def test_nested_virtual_arrays():
         nplike,
         shape=(3,),
         dtype=np.int64,
-        data_generator=lambda: inner_va,
+        generator=lambda: inner_va,
     )
 
     # Should materialize both
-    result = outer_va.materialize_data()
+    result = outer_va.materialize()
     np.testing.assert_array_equal(result, np.array([10, 20, 30]))
     assert inner_va.is_materialized
     assert outer_va.is_materialized
@@ -961,11 +950,11 @@ def test_complex_numbers():
         nplike,
         shape=(3,),
         dtype=np.complex128,
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     assert va.dtype == np.dtype(np.complex128)
-    materialized = va.materialize_data()
+    materialized = va.materialize()
     np.testing.assert_array_equal(materialized, np.array([1 + 2j, 3 + 4j, 5 + 6j]))
 
     # Test complex operations
@@ -981,7 +970,7 @@ def test_slice_zero_step():
         nplike,
         shape=(5,),
         dtype=np.int64,
-        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     with pytest.raises(ValueError):
@@ -1012,7 +1001,7 @@ def test_slice_length_calculation():
             nplike,
             shape=(array_length,),
             dtype=np.int64,
-            data_generator=create_generator(array_length),
+            generator=create_generator(array_length),
         )
 
         sliced = va[slice_obj]
@@ -1042,7 +1031,7 @@ def test_asarray_virtual_array_unmaterialized(numpy_like, virtual_array):
 
 def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
     # Test with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.asarray(virtual_array)
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
@@ -1054,12 +1043,12 @@ def test_asarray_virtual_array_with_dtype(numpy_like, virtual_array):
     assert isinstance(out, VirtualArray)
     assert out.dtype == np.dtype(np.float64)
     assert not out.is_materialized
-    assert out.materialize_data().dtype == np.dtype(np.float64)
+    assert out.materialize().dtype == np.dtype(np.float64)
 
 
 def test_asarray_virtual_array_with_copy(numpy_like, virtual_array):
     # Test with copy parameter
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     with pytest.raises(
         ValueError,
         match="asarray was called with copy=False for an array of a different dtype",
@@ -1079,7 +1068,7 @@ def test_ascontiguousarray_unmaterialized(numpy_like, virtual_array):
 
 def test_ascontiguousarray_materialized(numpy_like, virtual_array):
     # Test with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.ascontiguousarray(virtual_array)
     assert isinstance(result, np.ndarray)
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
@@ -1106,7 +1095,7 @@ def test_zeros_like_unmaterialized(numpy_like, virtual_array):
 
 def test_zeros_like_materialized(numpy_like, virtual_array):
     # Test zeros_like with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1126,7 +1115,7 @@ def test_ones_like_unmaterialized(numpy_like, virtual_array):
 
 def test_ones_like_materialized(numpy_like, virtual_array):
     # Test ones_like with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1146,7 +1135,7 @@ def test_full_like_unmaterialized(numpy_like, virtual_array):
 
 def test_full_like_materialized(numpy_like, virtual_array):
     # Test full_like with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1164,7 +1153,7 @@ def test_arange_with_virtual_array_start(numpy_like, scalar_virtual_array):
 
 def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
     # Test meshgrid with VirtualArray parameter
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.meshgrid(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
@@ -1178,7 +1167,7 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Test array_equal
@@ -1190,7 +1179,7 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1, 2, 3, 4, 6], dtype=np.int64
         ),  # Different last value
     )
@@ -1204,13 +1193,13 @@ def test_array_equal_with_equal_nan(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
     )
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
     )
 
     # Should be False by default (NaN != NaN)
@@ -1228,7 +1217,7 @@ def test_searchsorted_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+        generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
     result = numpy_like.searchsorted(virtual_array, values)
@@ -1248,7 +1237,7 @@ def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.apply_ufunc(np.multiply, "__call__", [virtual_array, va2])
@@ -1262,7 +1251,7 @@ def test_broadcast_arrays_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([10], dtype=np.int64),
+        generator=lambda: np.array([10], dtype=np.int64),
     )
 
     result = numpy_like.broadcast_arrays(virtual_array, va2)
@@ -1287,7 +1276,7 @@ def test_reshape_unmaterialized(numpy_like, virtual_array):
 
 def test_reshape_materialized(numpy_like, virtual_array):
     # Test reshape with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.reshape(virtual_array, (5, 1))
     assert isinstance(result, np.ndarray)
     assert result.shape == (5, 1)
@@ -1344,16 +1333,14 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array(
-            [True, False, True, False, True], dtype=np.bool_
-        ),
+        generator=lambda: np.array([True, False, True, False, True], dtype=np.bool_),
     )
 
     x1 = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.where(condition, virtual_array, x1)
@@ -1366,7 +1353,7 @@ def test_unique_values_with_virtual_array(numpy_like):
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
     )
 
     result = numpy_like.unique_values(va)
@@ -1379,7 +1366,7 @@ def test_unique_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
     )
 
     result = numpy_like.unique_all(va)
@@ -1395,7 +1382,7 @@ def test_sort_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Sort ascending
@@ -1411,7 +1398,7 @@ def test_sort_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.sort(va2d, axis=1)
@@ -1424,7 +1411,7 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([6, 7, 8], dtype=np.int64),
+        generator=lambda: np.array([6, 7, 8], dtype=np.int64),
     )
 
     result = numpy_like.concat([virtual_array, va2])
@@ -1435,14 +1422,14 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
+        generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
     )
 
     va2d2 = VirtualArray(
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
+        generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
     )
 
     result = numpy_like.concat([va2d1, va2d2], axis=1)
@@ -1459,7 +1446,7 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     result = numpy_like.repeat(va2d, 2, axis=0)
@@ -1474,7 +1461,7 @@ def test_stack_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
+        generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
     )
 
     result = numpy_like.stack([virtual_array, va2])
@@ -1493,7 +1480,7 @@ def test_packbits_with_virtual_array(numpy_like):
         numpy_like,
         shape=(8,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
+        generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
     )
 
     result = numpy_like.packbits(va)
@@ -1508,7 +1495,7 @@ def test_unpackbits_with_virtual_array(numpy_like):
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.uint8),
-        data_generator=lambda: np.array([170], dtype=np.uint8),
+        generator=lambda: np.array([170], dtype=np.uint8),
     )
 
     result = numpy_like.unpackbits(va)
@@ -1534,7 +1521,7 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
     assert numpy_like.strides(virtual_array) == (8,)  # 8 bytes per int64
 
     # Then test after materializing
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     assert numpy_like.strides(virtual_array) == (8,)
 
 
@@ -1545,7 +1532,7 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
     )
 
     result = numpy_like.add(virtual_array, va2)
@@ -1558,14 +1545,14 @@ def test_logical_or_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_or(va1, va2)
@@ -1578,14 +1565,14 @@ def test_logical_and_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_and(va1, va2)
@@ -1598,7 +1585,7 @@ def test_logical_not_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
     result = numpy_like.logical_not(va)
@@ -1612,7 +1599,7 @@ def test_sqrt_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
+        generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
     )
 
     result = numpy_like.sqrt(va)
@@ -1625,7 +1612,7 @@ def test_exp_with_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
+        generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
     )
 
     result = numpy_like.exp(va)
@@ -1638,14 +1625,14 @@ def test_divide_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
+        generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
+        generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
     )
 
     result = numpy_like.divide(va1, va2)
@@ -1659,9 +1646,7 @@ def test_nan_to_num_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.0, np.nan, np.inf, -np.inf], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.0, np.nan, np.inf, -np.inf], dtype=np.float64),
     )
 
     result = numpy_like.nan_to_num(va)
@@ -1678,14 +1663,14 @@ def test_isclose_with_virtual_arrays(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
+        generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
+        generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
     )
 
     # Default tolerance
@@ -1707,7 +1692,7 @@ def test_isnan_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
+        generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
     )
 
     result = numpy_like.isnan(va)
@@ -1721,14 +1706,14 @@ def test_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
+        generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
     )
 
     va_mixed = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
+        generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
     )
 
     # Test all(all True)
@@ -1744,7 +1729,7 @@ def test_all_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [[True, True, False], [True, True, True]], dtype=np.bool_
         ),
     )
@@ -1763,14 +1748,14 @@ def test_any_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
+        generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
     )
 
     va_mixed = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
+        generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
     )
 
     # Test any(all False)
@@ -1786,7 +1771,7 @@ def test_any_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [[False, False, False], [False, True, False]], dtype=np.bool_
         ),
     )
@@ -1801,7 +1786,7 @@ def test_min_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Test overall min
@@ -1813,7 +1798,7 @@ def test_min_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.min(va_2d, axis=1)
@@ -1826,7 +1811,7 @@ def test_max_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
     )
 
     # Test overall max
@@ -1838,7 +1823,7 @@ def test_max_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
     )
 
     result = numpy_like.max(va_2d, axis=1)
@@ -1851,7 +1836,7 @@ def test_count_nonzero_with_virtual_array(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
+        generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
     )
 
     # Test overall count
@@ -1863,7 +1848,7 @@ def test_count_nonzero_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
+        generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
     )
 
     result = numpy_like.count_nonzero(va_2d, axis=1)
@@ -1876,7 +1861,7 @@ def test_cumsum_with_virtual_array(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Test cumsum
@@ -1888,7 +1873,7 @@ def test_cumsum_with_virtual_array(numpy_like):
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
     )
 
     result = numpy_like.cumsum(va_2d, axis=1)
@@ -1901,7 +1886,7 @@ def test_real_imag_with_complex_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     # Test real
@@ -1919,7 +1904,7 @@ def test_angle_with_complex_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -1941,7 +1926,7 @@ def test_round_with_virtual_array(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     # Test round to nearest integer
@@ -1965,7 +1950,7 @@ def test_array_str_with_virtual_array_unmaterialized(numpy_like, virtual_array):
 
 def test_array_str_with_virtual_array_materialized(numpy_like, virtual_array):
     # Test array_str with materialized VirtualArray
-    virtual_array.materialize_data()
+    virtual_array.materialize()
     result = numpy_like.array_str(virtual_array)
     assert "[1 2 3 4 5]" in result
 
@@ -2000,14 +1985,14 @@ def test_materialize_if_virtual_function(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([4, 5, 6], dtype=np.int64),
+        generator=lambda: np.array([4, 5, 6], dtype=np.int64),
     )
 
     regular_array = np.array([7, 8, 9])
@@ -2028,9 +2013,9 @@ def test_materialize_if_virtual_function(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([10, 11], dtype=np.int64),
+        generator=lambda: np.array([10, 11], dtype=np.int64),
     )
-    va3.materialize_data()  # Pre-materialize
+    va3.materialize()  # Pre-materialize
 
     results = materialize_if_virtual(va3, regular_array)
     assert len(results) == 2
@@ -2044,21 +2029,21 @@ def test_operations_with_multiple_virtual_arrays(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
     )
 
     va2 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
+        generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
     )
 
     va3 = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
+        generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
     )
 
     # Expression: (va1 + va2) * va3
@@ -2081,7 +2066,7 @@ def test_is_own_array_with_virtual_array(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
 
     # Before materialization
@@ -2089,7 +2074,7 @@ def test_is_own_array_with_virtual_array(numpy_like):
     assert result  # Should be True because VirtualArray.nplike.ndarray is numpy.ndarray
 
     # After materialization
-    va.materialize_data()
+    va.materialize()
     result = numpy_like.is_own_array(va)
     assert result
 
@@ -2102,7 +2087,7 @@ def test_virtual_array_with_structured_dtype(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=dtype,
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [("Alice", 25, 55.0), ("Bob", 30, 70.5)], dtype=dtype
         ),
     )
@@ -2112,7 +2097,7 @@ def test_virtual_array_with_structured_dtype(numpy_like):
     assert va.shape == (2,)
 
     # Test materialization
-    materialized = va.materialize_data()
+    materialized = va.materialize()
     assert materialized["name"][0] == "Alice"
     assert materialized["age"][1] == 30
     assert materialized["weight"][1] == 70.5
@@ -2124,7 +2109,7 @@ def test_virtual_array_with_empty_array(numpy_like):
         numpy_like,
         shape=(0,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([], dtype=np.int64),
+        generator=lambda: np.array([], dtype=np.int64),
     )
 
     # Test properties
@@ -2132,7 +2117,7 @@ def test_virtual_array_with_empty_array(numpy_like):
     assert va.size == 0
 
     # Test materialization
-    materialized = va.materialize_data()
+    materialized = va.materialize()
     assert len(materialized) == 0
 
 
@@ -2142,7 +2127,7 @@ def test_chained_operations_materialization(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
     )
 
     # Chain of operations
@@ -2404,7 +2389,7 @@ def test_numpyarray_drop_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2412,7 +2397,7 @@ def test_numpyarray_drop_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2429,7 +2414,7 @@ def test_numpy_array_pad_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2437,7 +2422,7 @@ def test_numpy_array_pad_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2456,7 +2441,7 @@ def test_numpyarray_fill_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
+            generator=lambda: np.array([0, -1, 1, 2, -1, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2464,7 +2449,7 @@ def test_numpyarray_fill_none(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedOptionArray(virtual_index, virtual_content)
@@ -2491,7 +2476,7 @@ def test_numpyarray_singletons(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
+            generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
         )
     )
     virtual_content = ak.contents.NumpyArray(
@@ -2499,7 +2484,7 @@ def test_numpyarray_singletons(numpy_like):
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     )
     virtual_array = ak.contents.IndexedArray(virtual_index, virtual_content)
@@ -2574,7 +2559,7 @@ def test_numpyarray_nan_to_none(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
-            data_generator=lambda: np.array(
+            generator=lambda: np.array(
                 [1, np.nan, 2, 3, np.nan, 4, 5], dtype=np.float64
             ),
         )
@@ -2592,7 +2577,7 @@ def test_numpyarray_nan_to_num(numpy_like):
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
-            data_generator=lambda: np.array(
+            generator=lambda: np.array(
                 [1, np.nan, 2, 3, np.nan, 4, 5], dtype=np.float64
             ),
         )
@@ -2619,7 +2604,7 @@ def test_numpyarray_run_lengths(numpy_like):
             numpy_like,
             shape=(8,),
             dtype=np.dtype(np.int64),
-            data_generator=lambda: np.array([1, 1, 2, 3, 3, 3, 4, 5], dtype=np.int64),
+            generator=lambda: np.array([1, 1, 2, 3, 3, 3, 4, 5], dtype=np.int64),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2635,9 +2620,7 @@ def test_numpyarray_round(numpy_like):
             numpy_like,
             shape=(4,),
             dtype=np.dtype(np.float64),
-            data_generator=lambda: np.array(
-                [1.234, 2.567, 3.499, 4.501], dtype=np.float64
-            ),
+            generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2673,9 +2656,7 @@ def test_numpyarray_real(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
-            data_generator=lambda: np.array(
-                [1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128
-            ),
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -2691,9 +2672,7 @@ def test_numpyarray_imag(numpy_like):
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
-            data_generator=lambda: np.array(
-                [1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128
-            ),
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
         )
     )
     assert not virtual_array.is_any_materialized
@@ -3012,14 +2991,14 @@ def test_listoffsetarray_nanargmin(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3062,14 +3041,14 @@ def test_listoffsetarray_nanargmax(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3134,25 +3113,21 @@ def test_listoffsetarray_drop_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
-            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
-        ),
+        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -3184,14 +3159,14 @@ def test_listoffsetarray_pad_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -3228,25 +3203,21 @@ def test_listoffsetarray_fill_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
-            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
-        ),
+        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -3289,14 +3260,14 @@ def test_listoffsetarray_singletons(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3386,14 +3357,14 @@ def test_listoffsetarray_nan_to_none(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3424,14 +3395,14 @@ def test_listoffsetarray_nan_to_num(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -3471,14 +3442,14 @@ def test_listoffsetarray_run_lengths(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+        generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3505,14 +3476,14 @@ def test_listoffsetarray_round(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3558,14 +3529,14 @@ def test_listoffsetarray_real(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3591,14 +3562,14 @@ def test_listoffsetarray_imag(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListOffsetArray(
@@ -3624,14 +3595,14 @@ def test_listoffsetarray_angle(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -3988,21 +3959,21 @@ def test_listarray_nanargmin(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4046,21 +4017,21 @@ def test_listarray_nanargmax(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4130,32 +4101,28 @@ def test_listarray_drop_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
-            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
-        ),
+        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -4190,21 +4157,21 @@ def test_listarray_pad_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -4246,32 +4213,28 @@ def test_listarray_fill_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
-            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
-        ),
+        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_indexed_content = ak.contents.IndexedOptionArray(
@@ -4317,21 +4280,21 @@ def test_listarray_singletons(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
+        generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4424,21 +4387,21 @@ def test_listarray_nan_to_none(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4472,21 +4435,21 @@ def test_listarray_nan_to_num(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -4529,21 +4492,21 @@ def test_listarray_run_lengths(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 3], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([3, 6], dtype=np.int64),
+        generator=lambda: np.array([3, 6], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4573,21 +4536,21 @@ def test_listarray_round(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2], dtype=np.int64),
+        generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4], dtype=np.int64),
+        generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4636,21 +4599,21 @@ def test_listarray_real(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2], dtype=np.int64),
+        generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 3], dtype=np.int64),
+        generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4679,21 +4642,21 @@ def test_listarray_imag(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2], dtype=np.int64),
+        generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 3], dtype=np.int64),
+        generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_array = ak.contents.ListArray(
@@ -4722,21 +4685,21 @@ def test_listarray_angle(numpy_like):
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2], dtype=np.int64),
+        generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
     virtual_stops = VirtualArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([2, 4], dtype=np.int64),
+        generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -5310,14 +5273,14 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, np.nan, 3.3, np.nan, 5.5, 6.6, np.nan, 8.8, 9.9, np.nan],
             dtype=np.float64,
         ),
@@ -5327,7 +5290,7 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3, 0.4, 0.5], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5370,14 +5333,14 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.10], dtype=np.float64
         ),
     )
@@ -5386,9 +5349,7 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [0.1, np.nan, 0.3, np.nan, 0.5], dtype=np.float64
-        ),
+        generator=lambda: np.array([0.1, np.nan, 0.3, np.nan, 0.5], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5592,21 +5553,21 @@ def test_recordarray_run_lengths_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
+        generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5647,25 +5608,21 @@ def test_recordarray_run_lengths_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
+        generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [0.1, 0.1, 0.2, 0.3, 0.3, 0.3], dtype=np.float64
-        ),
+        generator=lambda: np.array([0.1, 0.1, 0.2, 0.3, 0.3, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5706,21 +5663,21 @@ def test_recordarray_round_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5761,21 +5718,21 @@ def test_recordarray_round_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.234, 2.567, 3.499], dtype=np.float64),
+        generator=lambda: np.array([1.234, 2.567, 3.499], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5836,21 +5793,21 @@ def test_recordarray_real_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5891,20 +5848,20 @@ def test_recordarray_real_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -5945,21 +5902,21 @@ def test_recordarray_imag_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6000,21 +5957,21 @@ def test_recordarray_imag_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6055,14 +6012,14 @@ def test_recordarray_angle_x_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array(
+        generator=lambda: np.array(
             [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
         ),
     )
@@ -6071,7 +6028,7 @@ def test_recordarray_angle_x_field(numpy_like):
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6112,21 +6069,21 @@ def test_recordarray_angle_y_field(numpy_like):
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
-        data_generator=lambda: np.array([1 + 0j, 0 + 1j, -1 + 0j], dtype=np.complex128),
+        generator=lambda: np.array([1 + 0j, 0 + 1j, -1 + 0j], dtype=np.complex128),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(
@@ -6165,7 +6122,7 @@ def test_recordarray_with_field(recordarray, virtual_recordarray, numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64),
     )
 
     # Test with_field method which adds a new field
@@ -6224,21 +6181,21 @@ def test_recordarray_with_custom_generator(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=compute_offsets,
+        generator=compute_offsets,
     )
 
     virtual_content = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
-        data_generator=compute_content,
+        generator=compute_content,
     )
 
     virtual_y = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
-        data_generator=compute_y_values,
+        generator=compute_y_values,
     )
 
     # Create the RecordArray
@@ -6320,39 +6277,35 @@ def test_recordarray_with_none_values(numpy_like):
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
+        generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
     virtual_x_index = VirtualArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array(
-            [0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64
-        ),
+        generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
     virtual_x_content = VirtualArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array(
-            [1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64
-        ),
+        generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
     virtual_y_index = VirtualArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
-        data_generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
+        generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
     )
 
     virtual_y_content = VirtualArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
-        data_generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        generator=lambda: np.array([0.1, 0.2, 0.3], dtype=np.float64),
     )
 
     virtual_x_field = ak.contents.ListOffsetArray(

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -345,7 +345,7 @@ def test_is_materialized(virtual_array):
 def test_materialize_shape_mismatch(numpy_like):
     # Generator returns array with different shape than declared
     with pytest.raises(
-        TypeError,
+        ValueError,
         match=r"had shape \(5,\) before materialization while the materialized array has shape \(3,\)",
     ):
         va = VirtualArray(
@@ -360,7 +360,7 @@ def test_materialize_shape_mismatch(numpy_like):
 def test_materialize_dtype_mismatch(numpy_like):
     # Generator returns array with different dtype than declared
     with pytest.raises(
-        TypeError,
+        ValueError,
         match=r"had dtype int64 before materialization while the materialized array has dtype float64",
     ):
         va = VirtualArray(
@@ -418,7 +418,7 @@ def test_view_invalid_size():
 
 # Test generator property
 def test_generator(virtual_array, simple_array_generator):
-    assert virtual_array.generator is simple_array_generator
+    assert virtual_array._generator is simple_array_generator
 
 
 # Test nplike property

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -258,7 +258,7 @@ def test_materialize_shape_mismatch(numpy_like):
     )
     va.get_shape()
     with pytest.raises(
-        TypeError,
+        ValueError,
         match=r"had shape \(5,\) before materialization while the materialized array has shape \(3,\)",
     ):
         va.materialize()
@@ -267,7 +267,7 @@ def test_materialize_shape_mismatch(numpy_like):
 def test_materialize_dtype_mismatch(numpy_like):
     # Generator returns array with different dtype than declared
     with pytest.raises(
-        TypeError,
+        ValueError,
         match=r"had dtype int64 before materialization while the materialized array has dtype float64",
     ):
         va = VirtualArray(
@@ -327,7 +327,7 @@ def test_view_invalid_size():
 
 # Test generator property
 def test_generator(virtual_array, simple_array_generator):
-    assert virtual_array.generator is simple_array_generator
+    assert virtual_array._generator is simple_array_generator
 
 
 # Test nplike property
@@ -338,11 +338,11 @@ def test_nplike(virtual_array, numpy_like):
 # Test shape_generator property
 def test_shape_generator(virtual_array, shape_generator_param):
     if shape_generator_param is None:
-        assert virtual_array.shape_generator is None
+        assert virtual_array._shape_generator is None
     else:
-        assert virtual_array.shape_generator is not None
+        assert virtual_array._shape_generator is not None
         # Can't directly compare lambdas, so check if it's callable
-        assert callable(virtual_array.shape_generator)
+        assert callable(virtual_array._shape_generator)
 
 
 # Test copy
@@ -355,7 +355,7 @@ def test_copy(virtual_array, shape_generator_param):
     if shape_generator_param is None:
         assert copy.is_materialized
     assert id(copy) != id(virtual_array)  # Different objects
-    assert copy.generator is virtual_array.generator
+    assert copy._generator is virtual_array._generator
 
 
 # Test tolist

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -1,0 +1,2832 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from awkward._backends.dispatch import backend_of_obj
+from awkward._nplikes.dispatch import nplike_of_obj
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.shape import unknown_length
+from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+
+
+@pytest.fixture
+def numpy_like():
+    return Numpy.instance()
+
+
+@pytest.fixture(
+    params=[
+        None,  # Don't use shape_generator
+        "use_shape_generator",  # Use shape_generator
+    ]
+)
+def shape_generator_param(request):
+    return request.param
+
+
+@pytest.fixture
+def simple_array_generator():
+    return lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64)
+
+
+@pytest.fixture
+def virtual_array(numpy_like, simple_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=simple_array_generator,
+        )
+    else:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=simple_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+
+@pytest.fixture
+def two_dim_array_generator():
+    return lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64)
+
+
+@pytest.fixture
+def two_dim_virtual_array(numpy_like, two_dim_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=two_dim_array_generator,
+        )
+    else:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=two_dim_array_generator,
+            shape_generator=lambda: (2, 3),
+        )
+
+
+@pytest.fixture
+def scalar_array_generator():
+    return lambda: np.array(42, dtype=np.int64)
+
+
+@pytest.fixture
+def scalar_virtual_array(numpy_like, scalar_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        return VirtualArray(
+            numpy_like,
+            shape=(),
+            dtype=np.dtype(np.int64),
+            generator=scalar_array_generator,
+        )
+    else:
+        return VirtualArray(
+            numpy_like,
+            shape=(),
+            dtype=np.dtype(np.int64),
+            generator=scalar_array_generator,
+            shape_generator=lambda: (),
+        )
+
+
+@pytest.fixture
+def float_array_generator():
+    return lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5], dtype=np.float64)
+
+
+@pytest.fixture
+def float_virtual_array(numpy_like, float_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+        )
+    else:
+        return VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+
+# Test initialization
+def test_init_valid(numpy_like, simple_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=simple_array_generator,
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=simple_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    assert va._shape == (unknown_length,)
+    assert va.shape == (5,)
+
+    assert va.dtype == np.dtype(np.int64)
+    if shape_generator_param is None:
+        assert va.is_materialized
+    else:
+        assert not va.is_materialized
+
+
+def test_init_invalid_shape():
+    nplike = Numpy.instance()
+    with pytest.raises(
+        TypeError,
+        match=r"Only shapes of integer dimensions or unknown_length are supported",
+    ):
+        VirtualArray(
+            nplike,
+            shape=("not_an_integer", 5),
+            dtype=np.int64,
+            generator=lambda: np.array([[1, 2, 3, 4, 5]], dtype=np.int64),
+        )
+
+
+# Test properties
+def test_dtype(virtual_array):
+    assert virtual_array.dtype == np.dtype(np.int64)
+
+
+def test_shape(virtual_array, two_dim_virtual_array, shape_generator_param):
+    assert virtual_array._shape == (unknown_length,)
+    assert two_dim_virtual_array._shape == (unknown_length, 3)
+    assert virtual_array.shape == (5,)
+    assert two_dim_virtual_array.shape == (2, 3)
+
+
+def test_ndim(virtual_array, two_dim_virtual_array, scalar_virtual_array):
+    assert virtual_array.ndim == 1
+    assert two_dim_virtual_array.ndim == 2
+    assert scalar_virtual_array.ndim == 0
+
+
+def test_size(
+    virtual_array, two_dim_virtual_array, scalar_virtual_array, shape_generator_param
+):
+    if shape_generator_param is None:
+        # Without shape_generator, we know exact sizes
+        assert virtual_array.size == 5
+        assert two_dim_virtual_array.size == 6
+    else:
+        # With shape_generator, materializing to check size
+        assert virtual_array.materialize().size == 5
+        assert two_dim_virtual_array.materialize().size == 6
+
+    assert scalar_virtual_array.size == 1
+
+
+def test_nbytes_unmaterialized(virtual_array, shape_generator_param):
+    if shape_generator_param is None:
+        assert virtual_array.nbytes == unknown_length
+    else:
+        # Materialize to check bytes
+        virtual_array.get_shape()
+        assert virtual_array.nbytes == 5 * virtual_array.dtype.itemsize
+
+
+def test_nbytes_materialized(virtual_array):
+    virtual_array.materialize()
+    assert virtual_array.nbytes == np.array([1, 2, 3, 4, 5], dtype=np.int64).nbytes
+
+
+def test_strides(virtual_array, shape_generator_param):
+    if shape_generator_param is not None:
+        virtual_array.materialize()
+
+    expected_strides = np.array([1, 2, 3, 4, 5], dtype=np.int64).strides
+    assert virtual_array.strides == expected_strides
+
+
+# Test materialization
+def test_materialize(virtual_array):
+    result = virtual_array.materialize()
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+    assert virtual_array.is_materialized
+
+    # After materialization, shape should be concrete regardless of shape_generator
+    assert virtual_array.shape == (5,)
+
+
+def test_is_materialized(virtual_array):
+    assert not virtual_array.is_materialized
+    virtual_array.materialize()
+    assert virtual_array.is_materialized
+
+
+def test_materialize_shape(numpy_like):
+    # Generator returns array with different shape than declared
+    va = VirtualArray(
+        numpy_like,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+    )
+    va.get_shape()
+    assert va.shape == (3,)
+
+
+def test_materialize_shape_mismatch(numpy_like):
+    # Generator returns array with different shape than declared
+    va = VirtualArray(
+        numpy_like,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        shape_generator=lambda: (5,),
+    )
+    va.get_shape()
+    with pytest.raises(
+        TypeError,
+        match=r"had shape \(5,\) before materialization while the materialized array has shape \(3,\)",
+    ):
+        va.materialize()
+
+
+def test_materialize_dtype_mismatch(numpy_like):
+    # Generator returns array with different dtype than declared
+    with pytest.raises(
+        TypeError,
+        match=r"had dtype int64 before materialization while the materialized array has dtype float64",
+    ):
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+        va.materialize()
+
+
+# Test transpose
+def test_T_unmaterialized(two_dim_virtual_array, shape_generator_param):
+    transposed = two_dim_virtual_array.T
+    assert isinstance(transposed, VirtualArray)
+
+    assert transposed._shape == (3, unknown_length)
+    assert transposed.shape == (3, 2)
+    assert not transposed.is_materialized
+
+
+def test_T_materialized(two_dim_virtual_array):
+    two_dim_virtual_array.materialize()
+    transposed = two_dim_virtual_array.T
+    assert isinstance(transposed, np.ndarray)
+    assert transposed.shape == (3, 2)
+
+
+# Test view
+def test_view_unmaterialized(virtual_array):
+    view = virtual_array.view(np.float64)
+    assert isinstance(view, VirtualArray)
+    assert view.dtype == np.dtype(np.float64)
+    assert not view.is_materialized
+
+
+def test_view_materialized(virtual_array):
+    virtual_array.materialize()
+    view = virtual_array.view(np.float64)
+    assert isinstance(view, np.ndarray)
+    assert view.dtype == np.dtype(np.float64)
+
+
+def test_view_invalid_size():
+    nplike = Numpy.instance()
+    va = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int8,
+        generator=lambda: np.array([1, 2, 3], dtype=np.int8),
+    )
+    with pytest.raises(
+        ValueError, match=r"new size of array with larger dtype must be a divisor"
+    ):
+        va.view(np.int32)
+
+
+# Test generator property
+def test_generator(virtual_array, simple_array_generator):
+    assert virtual_array.generator is simple_array_generator
+
+
+# Test nplike property
+def test_nplike(virtual_array, numpy_like):
+    assert virtual_array.nplike is numpy_like
+
+
+# Test shape_generator property
+def test_shape_generator(virtual_array, shape_generator_param):
+    if shape_generator_param is None:
+        assert virtual_array.shape_generator is None
+    else:
+        assert virtual_array.shape_generator is not None
+        # Can't directly compare lambdas, so check if it's callable
+        assert callable(virtual_array.shape_generator)
+
+
+# Test copy
+def test_copy(virtual_array, shape_generator_param):
+    copy = virtual_array.copy()
+    assert isinstance(copy, VirtualArray)
+    assert copy._shape == virtual_array._shape
+    assert copy.shape == virtual_array.shape
+    assert copy.dtype == virtual_array.dtype
+    if shape_generator_param is None:
+        assert copy.is_materialized
+    assert id(copy) != id(virtual_array)  # Different objects
+    assert copy.generator is virtual_array.generator
+
+
+# Test tolist
+def test_tolist(virtual_array):
+    assert virtual_array.tolist() == [1, 2, 3, 4, 5]
+    # Should be materialized after this
+    assert virtual_array.is_materialized
+
+
+# Test tobytes
+def test_tobytes(virtual_array):
+    assert virtual_array.tobytes(order="C") == np.array(
+        [1, 2, 3, 4, 5], dtype=np.int64
+    ).tobytes(order="C")
+    assert virtual_array.tobytes(order="F") == np.array(
+        [1, 2, 3, 4, 5], dtype=np.int64
+    ).tobytes(order="F")
+    assert virtual_array.is_materialized
+
+
+# Test ctypes
+def test_ctypes(virtual_array):
+    ctypes_data = virtual_array.ctypes
+    assert ctypes_data is not None
+    # Should be materialized after this
+    assert virtual_array.is_materialized
+
+
+# Test data
+def test_data(virtual_array):
+    data = virtual_array.data
+    assert data is not None
+    # Should be materialized after this
+    assert virtual_array.is_materialized
+
+
+# Test __repr__ and __str__
+def test_repr(virtual_array, shape_generator_param):
+    repr_str = repr(virtual_array)
+    assert "VirtualArray" in repr_str
+    assert "shape=(awkward._nplikes.shape.unknown_length,)" in repr_str
+
+
+def test_str_scalar(scalar_virtual_array):
+    assert str(scalar_virtual_array) == "??"
+
+
+def test_str_array(virtual_array):
+    str_val = str(virtual_array)
+    assert "VirtualArray" in str_val
+
+
+# Test __getitem__
+def test_getitem_index(virtual_array):
+    assert virtual_array[0] == 1
+    assert virtual_array[4] == 5
+    assert virtual_array[-1] == 5
+    # Should be materialized after this
+    assert virtual_array.is_materialized
+
+
+def test_getitem_slice(virtual_array, shape_generator_param):
+    sliced = virtual_array[1:4]
+    assert isinstance(sliced, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced.shape == (3,)
+    else:
+        # With shape_generator, need to materialize to check shape
+        materialized = sliced.materialize()
+        assert materialized.shape == (3,)
+
+    np.testing.assert_array_equal(sliced.materialize(), np.array([2, 3, 4]))
+
+
+def test_getitem_slice_with_step(virtual_array, shape_generator_param):
+    sliced = virtual_array[::2]
+    assert isinstance(sliced, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced.shape == (3,)
+    else:
+        # With shape_generator, need to materialize to check shape
+        materialized = sliced.materialize()
+        assert materialized.shape == (3,)
+
+    np.testing.assert_array_equal(sliced.materialize(), np.array([1, 3, 5]))
+
+
+def test_getitem_slice_with_unknown_length():
+    nplike = Numpy.instance()
+    va = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+    )
+    with pytest.raises(
+        TypeError, match=r"does not support slicing with unknown_length"
+    ):
+        va[unknown_length:4]
+
+
+# Test __setitem__
+def test_setitem(virtual_array):
+    virtual_array[2] = 10
+    assert virtual_array[2] == 10
+    np.testing.assert_array_equal(
+        virtual_array.materialize(), np.array([1, 2, 10, 4, 5])
+    )
+
+
+# Test __bool__
+def test_bool_scalar(scalar_virtual_array):
+    assert bool(scalar_virtual_array) is True
+
+    # Test with zero value
+    nplike = Numpy.instance()
+    va_zero = VirtualArray(
+        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(0, dtype=np.int64)
+    )
+    assert bool(va_zero) is False
+
+
+def test_bool_array(virtual_array):
+    with pytest.raises(
+        ValueError,
+        match=r"The truth value of an array with more than one element is ambiguous",
+    ):
+        bool(virtual_array)
+
+
+# Test __int__
+def test_int_scalar(scalar_virtual_array):
+    assert int(scalar_virtual_array) == 42
+
+
+def test_int_array(virtual_array):
+    with pytest.raises(
+        TypeError, match=r"Only scalar arrays can be converted to an int"
+    ):
+        int(virtual_array)
+
+
+# Test __index__
+def test_index_scalar(scalar_virtual_array):
+    assert scalar_virtual_array.__index__() == 42
+
+
+def test_index_array(virtual_array):
+    with pytest.raises(TypeError, match=r"Only scalar arrays can be used as an index"):
+        virtual_array.__index__()
+
+
+# Test __len__
+def test_len(virtual_array, two_dim_virtual_array, shape_generator_param):
+    if shape_generator_param is None:
+        assert len(virtual_array) == 5
+        assert len(two_dim_virtual_array) == 2
+    else:
+        # Materialize to get concrete length
+        virtual_array.materialize()
+        two_dim_virtual_array.materialize()
+        assert len(virtual_array) == 5
+        assert len(two_dim_virtual_array) == 2
+
+
+def test_len_scalar():
+    # Scalar arrays don't have a length
+    nplike = Numpy.instance()
+    scalar_va = VirtualArray(
+        nplike, shape=(), dtype=np.int64, generator=lambda: np.array(42, dtype=np.int64)
+    )
+    with pytest.raises(TypeError, match=r"len\(\) of unsized object"):
+        len(scalar_va)
+
+
+# Test __iter__
+def test_iter(virtual_array):
+    assert list(virtual_array) == [1, 2, 3, 4, 5]
+    # Should be materialized after this
+    assert virtual_array.is_materialized
+
+
+# Test __dlpack__ and __dlpack_device__
+@pytest.mark.skipif(
+    tuple(map(int, np.__version__.split(".")[:2])) < (1, 23),
+    reason="Test requires NumPy >= 1.23",
+)
+def test_dlpack_device(virtual_array):
+    virtual_array.__dlpack_device__()
+
+
+@pytest.mark.skipif(
+    tuple(map(int, np.__version__.split(".")[:2])) < (1, 23),
+    reason="Test requires NumPy >= 1.23",
+)
+def test_dlpack(virtual_array):
+    virtual_array.__dlpack__()
+
+
+# Test __array_ufunc__
+def test_array_ufunc(virtual_array, monkeypatch):
+    # Call a ufunc on the virtual array
+    result = np.add(virtual_array, np.array([1, 2, 3, 4, 5]))
+    assert virtual_array.is_materialized
+    np.testing.assert_array_equal(result, np.array([2, 4, 6, 8, 10]))
+
+
+# Test the helper function materialize_if_virtual
+def test_materialize_if_virtual():
+    nplike = Numpy.instance()
+    va1 = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+    )
+    va2 = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([4, 5], dtype=np.int64),
+    )
+    regular_array = np.array([6, 7, 8])
+
+    result = materialize_if_virtual(va1, regular_array, va2)
+
+    assert len(result) == 3
+    assert isinstance(result[0], np.ndarray)
+    assert isinstance(result[1], np.ndarray)
+    assert isinstance(result[2], np.ndarray)
+    np.testing.assert_array_equal(result[0], np.array([1, 2, 3]))
+    np.testing.assert_array_equal(result[1], np.array([6, 7, 8]))
+    np.testing.assert_array_equal(result[2], np.array([4, 5]))
+
+
+# Tests for float virtual array
+def test_float_array_init(numpy_like, float_array_generator, shape_generator_param):
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=float_array_generator,
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    assert va._shape == (unknown_length,)
+    assert va.shape == (5,)
+
+    assert va.dtype == np.dtype(np.float64)
+    if shape_generator_param is not None:
+        assert not va.is_materialized
+    else:
+        assert va.is_materialized
+
+
+def test_float_array_materialize(float_virtual_array):
+    result = float_virtual_array.materialize()
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1.1, 2.2, 3.3, 4.4, 5.5]))
+    assert float_virtual_array.is_materialized
+    assert float_virtual_array.shape == (
+        5,
+    )  # Now concrete regardless of shape_generator
+
+
+def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_param):
+    # Test basic slice
+    if shape_generator_param is None:
+        float_virtual_array1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+        )
+    else:
+        float_virtual_array1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    sliced = float_virtual_array1[1:4]
+    assert isinstance(sliced, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced.shape == (3,)
+    else:
+        # Materialize to check shape
+        result = sliced.materialize()
+        assert result.shape == (3,)
+
+    np.testing.assert_array_almost_equal(
+        sliced.materialize(), np.array([2.2, 3.3, 4.4])
+    )
+
+    # Test step slice
+    if shape_generator_param is None:
+        float_virtual_array2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+        )
+    else:
+        float_virtual_array2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    sliced_step = float_virtual_array2[::2]
+    assert isinstance(sliced_step, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced_step.shape == (3,)
+    else:
+        # Materialize to check shape
+        result = sliced_step.materialize()
+        assert result.shape == (3,)
+
+    np.testing.assert_array_almost_equal(
+        sliced_step.materialize(), np.array([1.1, 3.3, 5.5])
+    )
+
+    # Test negative step
+    if shape_generator_param is None:
+        float_virtual_array3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+        )
+    else:
+        float_virtual_array3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    sliced_neg = float_virtual_array3[::-1]
+    assert isinstance(sliced_neg, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced_neg.shape == (5,)
+    else:
+        # Materialize to check shape
+        result = sliced_neg.materialize()
+        assert result.shape == (5,)
+
+    np.testing.assert_array_almost_equal(
+        sliced_neg.materialize(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
+    )
+
+    # Test complex slice
+    if shape_generator_param is None:
+        float_virtual_array4 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+        )
+    else:
+        float_virtual_array4 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=float_array_generator,
+            shape_generator=lambda: (5,),
+        )
+
+    sliced_complex = float_virtual_array4[4:1:-2]
+    assert isinstance(sliced_complex, VirtualArray)
+
+    if shape_generator_param is None:
+        assert sliced_complex.shape == (2,)
+    else:
+        # Materialize to check shape
+        result = sliced_complex.materialize()
+        assert result.shape == (2,)
+
+    np.testing.assert_array_almost_equal(
+        sliced_complex.materialize(), np.array([5.5, 3.3])
+    )
+
+
+def test_float_array_operations(float_virtual_array):
+    # Test arithmetic operations
+    result = float_virtual_array + 1.0
+    np.testing.assert_array_almost_equal(result, np.array([2.1, 3.2, 4.3, 5.4, 6.5]))
+
+    # Test multiplication
+    result = float_virtual_array * 2.0
+    np.testing.assert_array_almost_equal(result, np.array([2.2, 4.4, 6.6, 8.8, 11.0]))
+
+    # Test division
+    result = float_virtual_array / 2.0
+    np.testing.assert_array_almost_equal(result, np.array([0.55, 1.1, 1.65, 2.2, 2.75]))
+
+    # Test mixed operation with integer array
+    int_array = np.array([1, 2, 3, 4, 5])
+    result = float_virtual_array + int_array
+    np.testing.assert_array_almost_equal(result, np.array([2.1, 4.2, 6.3, 8.4, 10.5]))
+
+
+def test_float_array_view(float_virtual_array):
+    # Test view as different float type
+    view = float_virtual_array.view(np.float32)
+    assert isinstance(view, VirtualArray)
+    assert view.dtype == np.dtype(np.float32)
+
+    # Test materialization of view
+    materialized = view.materialize()
+    assert materialized.dtype == np.dtype(np.float32)
+
+
+def test_float_to_int_comparison(float_virtual_array, virtual_array):
+    # Compare float and int arrays
+    float_data = float_virtual_array.materialize()
+    int_data = virtual_array.materialize()
+
+    # Test basic properties
+    assert float_virtual_array.shape == virtual_array.shape  # After materialization
+    assert float_virtual_array.ndim == virtual_array.ndim
+    assert float_virtual_array.size == virtual_array.size
+
+    # Test conversion between types
+    int_view = float_virtual_array.view(np.int64)
+    assert int_view.dtype == np.dtype(np.int64)
+
+    # Test operations between float and int arrays
+    result = float_virtual_array + virtual_array
+    expected = float_data + int_data
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+# Test rounding operations specific to float arrays
+def test_float_array_rounding(shape_generator_param):
+    nplike = Numpy.instance()
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
+            shape_generator=lambda: (5,),
+        )
+
+    # Test floor
+    result = np.floor(va)
+    np.testing.assert_array_almost_equal(result, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+
+    # Test ceil
+    result = np.ceil(va)
+    np.testing.assert_array_almost_equal(result, np.array([2.0, 3.0, 4.0, 5.0, 6.0]))
+
+    # Test round
+    result = np.round(va)
+    np.testing.assert_array_almost_equal(result, np.array([1.0, 2.0, 4.0, 4.0, 6.0]))
+
+
+# Test NaN handling
+def test_float_array_nan(shape_generator_param):
+    nplike = Numpy.instance()
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=lambda: np.array(
+                [1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64
+            ),
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.float64,
+            generator=lambda: np.array(
+                [1.1, np.nan, 3.3, np.nan, 5.5], dtype=np.float64
+            ),
+            shape_generator=lambda: (5,),
+        )
+
+    # Test isnan
+    result = np.isnan(va)
+    np.testing.assert_array_equal(result, np.array([False, True, False, True, False]))
+
+    # Test nanmean
+    result = np.nanmean(va)
+    np.testing.assert_almost_equal(result, (1.1 + 3.3 + 5.5) / 3)
+
+
+# Multidimensional slicing tests
+def test_multidim_slicing(two_dim_virtual_array):
+    # Test slicing on first dimension
+    sliced = two_dim_virtual_array[0]
+    assert isinstance(sliced, np.ndarray)  # Should be materialized
+    np.testing.assert_array_equal(sliced, np.array([1, 2, 3]))
+
+    # Fresh array for next test to avoid materialization effects
+    nplike = Numpy.instance()
+    va = VirtualArray(
+        nplike,
+        shape=(unknown_length, 3),
+        dtype=np.int64,
+        generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+    )
+
+    # Test advanced indexing
+    sliced = va[:, 1]
+    # This should materialize because it's not a simple first-dimension slice
+    assert isinstance(sliced, np.ndarray)
+    np.testing.assert_array_equal(sliced, np.array([2, 5]))
+
+
+# Test empty array handling
+def test_empty_array(shape_generator_param):
+    nplike = Numpy.instance()
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: np.array([], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: np.array([], dtype=np.int64),
+            shape_generator=lambda: (0,),
+        )
+
+    materialized = va.materialize()
+    assert len(materialized) == 0
+    assert va.size == 0
+
+    if shape_generator_param is None:
+        assert va.shape == (0,)
+    else:
+        # After materialization, shape should be concrete
+        assert va.shape == (0,)
+
+
+# Test with structured dtypes
+def test_structured_dtype(shape_generator_param):
+    dtype = np.dtype([("name", "U10"), ("age", "i4"), ("weight", "f8")])
+    data = np.array(
+        [("Alice", 25, 55.0), ("Bob", 30, 70.5), ("Charlie", 35, 65.2)], dtype=dtype
+    )
+
+    nplike = Numpy.instance()
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=dtype,
+            generator=lambda: data,
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=dtype,
+            generator=lambda: data,
+            shape_generator=lambda: (3,),
+        )
+
+    assert va.dtype == dtype
+    materialized = va.materialize()
+    assert materialized["name"][1] == "Bob"
+    assert materialized["age"][2] == 35
+    assert materialized["weight"][0] == 55.0
+
+
+# Test with large arrays to check memory efficiency
+def test_large_array_memory(shape_generator_param):
+    # Create a large array that would consume significant memory
+    nplike = Numpy.instance()
+
+    # Define a generator that would create a large array
+    def large_array_generator():
+        return np.ones((1000, 1000), dtype=np.float64)
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length, 1000),
+            dtype=np.float64,
+            generator=large_array_generator,
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length, 1000),
+            dtype=np.float64,
+            generator=large_array_generator,
+            shape_generator=lambda: (1000, 1000),
+        )
+
+    assert va.nbytes == unknown_length
+    va.get_shape()
+    assert va.nbytes == 1000 * 1000 * 8
+    if shape_generator_param is not None:
+        assert not va.is_materialized
+
+    # Access just one element to check if full materialization happens
+    element = va[0, 0]
+    assert element == 1.0
+
+    # Now the array should be materialized
+    assert va.nbytes == 1000 * 1000 * 8  # Should still be the same
+    assert va.is_materialized
+
+
+# Test error propagation from generator
+def test_generator_error():
+    nplike = Numpy.instance()
+
+    def failing_generator():
+        raise ValueError("Generator failure test")
+
+    va = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=failing_generator,
+    )
+
+    with pytest.raises(ValueError, match="Generator failure test"):
+        va.get_shape()
+
+
+# Test nested VirtualArrays (generator returns another VirtualArray)
+def test_nested_virtual_arrays(shape_generator_param):
+    nplike = Numpy.instance()
+
+    # Inner virtual array
+    if shape_generator_param is None:
+        inner_va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: np.array([10, 20, 30], np.int64),
+        )
+    else:
+        inner_va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: np.array([10, 20, 30], np.int64),
+            shape_generator=lambda: (3,),
+        )
+
+    # Outer virtual array, generator returns inner virtual array
+    if shape_generator_param is None:
+        outer_va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: inner_va,
+        )
+    else:
+        outer_va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=lambda: inner_va,
+            shape_generator=lambda: (3,),
+        )
+
+    # Should materialize both
+    result = outer_va.materialize()
+    np.testing.assert_array_equal(result, np.array([10, 20, 30]))
+    assert inner_va.is_materialized
+    assert outer_va.is_materialized
+
+
+# Test with complex numbers
+def test_complex_numbers(shape_generator_param):
+    nplike = Numpy.instance()
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.complex128,
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        )
+    else:
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.complex128,
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+            shape_generator=lambda: (3,),
+        )
+
+    assert va.dtype == np.dtype(np.complex128)
+    materialized = va.materialize()
+    np.testing.assert_array_equal(materialized, np.array([1 + 2j, 3 + 4j, 5 + 6j]))
+
+    # Test complex operations
+    result = va * (2 + 1j)
+    expected = np.array([1 + 2j, 3 + 4j, 5 + 6j]) * (2 + 1j)
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+# Test slice with 0 step raises error
+def test_slice_zero_step():
+    nplike = Numpy.instance()
+    va = VirtualArray(
+        nplike,
+        shape=(unknown_length,),
+        dtype=np.int64,
+        generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError):
+        va[::0]  # Step can't be zero
+
+
+def test_slice_length_calculation():
+    nplike = Numpy.instance()
+    test_cases = [
+        # (slice, expected_length, array_length)
+        (slice(None), 5, 5),  # [:] -> 5
+        (slice(1, 4), 3, 5),  # [1:4] -> 3
+        (slice(None, None, 2), 3, 5),  # [::2] -> 3
+        (slice(None, None, -1), 5, 5),  # [::-1] -> 5
+        (slice(4, 1, -1), 3, 5),  # [4:1:-1] -> 3
+        (slice(1, 10), 4, 5),  # [1:10] -> 4 (out of bounds)
+        (slice(-10, 10), 5, 5),  # [-10:10] -> 5 (both out of bounds)
+        (slice(10, 20), 0, 5),  # [10:20] -> 0 (start beyond length)
+        (slice(None, None, 3), 2, 5),  # [::3] -> 2
+    ]
+
+    for slice_obj, expected_length, array_length in test_cases:
+        # Create a closure that captures the current value of array_length
+        def create_generator(length):
+            return lambda: np.ones(length, dtype=np.int64)
+
+        va = VirtualArray(
+            nplike,
+            shape=(unknown_length,),
+            dtype=np.int64,
+            generator=create_generator(array_length),
+        )
+
+        sliced = va[slice_obj]
+
+        if shape_generator_param is None:
+            # Without shape_generator, we can check the shape directly
+            assert isinstance(sliced, VirtualArray)
+            assert sliced.shape[0] == expected_length, f"Failed for slice {slice_obj}"
+        else:
+            # With shape_generator, need to materialize to check shape
+            result = sliced.materialize()
+            assert len(result) == expected_length, f"Failed for slice {slice_obj}"
+
+
+# Test nplike of obj
+def test_nplike_of_obj(
+    virtual_array, float_virtual_array, numpy_like, shape_generator_param
+):
+    assert nplike_of_obj(virtual_array) is numpy_like
+    assert nplike_of_obj(float_virtual_array) is numpy_like
+
+
+# Test backend of obj
+def test_backend_of_obj(virtual_array, float_virtual_array, shape_generator_param):
+    assert backend_of_obj(virtual_array).name == "cpu"
+    assert backend_of_obj(float_virtual_array).name == "cpu"
+
+
+# Test array creation methods with VirtualArray
+def test_asarray_virtual_array_unmaterialized(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with unmaterialized VirtualArray
+    result = numpy_like.asarray(virtual_array)
+    assert result is virtual_array  # Should return the same object
+    assert not virtual_array.is_materialized
+
+
+def test_asarray_virtual_array_materialized(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_with_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with dtype parameter
+    out = numpy_like.asarray(virtual_array, dtype=np.float64)
+    assert isinstance(out, VirtualArray)
+    assert out.dtype == np.dtype(np.float64)
+    assert not out.is_materialized
+    assert out.materialize().dtype == np.dtype(np.float64)
+
+
+def test_asarray_virtual_array_with_copy(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with copy parameter
+    virtual_array.materialize()
+    with pytest.raises(
+        ValueError,
+        match="asarray was called with copy=False for an array of a different dtype",
+    ):
+        # Should raise because we're trying to change the dtype without copying
+        numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
+
+
+def test_ascontiguousarray_unmaterialized(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with unmaterialized VirtualArray
+    result = numpy_like.ascontiguousarray(virtual_array)
+    assert isinstance(result, VirtualArray)
+    assert not result.is_materialized
+    assert result.shape == virtual_array.shape
+    assert result.dtype == virtual_array.dtype
+
+
+def test_ascontiguousarray_materialized(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.ascontiguousarray(virtual_array)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+
+
+def test_frombuffer_with_virtual_array(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test frombuffer with VirtualArray (should raise TypeError)
+    with pytest.raises(
+        TypeError, match="virtual arrays are not supported in `frombuffer`"
+    ):
+        numpy_like.frombuffer(virtual_array)
+
+
+# Test array creation methods using materialization info
+def test_zeros_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
+    # Test zeros_like with unmaterialized VirtualArray
+    result = numpy_like.zeros_like(virtual_array)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.zeros(5, dtype=np.int64))
+    if shape_generator_param is None:
+        assert virtual_array.is_materialized
+    else:
+        assert not virtual_array.is_materialized
+
+
+def test_zeros_like_materialized(numpy_like, virtual_array, shape_generator_param):
+    # Test zeros_like with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.zeros_like(virtual_array)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.zeros(5, dtype=np.int64))
+
+
+def test_ones_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
+    # Test ones_like with unmaterialized VirtualArray
+    result = numpy_like.ones_like(virtual_array)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.ones(5, dtype=np.int64))
+    if shape_generator_param is None:
+        assert virtual_array.is_materialized
+    else:
+        assert not virtual_array.is_materialized
+
+
+def test_ones_like_materialized(numpy_like, virtual_array, shape_generator_param):
+    # Test ones_like with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.ones_like(virtual_array)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.ones(5, dtype=np.int64))
+
+
+def test_full_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
+    # Test full_like with unmaterialized VirtualArray
+    result = numpy_like.full_like(virtual_array, 7)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.full(5, 7, dtype=np.int64))
+    if shape_generator_param is None:
+        assert virtual_array.is_materialized
+    else:
+        assert not virtual_array.is_materialized
+
+
+def test_full_like_materialized(numpy_like, virtual_array):
+    # Test full_like with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.full_like(virtual_array, 7)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5,)
+    assert result.dtype == np.dtype(np.int64)
+    np.testing.assert_array_equal(result, np.full(5, 7, dtype=np.int64))
+
+
+# Test arange and meshgrid with VirtualArray parameters
+def test_arange_with_virtual_array_start(numpy_like, scalar_virtual_array):
+    # Test arange with VirtualArray parameter
+    arange = numpy_like.arange(scalar_virtual_array, 10)
+    assert scalar_virtual_array.is_materialized
+    np.testing.assert_array_equal(arange, np.arange(42, 10))
+
+
+def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
+    # Test meshgrid with VirtualArray parameter
+    virtual_array.materialize()
+    result = numpy_like.meshgrid(virtual_array)
+    assert len(result) == 1
+    np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
+
+
+# Test testing functions with VirtualArray
+def test_array_equal_with_virtual_arrays(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Create two identical VirtualArrays
+    va1 = virtual_array
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    # Test array_equal
+    result = numpy_like.array_equal(va1, va2)
+    assert result is True
+
+    # Test with a different VirtualArray
+    if shape_generator_param is None:
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array(
+                [1, 2, 3, 4, 6], dtype=np.int64
+            ),  # Different last value
+        )
+    else:
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array(
+                [1, 2, 3, 4, 6], dtype=np.int64
+            ),  # Different last value
+            shape_generator=lambda: (5,),
+        )
+
+    result = numpy_like.array_equal(va1, va3)
+    assert result is False
+
+
+def test_array_equal_with_equal_nan(numpy_like, shape_generator_param):
+    # Test array_equal with equal_nan=True
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+
+    # Should be False by default (NaN != NaN)
+    result = numpy_like.array_equal(va1, va2)
+    assert bool(result) is False
+
+    # Should be True with equal_nan=True
+    result = numpy_like.array_equal(va1, va2, equal_nan=True)
+    assert bool(result) is True
+
+
+def test_searchsorted_with_virtual_arrays(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test searchsorted with VirtualArray
+    if shape_generator_param is None:
+        values = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+        )
+    else:
+        values = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([0, 3, 6], dtype=np.int64),
+            shape_generator=lambda: (3,),
+        )
+
+    result = numpy_like.searchsorted(virtual_array, values)
+    np.testing.assert_array_equal(
+        result, np.array([0, 2, 5])
+    )  # Indices where values would be inserted
+
+
+# Test ufunc application with VirtualArray
+def test_apply_ufunc_with_virtual_arrays(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test apply_ufunc with add operation
+    result = numpy_like.apply_ufunc(np.add, "__call__", [virtual_array, 10])
+    np.testing.assert_array_equal(result, np.array([11, 12, 13, 14, 15]))
+
+    # Test apply_ufunc with multiple VirtualArrays
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    result = numpy_like.apply_ufunc(np.multiply, "__call__", [virtual_array, va2])
+    np.testing.assert_array_equal(result, np.array([10, 40, 90, 160, 250]))
+
+
+# Test manipulation functions with VirtualArray
+def test_broadcast_arrays_with_virtual_arrays(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test broadcast_arrays with VirtualArrays
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10], dtype=np.int64),
+            shape_generator=lambda: (1,),
+        )
+
+    result = numpy_like.broadcast_arrays(virtual_array, va2)
+    assert len(result) == 2
+    np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
+    np.testing.assert_array_equal(result[1], np.array([10, 10, 10, 10, 10]))
+
+
+def test_reshape_unmaterialized(numpy_like, virtual_array, shape_generator_param):
+    # Test reshape with unmaterialized VirtualArray
+    result = numpy_like.reshape(virtual_array, (5, 1))
+    assert isinstance(result, VirtualArray)
+    assert not result.is_materialized
+    assert result.shape == (5, 1)
+
+    # Test reshape with -1 dimension
+    result = numpy_like.reshape(virtual_array, (-1, 1))
+    if shape_generator_param is None:
+        assert isinstance(result, np.ndarray)
+        assert virtual_array.is_materialized
+    else:
+        assert isinstance(result, VirtualArray)
+        assert not virtual_array.is_materialized
+    assert result.shape == (5, 1)
+
+
+def test_reshape_materialized(numpy_like, virtual_array):
+    # Test reshape with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.reshape(virtual_array, (5, 1))
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5, 1)
+
+    # Test reshape with copy=True
+    result = numpy_like.reshape(virtual_array, (5, 1), copy=True)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5, 1)
+
+    # Test reshape with copy=False
+    result = numpy_like.reshape(virtual_array, (5, 1), copy=False)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (5, 1)
+
+
+def test_derive_slice_for_length(numpy_like):
+    # Test derive_slice_for_length method
+    slice_obj = slice(1, 4, 1)
+    start, stop, step, slice_length = numpy_like.derive_slice_for_length(slice_obj, 5)
+    assert start == 1
+    assert stop == 4
+    assert step == 1
+    assert slice_length == 3
+
+    # Test with negative step
+    slice_obj = slice(4, 1, -1)
+    start, stop, step, slice_length = numpy_like.derive_slice_for_length(slice_obj, 5)
+    assert start == 4
+    assert stop == 1
+    assert step == -1
+    assert slice_length == 3
+
+    # Test with None values
+    slice_obj = slice(None, None, 2)
+    start, stop, step, slice_length = numpy_like.derive_slice_for_length(slice_obj, 5)
+    assert start == 0
+    assert stop == 5
+    assert step == 2
+    assert slice_length == 3
+
+
+def test_nonzero_with_virtual_array(numpy_like, virtual_array):
+    # Test nonzero with VirtualArray
+    result = numpy_like.nonzero(virtual_array)
+    assert len(result) == 1
+    np.testing.assert_array_equal(
+        result[0], np.array([0, 1, 2, 3, 4])
+    )  # All values are non-zero
+
+
+def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
+    # Test where with VirtualArrays
+    if shape_generator_param is None:
+        condition = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [True, False, True, False, True], dtype=np.bool_
+            ),
+        )
+        x1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        )
+    else:
+        condition = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [True, False, True, False, True], dtype=np.bool_
+            ),
+            shape_generator=lambda: (5,),
+        )
+        x1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    result = numpy_like.where(condition, virtual_array, x1)
+    np.testing.assert_array_equal(result, np.array([1, 20, 3, 40, 5]))
+
+
+def test_unique_values_with_virtual_array(numpy_like, shape_generator_param):
+    # Test unique_values with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+            shape_generator=lambda: (7,),
+        )
+
+    result = numpy_like.unique_values(va)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+def test_unique_all_with_virtual_array(numpy_like, shape_generator_param):
+    # Test unique_all with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
+            shape_generator=lambda: (7,),
+        )
+
+    result = numpy_like.unique_all(va)
+    np.testing.assert_array_equal(result.values, np.array([1, 2, 3]))
+    np.testing.assert_array_equal(result.counts, np.array([2, 2, 3]))
+    # Check inverse indices have original shape
+    assert result.inverse_indices.shape == (7,)
+
+
+def test_sort_with_virtual_array(numpy_like, shape_generator_param):
+    # Test sort with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    # Sort ascending
+    result = numpy_like.sort(va)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+
+    # Sort descending
+    result = numpy_like.sort(va, descending=True)
+    np.testing.assert_array_equal(result, np.array([5, 4, 3, 2, 1]))
+
+    # Test with 2D array and axis
+    if shape_generator_param is None:
+        va2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        )
+    else:
+        va2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    result = numpy_like.sort(va2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([[1, 2, 3], [4, 5, 6]]))
+
+
+def test_concat_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
+    # Test concat with VirtualArrays
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([6, 7, 8], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([6, 7, 8], dtype=np.int64),
+            shape_generator=lambda: (3,),
+        )
+
+    result = numpy_like.concat([virtual_array, va2])
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5, 6, 7, 8]))
+
+    # Test with axis parameter
+    if shape_generator_param is None:
+        va2d1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 2),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
+        )
+        va2d2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 2),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
+        )
+    else:
+        va2d1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 2),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
+            shape_generator=lambda: (2, 2),
+        )
+        va2d2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 2),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
+            shape_generator=lambda: (2, 2),
+        )
+
+    result = numpy_like.concat([va2d1, va2d2], axis=1)
+    np.testing.assert_array_equal(result, np.array([[1, 2, 5, 6], [3, 4, 7, 8]]))
+
+
+def test_repeat_with_virtual_array(numpy_like, virtual_array, shape_generator_param):
+    # Test repeat with VirtualArray
+    result = numpy_like.repeat(virtual_array, 2)
+    np.testing.assert_array_equal(result, np.array([1, 1, 2, 2, 3, 3, 4, 4, 5, 5]))
+
+    # Test with axis parameter
+    if shape_generator_param is None:
+        va2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        )
+    else:
+        va2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    result = numpy_like.repeat(va2d, 2, axis=0)
+    np.testing.assert_array_equal(
+        result, np.array([[1, 2, 3], [1, 2, 3], [4, 5, 6], [4, 5, 6]])
+    )
+
+
+def test_stack_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
+    # Test stack with VirtualArrays
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    result = numpy_like.stack([virtual_array, va2])
+    np.testing.assert_array_equal(result, np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]))
+
+    # Test with axis parameter
+    result = numpy_like.stack([virtual_array, va2], axis=1)
+    np.testing.assert_array_equal(
+        result, np.array([[1, 6], [2, 7], [3, 8], [4, 9], [5, 10]])
+    )
+
+
+def test_packbits_with_virtual_array(numpy_like, shape_generator_param):
+    # Test packbits with VirtualArray of booleans
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
+            shape_generator=lambda: (8,),
+        )
+
+    result = numpy_like.packbits(va)
+    np.testing.assert_array_equal(
+        result, np.array([170], dtype=np.uint8)
+    )  # 10101010 in binary = 170
+
+
+def test_unpackbits_with_virtual_array(numpy_like, shape_generator_param):
+    # Test unpackbits with VirtualArray of uint8
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.uint8),
+            generator=lambda: np.array([170], dtype=np.uint8),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.uint8),
+            generator=lambda: np.array([170], dtype=np.uint8),
+            shape_generator=lambda: (1,),
+        )
+
+    result = numpy_like.unpackbits(va)
+    np.testing.assert_array_equal(
+        result, np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=np.uint8)
+    )
+
+
+def test_broadcast_to_with_virtual_array(numpy_like, virtual_array):
+    # Test broadcast_to with VirtualArray
+    result = numpy_like.broadcast_to(virtual_array, (3, 5))
+    assert result.shape == (3, 5)
+
+    # Check all rows are the same
+    np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
+    np.testing.assert_array_equal(result[1], np.array([1, 2, 3, 4, 5]))
+    np.testing.assert_array_equal(result[2], np.array([1, 2, 3, 4, 5]))
+
+
+def test_strides_with_virtual_array(numpy_like, virtual_array):
+    # Test strides with VirtualArray
+    # First test without materializing
+    assert numpy_like.strides(virtual_array) == (8,)  # 8 bytes per int64
+
+    # Then test after materializing
+    virtual_array.materialize()
+    assert numpy_like.strides(virtual_array) == (8,)
+
+
+# Test addition and logical operations
+def test_add_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
+    # Test add with VirtualArrays
+    if shape_generator_param is None:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+        )
+    else:
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    result = numpy_like.add(virtual_array, va2)
+    np.testing.assert_array_equal(result, np.array([11, 22, 33, 44, 55]))
+
+
+def test_logical_or_with_virtual_arrays(numpy_like, shape_generator_param):
+    # Test logical_or with VirtualArrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.logical_or(va1, va2)
+    np.testing.assert_array_equal(result, np.array([True, True, True, False]))
+
+
+def test_logical_and_with_virtual_arrays(numpy_like, shape_generator_param):
+    # Test logical_and with VirtualArrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.logical_and(va1, va2)
+    np.testing.assert_array_equal(result, np.array([True, False, False, False]))
+
+
+def test_logical_not_with_virtual_array(numpy_like, shape_generator_param):
+    # Test logical_not with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.logical_not(va)
+    np.testing.assert_array_equal(result, np.array([False, True, False, True]))
+
+
+# Test mathematical operations
+def test_sqrt_with_virtual_array(numpy_like, shape_generator_param):
+    # Test sqrt with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.sqrt(va)
+    np.testing.assert_array_almost_equal(result, np.array([2.0, 3.0, 4.0, 5.0]))
+
+
+def test_exp_with_virtual_array(numpy_like, shape_generator_param):
+    # Test exp with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+
+    result = numpy_like.exp(va)
+    np.testing.assert_array_almost_equal(result, np.array([1.0, np.e, np.e**2]))
+
+
+def test_divide_with_virtual_arrays(numpy_like, shape_generator_param):
+    # Test divide with VirtualArrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.divide(va1, va2)
+    np.testing.assert_array_almost_equal(result, np.array([5.0, 5.0, 6.0, 5.0]))
+
+
+# Test special operations
+def test_nan_to_num_with_virtual_array(numpy_like, shape_generator_param):
+    # Test nan_to_num with VirtualArray containing NaN and infinity
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array(
+                [1.0, np.nan, np.inf, -np.inf], dtype=np.float64
+            ),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array(
+                [1.0, np.nan, np.inf, -np.inf], dtype=np.float64
+            ),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.nan_to_num(va)
+    # NaN becomes 0.0, inf becomes large finite number, -inf becomes large negative number
+    assert result[0] == 1.0
+    assert result[1] == 0.0
+    assert result[2] > 1e300  # Large positive number
+    assert result[3] < -1e300  # Large negative number
+
+
+def test_isclose_with_virtual_arrays(numpy_like, shape_generator_param):
+    # Test isclose with VirtualArrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+
+    # Default tolerance
+    result = numpy_like.isclose(va1, va2)
+    np.testing.assert_array_equal(result, np.array([False, True, False, False]))
+
+    # Custom tolerance
+    result = numpy_like.isclose(va1, va2, rtol=0.05)
+    np.testing.assert_array_equal(result, np.array([True, True, True, False]))
+
+    # Equal_nan parameter
+    result = numpy_like.isclose(va1, va2, equal_nan=True)
+    np.testing.assert_array_equal(result, np.array([False, True, False, True]))
+
+
+def test_isnan_with_virtual_array(numpy_like, shape_generator_param):
+    # Test isnan with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+
+    result = numpy_like.isnan(va)
+    np.testing.assert_array_equal(result, np.array([False, True, False, True]))
+
+
+# Test reduction operations
+def test_all_with_virtual_array(numpy_like, shape_generator_param):
+    # Test all with VirtualArray
+    if shape_generator_param is None:
+        va_all_true = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
+        )
+        va_mixed = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [[True, True, False], [True, True, True]], dtype=np.bool_
+            ),
+        )
+    else:
+        va_all_true = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va_mixed = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [[True, True, False], [True, True, True]], dtype=np.bool_
+            ),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test all(all True)
+    result = numpy_like.all(va_all_true)
+    assert result
+
+    # Test all(mixed)
+    result = numpy_like.all(va_mixed)
+    assert not result
+
+    # Test with axis parameter
+    result = numpy_like.all(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([False, True]))
+
+    # Test with keepdims
+    result = numpy_like.all(va_2d, axis=1, keepdims=True)
+    np.testing.assert_array_equal(result, np.array([[False], [True]]))
+
+
+def test_any_with_virtual_array(numpy_like, shape_generator_param):
+    # Test any with VirtualArray
+    if shape_generator_param is None:
+        va_all_false = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
+        )
+        va_mixed = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [[False, False, False], [False, True, False]], dtype=np.bool_
+            ),
+        )
+    else:
+        va_all_false = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va_mixed = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
+            shape_generator=lambda: (4,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.bool_),
+            generator=lambda: np.array(
+                [[False, False, False], [False, True, False]], dtype=np.bool_
+            ),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test any(all False)
+    result = numpy_like.any(va_all_false)
+    assert not result
+
+    # Test any(mixed)
+    result = numpy_like.any(va_mixed)
+    assert result
+
+    # Test with axis parameter
+    result = numpy_like.any(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([False, True]))
+
+
+def test_min_with_virtual_array(numpy_like, shape_generator_param):
+    # Test min with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test overall min
+    result = numpy_like.min(va)
+    assert result == 1
+
+    # Test with 2D array and axis
+    result = numpy_like.min(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([1, 4]))
+
+
+def test_max_with_virtual_array(numpy_like, shape_generator_param):
+    # Test max with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test overall max
+    result = numpy_like.max(va)
+    assert result == 5
+
+    # Test with 2D array and axis
+    result = numpy_like.max(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([3, 6]))
+
+
+def test_count_nonzero_with_virtual_array(numpy_like, shape_generator_param):
+    # Test count_nonzero with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
+            shape_generator=lambda: (6,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test overall count
+    result = numpy_like.count_nonzero(va)
+    assert result == 3
+
+    # Test with 2D array and axis
+    result = numpy_like.count_nonzero(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([2, 1]))
+
+
+def test_cumsum_with_virtual_array(numpy_like, shape_generator_param):
+    # Test cumsum with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+        va_2d = VirtualArray(
+            numpy_like,
+            shape=(unknown_length, 3),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
+            shape_generator=lambda: (2, 3),
+        )
+
+    # Test cumsum
+    result = numpy_like.cumsum(va)
+    np.testing.assert_array_equal(result, np.array([1, 3, 6, 10, 15]))
+
+    # Test with 2D array and axis
+    result = numpy_like.cumsum(va_2d, axis=1)
+    np.testing.assert_array_equal(result, np.array([[1, 3, 6], [4, 9, 15]]))
+
+
+def test_real_imag_with_complex_virtual_array(numpy_like, shape_generator_param):
+    # Test real and imag with complex VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.complex128),
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.complex128),
+            generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
+            shape_generator=lambda: (3,),
+        )
+
+    # Test real
+    result = numpy_like.real(va)
+    np.testing.assert_array_equal(result, np.array([1.0, 3.0, 5.0]))
+
+    # Test imag
+    result = numpy_like.imag(va)
+    np.testing.assert_array_equal(result, np.array([2.0, 4.0, 6.0]))
+
+
+def test_angle_with_complex_virtual_array(numpy_like, shape_generator_param):
+    # Test angle with complex VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.complex128),
+            generator=lambda: np.array(
+                [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
+            ),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.complex128),
+            generator=lambda: np.array(
+                [1 + 0j, 0 + 1j, -1 + 0j, 0 - 1j], dtype=np.complex128
+            ),
+            shape_generator=lambda: (4,),
+        )
+
+    # Test angle in radians
+    result = numpy_like.angle(va)
+    np.testing.assert_array_almost_equal(
+        result, np.array([0, np.pi / 2, np.pi, -np.pi / 2])
+    )
+
+    # Test angle in degrees
+    result = numpy_like.angle(va, deg=True)
+    np.testing.assert_array_almost_equal(result, np.array([0, 90, 180, -90]))
+
+
+def test_round_with_virtual_array(numpy_like, shape_generator_param):
+    # Test round with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
+            shape_generator=lambda: (4,),
+        )
+
+    # Test round to nearest integer
+    result = numpy_like.round(va)
+    np.testing.assert_array_equal(result, np.array([1.0, 3.0, 3.0, 5.0]))
+
+    # Test round to 1 decimal place
+    result = numpy_like.round(va, decimals=1)
+    np.testing.assert_array_equal(result, np.array([1.2, 2.6, 3.5, 4.5]))
+
+    # Test round to 2 decimal places
+    result = numpy_like.round(va, decimals=2)
+    np.testing.assert_array_equal(result, np.array([1.23, 2.57, 3.50, 4.50]))
+
+
+def test_array_str_with_virtual_array_unmaterialized(numpy_like, virtual_array):
+    # Test array_str with unmaterialized VirtualArray
+    result = numpy_like.array_str(virtual_array)
+    assert result == "[## ... ##]"
+
+
+def test_array_str_with_virtual_array_materialized(numpy_like, virtual_array):
+    # Test array_str with materialized VirtualArray
+    virtual_array.materialize()
+    result = numpy_like.array_str(virtual_array)
+    assert "[1 2 3 4 5]" in result
+
+
+def test_astype_with_virtual_array(numpy_like, virtual_array):
+    # Test astype with VirtualArray
+    result = numpy_like.astype(virtual_array, np.float64)
+    np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+    assert result.dtype == np.dtype(np.float64)
+
+    # Test with copy=False
+    result = numpy_like.astype(virtual_array, np.int64, copy=False)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+    assert result.dtype == np.dtype(np.int64)
+
+
+def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
+    # Test can_cast with VirtualArray's dtype
+    # int64 can be cast to float64 with same_kind casting
+    assert numpy_like.can_cast(virtual_array.dtype, np.float64) is True
+
+    # int64 can be cast to complex64 with same_kind casting
+    assert numpy_like.can_cast(virtual_array.dtype, np.complex64) is True
+
+
+# Test various combinations and edge cases
+def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
+    # Test the materialize_if_virtual utility function directly
+
+    # Create a mix of VirtualArrays and regular arrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([4, 5, 6], dtype=np.int64),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+            shape_generator=lambda: (3,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([4, 5, 6], dtype=np.int64),
+            shape_generator=lambda: (3,),
+        )
+
+    regular_array = np.array([7, 8, 9])
+
+    # Materialize none of them
+    results = materialize_if_virtual(va1, va2, regular_array)
+    assert len(results) == 3
+    np.testing.assert_array_equal(results[0], np.array([1, 2, 3]))
+    np.testing.assert_array_equal(results[1], np.array([4, 5, 6]))
+    np.testing.assert_array_equal(results[2], np.array([7, 8, 9]))
+
+    # Check that the VirtualArrays were materialized
+    assert va1.is_materialized
+    assert va2.is_materialized
+
+    # Test with already materialized VirtualArrays
+    if shape_generator_param is None:
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 11], dtype=np.int64),
+        )
+    else:
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([10, 11], dtype=np.int64),
+            shape_generator=lambda: (2,),
+        )
+
+    va3.materialize()  # Pre-materialize
+
+    results = materialize_if_virtual(va3, regular_array)
+    assert len(results) == 2
+    np.testing.assert_array_equal(results[0], np.array([10, 11]))
+    np.testing.assert_array_equal(results[1], np.array([7, 8, 9]))
+
+
+def test_operations_with_multiple_virtual_arrays(numpy_like, shape_generator_param):
+    # Test a complex operation involving multiple VirtualArrays
+    if shape_generator_param is None:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
+        )
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
+        )
+    else:
+        va1 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+        va2 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+        va3 = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.float64),
+            generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
+            shape_generator=lambda: (3,),
+        )
+
+    # Expression: (va1 + va2) * va3
+    # Should materialize all VirtualArrays
+    result = numpy_like.add(va1, va2) * va3
+    np.testing.assert_array_equal(
+        result,
+        np.array([35.0, 56.0, 81.0]),  # (1+4)*7, (2+5)*8, (3+6)*9
+    )
+
+    # Check that all VirtualArrays were materialized
+    assert va1.is_materialized
+    assert va2.is_materialized
+    assert va3.is_materialized
+
+
+def test_is_own_array_with_virtual_array(numpy_like, shape_generator_param):
+    # Test is_own_array method with VirtualArray
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3], dtype=np.int64),
+            shape_generator=lambda: (3,),
+        )
+
+    # Before materialization
+    result = numpy_like.is_own_array(va)
+    assert result  # Should be True because VirtualArray.nplike.ndarray is numpy.ndarray
+
+    # After materialization
+    va.materialize()
+    result = numpy_like.is_own_array(va)
+    assert result
+
+
+def test_virtual_array_with_structured_dtype(numpy_like, shape_generator_param):
+    # Test VirtualArray with structured dtype
+    dtype = np.dtype([("name", "U10"), ("age", "i4"), ("weight", "f8")])
+
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=dtype,
+            generator=lambda: np.array(
+                [("Alice", 25, 55.0), ("Bob", 30, 70.5)], dtype=dtype
+            ),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=dtype,
+            generator=lambda: np.array(
+                [("Alice", 25, 55.0), ("Bob", 30, 70.5)], dtype=dtype
+            ),
+            shape_generator=lambda: (2,),
+        )
+
+    # Test properties
+    assert va.dtype == dtype
+    assert va._shape[0] == unknown_length
+    assert va.shape[0] == 2
+
+    # Test materialization
+    materialized = va.materialize()
+    assert materialized["name"][0] == "Alice"
+    assert materialized["age"][1] == 30
+    assert materialized["weight"][1] == 70.5
+
+
+def test_virtual_array_with_empty_array(numpy_like, shape_generator_param):
+    # Test VirtualArray with empty array
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([], dtype=np.int64),
+            shape_generator=lambda: (0,),
+        )
+
+    # Test materialization
+    materialized = va.materialize()
+    assert len(materialized) == 0
+    assert materialized.size == 0
+
+
+def test_chained_operations_materialization(numpy_like, shape_generator_param):
+    # Test that chained operations correctly materialize VirtualArrays
+    if shape_generator_param is None:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        )
+    else:
+        va = VirtualArray(
+            numpy_like,
+            shape=(unknown_length,),
+            dtype=np.dtype(np.int64),
+            generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
+            shape_generator=lambda: (5,),
+        )
+
+    # Chain of operations
+    # 1. Add 10
+    # 2. Multiply by 2
+    # 3. Check if > 25
+    # Each step should materialize the VirtualArray
+
+    result1 = numpy_like.add(va, 10)  # [11, 12, 13, 14, 15]
+    assert va.is_materialized
+
+    result2 = result1 * 2  # [22, 24, 26, 28, 30]
+
+    result3 = result2 > 25  # [False, False, True, True, True]
+    np.testing.assert_array_equal(result3, np.array([False, False, True, True, True]))


### PR DESCRIPTION
This PR introduces `unknown_length` support for virtual arrays.

Because multiple arrays can have the same shape (coming from the same offsets for example) and because the awkward codebase wants us to know shapes/length very often, the most consistent way to add `unknown_length` support is via introducing a separate shape generator for virtual arrays that returns a shape tuple when called. This is in order to be able to generate the shape of something without generating its data.

We make the distinction between private `._shape` and `._length` versus public `.shape` and `.length` properties.
The public ones materialize the shape while the private ones don't. We extend this logic to the layouts and for the layouts that define a private `self._length` property as a function of the content, we instantiate that with `unknown_length` in the virtual array case in the `__init__` method and we actually calculate it the first time `.length` of that layout is called in order to be able to instantiate layouts without materializing shapes. We also avoid materializing shapes for the `__repr__` of the layouts.
To make our life easier, we introduce two helper utils `maybe_shape_of` and `maybe_length_of`.

Finally, we make the necessary changes in `from_buffers` in order to be able to to construct the proper data and shape generators to pass down to the `VirtualArray` buffers.

This has been tested through coffea as well with the ADL benchmarks, the coffea processors example and the AGC where we observe no materialization when reading with nanoevents and proper materialization of exactly the right buffers when running the analyses snippets.