### PR TITLE
feat: adapt `__array__` according to numpy guidelines

### DIFF
--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -509,20 +509,14 @@ def action_for_matmul(inputs):
 
 def convert_to_array(layout, dtype=None, copy=None):
     out = ak.operations.to_numpy(layout, allow_missing=False)
-    needs_copy_for_dtype = dtype is not None and out.dtype != dtype
-    if copy is False:
-        if needs_copy_for_dtype:
+    if copy:
+        return numpy.array(out, dtype=dtype, copy=True)
+    elif copy is None:
+        return numpy.asarray(out, dtype=dtype)
+    else:
+        if getattr(out, "dtype", dtype) != dtype:
             raise ValueError(
                 "Unable to avoid copy while creating an array as requested"
             )
-        return out
-    elif copy is True:
-        if needs_copy_for_dtype:
-            return out.astype(dtype)
         else:
-            return out.copy()
-    else:
-        if needs_copy_for_dtype:
-            return out.astype(dtype)
-        else:
-            return out
+            return numpy.asarray(out, dtype=dtype)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -514,7 +514,7 @@ def convert_to_array(layout, dtype=None, copy=None):
     elif copy is None:
         return numpy.asarray(out, dtype=dtype)
     else:
-        if getattr(out, "dtype", dtype) != dtype:
+        if dtype is not None and getattr(out, "dtype", dtype) != dtype:
             raise ValueError(
                 "Unable to avoid copy while creating an array as requested"
             )

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -507,9 +507,6 @@ def action_for_matmul(inputs):
     raise NotImplementedError
 
 
-def convert_to_array(layout, dtype=None):
+def convert_to_array(layout, dtype=None, copy=None):
     out = ak.operations.to_numpy(layout, allow_missing=False)
-    if dtype is None:
-        return out
-    else:
-        return numpy.array(out, dtype=dtype)
+    return numpy.asarray(out, dtype=dtype, copy=copy)

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -513,7 +513,7 @@ def convert_to_array(layout, dtype=None, copy=None):
     if copy is False:
         if needs_copy_for_dtype:
             raise ValueError(
-                "ValueError: Unable to avoid copy while creating an array as requested"
+                "Unable to avoid copy while creating an array as requested"
             )
         return out
     elif copy is True:

--- a/src/awkward/_connect/numpy.py
+++ b/src/awkward/_connect/numpy.py
@@ -509,4 +509,20 @@ def action_for_matmul(inputs):
 
 def convert_to_array(layout, dtype=None, copy=None):
     out = ak.operations.to_numpy(layout, allow_missing=False)
-    return numpy.asarray(out, dtype=dtype, copy=copy)
+    needs_copy_for_dtype = dtype is not None and out.dtype != dtype
+    if copy is False:
+        if needs_copy_for_dtype:
+            raise ValueError(
+                "ValueError: Unable to avoid copy while creating an array as requested"
+            )
+        return out
+    elif copy is True:
+        if needs_copy_for_dtype:
+            return out.astype(dtype)
+        else:
+            return out.copy()
+    else:
+        if needs_copy_for_dtype:
+            return out.astype(dtype)
+        else:
+            return out

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -395,7 +395,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
             "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
         )
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         raise AssertionError(
             "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
         )

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -304,7 +304,7 @@ class Content(Meta):
             "do not apply NumPy functions to low-level layouts (Content subclasses); put them in ak.highlevel.Array"
         )
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         raise TypeError(
             "do not try to convert low-level layouts (Content subclasses) into NumPy arrays; put them in ak.highlevel.Array"
         )

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1516,10 +1516,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             "text/plain": repr(self),
         }
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """
         Intercepts attempts to convert this Array into a NumPy array and
-        either performs a zero-copy conversion or raises an error.
+        either performs a conversion if possible or raises an error.
+        The array may be copied depending on the values of `dtype` and `copy`.
+        The rules for copying are specified in the
+        [np.asarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html)
+        documentation.
 
         This function is also called by the
         [np.asarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html)
@@ -1542,11 +1546,11 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         cannot be sliced as dimensions.
         """
         with ak._errors.OperationErrorContext(
-            "numpy.asarray", (self,), {"dtype": dtype}
+            "numpy.asarray", (self,), {"dtype": dtype, "copy": copy}
         ):
             from awkward._connect.numpy import convert_to_array
 
-            return convert_to_array(self._layout, dtype=dtype)
+            return convert_to_array(self._layout, dtype=dtype, copy=copy)
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(
@@ -2879,20 +2883,19 @@ class ArrayBuilder(Sized):
             formatter=formatter_impl,
         )
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """
         Intercepts attempts to convert a #snapshot of this array into a
-        NumPy array and either performs a zero-copy conversion or raises
-        an error.
+        NumPy array and either performs a conversion if possible or raises an error.
 
         See #ak.Array.__array__ for a more complete description.
         """
         with ak._errors.OperationErrorContext(
-            "numpy.asarray", (self,), {"dtype": dtype}
+            "numpy.asarray", (self,), {"dtype": dtype, "copy": copy}
         ):
             from awkward._connect.numpy import convert_to_array
 
-            return convert_to_array(self.snapshot(), dtype=dtype)
+            return convert_to_array(self.snapshot(), dtype=dtype, copy=copy)
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(

--- a/tests/test_3592_dunder_array.py
+++ b/tests/test_3592_dunder_array.py
@@ -28,7 +28,7 @@ def test_numpy2(iterable):
     out = np.asarray(akarray)
     assert np.array_equal(out, nparray)
 
-    if "__array__" not in akarray.layout.parameters:
+    if np.issubdtype(nparray.dtype, np.floating):
         # copy=None and dtype=None, no copy is required
         out = np.asarray(akarray, dtype=None, copy=None)
         assert np.array_equal(out, nparray)
@@ -153,7 +153,7 @@ def test_numpy1(iterable):
     out = np.asarray(akarray)
     assert np.array_equal(out, nparray)
 
-    if "__array__" not in akarray.layout.parameters:
+    if np.issubdtype(nparray.dtype, np.floating):
         # asarray with dtype=None, copy only if required
         out = np.asarray(akarray, dtype=None)
         assert np.array_equal(out, nparray)

--- a/tests/test_3592_dunder_array.py
+++ b/tests/test_3592_dunder_array.py
@@ -1,0 +1,209 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from packaging.version import parse as parse_version
+
+import awkward as ak
+
+
+@pytest.mark.skipif(
+    parse_version(np.__version__) < parse_version("2.0.0"),
+    reason="NumPy 2 is required for the copy kwarg in np.asarray",
+)
+@pytest.mark.parametrize(
+    "iterable",
+    (
+        [1.1, 2.2, 3.3, 4.4, 5.5],
+        [[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]],
+        ["one", "two", "three"],
+        [b"one", b"two", b"three"],
+    ),
+)
+def test_numpy2(iterable):
+    nparray = np.asarray(iterable)
+    akarray = ak.highlevel.Array(nparray, check_valid=True)
+    out = np.asarray(akarray)
+    assert np.array_equal(out, nparray)
+
+    if "__array__" not in akarray.layout.parameters:
+        # copy=None and dtype=None, no copy is required
+        out = np.asarray(akarray, dtype=None, copy=None)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=None and the same dtype is requested, no copy is required
+        out = np.asarray(akarray, dtype=np.float64, copy=None)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # changing dtype and copy=None, copy is required
+        out = np.asarray(akarray, dtype=np.float32, copy=None)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True, copy is enforced
+        out = np.asarray(akarray, dtype=None, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and the same dtype is requested, copy is enforced
+        out = np.asarray(akarray, dtype=np.float64, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and different dtype is requested, copy is enforced
+        out = np.asarray(akarray, dtype=np.float32, copy=True)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=False and dtype=None, no copy is required
+        out = np.asarray(akarray, dtype=None, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and the same dtype is requested, no copy is required
+        out = np.asarray(akarray, dtype=np.float64, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and a different dtype is requested, copy is required
+        with pytest.raises(ValueError):
+            np.asarray(akarray, dtype=np.float32, copy=False)
+
+        # copy=None and dtype=None, no copy is required
+        out = np.array(akarray, dtype=None, copy=None)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=None and the same dtype is requested, no copy is required
+        out = np.array(akarray, dtype=np.float64, copy=None)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # changing dtype and copy=None, copy is required
+        out = np.array(akarray, dtype=np.float32, copy=None)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True, copy is enforced
+        out = np.array(akarray, dtype=None, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and the same dtype is requested, copy is enforced
+        out = np.array(akarray, dtype=np.float64, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and different dtype is requested, copy is enforced
+        out = np.array(akarray, dtype=np.float32, copy=True)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=False and dtype=None, no copy is required
+        out = np.array(akarray, dtype=None, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and the same dtype is requested, no copy is required
+        out = np.array(akarray, dtype=np.float64, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and a different dtype is requested, copy is required
+        with pytest.raises(ValueError):
+            np.array(akarray, dtype=np.float32, copy=False)
+
+
+@pytest.mark.skipif(
+    parse_version(np.__version__) >= parse_version("2.0.0"),
+    reason="NumPy 1 does not support the copy kwarg in np.asarray but does in np.array",
+)
+@pytest.mark.parametrize(
+    "iterable",
+    (
+        [1.1, 2.2, 3.3, 4.4, 5.5],
+        [[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]],
+        ["one", "two", "three"],
+        [b"one", b"two", b"three"],
+    ),
+)
+def test_numpy1(iterable):
+    nparray = np.asarray(iterable)
+    akarray = ak.highlevel.Array(nparray, check_valid=True)
+    out = np.asarray(akarray)
+    assert np.array_equal(out, nparray)
+
+    if "__array__" not in akarray.layout.parameters:
+        # asarray with dtype=None, copy only if required
+        out = np.asarray(akarray, dtype=None)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # asarray with same dtype, copy only if required
+        out = np.asarray(akarray, dtype=np.float64)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # asarray with different dtype, copy is required
+        out = np.asarray(akarray, dtype=np.float32)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and dtype=None, copy is enforced
+        out = np.array(akarray, dtype=None, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and the same dtype is requested, copy is enforced
+        out = np.array(akarray, dtype=np.float64, copy=True)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=True and different dtype is requested, copy is enforced
+        out = np.array(akarray, dtype=np.float32, copy=True)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)
+
+        # copy=False and dtype=None, copy only if required
+        out = np.array(akarray, dtype=None, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and the same dtype is requested, copy only if required
+        out = np.array(akarray, dtype=np.float64, copy=False)
+        assert np.array_equal(out, nparray)
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert np.shares_memory(out, nparray)
+
+        # copy=False and a different dtype is requested, copy is required
+        out = np.array(akarray, dtype=np.float32, copy=False)
+        assert np.array_equal(out, nparray.astype(np.float32))
+        assert np.shares_memory(akarray.layout.data, nparray)
+        assert not np.shares_memory(out, nparray)

--- a/tests/test_3592_dunder_array.py
+++ b/tests/test_3592_dunder_array.py
@@ -154,13 +154,13 @@ def test_numpy1(iterable):
     assert np.array_equal(out, nparray)
 
     if np.issubdtype(nparray.dtype, np.floating):
-        # asarray with dtype=None, copy only if required
+        # asarray with dtype=None, no copy is required
         out = np.asarray(akarray, dtype=None)
         assert np.array_equal(out, nparray)
         assert np.shares_memory(akarray.layout.data, nparray)
         assert np.shares_memory(out, nparray)
 
-        # asarray with same dtype, copy only if required
+        # asarray with same dtype, no copy is required
         out = np.asarray(akarray, dtype=np.float64)
         assert np.array_equal(out, nparray)
         assert np.shares_memory(akarray.layout.data, nparray)
@@ -190,13 +190,13 @@ def test_numpy1(iterable):
         assert np.shares_memory(akarray.layout.data, nparray)
         assert not np.shares_memory(out, nparray)
 
-        # copy=False and dtype=None, copy only if required
+        # copy=False and dtype=None, no copy is required
         out = np.array(akarray, dtype=None, copy=False)
         assert np.array_equal(out, nparray)
         assert np.shares_memory(akarray.layout.data, nparray)
         assert np.shares_memory(out, nparray)
 
-        # copy=False and the same dtype is requested, copy only if required
+        # copy=False and the same dtype is requested, no copy is required
         out = np.array(akarray, dtype=np.float64, copy=False)
         assert np.array_equal(out, nparray)
         assert np.shares_memory(akarray.layout.data, nparray)


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3583

Implements `__array__` according to the guidelines specified by https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword and https://numpy.org/devdocs/user/basics.interoperability.html#the-array-method