### PR TITLE
fix: ak.categories should return None if no categories are present

### DIFF
--- a/src/awkward/operations/ak_categories.py
+++ b/src/awkward/operations/ak_categories.py
@@ -52,7 +52,7 @@ def _impl(array, highlevel, behavior, attrs):
 
     ak._do.recursively_apply(layout, action)
 
-    wrapped_out = ctx.wrap(output, highlevel=highlevel)
+    wrapped_out = ctx.wrap(output, highlevel=highlevel, allow_other=True)
 
     # propagate named axis from input to output,
     #   use strategy "drop all" (see: awkward._namedaxis)

--- a/tests/test_3553_ak_categories_noop.py
+++ b/tests/test_3553_ak_categories_noop.py
@@ -1,0 +1,9 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_noop():
+    assert ak.categories(ak.Array([1])) is None


### PR DESCRIPTION
See title