### PR TITLE
ci: add workflow to run GPU tests on selfhosted runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,8 +179,8 @@ jobs:
     steps:
       - name: Clean the workspace and mamba
         run: |
-          rm -rf * .[!.]*
-          rm -rf ~/micromamba*
+          rm -rf * .[!.]* || echo "Nothing to clean"
+          rm -rf ~/micromamba* || echo "Nothing to clean"
 
       - uses: actions/checkout@v4
         with:
@@ -193,7 +193,6 @@ jobs:
           init-shell: bash
           create-args: >-
             python=3.13
-            cudatoolkit
 
       - name: Generate build files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,79 @@ jobs:
         if: (matrix.python-version == '3.9') && (matrix.runs-on == 'ubuntu-latest')
         uses: codecov/codecov-action@v5
 
+  run-gpu-tests:
+    name: Run GPU Tests
+
+    runs-on: self-hosted
+
+    env:
+      PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr
+
+    # Required for miniconda to activate conda
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Clean the workspace and mamba
+        run: |
+          rm -rf * .[!.]*
+          rm -rf ~/micromamba*
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get micromamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: test-env
+          init-shell: bash
+          create-args: >-
+            python=3.13
+            cudatoolkit
+
+      - name: Generate build files
+        run: |
+          pip install pipx
+          pipx run nox -s prepare -- --headers --signatures --tests
+
+      - name: Cache awkward-cpp wheel
+        id: cache-awkward-cpp-wheel
+        uses: actions/cache@v4
+        with:
+          path: awkward-cpp/dist
+          key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
+
+      - name: Build awkward-cpp wheel
+        if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install build
+          python -m build -w awkward-cpp
+
+      - name: Find built wheel
+        uses: tj-actions/glob@v22
+        id: find-wheel
+        with:
+          files: |
+            awkward-cpp/dist/*.whl
+
+      - name: Add workaround for 3.13 + cramjam
+        run: echo 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1' >> $GITHUB_ENV
+        shell: bash
+
+      - name: Install awkward, awkward-cpp, and dependencies
+        run: >-
+          python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
+          -r "requirements-test-gpu.txt"
+
+      - name: Print versions
+        run: python -m pip list
+
+      - name: Run GPU tests
+        run: >-
+          python -m pytest -vv -rs tests-cuda
+
   Linux-ROOT:
     runs-on: ubuntu-latest
 

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -1,7 +1,8 @@
 cudf-cu12
 cupy-cuda12x
 fsspec>=2022.11.0
-numba>=0.50.0
+numba>=0.60
+numba-cuda
 pyarrow
 pytest>=6
 pytest-cov

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -1,0 +1,9 @@
+cudf-cu12
+cupy-cuda12x
+fsspec>=2022.11.0
+numba>=0.50.0
+pyarrow
+pytest>=6
+pytest-cov
+pytest-xdist
+uproot>=5

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -47,6 +47,7 @@ def test_null():
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
+@pytest.mark.xfail(reason="The StringColumn constructor in cudf was changed. See #3480")
 def test_strings():
     arr = ak.Array(["hey", "hi", "hum"])
     out = ak.to_cudf(arr)


### PR DESCRIPTION
This PR adds a workflow to run the GPU tests on the new CI node at Princeton. There are a couple of things to discuss:

- I intentionally didn't add the new job to `pass-tests.needs` since I think we should first make sure that it is reliable enough that it's not going to end up blocking PR regularly.
- For now, I added it as a job in the usual `test.yml` workflow. This means that it will run for all PRs and pushes to main. There are some security concerns with this, so we could consider moving it to a separate workflow that needs to be triggered by a `workflow_dispatch` trigger, which only people with write permissions can do. And we could also run nightly tests to make sure things are not breaking. But I think it might also be fine to leave it it with the normal workflow for the following reasons:
  - For first-time contributors we need to approve running the tests.
  - I have the runner running inside a container with very limited access to the filesystem. So even if they wipe everything it's fine. I think a bigger concern would be someone trying to mine bitcoin or use the cluster for a DDOS attack or something.
  - Many of us have eyes on this repo, so I think if someone tries to do something we'll find out and stop it pretty quickly.

I don't have permissions to add a runner for this repo, so I'll need someone (probably @ianna) to help me with that. I tested it on [my fork](https://github.com/ariostas/awkward) and it's working well. [Here](https://github.com/ariostas/awkward/actions/runs/15635839088/job/44050581552) are the logs for a test run I did. There's actually one test that fails, so we should look into that.

After we settle all these things, I'll add a page in the wiki describing how to set up the selfhoster runner.