### PR TITLE
fix: allow numpy integers and 0-dim arrays through `shape_item_as_index` to support numpy 2.3

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,7 +1,7 @@
 fsspec>=2022.11.0;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.13"
 numba>=0.50.0;sys_platform != "win32" and python_version < "3.13"
-numexpr>=2.7; python_version < "3.13"
+numexpr>=2.7,<2.11; python_version < "3.13"
 pandas>=0.24.0;sys_platform != "win32"
 pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -379,6 +379,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             raise TypeError("array module nplikes do not support unknown lengths")
         elif isinstance(x1, int):
             return x1
+        elif isinstance(x1, (np.int64, np.int32, np.uint64, np.uint32)):
+            return int(x1)
         else:
             raise TypeError(f"expected None or int type, received {x1}")
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -17,6 +17,7 @@ from awkward._nplikes.numpy_like import (
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._regularize import is_integer_like
 from awkward._typing import TYPE_CHECKING, Any, DType, Final, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
@@ -377,9 +378,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def shape_item_as_index(self, x1: ShapeItem) -> int:
         if x1 is unknown_length:
             raise TypeError("array module nplikes do not support unknown lengths")
-        elif isinstance(x1, int):
-            return x1
-        elif isinstance(x1, (np.int64, np.int32, np.uint64, np.uint32)):
+        elif is_integer_like(x1):
             return int(x1)
         else:
             raise TypeError(f"expected None or int type, received {x1}")

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -22,7 +22,7 @@ from awkward._nplikes.numpy_like import (
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._operators import NDArrayOperatorsMixin
-from awkward._regularize import is_integer, is_non_string_like_sequence
+from awkward._regularize import is_integer, is_integer_like, is_non_string_like_sequence
 from awkward._typing import (
     TYPE_CHECKING,
     Any,
@@ -1040,8 +1040,8 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
     def shape_item_as_index(self, x1: ShapeItem) -> IndexType:
         if x1 is unknown_length:
             return TypeTracerArray._new(np.dtype(np.int64), shape=())
-        elif isinstance(x1, int):
-            return x1
+        elif is_integer_like(x1):
+            return int(x1)
         else:
             raise TypeError(f"expected unknown_length or int type, received {x1}")
 


### PR DESCRIPTION
fixes #3530 (but we'll see what the tests say)