### PR TITLE
refactor: move `form_with_unique_keys` here

### DIFF
--- a/src/awkward/forms/__init__.py
+++ b/src/awkward/forms/__init__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from awkward.forms.bitmaskedform import BitMaskedForm  # noqa: F401
 from awkward.forms.bytemaskedform import ByteMaskedForm  # noqa: F401
 from awkward.forms.emptyform import EmptyForm  # noqa: F401
-from awkward.forms.form import Form, from_dict, from_json, from_type  # noqa: F401
+from awkward.forms.form import (  # noqa: F401
+    Form,
+    form_with_unique_keys,
+    from_dict,
+    from_json,
+    from_type,
+)
 from awkward.forms.indexedform import IndexedForm  # noqa: F401
 from awkward.forms.indexedoptionform import IndexedOptionForm  # noqa: F401
 from awkward.forms.listform import ListForm  # noqa: F401

--- a/tests/test_3482_form_with_unique_keys.py
+++ b/tests/test_3482_form_with_unique_keys.py
@@ -1,0 +1,144 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import ast
+
+import numpy as np  # noqa: F401
+
+import awkward as ak
+
+PREFIX = "foo"
+
+
+def test_NumpyForm():
+    form = ak.forms.NumpyForm("float64")
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+
+
+def test_BitMaskedForm():
+    form = ak.forms.BitMaskedForm(
+        "i8",
+        ak.forms.NumpyForm("float64"),
+        True,
+        False,
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_EmptyForm():
+    form = ak.forms.EmptyForm()
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+
+
+def test_IndexedForm():
+    form = ak.forms.IndexedForm(
+        "i64",
+        ak.forms.NumpyForm("float64"),
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_IndexedOptionForm():
+    form = ak.forms.IndexedOptionForm(
+        "i64",
+        ak.forms.NumpyForm("float64"),
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_ListForm():
+    form = ak.forms.ListForm(
+        "i64",
+        "i64",
+        ak.forms.NumpyForm("float64"),
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_ListOffsetForm():
+    form = ak.forms.ListOffsetForm(
+        "i64",
+        ak.forms.NumpyForm("float64"),
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_RecordForm():
+    form = ak.forms.RecordForm(
+        [ak.forms.NumpyForm("float64"), ak.forms.NumpyForm("bool")],
+        ["one", "two"],
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.content("one").form_key) == (
+        PREFIX,
+        "one",
+    )
+    assert ast.literal_eval(form_with_unique_key.content("two").form_key) == (
+        PREFIX,
+        "two",
+    )
+
+
+def test_RegularForm():
+    form = ak.forms.RegularForm(
+        ak.forms.NumpyForm("float64"),
+        10,
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)
+
+
+def test_UnionForm():
+    form = ak.forms.UnionForm(
+        "i8",
+        "i64",
+        [ak.forms.NumpyForm("float64"), ak.forms.NumpyForm("bool")],
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.contents[0].form_key) == (PREFIX, 0)
+    assert ast.literal_eval(form_with_unique_key.contents[1].form_key) == (PREFIX, 1)
+
+
+def test_UnmaskedForm():
+    form = ak.forms.UnmaskedForm(
+        ak.forms.NumpyForm("float64"),
+    )
+    assert form.form_key is None
+
+    form_with_unique_key = ak.forms.form_with_unique_keys(form, (PREFIX,))
+    assert ast.literal_eval(form_with_unique_key.form_key) == (PREFIX,)
+    assert ast.literal_eval(form_with_unique_key.content.form_key) == (PREFIX, None)


### PR DESCRIPTION
Moves https://github.com/dask-contrib/dask-awkward/blob/main/src/dask_awkward/lib/utils.py#L140 into awkward so we can use it also in uproot without introducing a dask-awkward dependency.

In addition, this is a slightly modified implementation that also resolves the problem of having dots as field separators, because fields (ie ROOT TBranch names) can contain dots as well, see: https://github.com/dask-contrib/dask-awkward/issues/552