### PR TITLE
fix: first maybe materialize, then check for PlaceholderArray

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -192,10 +192,10 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         dtype: DTypeLike | None = None,
     ) -> ArrayLikeT:
+        start, stop, step = materialize_if_virtual(start, stop, step)
         assert not isinstance(start, PlaceholderArray)
         assert not isinstance(stop, PlaceholderArray)
         assert not isinstance(step, PlaceholderArray)
-        start, stop, step = materialize_if_virtual(start, stop, step)
         return self._module.arange(start, stop, step, dtype=dtype)
 
     def meshgrid(
@@ -210,9 +210,9 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def array_equal(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, equal_nan: bool = False
     ) -> bool:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         if equal_nan:
             # Only newer numpy.array_equal supports the equal_nan parameter.
             both_nan = self._module.logical_and(
@@ -231,10 +231,10 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         side: Literal["left", "right"] = "left",
         sorter: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
+        x, values, sorter = materialize_if_virtual(x, values, sorter)
         assert not isinstance(x, PlaceholderArray)
         assert not isinstance(values, PlaceholderArray)
         assert not isinstance(sorter, PlaceholderArray)
-        x, values, sorter = materialize_if_virtual(x, values, sorter)
         return self._module.searchsorted(x, values, side=side, sorter=sorter)
 
     ############################ manipulation
@@ -318,8 +318,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         return impl(*non_generic_value_promoted_args, **(kwargs or {}))
 
     def broadcast_arrays(self, *arrays: ArrayLikeT) -> list[ArrayLikeT]:
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         arrays = materialize_if_virtual(*arrays)
+        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         return self._module.broadcast_arrays(*arrays)
 
     def _compute_compatible_shape(
@@ -437,23 +437,23 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             raise IndexError(f"index value out of bounds (0, {length}): {index}")
 
     def nonzero(self, x: ArrayLikeT) -> tuple[ArrayLikeT, ...]:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.nonzero(x)
 
     def where(
         self, condition: ArrayLikeT, x1: ArrayLikeT, x2: ArrayLikeT
     ) -> ArrayLikeT:
+        condition, x1, x2 = materialize_if_virtual(condition, x1, x2)
         assert not isinstance(condition, PlaceholderArray)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        condition, x1, x2 = materialize_if_virtual(condition, x1, x2)
 
         return self._module.where(condition, x1, x2)
 
     def unique_values(self, x: ArrayLikeT) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         np_unique_accepts_equal_nan = (
             "equal_nan" in inspect.signature(self._module.unique).parameters
         )
@@ -475,8 +475,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             )
 
     def unique_all(self, x: ArrayLikeT) -> UniqueAllResult:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         values, indices, inverse_indices, counts = self._module.unique(
             x, return_counts=True, return_index=True, return_inverse=True
         )
@@ -493,8 +493,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         descending: bool = False,
         stable: bool = True,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         # Note: this keyword argument is different, and the default is different.
         kind = "stable" if stable else "quicksort"
         res = self._module.sort(x, axis=axis, kind=kind)
@@ -509,8 +509,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int | None = 0,
     ) -> ArrayLikeT:
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         arrays = materialize_if_virtual(*arrays)
+        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         if _nplike_concatenate_has_casting(self._module):
             return self._module.concatenate(arrays, axis=axis, casting="same_kind")
         else:
@@ -523,9 +523,9 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int | None = None,
     ) -> ArrayLikeT:
+        x, repeats = materialize_if_virtual(x, repeats)
         assert not isinstance(x, PlaceholderArray)
         assert not isinstance(repeats, PlaceholderArray)
-        x, repeats = materialize_if_virtual(x, repeats)
         return self._module.repeat(x, repeats=repeats, axis=axis)
 
     def stack(
@@ -534,8 +534,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int = 0,
     ) -> ArrayLikeT:
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         arrays = materialize_if_virtual(*arrays)
+        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
         arrays = list(arrays)
         return self._module.stack(arrays, axis=axis)
 
@@ -546,8 +546,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         axis: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.packbits(x, axis=axis, bitorder=bitorder)
 
     def unpackbits(
@@ -558,16 +558,17 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         count: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
 
     def broadcast_to(self, x: ArrayLikeT, shape: tuple[ShapeItem, ...]) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.broadcast_to(x, shape)
 
     def strides(self, x: ArrayLikeT | PlaceholderArray) -> tuple[ShapeItem, ...]:
+        (x,) = materialize_if_virtual(x)
         if isinstance(x, PlaceholderArray):
             # Assume contiguous
             strides: tuple[ShapeItem, ...] = (x.dtype.itemsize,)
@@ -575,58 +576,57 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                 strides = (item * strides[0], *strides)
             return strides
 
-        (x,) = materialize_if_virtual(x)
-        return x.strides  # type: ignore[union-attr]
+        return x.strides  # type: ignore[attr-defined]
 
     ############################ ufuncs
 
     def add(
         self, x1: ArrayLikeT, x2: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.add(x1, x2, out=maybe_out)
 
     def logical_or(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.logical_or(x1, x2, out=maybe_out)
 
     def logical_and(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.logical_and(x1, x2, out=maybe_out)
 
     def logical_not(
         self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.logical_not(x, out=maybe_out)
 
     def sqrt(self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.sqrt(x, out=maybe_out)
 
     def exp(self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.exp(x, out=maybe_out)
 
     def divide(
         self, x1: ArrayLikeT, x2: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.divide(x1, x2, out=maybe_out)
 
     ############################ almost-ufuncs
@@ -640,8 +640,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         posinf: int | float | None = None,
         neginf: int | float | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.nan_to_num(
             x, copy=copy, nan=nan, posinf=posinf, neginf=neginf
         )
@@ -655,14 +655,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         atol: float = 1e-8,
         equal_nan: bool = False,
     ) -> ArrayLikeT:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def isnan(self, x: ArrayLikeT) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.isnan(x)
 
     def all(
@@ -673,8 +673,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.all(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def any(
@@ -685,8 +685,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.any(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def min(
@@ -697,8 +697,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def max(
@@ -709,16 +709,16 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def count_nonzero(
         self, x: ArrayLikeT, *, axis: ShapeItem | tuple[ShapeItem, ...] | None = None
     ) -> ArrayLikeT:
+        (x,) = materialize_if_virtual(x)
         assert not isinstance(x, PlaceholderArray)
         assert isinstance(axis, int) or axis is None
-        (x,) = materialize_if_virtual(x)
         return self._module.count_nonzero(x, axis=axis)
 
     def cumsum(
@@ -728,32 +728,32 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         axis: int | None = None,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.cumsum(x, axis=axis, out=maybe_out)
 
     def real(self, x: ArrayLikeT) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         xr = self._module.real(x)
         # For numpy, xr is a view on x, but we don't want to mutate x.
         return self._module.copy(xr)
 
     def imag(self, x: ArrayLikeT) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         xr = self._module.imag(x)
         # For numpy, xr is a view on x, but we don't want to mutate x.
         return self._module.copy(xr)
 
     def angle(self, x: ArrayLikeT, deg: bool = False) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.angle(x, deg)
 
     def round(self, x: ArrayLikeT, decimals: int = 0) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.round(x, decimals=decimals)
 
     def array_str(
@@ -764,11 +764,11 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         precision: int | None = None,
         suppress_small: bool | None = None,
     ):
-        if isinstance(x, PlaceholderArray):
-            return "[## ... ##]"
         if isinstance(x, VirtualArray) and not x.is_materialized:
             return "[## ... ##]"
         (x,) = materialize_if_virtual(x)
+        if isinstance(x, PlaceholderArray):
+            return "[## ... ##]"
         return self._module.array_str(
             x,
             max_line_width=max_line_width,
@@ -779,8 +779,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def astype(
         self, x: ArrayLikeT, dtype: DTypeLike, *, copy: bool | None = True
     ) -> ArrayLikeT:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return x.astype(dtype, copy=copy)  # type: ignore[attr-defined]
 
     def can_cast(

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -57,9 +57,9 @@ class Cupy(ArrayModuleNumpyLike):
     def array_equal(
         self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
     ) -> bool:
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         if x1.shape != x2.shape:
             return False
         else:
@@ -68,9 +68,9 @@ class Cupy(ArrayModuleNumpyLike):
     def repeat(
         self, x: ArrayLike, repeats: ArrayLike | int, *, axis: int | None = None
     ):
+        x, repeats = materialize_if_virtual(x, repeats)
         assert not isinstance(x, PlaceholderArray)
         assert not isinstance(repeats, PlaceholderArray)
-        x, repeats = materialize_if_virtual(x, repeats)
         if axis is not None:
             raise NotImplementedError(f"repeat for CuPy with axis={axis!r}")
         # https://github.com/cupy/cupy/issues/3849
@@ -94,8 +94,8 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         out = self._module.all(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -110,8 +110,8 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         out = self._module.any(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -121,8 +121,8 @@ class Cupy(ArrayModuleNumpyLike):
     def count_nonzero(
         self, x: ArrayLike, *, axis: ShapeItem | tuple[ShapeItem, ...] | None = None
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         assert isinstance(axis, int) or axis is None
         out = self._module.count_nonzero(x, axis=axis)
         if axis is None and isinstance(out, self._module.ndarray):
@@ -138,8 +138,8 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         out = self._module.min(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -154,8 +154,8 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         out = self._module.max(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -104,54 +104,54 @@ class Jax(ArrayModuleNumpyLike):
         self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.add(x1, x2)
 
     def logical_or(
         self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.logical_or(x1, x2)
 
     def logical_and(
         self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.logical_and(x1, x2)
 
     def logical_not(
         self, x: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.logical_not(x)
 
     def sqrt(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
         del maybe_out
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.sqrt(x)
 
     def exp(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
         del maybe_out
-        assert not isinstance(x, PlaceholderArray)
         (x,) = materialize_if_virtual(x)
+        assert not isinstance(x, PlaceholderArray)
         return self._module.exp(x)
 
     def divide(
         self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
+        x1, x2 = materialize_if_virtual(x1, x2)
         assert not isinstance(x1, PlaceholderArray)
         assert not isinstance(x2, PlaceholderArray)
-        x1, x2 = materialize_if_virtual(x1, x2)
         return self._module.divide(x1, x2)


### PR DESCRIPTION
This was a logical error. First, we have to materialize if it's a VirtualArray, then we should check for PlaceholderArrays. Otherwise we won't catch the case where a VirtualArray would materialize into a PlaceholderArray...