### PR TITLE
fix: Python 3.13 classifier to awkward-cpp

### DIFF
--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
awkward itself has the 3.13 classifier already so I guess it should also be added to awkward-cpp?