### PR TITLE
feat: add a ref to the original 'unclipped' buffer generator

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -207,6 +207,10 @@ def _from_buffer(
                 nplike, buffer(), dtype, length, byteorder, field_path, None
             )
 
+        # also store a ref to the original/raw buffer generator
+        # this allows us to access it later again
+        generator.__awkward_raw_generator__ = buffer
+
         return VirtualArray(
             nplike=nplike,
             shape=(count,),


### PR DESCRIPTION
This allows us to access the original buffer generator at some later stage. 