### PR TITLE
refactor: define common nplike method to get pointer to memory

### DIFF
--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -73,7 +73,7 @@ class NumpyKernel(BaseKernel):
             if numpy.is_own_array(x):
                 assert numpy.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
-                    return ctypes.cast(x.ctypes.data, t)
+                    return ctypes.cast(numpy.memory_ptr(x), t)
                 else:
                     return x
             # Or, do we have a ctypes type
@@ -116,7 +116,7 @@ class JaxKernel(BaseKernel):
                     raise ValueError(msg)
                 assert self._jax.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
-                    return ctypes.cast(x.unsafe_buffer_pointer(), t)
+                    return ctypes.cast(self._jax.memory_ptr(x), t)
                 else:
                     return x
             # Or, do we have a ctypes type

--- a/src/awkward/_lookup.py
+++ b/src/awkward/_lookup.py
@@ -16,10 +16,7 @@ class Lookup:
         def arrayptr(x):
             if isinstance(x, int):
                 return x
-            elif isinstance(self.nplike, ak._nplikes.cupy.Cupy):
-                return x.data.ptr
-            else:
-                return x.ctypes.data
+            return self.nplike.memory_ptr(x)
 
         self.nplike = layout.backend.nplike
         self.generator = generator

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -800,3 +800,6 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         if isinstance(obj, VirtualArray):
             return cls.is_own_array_type(obj.nplike.ndarray)
         return cls.is_own_array_type(type(obj))
+
+    def memory_ptr(self, x: ArrayLikeT) -> int:
+        raise NotImplementedError()

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -180,3 +180,8 @@ class Cupy(ArrayModuleNumpyLike):
         else:
             (x,) = materialize_if_virtual(x)
             return x.flags["C_CONTIGUOUS"]  # type: ignore[attr-defined]
+
+    def memory_ptr(self, x: ArrayLike) -> int:
+        (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
+        return x.data.ptr  # type: ignore[attr-defined]

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -155,3 +155,8 @@ class Jax(ArrayModuleNumpyLike):
         assert not isinstance(x2, PlaceholderArray)
         x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.divide(x1, x2)
+
+    def memory_ptr(self, x: ArrayLike) -> int:
+        (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
+        return x.unsafe_buffer_pointer()  # type: ignore[attr-defined]

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -76,3 +76,8 @@ class Numpy(ArrayModuleNumpyLike["NDArray"]):
     ):
         assert not isinstance(x, PlaceholderArray)
         return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)  # type: ignore[arg-type]
+
+    def memory_ptr(self, x: NDArray) -> int:
+        (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
+        return x.ctypes.data

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -521,3 +521,6 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
     @classmethod
     @abstractmethod
     def is_own_array_type(cls, type_: type) -> bool: ...
+
+    @abstractmethod
+    def memory_ptr(self, x: ArrayLikeT) -> int: ...

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1674,6 +1674,10 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         assert isinstance(x, TypeTracerArray)
         return True
 
+    def memory_ptr(self, x: TypeTracerArray | PlaceholderArray) -> int:
+        assert isinstance(x, TypeTracerArray)
+        return 0
+
     def __dlpack_device__(self) -> tuple[int, int]:
         raise NotImplementedError
 

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -214,20 +214,6 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     def tolist(self) -> list:
         return self.materialize().tolist()  # type: ignore[attr-defined]
 
-    @property
-    def ctypes(self):
-        if isinstance((self._nplike), ak._nplikes.cupy.Cupy):
-            raise AttributeError("Cupy ndarrays do not have a ctypes attribute")
-        return self.materialize().ctypes
-
-    @property
-    def data(self):
-        return self.materialize().data
-
-    def unsafe_buffer_pointer(self):
-        assert isinstance(self._nplike, ak._nplikes.jax.Jax)
-        return self.materialize().unsafe_buffer_pointer()
-
     def byteswap(self, inplace=False):
         if self._array is not UNMATERIALIZED:
             return self._array.byteswap(inplace=inplace)

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -137,18 +137,7 @@ class Index:
 
     @property
     def ptr(self):
-        if isinstance(self._nplike, Numpy):
-            return self._data.ctypes.data
-        elif isinstance(self._nplike, Cupy):
-            return self._data.data.ptr
-        elif isinstance(self._nplike, Jax):
-            return self._data.unsafe_buffer_pointer()
-        elif isinstance(self._nplike, TypeTracer):
-            return 0
-        else:
-            raise NotImplementedError(
-                f"this function hasn't been implemented for the {type(self._nplike).__name__} backend"
-            )
+        return self._nplike.memory_ptr(self._data)
 
     @property
     def length(self) -> ShapeItem:

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -454,18 +454,6 @@ def test_tobytes(virtual_array):
     assert virtual_array.is_materialized
 
 
-# Test ctypes
-def test_ctypes(virtual_array):
-    ctypes_data = virtual_array.ctypes
-    assert ctypes_data is not None
-
-
-# Test data
-def test_data(virtual_array):
-    data = virtual_array.data
-    assert data is not None
-
-
 # Test __repr__ and __str__
 def test_repr(virtual_array):
     repr_str = repr(virtual_array)

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -388,22 +388,6 @@ def test_tobytes(virtual_array):
     assert virtual_array.is_materialized
 
 
-# Test ctypes
-def test_ctypes(virtual_array):
-    ctypes_data = virtual_array.ctypes
-    assert ctypes_data is not None
-    # Should be materialized after this
-    assert virtual_array.is_materialized
-
-
-# Test data
-def test_data(virtual_array):
-    data = virtual_array.data
-    assert data is not None
-    # Should be materialized after this
-    assert virtual_array.is_materialized
-
-
 # Test __repr__ and __str__
 def test_repr(virtual_array, shape_generator_param):
     repr_str = repr(virtual_array)


### PR DESCRIPTION
Defines a `memory_ptr` function for each nplike and thus unifies their interface throughout the codebase (as suggested in https://github.com/scikit-hep/awkward/issues/3413). 

Closes https://github.com/scikit-hep/awkward/issues/3413