### PR TITLE
fix: pass backend to RecordArray

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -634,6 +634,7 @@ def _reconstitute(
             None if form.is_tuple else form.fields,
             length,
             parameters=form._parameters,
+            backend=backend,
         )
 
     elif isinstance(form, ak.forms.UnionForm):


### PR DESCRIPTION
Fixes an unnecessary Device to Host copy - reported by @fstrug

Here is the reproducer:
```python
import uproot
import skhep_testdata as skhtd
from uproot._util import no_filter
from uproot.behaviors.RNTuple import _recursive_find
import numpy, cupy

def test(rntple, backend, library):
    filter_name = "TruthMuons"
    target_cols = []
    form = rntple.to_akform(
                filter_name=filter_name,
                filter_typename=no_filter,
                filter_field=no_filter,
                filter_branch=no_filter,
            )
    _recursive_find(form, target_cols)
    
    data = library.array([ 0,   1,   2,   3,   4,   5,   5,   6,   8,   8,   8,   9,  10,
            14,  15,  16,  17,  19,  20,  23,  23,  24,  24,  25,  25,  25,
            25,  26,  30,  32,  34,  36,  37,  38,  40,  42,  43,  44,  46,
            47,  48,  49,  50,  50,  51,  53,  55,  56,  57,  59,  60,  61,
            62,  63,  64,  64,  64,  66,  67,  68,  71,  71,  72,  73,  74,
            74,  74,  75,  76,  77,  78,  79,  82,  82,  84,  84,  86,  87,
            88,  89,  89,  91,  93,  94,  97, 100, 100, 102, 102, 104, 105,
           107, 107, 108, 109, 110, 110, 111, 112, 114, 114], dtype = library.uint64)
    container_dict = {}
    container_dict['column-157-data'] = data
    container_dict['column-157-offsets'] = data
    
    entry_start, entry_stop = (
        uproot.behaviors.TBranch._regularize_entries_start_stop(
            rntple.num_entries, None, None
        )
    )
    clusters = rntple.ntuple.cluster_summaries
    cluster_starts = numpy.array([c.num_first_entry for c in clusters])
    start_cluster_idx = (
        numpy.searchsorted(cluster_starts, entry_start, side="right") - 1
    )
    stop_cluster_idx = numpy.searchsorted(cluster_starts, entry_stop, side="right")
    cluster_num_entries = numpy.sum(
        [c.num_entries for c in clusters[start_cluster_idx:stop_cluster_idx]]
    )
    
    arrays = uproot.extras.awkward().from_buffers(
                form,
                cluster_num_entries,
                container_dict,
                allow_noncanonical_form=True,
                backend = backend
    )[entry_start:entry_stop]



file_path = skhtd.data_path("uproot-physlite-rntuple_v1-0-0-0.root")
f = uproot.open(file_path)
rntple = f["EventData"]
test(rntple, "cpu", numpy)
test(rntple, "cuda", cupy)
```