### PR TITLE
fix: do not use `atol=np.inf` in a jax test and `xfail` sorting test which fails

### DIFF
--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -55,58 +55,58 @@ def test_reducer(func_ak, axis):
     value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
 
     numpy.testing.assert_allclose(
-        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
-        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
-        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=np.inf
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(vjp_func(value_vjp)[0]),
-        (vjp_func_jax(value_vjp_jax)[0]).tolist(),
-        rtol=1e-9,
-        atol=np.inf,
-    )
-
-
-@pytest.mark.parametrize("axis", [0, 1])
-@pytest.mark.parametrize("func_ak", [ak.sort])
-def test_sort(func_ak, axis):
-    func_jax = getattr(jax.numpy, func_ak.__name__)
-
-    def func_ak_with_axis(x):
-        return func_ak(x, axis=axis)
-
-    def func_jax_with_axis(x):
-        return func_jax(x, axis=axis)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
-
-    numpy.testing.assert_allclose(
-        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=np.inf
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=np.inf
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
         ak.to_list(vjp_func(value_vjp)[0]),
         (vjp_func_jax(value_vjp_jax)[0]).tolist(),
         rtol=1e-9,
-        atol=np.inf,
+        atol=1e-9,
     )
+
+
+# @pytest.mark.parametrize("axis", [0, 1])
+# @pytest.mark.parametrize("func_ak", [ak.sort])
+# def test_sort(func_ak, axis):
+#     func_jax = getattr(jax.numpy, func_ak.__name__)
+#
+#     def func_ak_with_axis(x):
+#         return func_ak(x, axis=axis)
+#
+#     def func_jax_with_axis(x):
+#         return func_jax(x, axis=axis)
+#
+#     value_jvp, jvp_grad = jax.jvp(
+#         func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
+#     )
+#     value_jvp_jax, jvp_grad_jax = jax.jvp(
+#         func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
+#     )
+#
+#     value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
+#     value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
+#
+#     numpy.testing.assert_allclose(
+#         ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
+#     )
+#     numpy.testing.assert_allclose(
+#         ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
+#     )
+#     numpy.testing.assert_allclose(
+#         ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
+#     )
+#     numpy.testing.assert_allclose(
+#         ak.to_list(vjp_func(value_vjp)[0]),
+#         (vjp_func_jax(value_vjp_jax)[0]).tolist(),
+#         rtol=1e-9,
+#         atol=1e-9,
+#     )
 
 
 @pytest.mark.parametrize("func_ak", [ak.ravel])
@@ -130,19 +130,19 @@ def test_ravel(func_ak):
     value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_no_axis, test_regulararray_jax)
 
     numpy.testing.assert_allclose(
-        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
-        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
-        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=np.inf
+        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
     )
     numpy.testing.assert_allclose(
         ak.to_list(vjp_func(value_vjp)[0]),
         (vjp_func_jax(value_vjp_jax)[0]).tolist(),
         rtol=1e-9,
-        atol=np.inf,
+        atol=1e-9,
     )
 
 
@@ -176,7 +176,7 @@ def test_bool_returns(func_ak, axis):
         ak.to_list(vjp_func(value_vjp)[0]),
         (vjp_func_jax(value_vjp_jax)[0]).tolist(),
         rtol=1e-9,
-        atol=np.inf,
+        atol=1e-9,
     )
 
 

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -71,43 +71,45 @@ def test_reducer(func_ak, axis):
     )
 
 
-# TODO: Enable this when https://github.com/scikit-hep/awkward/issues/3541 is resolved.
-# @pytest.mark.parametrize("axis", [0, 1])
-# @pytest.mark.parametrize("func_ak", [ak.sort])
-# def test_sort(func_ak, axis):
-#     func_jax = getattr(jax.numpy, func_ak.__name__)
-#
-#     def func_ak_with_axis(x):
-#         return func_ak(x, axis=axis)
-#
-#     def func_jax_with_axis(x):
-#         return func_jax(x, axis=axis)
-#
-#     value_jvp, jvp_grad = jax.jvp(
-#         func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
-#     )
-#     value_jvp_jax, jvp_grad_jax = jax.jvp(
-#         func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
-#     )
-#
-#     value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
-#     value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
-#
-#     numpy.testing.assert_allclose(
-#         ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
-#     )
-#     numpy.testing.assert_allclose(
-#         ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
-#     )
-#     numpy.testing.assert_allclose(
-#         ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
-#     )
-#     numpy.testing.assert_allclose(
-#         ak.to_list(vjp_func(value_vjp)[0]),
-#         (vjp_func_jax(value_vjp_jax)[0]).tolist(),
-#         rtol=1e-9,
-#         atol=1e-9,
-#     )
+@pytest.mark.xfail(
+    reason="Sorting in the jax backend gives wrong JVP and VJP results. See issue #3541."
+)
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("func_ak", [ak.sort])
+def test_sort(func_ak, axis):
+    func_jax = getattr(jax.numpy, func_ak.__name__)
+
+    def func_ak_with_axis(x):
+        return func_ak(x, axis=axis)
+
+    def func_jax_with_axis(x):
+        return func_jax(x, axis=axis)
+
+    value_jvp, jvp_grad = jax.jvp(
+        func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
+    )
+    value_jvp_jax, jvp_grad_jax = jax.jvp(
+        func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
+    )
+
+    value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
+    value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
+
+    numpy.testing.assert_allclose(
+        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        ak.to_list(vjp_func(value_vjp)[0]),
+        (vjp_func_jax(value_vjp_jax)[0]).tolist(),
+        rtol=1e-9,
+        atol=1e-9,
+    )
 
 
 @pytest.mark.parametrize("func_ak", [ak.ravel])

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -71,6 +71,7 @@ def test_reducer(func_ak, axis):
     )
 
 
+# TODO: Enable this when https://github.com/scikit-hep/awkward/issues/3541 is resolved.
 # @pytest.mark.parametrize("axis", [0, 1])
 # @pytest.mark.parametrize("func_ak", [ak.sort])
 # def test_sort(func_ak, axis):


### PR DESCRIPTION
This has to do with numpy 2.3 which raises a warning about invalid `atol` if it's set to infinity and also the fact that this test is not right and jax and awkward give different values. See https://github.com/scikit-hep/awkward/issues/3541