### PR TITLE
chore: restrict numpy and numexpr for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==46",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.18.0",
+    "numpy>=1.22,<2.3",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==46",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.22,<2.3",
+    "numpy>=1.18.1,<2.3",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==46",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.18.1,<2.3",
+    "numpy>=1.18.0,<2.3",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,7 +1,7 @@
 fsspec>=2022.11.0;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.13"
 numba>=0.50.0;sys_platform != "win32" and python_version < "3.13"
-numexpr>=2.7; python_version < "3.13"
+numexpr>=2.7,<2.11; python_version < "3.13"
 pandas>=0.24.0;sys_platform != "win32"
 pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6


### PR DESCRIPTION
As per the upstream pinning recommendation:
https://numpy.org/doc/stable/dev/depending_on_numpy.html#runtime-dependency-version-ranges
See
https://github.com/numpy/numpy/pull/18505
https://github.com/scipy/scipy/pull/12862