### PR TITLE
fix: avoid calling `shape_generator` inside `generator` if it has already been called

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -127,6 +127,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                     f"Only shapes of integer dimensions are supported for materialized shapes. Received shape {shape}"
                 )
             self._shape = tuple(map(int, shape))
+            self._shape_generator = None
 
     def materialize(self) -> ArrayLike:
         if self._array is UNMATERIALIZED:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 UNMATERIALIZED = Sentinel("UNMATERIALIZED", None)
 
 
+def assert_never():
+    raise AssertionError("this shape_generator should never be run!")
+
+
 def materialize_if_virtual(*args: Any) -> tuple[Any, ...]:
     """
     A little helper function to materialize all virtual arrays in a list of arrays.
@@ -127,7 +131,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                     f"Only shapes of integer dimensions are supported for materialized shapes. Received shape {shape}"
                 )
             self._shape = tuple(map(int, shape))
-            self._shape_generator = None
+            self._shape_generator = assert_never
 
     def materialize(self) -> ArrayLike:
         if self._array is UNMATERIALIZED:

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -338,11 +338,23 @@ def test_nplike(virtual_array, numpy_like):
 # Test shape_generator property
 def test_shape_generator(virtual_array, shape_generator_param):
     if shape_generator_param is None:
+        assert virtual_array._shape == (unknown_length,)
         assert virtual_array._shape_generator is None
+        virtual_array.get_shape()
+        assert virtual_array.is_materialized
+        assert virtual_array._shape == (5,)
     else:
+        assert virtual_array._shape == (unknown_length,)
         assert virtual_array._shape_generator is not None
         # Can't directly compare lambdas, so check if it's callable
         assert callable(virtual_array._shape_generator)
+        virtual_array.get_shape()
+        assert virtual_array._shape == (5,)
+        assert not virtual_array.is_materialized
+        with pytest.raises(
+            AssertionError, match="this shape_generator should never be run!"
+        ):
+            assert virtual_array._shape_generator() == (5,)
 
 
 # Test copy


### PR DESCRIPTION
This is done via introducing an LRU cache of size 1 to hold the previous call.