### PR TITLE
fix: add `maps_as_pydicts` parameter to `to_pylist`

### DIFF
--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -18,7 +18,7 @@ np = NumpyMetadata.instance()
 
 class AwkwardArrowArray(pyarrow.ExtensionArray):
     def to_pylist(self, maps_as_pydicts=None):
-        out = super().to_pylist(maps_as_pydicts=maps_as_pydicts)
+        out = super().to_pylist()
         if (
             isinstance(self.type, AwkwardArrowType)
             and self.type.node_type == "RecordArray"

--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -17,8 +17,8 @@ np = NumpyMetadata.instance()
 
 
 class AwkwardArrowArray(pyarrow.ExtensionArray):
-    def to_pylist(self):
-        out = super().to_pylist()
+    def to_pylist(self, maps_as_pydicts=None):
+        out = super().to_pylist(maps_as_pydicts=maps_as_pydicts)
         if (
             isinstance(self.type, AwkwardArrowType)
             and self.type.node_type == "RecordArray"


### PR DESCRIPTION
fixes #3483