### PR TITLE
fix: add field metadata to record its option type 

### DIFF
--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -931,9 +931,6 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
 
 def form_handle_arrow(schema, pass_empty_field=False):
     if pass_empty_field and list(schema.names) == [""]:
-        for i, _arrowtype in enumerate(schema.types):
-            field = schema.field(i)
-
         awkwardarrow_type, storage_type = to_awkwardarrow_storage_types(schema.types[0])
         akform = form_popbuffers(awkwardarrow_type, storage_type)
         if not schema.field(0).nullable:

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -378,14 +378,11 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 
             option_str = get_field_option(field, b"option_type")
 
-            print(f"line #381 Field: {field_name}, Metadata:  option_type {option_str}")  # noqa: T201
-
             # Build the awkward array content from field buffers
             a, b = to_awkwardarrow_storage_types(field.type)
             akcontent = popbuffers(
                 paarray.field(field_name), a, b, buffers, generate_bitmasks
             )
-            print(akcontent)  # noqa: T201
 
             if not field.nullable or option_str == "False":
                 # strip the dummy option-type node
@@ -647,11 +644,8 @@ def form_popbuffers(awkwardarrow_type, storage_type):
 
             option_str = get_field_option(field, b"option_type")
 
-            print(f"line #647 Field: {field_name}, Metadata: option_type {option_str}")  # noqa: T201
-
             a, b = to_awkwardarrow_storage_types(field.type)
             akcontent = form_popbuffers(a, b)
-            print(akcontent)  # noqa: T201
 
             if not field.nullable or option_str == "False":
                 # strip the dummy option-type node
@@ -947,12 +941,8 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
 
 def form_handle_arrow(schema, pass_empty_field=False):
     if pass_empty_field and list(schema.names) == [""]:
-        print("line #948 HERE")  # noqa: T201
         for i, _arrowtype in enumerate(schema.types):
             field = schema.field(i)
-            option_str = get_field_option(field, b"option_type")
-
-            print(f"line #953 Field: {field.name}, Metadata: option_type {option_str}")  # noqa: T201
 
         awkwardarrow_type, storage_type = to_awkwardarrow_storage_types(schema.types[0])
         akform = form_popbuffers(awkwardarrow_type, storage_type)

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -374,8 +374,8 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
                 paarray.field(field_name), a, b, buffers, generate_bitmasks
             )
 
-            option_str = get_field_option(field, b"option_type")
-            if not field.nullable or option_str == "False":
+            option_type = get_field_option(field, b"option_type")
+            if not field.nullable or option_type is False:
                 # strip the dummy option-type node
                 akcontent = remove_optiontype(akcontent)
             contents.append(akcontent)
@@ -636,8 +636,8 @@ def form_popbuffers(awkwardarrow_type, storage_type):
             a, b = to_awkwardarrow_storage_types(field.type)
             akcontent = form_popbuffers(a, b)
 
-            option_str = get_field_option(field, b"option_type")
-            if not field.nullable or option_str == "False":
+            option_type = get_field_option(field, b"option_type")
+            if not field.nullable or option_type is False:
                 # strip the dummy option-type node
                 akcontent = form_remove_optiontype(akcontent)
             contents.append(akcontent)
@@ -830,7 +830,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
             contents = []
             for i in range(obj.num_columns):
                 field = obj.schema.field(i)
-                option_str = get_field_option(field, b"option_type")
+                option_type = get_field_option(field, b"option_type")
 
                 layout = handle_arrow(obj.column(i), generate_bitmasks)
                 if record_is_optiontype:
@@ -841,7 +841,7 @@ def handle_arrow(obj, generate_bitmasks=False, pass_empty_field=False):
                 if (
                     (record_is_optiontype and field.name not in optiontype_fields)
                     or not field.nullable
-                    or option_str == "False"
+                    or option_type is False
                 ):
                     contents.append(remove_optiontype(layout))
                 else:
@@ -963,7 +963,7 @@ def form_handle_arrow(schema, pass_empty_field=False):
         forms = []
         for i, arrowtype in enumerate(schema.types):
             field = schema.field(i)
-            option_str = get_field_option(field, b"option_type")
+            option_type = get_field_option(field, b"option_type")
 
             awkwardarrow_type, storage_type = to_awkwardarrow_storage_types(arrowtype)
             akform = form_popbuffers(awkwardarrow_type, storage_type)
@@ -971,7 +971,7 @@ def form_handle_arrow(schema, pass_empty_field=False):
             if (
                 (record_is_optiontype and field.name not in optiontype_fields)
                 or not field.nullable
-                or option_str == "False"
+                or option_type is False
             ):
                 forms.append(form_remove_optiontype(akform))
             else:

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -14,7 +14,11 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._parameters import parameters_union
 
-from .extn_types import AwkwardArrowType, to_awkwardarrow_storage_types
+from .extn_types import (
+    AwkwardArrowType,
+    get_field_option,
+    to_awkwardarrow_storage_types,
+)
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -175,29 +179,6 @@ def form_popbuffers_finalize(out, awkwardarrow_type):
             ),
             out,
         )
-
-
-# def get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
-#     if not meta:
-#         return None
-#     key_str = key.decode("utf-8")
-#     value = meta.get(key) or meta.get(key_str.encode("utf-8"))
-#     return value.decode("utf-8") if value else None
-
-def _get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
-    if not meta:
-        return None
-    key_str = key.decode("utf-8")
-    value = (
-        meta.get(key)
-        or meta.get(key_str.encode("utf-8"))
-        or meta.get(key_str)
-    )
-    return value.decode("utf-8") if isinstance(value, bytes) else value
-
-
-def get_field_option(field: pyarrow.Field, key: bytes) -> str | None:
-    return _get_meta_str(field.metadata, key)
 
 
 def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitmasks):

--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -118,7 +118,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
             metadata["record_is_tuple"],
             metadata["record_is_scalar"],
             is_nonnullable_nulltype=metadata.get("is_nonnullable_nulltype", False),
-            option_type=metadata["option_type"],
+            option_type=metadata.get("option_type", False),
         )
 
     @property

--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -143,3 +143,15 @@ def to_awkwardarrow_storage_types(arrowtype):
         return arrowtype, arrowtype.storage_type
     else:
         return None, arrowtype
+
+
+def _get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
+    if not meta:
+        return None
+    key_str = key.decode("utf-8")
+    value = meta.get(key) or meta.get(key_str.encode("utf-8")) or meta.get(key_str)
+    return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def get_field_option(field: pyarrow.Field, key: bytes) -> str | None:
+    return _get_meta_str(field.metadata, key)

--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -41,6 +41,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
         record_is_tuple,
         record_is_scalar,
         is_nonnullable_nulltype=False,
+        option_type=False,
     ):
         self._mask_type = mask_type
         self._node_type = node_type
@@ -49,6 +50,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
         self._record_is_tuple = record_is_tuple
         self._record_is_scalar = record_is_scalar
         self._is_nonnullable_nulltype = is_nonnullable_nulltype
+        self._option_type = option_type
         super().__init__(storage_type, "awkward")
 
     def __str__(self):
@@ -96,6 +98,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
             "record_is_tuple": self._record_is_tuple,
             "record_is_scalar": self._record_is_scalar,
             "is_nonnullable_nulltype": self._is_nonnullable_nulltype,
+            "option_type": self._option_type,
         }
 
     @classmethod
@@ -115,6 +118,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
             metadata["record_is_tuple"],
             metadata["record_is_scalar"],
             is_nonnullable_nulltype=metadata.get("is_nonnullable_nulltype", False),
+            option_type=metadata.get("option_type", False),
         )
 
     @property

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -68,18 +68,6 @@ def convert_native_arrow_table_to_awkward(table: pyarrow.Table) -> pyarrow.Table
     return replace_schema(table, new_schema)
 
 
-# def get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
-#     if not meta:
-#         return None
-#     key_str = key.decode("utf-8")
-#     value = meta.get(key) or meta.get(key_str.encode("utf-8"))
-#     return value.decode("utf-8") if value else None
-
-
-# def get_field_option(field: pyarrow.Field, key: bytes) -> str | None:
-#     return get_meta_str(field.metadata, key)
-
-
 def collect_ak_arr_type_metadata(aafield: pyarrow.Field) -> dict | list | None:
     """
     Given a Field, collect ArrowExtensionArray metadata as an object.

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -9,6 +9,7 @@ import pyarrow
 from .extn_types import (
     AwkwardArrowArray,
     AwkwardArrowType,
+    get_field_option,
     to_awkwardarrow_storage_types,
 )
 
@@ -67,16 +68,16 @@ def convert_native_arrow_table_to_awkward(table: pyarrow.Table) -> pyarrow.Table
     return replace_schema(table, new_schema)
 
 
-def get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
-    if not meta:
-        return None
-    key_str = key.decode("utf-8")
-    value = meta.get(key) or meta.get(key_str.encode("utf-8"))
-    return value.decode("utf-8") if value else None
+# def get_meta_str(meta: dict[bytes, bytes] | None, key: bytes) -> str | None:
+#     if not meta:
+#         return None
+#     key_str = key.decode("utf-8")
+#     value = meta.get(key) or meta.get(key_str.encode("utf-8"))
+#     return value.decode("utf-8") if value else None
 
 
-def get_field_option(field: pyarrow.Field, key: bytes) -> str | None:
-    return get_meta_str(field.metadata, key)
+# def get_field_option(field: pyarrow.Field, key: bytes) -> str | None:
+#     return get_meta_str(field.metadata, key)
 
 
 def collect_ak_arr_type_metadata(aafield: pyarrow.Field) -> dict | list | None:

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -153,13 +153,6 @@ def native_arrow_field_to_akarraytype(
     ntv_field: pyarrow.Field, metadata: dict
 ) -> pyarrow.Field:
     option_str = _get_option_type_from_metadata(metadata)
-    # nullable = ntv_field.nullable
-
-    # if metadata is not None:
-    #     non_nullable = metadata.get("is_nonnullable_nulltype", None)
-
-    # if option_str == "False":
-    #     nullable = False
 
     if isinstance(ntv_field, AwkwardArrowType):
         raise ValueError(f"field {ntv_field} is already an AwkwardArrowType")

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -175,10 +175,6 @@ def native_arrow_field_to_akarraytype(
 
     ak_type = AwkwardArrowType._from_metadata_object(storage_type, metadata)
 
-    """
-    Given a native Arrow field and its associated metadata,
-    adjust the field based on the 'option_type' metadata.
-    """
     option_type = _get_option_type_from_metadata(metadata)
 
     # Determine nullability: if option_type is 'False', force nullable to False

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -77,15 +77,15 @@ def collect_ak_arr_type_metadata(aafield: pyarrow.Field) -> dict | list | None:
     """
     typ = aafield.type
 
-    option_str = get_field_option(aafield, b"option_type")
+    option_type = get_field_option(aafield, b"option_type")
 
     if not isinstance(typ, AwkwardArrowType):
         return None  # Not expected to reach here
     subfields = _fields_of_strg_type(typ.storage_type)
     metadata = typ._metadata_as_dict()
     metadata["field_name"] = aafield.name
-    if option_str == "False":
-        metadata["option_type"] = option_str
+    if option_type is False:
+        metadata["option_type"] = "False"
 
     if len(subfields) == 0:
         # Simple type
@@ -128,14 +128,6 @@ def awkward_arrow_field_to_native(aafield: pyarrow.Field) -> pyarrow.Field:
     return new_field
 
 
-def _get_option_type_from_metadata(metadata: dict | None) -> str | None:
-    """
-    Extracts 'option_type' from a metadata dict, if present.
-    Returns None if metadata is None or missing the key.
-    """
-    return metadata.get("option_type") if metadata else None
-
-
 def native_arrow_field_to_akarraytype(
     ntv_field: pyarrow.Field, metadata: dict
 ) -> pyarrow.Field:
@@ -175,10 +167,10 @@ def native_arrow_field_to_akarraytype(
 
     ak_type = AwkwardArrowType._from_metadata_object(storage_type, metadata)
 
-    option_type = _get_option_type_from_metadata(metadata)
+    option_str = metadata.get("option_type") if metadata else None
 
     # Determine nullability: if option_type is 'False', force nullable to False
-    nullable = False if option_type == "False" else ntv_field.nullable
+    nullable = False if option_str == "False" else ntv_field.nullable
 
     return pyarrow.field(
         ntv_field.name,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1116,9 +1116,9 @@ class RecordArray(RecordMeta[Content], Content):
                     )
                     or x._arrow_needs_option_type(),
                     metadata={
-                        b"option_type": str(x._arrow_needs_option_type()).encode(
-                            "utf-8"
-                        ),
+                        b"option_type": b"True"
+                        if x._arrow_needs_option_type()
+                        else b"False",
                     },
                 )
                 for i, x in enumerate(self._contents)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1125,14 +1125,14 @@ class RecordArray(RecordMeta[Content], Content):
             ]
         )
 
-        # Iterate through fields in the StructType and extract metadata
-        field_metadata = {
-            field.name: {
-                k.decode("utf-8"): v.decode("utf-8")
-                for k, v in (field.metadata or {}).items()
-            }
-            for field in types
-        }
+        # # Iterate through fields in the StructType and extract metadata
+        # field_metadata = {
+        #     field.name: {
+        #         k.decode("utf-8"): v.decode("utf-8")
+        #         for k, v in (field.metadata or {}).items()
+        #     }
+        #     for field in types
+        # }
 
         return pyarrow.Array.from_buffers(
             ak._connect.pyarrow.to_awkwardarrow_type(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1133,9 +1133,6 @@ class RecordArray(RecordMeta[Content], Content):
             }
             for field in types
         }
-        # Print extracted metadata
-        for field_name, metadata in field_metadata.items():
-            print(f"Field: {field_name}, Metadata: {metadata}")  # noqa: T201
 
         return pyarrow.Array.from_buffers(
             ak._connect.pyarrow.to_awkwardarrow_type(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1125,15 +1125,6 @@ class RecordArray(RecordMeta[Content], Content):
             ]
         )
 
-        # # Iterate through fields in the StructType and extract metadata
-        # field_metadata = {
-        #     field.name: {
-        #         k.decode("utf-8"): v.decode("utf-8")
-        #         for k, v in (field.metadata or {}).items()
-        #     }
-        #     for field in types
-        # }
-
         return pyarrow.Array.from_buffers(
             ak._connect.pyarrow.to_awkwardarrow_type(
                 types,

--- a/tests/test_1440_start_v2_to_parquet.py
+++ b/tests/test_1440_start_v2_to_parquet.py
@@ -20,7 +20,6 @@ def parquet_round_trip(
     akarray, extensionarray, tmp_path, categorical_as_dictionary=False
 ):
     filename = os.path.join(tmp_path, "whatever.parquet")
-    print("writing to_parquet")
 
     ak.to_parquet(
         akarray,
@@ -28,7 +27,6 @@ def parquet_round_trip(
         extensionarray=extensionarray,
         categorical_as_dictionary=categorical_as_dictionary,
     )
-    print("now reading from_parquet")
     akarray2 = ak.from_parquet(filename)
 
     assert to_list(akarray2) == to_list(akarray)

--- a/tests/test_1440_start_v2_to_parquet.py
+++ b/tests/test_1440_start_v2_to_parquet.py
@@ -20,12 +20,15 @@ def parquet_round_trip(
     akarray, extensionarray, tmp_path, categorical_as_dictionary=False
 ):
     filename = os.path.join(tmp_path, "whatever.parquet")
+    print("writing to_parquet")
+
     ak.to_parquet(
         akarray,
         filename,
         extensionarray=extensionarray,
         categorical_as_dictionary=categorical_as_dictionary,
     )
+    print("now reading from_parquet")
     akarray2 = ak.from_parquet(filename)
 
     assert to_list(akarray2) == to_list(akarray)
@@ -76,76 +79,76 @@ def test_listoffsetarray_numpyarray(tmp_path, dtype, list_to32, extensionarray):
     )
     parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
-    # akarray = ak.contents.ListOffsetArray(
-    #     ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
-    #     ak.contents.ByteMaskedArray(
-    #         ak.index.Index8(
-    #             np.array(
-    #                 [False, True, False, True, True, False, True, True, False, False],
-    #                 dtype=np.int8,
-    #             )
-    #         ),
-    #         ak.contents.NumpyArray(
-    #             np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
-    #             parameters={"which": "inner"},
-    #         ),
-    #         valid_when=False,
-    #         parameters={"which": "middle"},
-    #     ),
-    #     parameters={"which": "outer"},
-    # )
-    # parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
+    akarray = ak.contents.ListOffsetArray(
+        ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
+        ak.contents.ByteMaskedArray(
+            ak.index.Index8(
+                np.array(
+                    [False, True, False, True, True, False, True, True, False, False],
+                    dtype=np.int8,
+                )
+            ),
+            ak.contents.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
+                parameters={"which": "inner"},
+            ),
+            valid_when=False,
+            parameters={"which": "middle"},
+        ),
+        parameters={"which": "outer"},
+    )
+    parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
-    # akarray = ak.contents.ByteMaskedArray(
-    #     ak.index.Index8(np.array([True, False, True, True, True], dtype=np.int8)),
-    #     ak.contents.ListOffsetArray(
-    #         ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
-    #         ak.contents.NumpyArray(
-    #             np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
-    #             parameters={"which": "inner"},
-    #         ),
-    #         parameters={"which": "middle"},
-    #     ),
-    #     valid_when=True,
-    #     parameters={"which": "outer"},
-    # )
-    # parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
+    akarray = ak.contents.ByteMaskedArray(
+        ak.index.Index8(np.array([True, False, True, True, True], dtype=np.int8)),
+        ak.contents.ListOffsetArray(
+            ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
+            ak.contents.NumpyArray(
+                np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
+                parameters={"which": "inner"},
+            ),
+            parameters={"which": "middle"},
+        ),
+        valid_when=True,
+        parameters={"which": "outer"},
+    )
+    parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
-    # akarray = ak.contents.ByteMaskedArray(
-    #     ak.index.Index8(np.array([True, False, True, True, True], dtype=np.int8)),
-    #     ak.contents.ListOffsetArray(
-    #         ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
-    #         ak.contents.ByteMaskedArray(
-    #             ak.index.Index8(
-    #                 np.array(
-    #                     [
-    #                         False,
-    #                         True,
-    #                         False,
-    #                         True,
-    #                         True,
-    #                         False,
-    #                         True,
-    #                         True,
-    #                         False,
-    #                         False,
-    #                     ],
-    #                     dtype=np.int8,
-    #                 )
-    #             ),
-    #             ak.contents.NumpyArray(
-    #                 np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
-    #                 parameters={"which": "inner"},
-    #             ),
-    #             valid_when=False,
-    #             parameters={"which": "middle-1"},
-    #         ),
-    #         parameters={"which": "middle-2"},
-    #     ),
-    #     valid_when=True,
-    #     parameters={"which": "outer"},
-    # )
-    # parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
+    akarray = ak.contents.ByteMaskedArray(
+        ak.index.Index8(np.array([True, False, True, True, True], dtype=np.int8)),
+        ak.contents.ListOffsetArray(
+            ak.index.Index(np.array([0, 3, 3, 5, 6, 10], dtype=dtype)),
+            ak.contents.ByteMaskedArray(
+                ak.index.Index8(
+                    np.array(
+                        [
+                            False,
+                            True,
+                            False,
+                            True,
+                            True,
+                            False,
+                            True,
+                            True,
+                            False,
+                            False,
+                        ],
+                        dtype=np.int8,
+                    )
+                ),
+                ak.contents.NumpyArray(
+                    np.array([0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9]),
+                    parameters={"which": "inner"},
+                ),
+                valid_when=False,
+                parameters={"which": "middle-1"},
+            ),
+            parameters={"which": "middle-2"},
+        ),
+        valid_when=True,
+        parameters={"which": "outer"},
+    )
+    parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
 
 @pytest.mark.parametrize("dtype", [np.int32, np.uint32, np.int64])
@@ -402,6 +405,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
     if not is_tuple or extensionarray:
         parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_1(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.RecordArray(
         [
             ak.contents.ByteMaskedArray(
@@ -424,6 +431,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
     if not is_tuple or extensionarray:
         parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_2(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.RecordArray(
         [
             ak.contents.ByteMaskedArray(
@@ -449,6 +460,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
     if not is_tuple or extensionarray:
         parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_3(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.IndexedOptionArray(
         ak.index.Index64(np.array([2, 0, -1, 0, 1], dtype=np.int64)),
         ak.contents.RecordArray(
@@ -471,6 +486,10 @@ def test_recordarray(tmp_path, is_tuple, extensionarray):
     if not is_tuple or extensionarray:
         parquet_round_trip(ak.Array(akarray), extensionarray, tmp_path)
 
+
+@pytest.mark.parametrize("is_tuple", [False, True])
+@pytest.mark.parametrize("extensionarray", [False, True])
+def test_recordarray_4(tmp_path, is_tuple, extensionarray):
     akarray = ak.contents.IndexedOptionArray(
         ak.index.Index64(np.array([2, 0, -1, 0, 1], dtype=np.int64)),
         ak.contents.RecordArray(


### PR DESCRIPTION
Newer versions of pyarrow require that `RecordArray` fields be declared as `nullable`, even if their content is not an `Option` type. This introduces an unnecessary option-type node in the schema.

This PR adds field metadata to track that requirement, so that when converting the field back to an Awkward `RecordArray` field, we can safely remove the dummy option-type node.

fixes https://github.com/scikit-hep/awkward/issues/3402