### PR TITLE
fix: simplify unmasked array

### DIFF
--- a/src/awkward/_meta/meta.py
+++ b/src/awkward/_meta/meta.py
@@ -21,6 +21,7 @@ class Meta:
     is_record: ClassVar[bool] = False
     is_union: ClassVar[bool] = False
     is_leaf: ClassVar[bool] = False
+    is_unmasked: ClassVar[bool] = False
 
     _parameters: JSONMapping | None
 

--- a/src/awkward/_meta/unmaskedmeta.py
+++ b/src/awkward/_meta/unmaskedmeta.py
@@ -10,6 +10,7 @@ T = TypeVar("T", bound=Meta)
 
 class UnmaskedMeta(Meta, Generic[T]):
     is_option = True
+    is_unmasked = True
     _content: T
 
     def purelist_parameters(self, *keys: str) -> JSONSerializable:

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -123,6 +123,10 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
                 contents=[cls.simplified(x) for x in content.contents],
                 parameters=parameters_union(content._parameters, parameters),
             )
+        elif content.is_unmasked:
+            return content.copy(
+                parameters=parameters_union(content._parameters, parameters)
+            )
         elif content.is_indexed or content.is_option:
             return content.to_IndexedOptionArray64().copy(
                 parameters=parameters_union(content._parameters, parameters)


### PR DESCRIPTION
Fixes Issue 1 in #3403

An `Unmasked` array has no missing values by definition. It is still an **option type**, though.
That’s why, when its content was an `Unmasked` array, the simplified method was introducing an `IndexedOptionArray` node.

@martindurant - FYI
