### PR TITLE
docs: fix a small typo in `IndexedArray` docstring

### DIFF
--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -58,7 +58,7 @@ class IndexedArray(IndexedMeta[Content], Content):
     IndexedArray is a general-purpose tool for *lazily* changing the order of
     and/or duplicating some `content` with a
     [np.take](https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html)
-    over the integer buffer `index.
+    over the integer buffer `index`.
 
     It has many uses:
 


### PR DESCRIPTION
just noticed this as I was looking for something in the docs.