### PR TITLE
fix: cuda atomicMin and atomicMax for <double>s

### DIFF
--- a/src/awkward/_connect/cuda/cuda_kernels/cuda_common.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/cuda_common.cu
@@ -170,14 +170,21 @@ __device__ float atomicMin<float>(float* addr, float value) {
 }
 
 // atomicMin() specialization for double
+// https://stackoverflow.com/a/55145948
 template <>
-__device__ double atomicMin<double>(double* addr, double value) {
-  double old;
-  old = !signbit(value) ? __longlong_as_double(atomicMin((long long int*)addr, __double_as_longlong(value))) :
-      __ull2double_rz(atomicMax((unsigned long long int*)addr, __double2ull_ru(value)));
-  return old;
-}
+__device__ double atomicMin<double>(double* address, double val) {
+    unsigned long long int* addr_as_ull = (unsigned long long int*)address;
+    unsigned long long int old = *addr_as_ull, assumed;
 
+    do {
+        assumed = old;
+        double assumed_val = __longlong_as_double(assumed);
+        if (val >= assumed_val) break;
+        old = atomicCAS(addr_as_ull, assumed, __double_as_longlong(val));
+    } while (assumed != old);
+
+    return __longlong_as_double(old);
+}
 
 // atomicMax() specializations
 template <typename T>
@@ -253,12 +260,20 @@ __device__ float atomicMax<float>(float* addr, float value) {
 }
 
 // atomicMax() specialization for double
+// https://stackoverflow.com/a/55145948
 template <>
-__device__ double atomicMax<double>(double* addr, double value) {
-  double old;
-  old = !signbit(value) ? __longlong_as_double(atomicMax((long long int*)addr, __double_as_longlong(value))) :
-      __ull2double_rz(atomicMin((unsigned long long int*)addr, __double2ull_ru(value)));
-  return old;
+__device__ double atomicMax<double>(double* address, double val) {
+    unsigned long long int* address_as_ull = (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull, assumed;
+
+    do {
+        assumed = old;
+        double assumed_val = __longlong_as_double(assumed);
+        if (val <= assumed_val) break; // Already larger or equal, no update needed
+        old = atomicCAS(address_as_ull, assumed, __double_as_longlong(val));
+    } while (assumed != old);
+
+    return __longlong_as_double(old);
 }
 
 


### PR DESCRIPTION
fix #3528

the root cause is that the trick for `float` does not work for `double` due to, eh, IEEE754 ... My understanding is you can't cast `double` into `long long` and still have a total order like you would have for `float -> int`. See also: https://stackoverflow.com/questions/55140908/can-anybody-help-me-with-atomicmin-function-syntax-for-cuda/55145948#55145948
