### PR TITLE
feat: do not allow records, primitives, or bare strings in `ak.materialize` (+ docs display fix)

### DIFF
--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -73,7 +73,7 @@
     generated/ak.to_packed
     generated/ak.copy
 
- .. toctree::
+.. toctree::
     :caption: Materializing virtual arrays
 
     generated/ak.materialize

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1195,7 +1195,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         )
 
     def _materialize(self) -> Self:
-        content = self._content._materialize()
+        content = self._content.materialize()
         mask = self._mask.materialize()
         return ByteMaskedArray(
             mask, content, valid_when=self._valid_when, parameters=self._parameters

--- a/src/awkward/operations/ak_materialize.py
+++ b/src/awkward/operations/ak_materialize.py
@@ -17,7 +17,7 @@ def materialize(
 ):
     """
     Args:
-        array : Array-like data (anything #ak.to_layout recognizes).
+        array : Array-like data (either an #ak.Array or an #ak.contents.Content).
             An array that may contain virtual buffers to be materialized.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
@@ -28,7 +28,7 @@ def materialize(
 
     Traverses the input array and materializes any virtual buffers.
     If the input array is not an #ak.Array or an #ak.contents.Content,
-    it will just be cast to an #ak.Array.
+    an error will be raised.
     The buffers of the returned array are no longer `VirtualArray` objects even if there were any.
     They will become one of `numpy.ndarray`, `cupy.ndarray`, or `jax.numpy.ndarray` objects,
     depending on the array's backend.

--- a/src/awkward/operations/ak_materialize.py
+++ b/src/awkward/operations/ak_materialize.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 from __future__ import annotations
 
-import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
 
@@ -17,8 +16,8 @@ def materialize(
 ):
     """
     Args:
-        array : array_like
-            An array with possible virtual buffers materialize.
+        array : Array-like data (anything #ak.to_layout recognizes).
+            An array that may contain virtual buffers to be materialized.
         highlevel (bool, default is True): If True, return an #ak.Array;
             otherwise, return a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if
@@ -27,10 +26,11 @@ def materialize(
             high-level.
 
     Traverses the input array and materializes any virtual buffers.
-    The buffers of the returned array are no longer `VirtualArray` objects.
-    They will become either `numpy.ndarray` or `cupy.ndarray` objects depending on the array's backend.
-    Possible inputs that will be traversed are instances of #ak.Array, #ak.Record, #ak.contents.Content, and #ak.record.Record.
-    All other types of inputs will be returned as is.
+    If the input array is not one of #ak.Array, #ak.Record, #ak.contents.Content, or #ak.record.Record,
+    it will just be cast to an #ak.Array.
+    The buffers of the returned array are no longer `VirtualArray` objects if there were any.
+    They will become one of `numpy.ndarray`, `cupy.ndarray`, or `jax.numpy.ndarray` objects,
+    depending on the array's backend.
     """
     # Dispatch
     yield (array,)
@@ -40,18 +40,7 @@ def materialize(
 
 
 def _impl(array, highlevel, behavior, attrs):
-    if not isinstance(
-        array,
-        (
-            ak.highlevel.Array,
-            ak.highlevel.Record,
-            ak.contents.Content,
-            ak.record.Record,
-        ),
-    ):
-        return array
-
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
-        layout = ctx.unwrap(array, allow_record=True, allow_unknown=False)
+        layout = ctx.unwrap(array, primitive_policy="error", string_policy="error")
     out = layout.materialize()
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_materialize.py
+++ b/src/awkward/operations/ak_materialize.py
@@ -1,6 +1,7 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 from __future__ import annotations
 
+import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._layout import HighLevelContext
 
@@ -40,9 +41,18 @@ def materialize(
 
 
 def _impl(array, highlevel, behavior, attrs):
+    if not isinstance(array, (ak.highlevel.Array, ak.contents.Content)):
+        raise TypeError(
+            f"Only an ak.Array (or low-level equivalent) should be passed into ak.materialize. Received {type(array)}"
+        )
+
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
         layout = ctx.unwrap(
-            array, allow_record=False, primitive_policy="error", string_policy="error"
+            array,
+            allow_record=False,
+            primitive_policy="error",
+            string_policy="error",
+            use_from_iter=False,
         )
     out = layout.materialize()
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_materialize.py
+++ b/src/awkward/operations/ak_materialize.py
@@ -26,9 +26,9 @@ def materialize(
             high-level.
 
     Traverses the input array and materializes any virtual buffers.
-    If the input array is not one of #ak.Array, #ak.Record, #ak.contents.Content, or #ak.record.Record,
+    If the input array is not an #ak.Array or an #ak.contents.Content,
     it will just be cast to an #ak.Array.
-    The buffers of the returned array are no longer `VirtualArray` objects if there were any.
+    The buffers of the returned array are no longer `VirtualArray` objects even if there were any.
     They will become one of `numpy.ndarray`, `cupy.ndarray`, or `jax.numpy.ndarray` objects,
     depending on the array's backend.
     """
@@ -41,6 +41,8 @@ def materialize(
 
 def _impl(array, highlevel, behavior, attrs):
     with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
-        layout = ctx.unwrap(array, primitive_policy="error", string_policy="error")
+        layout = ctx.unwrap(
+            array, allow_record=False, primitive_policy="error", string_policy="error"
+        )
     out = layout.materialize()
     return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/ak_to_raggedtensor.py
+++ b/src/awkward/operations/ak_to_raggedtensor.py
@@ -46,7 +46,12 @@ or
 
     # unwrap the awkward array if it was made with ak.Array function
     # also transforms a python list to awkward array
-    array = ak.to_layout(ak.operations.materialize(array), allow_record=False)
+    array = ak.to_layout(
+        ak.operations.materialize(array)
+        if isinstance(array, (ak.highlevel.Array, ak.contents.Content))
+        else array,
+        allow_record=False,
+    )
 
     # keep the same device
     ak_device = ak.backend(array)

--- a/src/awkward/operations/ak_to_rdataframe.py
+++ b/src/awkward/operations/ak_to_rdataframe.py
@@ -75,7 +75,9 @@ def _impl(
     length = None
     for name, array in arrays.items():
         layouts[name] = ak.operations.ak_to_layout._impl(
-            ak.operations.materialize(array),
+            ak.operations.materialize(array)
+            if isinstance(array, (ak.highlevel.Array, ak.contents.Content))
+            else array,
             allow_record=False,
             allow_unknown=False,
             none_policy="error",


### PR DESCRIPTION
Records give dangerous materializations where you materialize a whole array to figure out one row only and I don't think single numbers or strings should go through this function in the same way `ak.Array` doesn't allow them.

Also noticed that `ak.materialize` doesn't display on the docs website due to a single space typo so I fixed that as well.