### PR TITLE
feat: improve assertion error message in kernels

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -81,7 +81,7 @@ class NumpyKernel(BaseKernel):
                 return ctypes.cast(x, t)
             else:
                 raise AssertionError(
-                    f"Only NumPy buffers should be passed to Numpy Kernels, received {type(t).__name__}"
+                    f"Only NumPy buffers should be passed to Numpy Kernels, received {x} (ptr type={type(t).__name__})"
                 )
         else:
             return x

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -162,11 +162,7 @@ class CupyKernel(BaseKernel):
             # Do we have a CuPy-owned array?
             if self._cupy.is_own_array(x):
                 assert self._cupy.is_c_contiguous(x)
-                return x
-            else:
-                raise AssertionError(
-                    f"Only CuPy buffers should be passed to CuPy Kernels, received {x} (ptr type={type(type_).__name__})"
-                )
+            return x
         else:
             return x
 

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -116,7 +116,7 @@ class JaxKernel(BaseKernel):
                 return ctypes.cast(x, t)
             else:
                 raise AssertionError(
-                    f"Only JAX buffers should be passed to JAX Kernels, received {type(t).__name__}"
+                    f"Only JAX buffers should be passed to JAX Kernels, received {x} (ptr type={type(t).__name__})"
                 )
         else:
             return x
@@ -162,7 +162,11 @@ class CupyKernel(BaseKernel):
             # Do we have a CuPy-owned array?
             if self._cupy.is_own_array(x):
                 assert self._cupy.is_c_contiguous(x)
-            return x
+                return x
+            else:
+                raise AssertionError(
+                    f"Only CuPy buffers should be passed to CuPy Kernels, received {x} (ptr type={type(type_).__name__})"
+                )
         else:
             return x
 


### PR DESCRIPTION
This turns:
```
AssertionError: Only NumPy buffers should be passed to Numpy Kernels, received PyCPointerType
```
into
```
AssertionError: Only NumPy buffers should be passed to Numpy Kernels, received PlaceholderArray(dtype('uint8'), shape=(1,)) (ptr type=PyCPointerType)
```
where you can see what kind of object (PlaceHolderArray) was the cause of the error.