### PR TITLE
fix: improve type consistency in `to_packed` for `num_none`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==46",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.18.0,<2.3",
+    "numpy>=1.22.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ filterwarnings = [
     "ignore:.*np\\.MachAr.*:DeprecationWarning",
     "ignore:module 'sre_.*' is deprecated:DeprecationWarning",
     "ignore:Jitify is performing a one-time only warm-up",
-    "ignore:One of rtol or atol is not valid:RuntimeWarning",
 ]
 log_cli_level = "info"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==46",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.22.0",
+    "numpy>=1.18.0",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
     "ignore:.*np\\.MachAr.*:DeprecationWarning",
     "ignore:module 'sre_.*' is deprecated:DeprecationWarning",
     "ignore:Jitify is performing a one-time only warm-up",
+    "ignore:One of rtol or atol is not valid:RuntimeWarning",
 ]
 log_cli_level = "info"
 

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,7 +1,7 @@
 fsspec>=2022.11.0;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.13"
 numba>=0.50.0;sys_platform != "win32" and python_version < "3.13"
-numexpr>=2.7; python_version < "3.13"
+numexpr>=2.7,<2.11; python_version < "3.13"
 pandas>=0.24.0;sys_platform != "win32"
 pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,7 +1,7 @@
 fsspec>=2022.11.0;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.13"
 numba>=0.50.0;sys_platform != "win32" and python_version < "3.13"
-numexpr>=2.7,<2.11; python_version < "3.13"
+numexpr>=2.7; python_version < "3.13"
 pandas>=0.24.0;sys_platform != "win32"
 pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import operator
 from collections.abc import Mapping, MutableMapping, Sequence
 
 import awkward as ak
@@ -1721,7 +1722,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             nplike = self._backend.nplike
             original_index = self._index.data
             is_none = original_index < 0
-            num_none = int(nplike.count_nonzero(is_none))
+            num_none = operator.index(nplike.count_nonzero(is_none))
             new_index = nplike.empty(self._index.length, dtype=self._index.dtype)
             if isinstance(nplike, Jax):
                 new_index = new_index.at[is_none].set(-1)

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1721,10 +1721,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             nplike = self._backend.nplike
             original_index = self._index.data
             is_none = original_index < 0
-            num_none = nplike.count_nonzero(is_none)
+            num_none = int(nplike.count_nonzero(is_none))
             new_index = nplike.empty(self._index.length, dtype=self._index.dtype)
             if isinstance(nplike, Jax):
-                num_none = num_none.item()
                 new_index = new_index.at[is_none].set(-1)
                 new_index = new_index.at[~is_none].set(
                     nplike.arange(


### PR DESCRIPTION
This PR ensures that the variable `num_none` in the `to_packed` method consistently holds a plain Python `int`, regardless of the nplike backend (NumPy, CuPy, JAX, etc.). This prevents potential type issues or unexpected behavior when performing downstream operations that expect a native `int`.