### PR TITLE
fix: removal of `pyarrow.lib.PyExtensionType` in pyarrow 21

### DIFF
--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -192,7 +192,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
     except AttributeError:
-        # pyarrow >= 21.0.0 does not have PyExtensionType.
+        # PyExtensionType is deprecated in pyarrow 21.0.0.
         pass
 
     if isinstance(storage_type, pyarrow.lib.ExtensionType):
@@ -504,7 +504,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
                 "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
             )
     except AttributeError:
-        # pyarrow >= 21.0.0 does not have PyExtensionType.
+        # PyExtensionType is deprecated in pyarrow 21.0.0.
         pass
 
     if isinstance(storage_type, pyarrow.lib.ExtensionType):

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -191,7 +191,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
         paarray = paarray.storage
     ### Beginning of the big if-elif-elif chain!
     if _pyarrow_version_lt_21_0_0 and isinstance(
-        storage_type, pyarrow.lib.ExtensionType
+        storage_type, pyarrow.lib.PyExtensionType
     ):
         raise ValueError(
             "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
@@ -501,7 +501,7 @@ def form_popbuffers(awkwardarrow_type, storage_type):
     ### Beginning of the big if-elif-elif chain!
 
     if _pyarrow_version_lt_21_0_0 and isinstance(
-        storage_type, pyarrow.lib.ExtensionType
+        storage_type, pyarrow.lib.PyExtensionType
     ):
         raise ValueError(
             "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from collections.abc import Iterable, Sized
 from functools import lru_cache
 
 import pyarrow
+from packaging.version import parse as parse_version
 
 import awkward as ak
 from awkward._backends.numpy import NumpyBackend
@@ -22,6 +24,8 @@ from .extn_types import (
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
+_pyarrow_version = importlib.metadata.version("pyarrow")
+_pyarrow_version_le_21_0_0 = parse_version(_pyarrow_version) < parse_version("21.0.0")
 
 
 def and_validbytes(validbytes1, validbytes2):
@@ -186,8 +190,9 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     if awkwardarrow_type is not None:
         paarray = paarray.storage
     ### Beginning of the big if-elif-elif chain!
-
-    if isinstance(storage_type, pyarrow.lib.PyExtensionType):
+    if _pyarrow_version_le_21_0_0 and isinstance(
+        storage_type, pyarrow.lib.ExtensionType
+    ):
         raise ValueError(
             "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
         )
@@ -495,7 +500,9 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 def form_popbuffers(awkwardarrow_type, storage_type):
     ### Beginning of the big if-elif-elif chain!
 
-    if isinstance(storage_type, pyarrow.lib.PyExtensionType):
+    if _pyarrow_version_le_21_0_0 and isinstance(
+        storage_type, pyarrow.lib.ExtensionType
+    ):
         raise ValueError(
             "Arrow arrays containing pickled Python objects can't be converted into Awkward Arrays"
         )

--- a/src/awkward/_connect/pyarrow/conversions.py
+++ b/src/awkward/_connect/pyarrow/conversions.py
@@ -25,7 +25,7 @@ from .extn_types import (
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
 _pyarrow_version = importlib.metadata.version("pyarrow")
-_pyarrow_version_le_21_0_0 = parse_version(_pyarrow_version) < parse_version("21.0.0")
+_pyarrow_version_lt_21_0_0 = parse_version(_pyarrow_version) < parse_version("21.0.0")
 
 
 def and_validbytes(validbytes1, validbytes2):
@@ -190,7 +190,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
     if awkwardarrow_type is not None:
         paarray = paarray.storage
     ### Beginning of the big if-elif-elif chain!
-    if _pyarrow_version_le_21_0_0 and isinstance(
+    if _pyarrow_version_lt_21_0_0 and isinstance(
         storage_type, pyarrow.lib.ExtensionType
     ):
         raise ValueError(
@@ -500,7 +500,7 @@ def popbuffers(paarray, awkwardarrow_type, storage_type, buffers, generate_bitma
 def form_popbuffers(awkwardarrow_type, storage_type):
     ### Beginning of the big if-elif-elif chain!
 
-    if _pyarrow_version_le_21_0_0 and isinstance(
+    if _pyarrow_version_lt_21_0_0 and isinstance(
         storage_type, pyarrow.lib.ExtensionType
     ):
         raise ValueError(


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/3579