### PR TITLE
fix: error if a complex JAX arrays type is passed to Awkward's C++ kernels

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -106,6 +106,14 @@ class JaxKernel(BaseKernel):
         if issubclass(t, ctypes._Pointer):
             # Do we have a JAX-owned array?
             if self._jax.is_own_array(x):
+                if self._jax.is_tracer_type(type(x)):
+                    jax_module = ak.jax.import_jax()
+                    # general message for any invalid JAX input type
+                    msg = f"Encountered {x} as an (invalid) input to the '{self._key[0]}' Awkward C++ kernel."
+                    # message specification for autodiff (i.e. when encountaring a JVPTracer)
+                    if isinstance(x, jax_module._src.interpreters.ad.JVPTracer):
+                        msg += " This kernel is not differentiable by the JAX backend."
+                    raise ValueError(msg)
                 assert self._jax.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
                     return ctypes.cast(x.unsafe_buffer_pointer(), t)
@@ -126,10 +134,9 @@ class JaxKernel(BaseKernel):
 
         args = materialize_if_virtual(*args)
 
-        if not any(Jax.is_tracer_type(type(arg)) for arg in args):
-            return self._impl(
-                *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
-            )
+        return self._impl(
+            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
+        )
 
 
 class CupyKernel(BaseKernel):

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -110,7 +110,7 @@ class JaxKernel(BaseKernel):
                     jax_module = ak.jax.import_jax()
                     # general message for any invalid JAX input type
                     msg = f"Encountered {x} as an (invalid) input to the '{self._key[0]}' Awkward C++ kernel."
-                    # message specification for autodiff (i.e. when encountaring a JVPTracer)
+                    # message specification for autodiff (i.e. when encountering a JVPTracer)
                     if isinstance(x, jax_module._src.interpreters.ad.JVPTracer):
                         msg += " This kernel is not differentiable by the JAX backend."
                     raise ValueError(msg)

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -71,45 +71,19 @@ def test_reducer(func_ak, axis):
     )
 
 
-@pytest.mark.xfail(
-    reason="Sorting in the jax backend gives wrong JVP and VJP results. See issue #3541."
-)
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("func_ak", [ak.sort])
 def test_sort(func_ak, axis):
-    func_jax = getattr(jax.numpy, func_ak.__name__)
-
     def func_ak_with_axis(x):
         return func_ak(x, axis=axis)
 
-    def func_jax_with_axis(x):
-        return func_jax(x, axis=axis)
-
-    value_jvp, jvp_grad = jax.jvp(
-        func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
-    )
-    value_jvp_jax, jvp_grad_jax = jax.jvp(
-        func_jax_with_axis, (test_regulararray_jax,), (test_regulararray_tangent_jax,)
-    )
-
-    value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
-    value_vjp_jax, vjp_func_jax = jax.vjp(func_jax_with_axis, test_regulararray_jax)
-
-    numpy.testing.assert_allclose(
-        ak.to_list(value_jvp), value_jvp_jax.tolist(), rtol=1e-9, atol=1e-9
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(value_vjp), value_vjp_jax.tolist(), rtol=1e-9, atol=1e-9
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(jvp_grad), jvp_grad_jax.tolist(), rtol=1e-9, atol=1e-9
-    )
-    numpy.testing.assert_allclose(
-        ak.to_list(vjp_func(value_vjp)[0]),
-        (vjp_func_jax(value_vjp_jax)[0]).tolist(),
-        rtol=1e-9,
-        atol=1e-9,
-    )
+    match = r".*This kernel is not differentiable by the JAX backend.*"
+    with pytest.raises(ValueError, match=match):
+        value_jvp, jvp_grad = jax.jvp(
+            func_ak_with_axis, (test_regulararray,), (test_regulararray_tangent,)
+        )
+    with pytest.raises(ValueError, match=match):
+        value_vjp, vjp_func = jax.vjp(func_ak_with_axis, test_regulararray)
 
 
 @pytest.mark.parametrize("func_ak", [ak.ravel])


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3541.

Let's error instead of silently skipping the Awkward C++ kernel call (and thus returning _wrong_ zeros)

Example error with this PR:
```python
import awkward as ak
import numpy as np
import jax

ak.jax.register_and_check()

test_regulararray = ak.Array(
  [[1.0, 2.0, 3.0],
    [4.0, 5.0, 6.0],
    [7.0, 8.0, 9.0]],
  backend="jax"
)

test_regulararray_tangent = ak.Array(
  [[1.0, 2.0, 3.0],
    [4.0, 5.0, 6.0],
    [7.0, 8.0, 9.0]],
  backend="jax"
)

value_jvp, jvp_grad = jax.jvp(
  lambda x: ak.sort(x, axis=0), (test_regulararray,), (test_regulararray_tangent,)
)
# >> ValueError: Encountered Traced<float64[9]>with<JVPTrace> with
#   primal = Array([1., 4., 7., 2., 5., 8., 3., 6., 9.], dtype=float64)
#   tangent = Array([1., 4., 7., 2., 5., 8., 3., 6., 9.], dtype=float64) as an (invalid) input to the 'awkward_sort' Awkward C++ kernel. This kernel is not differentiable by the JAX backend.
# 
# This error occurred while calling
#
#    ak.sort(
#        <Array [[...], [...], [...]] type='3 * var * float64'>
#        axis = 0
#    )
```
---
Making Awkward's C++ kernels differentiable with JAX is quite complicated. If we ever want to do that we'd have to define per kernel the forward and backward differentiation implementation, and properly pass the dual number (primal & tangent) that's passed by JAX to the kernel through those. Alternatively, we could try expressing those kernels with JAX own primitives that define those implementations already - not sure if that is possible for all kernels though.