### PR TITLE
feat: add `with_name` to `ak.concatenate`

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -276,6 +276,7 @@ def _load(
             arrays,
             axis=0,
             mergebool=True,
+            with_name=None,
             highlevel=highlevel,
             behavior=behavior,
             attrs=attrs,


### PR DESCRIPTION
It's pretty common that people want to do a `ak.with_name` after `ak.concatenate` when concatenating different types of particles. However, it's not immediately obvious to them that they should and what it does. This provides a shortcut for this common operation and makes it also easier for people to take a look at `ak.with_name` overall.

NEEDS TESTS