### PR TITLE
fix: consistent materializing length across all layouts

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -320,7 +320,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             self._mask.to_nplike(tt),
             self._content._to_typetracer(forget_length),
             self._valid_when,
-            unknown_length if forget_length else self.length,
+            unknown_length if forget_length else self._length,
             self._lsb_order,
             parameters=self._parameters,
         )
@@ -378,7 +378,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             ),
         )
         return ak.contents.IndexedOptionArray(
-            index[0 : self._length], self._content, parameters=self._parameters
+            index[0 : self.length], self._content, parameters=self._parameters
         )
 
     def to_ByteMaskedArray(self):
@@ -401,7 +401,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             )
         )
         return ByteMaskedArray(
-            bytemask[: self._length],
+            bytemask[: self.length],
             self._content,
             self._valid_when,
             parameters=self._parameters,
@@ -416,7 +416,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                     ak.index.IndexU8(self._backend.nplike.logical_not(self._mask.data)),
                     self._content,
                     valid_when,
-                    self._length,
+                    self.length,
                     lsb_order,
                     parameters=self._parameters,
                 )
@@ -435,7 +435,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 ak.index.IndexU8(bitmask),
                 self._content,
                 valid_when,
-                self._length,
+                self.length,
                 lsb_order,
                 parameters=self._parameters,
             )
@@ -463,7 +463,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             )
         )
         return bytemask.data[
-            : self._backend.nplike.shape_item_as_index(self._length)
+            : self._backend.nplike.shape_item_as_index(self.length)
         ].view(np.bool_)
 
     def _getitem_nothing(self):
@@ -741,7 +741,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         options: ApplyActionOptions,
     ) -> Content | None:
         if self._backend.nplike.known_data:
-            content = self._content[0 : self._length]
+            content = self._content[0 : self.length]
         else:
             content = self._content
 
@@ -762,7 +762,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                         options,
                     ),
                     self._valid_when,
-                    self._length,
+                    self.length,
                     self._lsb_order,
                     parameters=self._parameters if options["keep_parameters"] else None,
                 )
@@ -800,9 +800,9 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             next = self.to_IndexedOptionArray64()
 
             content = (
-                next._content[: self._length].to_packed(True)
+                next._content[: self.length].to_packed(True)
                 if recursive
-                else next._content[: self._length]
+                else next._content[: self.length]
             )
 
             return ak.contents.IndexedOptionArray(
@@ -810,7 +810,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             )
 
         else:
-            excess_length = math.ceil(self._length / 8.0)
+            excess_length = math.ceil(self.length / 8.0)
             if (
                 self._mask.length is not unknown_length
                 and self._mask.length == excess_length
@@ -820,16 +820,16 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
                 mask = self._mask[:excess_length]
 
             content = (
-                self._content[: self._length].to_packed(True)
+                self._content[: self.length].to_packed(True)
                 if recursive
-                else self._content[: self._length]
+                else self._content[: self.length]
             )
 
             return BitMaskedArray(
                 mask,
                 content,
                 self._valid_when,
-                self._length,
+                self.length,
                 self._lsb_order,
                 parameters=self._parameters,
             )
@@ -842,8 +842,8 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         if out is not None:
             return out
 
-        mask = self.mask_as_bool(valid_when=True)[: self._length]
-        out = self._content._getitem_range(0, self._length)._to_list(
+        mask = self.mask_as_bool(valid_when=True)[: self.length]
+        out = self._content._getitem_range(0, self.length)._to_list(
             behavior, json_conversions
         )
 
@@ -860,7 +860,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             mask,
             content,
             valid_when=self._valid_when,
-            length=len(self),
+            length=self._length,
             lsb_order=self._lsb_order,
             parameters=self._parameters,
         )
@@ -872,7 +872,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             mask,
             content,
             valid_when=self._valid_when,
-            length=len(self),
+            length=self._length,
             lsb_order=self._lsb_order,
             parameters=self._parameters,
         )

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -511,7 +511,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             self._mask,
             self._content._getitem_field(where, only_fields),
             self._valid_when,
-            self.length,
+            self._length,
             self._lsb_order,
             parameters=None,
         )
@@ -523,7 +523,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             self._mask,
             self._content._getitem_fields(where, only_fields),
             self._valid_when,
-            self.length,
+            self._length,
             self._lsb_order,
             parameters=None,
         )

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -511,7 +511,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             self._mask,
             self._content._getitem_field(where, only_fields),
             self._valid_when,
-            self._length,
+            self.length,
             self._lsb_order,
             parameters=None,
         )
@@ -523,7 +523,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             self._mask,
             self._content._getitem_fields(where, only_fields),
             self._valid_when,
-            self._length,
+            self.length,
             self._lsb_order,
             parameters=None,
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -401,7 +401,7 @@ class Content(Meta):
                 index.data,
                 index.length,
                 length,
-                raw._size,
+                raw.size,
             ),
             slicer=head,
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1309,7 +1309,7 @@ class RecordArray(RecordMeta[Content], Content):
         return RecordArray(
             contents,
             self._fields,
-            length=self.length,
+            length=self._length,
             parameters=self._parameters,
             backend=backend,
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -510,7 +510,7 @@ class RecordArray(RecordMeta[Content], Content):
                     self.content(i)._getitem_fields(nexthead, nexttail) for i in indexes
                 ]
         return RecordArray(
-            contents, fields, self.length, parameters=None, backend=self._backend
+            contents, fields, self._length, parameters=None, backend=self._backend
         )
 
     def _carry(self, carry: Index, allow_lazy: bool) -> Content:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -510,7 +510,7 @@ class RecordArray(RecordMeta[Content], Content):
                     self.content(i)._getitem_fields(nexthead, nexttail) for i in indexes
                 ]
         return RecordArray(
-            contents, fields, self._length, parameters=None, backend=self._backend
+            contents, fields, self.length, parameters=None, backend=self._backend
         )
 
     def _carry(self, carry: Index, allow_lazy: bool) -> Content:

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -347,7 +347,7 @@ class RegularArray(RegularMeta[Content], Content):
         return RegularArray(
             self._content._getitem_field(where, only_fields),
             self._size,
-            self._length,
+            self.length,
             parameters=None,
         )
 
@@ -357,7 +357,7 @@ class RegularArray(RegularMeta[Content], Content):
         return RegularArray(
             self._content._getitem_fields(where, only_fields),
             self._size,
-            self._length,
+            self.length,
             parameters=None,
         )
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -347,7 +347,7 @@ class RegularArray(RegularMeta[Content], Content):
         return RegularArray(
             self._content._getitem_field(where, only_fields),
             self._size,
-            self.length,
+            self._length,
             parameters=None,
         )
 
@@ -357,7 +357,7 @@ class RegularArray(RegularMeta[Content], Content):
         return RegularArray(
             self._content._getitem_fields(where, only_fields),
             self._size,
-            self.length,
+            self._length,
             parameters=None,
         )
 

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -418,9 +418,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
         if isinstance(out, ak.contents.RegularArray):
             tmp = ak.contents.UnmaskedArray.simplified(out._content, parameters=None)
-            return ak.contents.RegularArray(
-                tmp, out._size, out._length, parameters=None
-            )
+            return ak.contents.RegularArray(tmp, out.size, out.length, parameters=None)
 
         else:
             return out
@@ -436,7 +434,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             )
 
             return ak.contents.RegularArray(
-                tmp, out._size, out._length, parameters=self._parameters
+                tmp, out.size, out.length, parameters=self._parameters
             )
 
         else:


### PR DESCRIPTION
This PR makes the use of `._length` (non materializing) versus `.length` (materializing) consistent across all layouts.
Length is non materializing in `__init__`,  when copying, when converting to typetracer, when switching backends and when getting a field via `._getitem_field(s)`. The last one will materialize the length anyways in the record array case because it's using `self.content` which materializes the length because it needs to slice the content. It's materializing everywhere else.