### PR TITLE
fix: properly handle `VirtualArray` in `nplike.asarray`

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -365,7 +365,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[union-attr]
+                    lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[arg-type]
                     None,
                 )
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -347,17 +347,17 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             next_shape = self._compute_compatible_shape(shape, x.shape)
             return PlaceholderArray(self, next_shape, x.dtype, x._field_path)
         if isinstance(x, VirtualArray):
-            if not x.is_materialized:
+            if x.is_materialized:
+                return self.reshape(x.materialize(), shape, copy=copy)  # type: ignore[arg-type]
+            else:
                 next_shape = self._compute_compatible_shape(shape, x.shape)
                 return VirtualArray(
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[union-attr]
+                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[arg-type]
                     lambda: next_shape,
                 )
-            else:
-                x = x.materialize()  # type: ignore[assignment]
 
         if copy is None:
             return self._module.reshape(x, shape)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -73,14 +73,13 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                 # this avoids unnecessary VirtualArray creation and method-chaining
                 if not copy and (obj.dtype == dtype or dtype is None):
                     return obj
-                else:
-                    return VirtualArray(
-                        obj._nplike,
-                        obj._shape,
-                        obj._dtype if dtype is None else dtype,
-                        lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
-                        lambda: obj.shape,
-                    )
+                return VirtualArray(
+                    obj._nplike,
+                    obj._shape,
+                    obj._dtype if dtype is None else dtype,
+                    lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
+                    lambda: obj.shape,
+                )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
         elif copy is None:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -68,11 +68,6 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             if obj.is_materialized:
                 return self.asarray(obj.materialize(), dtype=dtype, copy=copy)
             else:
-                # if we are not copying and the dtype is _exactly_ the dtype of the existing array
-                # or dtype is None, we can return the VirtualArray directly
-                # this avoids unnecessary VirtualArray creation and method-chaining
-                if not copy and (obj.dtype == dtype or dtype is None):
-                    return obj
                 return VirtualArray(
                     obj._nplike,
                     obj._shape,

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -355,7 +355,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[arg-type]
+                    lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[arg-type]
                     lambda: next_shape,
                 )
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -66,24 +66,21 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return obj
         if isinstance(obj, VirtualArray):
             if obj.is_materialized:
-                obj = obj.materialize()
+                return self.asarray(obj.materialize(), dtype=dtype, copy=copy)
             else:
-                if obj.dtype == dtype or dtype is None:
-                    return obj
-                else:
-                    return VirtualArray(
-                        obj._nplike,
-                        obj._shape,
-                        dtype,
-                        lambda: self.asarray(obj.materialize(), dtype=dtype),
-                        lambda: obj.shape,
-                    )
+                return VirtualArray(
+                    obj._nplike,
+                    obj._shape,
+                    obj._dtype if dtype is None else dtype,
+                    lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
+                    lambda: obj.shape,
+                )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
         elif copy is None:
             return self._module.asarray(obj, dtype=dtype)
         else:
-            if getattr(obj, "dtype", dtype) != dtype:
+            if dtype is not None and getattr(obj, "dtype", dtype) != dtype:
                 raise ValueError(
                     "asarray was called with copy=False for an array of a different dtype"
                 )

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -1069,7 +1069,9 @@ def test_asarray_virtual_array_copy_false_same_dtype(numpy_like, virtual_array):
     assert not result.is_materialized
 
 
-def test_asarray_virtual_array_copy_false_different_dtype_creates_new(numpy_like, virtual_array):
+def test_asarray_virtual_array_copy_false_different_dtype_creates_new(
+    numpy_like, virtual_array
+):
     # Test VirtualArray copy=False with dtype change creates new VirtualArray (no error for unmaterialized)
     result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
     assert isinstance(result, VirtualArray)
@@ -1077,7 +1079,9 @@ def test_asarray_virtual_array_copy_false_different_dtype_creates_new(numpy_like
     assert not result.is_materialized
 
 
-def test_asarray_virtual_array_materialized_copy_false_dtype_error(numpy_like, virtual_array):
+def test_asarray_virtual_array_materialized_copy_false_dtype_error(
+    numpy_like, virtual_array
+):
     # Test materialized VirtualArray copy=False with dtype change raises error
     virtual_array.materialize()
     with pytest.raises(

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -1016,7 +1016,7 @@ def test_backend_of_obj(virtual_array, float_virtual_array):
 def test_asarray_virtual_array_unmaterialized(numpy_like, virtual_array):
     # Test with unmaterialized VirtualArray
     result = numpy_like.asarray(virtual_array)
-    assert isinstance(result, VirtualArray)
+    assert result is virtual_array  # Should return the same object
     assert not virtual_array.is_materialized
     assert not result.is_materialized
     # Check materialized values are correct

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -1014,8 +1014,12 @@ def test_backend_of_obj(virtual_array, float_virtual_array):
 # Test array creation methods with VirtualArray
 def test_asarray_virtual_array_unmaterialized(numpy_like, virtual_array):
     # Test with unmaterialized VirtualArray
-    numpy_like.asarray(virtual_array)
+    result = numpy_like.asarray(virtual_array)
+    assert isinstance(result, VirtualArray)
     assert not virtual_array.is_materialized
+    assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
 
 
 def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
@@ -1028,21 +1032,27 @@ def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
 
 def test_asarray_virtual_array_with_dtype(numpy_like, virtual_array):
     # Test with dtype parameter
-    out = numpy_like.asarray(virtual_array, dtype=np.float64)
-    assert isinstance(out, VirtualArray)
-    assert out.dtype == np.dtype(np.float64)
-    assert not out.is_materialized
-    assert out.materialize().dtype == np.dtype(np.float64)
+    result = numpy_like.asarray(virtual_array, dtype=np.float64)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
 
 
-def test_asarray_virtual_array_with_copy(numpy_like, virtual_array):
-    # Test with copy parameter
+def test_asarray_virtual_array_materialized_copy_false_dtype_error(
+    numpy_like, virtual_array
+):
+    # Test materialized VirtualArray with copy=False and different dtype raises error
     virtual_array.materialize()
     with pytest.raises(
         ValueError,
         match="asarray was called with copy=False for an array of a different dtype",
     ):
-        # Should raise because we're trying to change the dtype without copying
         numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
 
 
@@ -1052,43 +1062,72 @@ def test_asarray_virtual_array_copy_true_same_dtype(numpy_like, virtual_array):
     assert isinstance(result, VirtualArray)
     assert result is not virtual_array
     assert not result.is_materialized
+    assert result.dtype == virtual_array.dtype
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
 
 
-def test_asarray_virtual_array_copy_none_preserves_lazy(numpy_like, virtual_array):
+def test_asarray_virtual_array_copy_true_different_dtype(numpy_like, virtual_array):
+    # Test copy=True with different dtype
+    result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=True)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
+
+
+def test_asarray_virtual_array_copy_none_same_dtype(numpy_like, virtual_array):
     # Test copy=None preserves lazy evaluation with same dtype
     result = numpy_like.asarray(virtual_array, copy=None)
     assert isinstance(result, VirtualArray)
     assert not result.is_materialized
+    assert result.dtype == virtual_array.dtype
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_copy_none_different_dtype(numpy_like, virtual_array):
+    # Test copy=None with different dtype
+    result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=None)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
 
 
 def test_asarray_virtual_array_copy_false_same_dtype(numpy_like, virtual_array):
-    # Test VirtualArray with copy=False and same dtype - creates new VirtualArray with same dtype
+    # Test VirtualArray with copy=False and same dtype
     result = numpy_like.asarray(virtual_array, copy=False)
     assert isinstance(result, VirtualArray)
     assert result.dtype == virtual_array.dtype
     assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
 
 
-def test_asarray_virtual_array_copy_false_different_dtype_creates_new(
-    numpy_like, virtual_array
-):
-    # Test VirtualArray copy=False with dtype change creates new VirtualArray (no error for unmaterialized)
+def test_asarray_virtual_array_copy_false_different_dtype(numpy_like, virtual_array):
+    # Test VirtualArray copy=False with dtype change - should create VirtualArray but error on materialization
     result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
     assert isinstance(result, VirtualArray)
     assert result.dtype == np.dtype(np.float64)
     assert not result.is_materialized
 
-
-def test_asarray_virtual_array_materialized_copy_false_dtype_error(
-    numpy_like, virtual_array
-):
-    # Test materialized VirtualArray copy=False with dtype change raises error
-    virtual_array.materialize()
+    # Should error when trying to materialize due to copy=False constraint
     with pytest.raises(
         ValueError,
         match="asarray was called with copy=False for an array of a different dtype",
     ):
-        numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
+        result.materialize()
 
 
 def test_asarray_virtual_array_dtype_none_behavior(numpy_like, virtual_array):
@@ -1096,6 +1135,58 @@ def test_asarray_virtual_array_dtype_none_behavior(numpy_like, virtual_array):
     result = numpy_like.asarray(virtual_array, dtype=None)
     assert isinstance(result, VirtualArray)
     assert result.dtype == virtual_array.dtype
+    assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_materialized_copy_true(numpy_like, virtual_array):
+    # Test materialized VirtualArray with copy=True
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, copy=True)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+    # Should be a copy - modifying result shouldn't affect original
+    result[0] = 999
+    assert virtual_array.materialize()[0] == 1
+
+
+def test_asarray_virtual_array_materialized_copy_false_same_dtype(
+    numpy_like, virtual_array
+):
+    # Test materialized VirtualArray with copy=False and same dtype
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, copy=False)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_materialized_dtype_conversion(numpy_like, virtual_array):
+    # Test materialized VirtualArray with dtype conversion
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, dtype=np.float64)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5], dtype=np.float64))
+
+
+def test_asarray_virtual_array_complex_dtype_chain(numpy_like, virtual_array):
+    # Test chaining dtype conversions with VirtualArray
+    float_result = numpy_like.asarray(virtual_array, dtype=np.float32)
+    assert isinstance(float_result, VirtualArray)
+    assert float_result.dtype == np.dtype(np.float32)
+
+    # Further conversion
+    double_result = numpy_like.asarray(float_result, dtype=np.float64)
+    assert isinstance(double_result, VirtualArray)
+    assert double_result.dtype == np.dtype(np.float64)
+
+    # Check final materialized values
+    materialized = double_result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
 
 
 def test_ascontiguousarray_unmaterialized(numpy_like, virtual_array):

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -1195,10 +1195,10 @@ def test_asarray_virtual_array_with_dtype(
     )
 
 
-def test_asarray_virtual_array_with_copy(
+def test_asarray_virtual_array_materialized_copy_false_dtype_error(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test with copy parameter
+    # Test materialized VirtualArray with copy=False and different dtype raises error
     virtual_array.materialize()
     with pytest.raises(
         ValueError,

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -1161,7 +1161,7 @@ def test_asarray_virtual_array_unmaterialized(
 ):
     # Test with unmaterialized VirtualArray
     result = numpy_like.asarray(virtual_array)
-    assert isinstance(result, VirtualArray)  # Should be a VirtualArray
+    assert result is virtual_array  # Should return the same object
     assert result.dtype == virtual_array.dtype  # Should have same dtype
     assert not virtual_array.is_materialized
     assert not result.is_materialized

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -1161,8 +1161,12 @@ def test_asarray_virtual_array_unmaterialized(
 ):
     # Test with unmaterialized VirtualArray
     result = numpy_like.asarray(virtual_array)
-    assert result is virtual_array  # Should return the same object
+    assert isinstance(result, VirtualArray)  # Should be a VirtualArray
+    assert result.dtype == virtual_array.dtype  # Should have same dtype
     assert not virtual_array.is_materialized
+    assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
 
 
 def test_asarray_virtual_array_materialized(
@@ -1179,11 +1183,16 @@ def test_asarray_virtual_array_with_dtype(
     numpy_like, virtual_array, shape_generator_param
 ):
     # Test with dtype parameter
-    out = numpy_like.asarray(virtual_array, dtype=np.float64)
-    assert isinstance(out, VirtualArray)
-    assert out.dtype == np.dtype(np.float64)
-    assert not out.is_materialized
-    assert out.materialize().dtype == np.dtype(np.float64)
+    result = numpy_like.asarray(virtual_array, dtype=np.float64)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
 
 
 def test_asarray_virtual_array_with_copy(
@@ -1197,6 +1206,159 @@ def test_asarray_virtual_array_with_copy(
     ):
         # Should raise because we're trying to change the dtype without copying
         numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
+
+
+def test_asarray_virtual_array_copy_true_same_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test copy=True with same dtype returns new VirtualArray
+    result = numpy_like.asarray(virtual_array, copy=True)
+    assert isinstance(result, VirtualArray)
+    assert result is not virtual_array
+    assert not result.is_materialized
+    assert result.dtype == virtual_array.dtype
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_copy_true_different_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test copy=True with different dtype
+    result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=True)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
+
+
+def test_asarray_virtual_array_copy_none_same_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test copy=None preserves lazy evaluation with same dtype
+    result = numpy_like.asarray(virtual_array, copy=None)
+    assert isinstance(result, VirtualArray)
+    assert not result.is_materialized
+    assert result.dtype == virtual_array.dtype
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_copy_none_different_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test copy=None with different dtype
+    result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=None)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+    # Check materialized values have correct dtype and values
+    materialized = result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
+
+
+def test_asarray_virtual_array_copy_false_same_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test VirtualArray with copy=False and same dtype
+    result = numpy_like.asarray(virtual_array, copy=False)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == virtual_array.dtype
+    assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_copy_false_different_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test VirtualArray copy=False with dtype change - should create VirtualArray but error on materialization
+    result = numpy_like.asarray(virtual_array, dtype=np.float64, copy=False)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == np.dtype(np.float64)
+    assert not result.is_materialized
+
+    # Should error when trying to materialize due to copy=False constraint
+    with pytest.raises(
+        ValueError,
+        match="asarray was called with copy=False for an array of a different dtype",
+    ):
+        result.materialize()
+
+
+def test_asarray_virtual_array_dtype_none_behavior(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test VirtualArray with dtype=None preserves original dtype
+    result = numpy_like.asarray(virtual_array, dtype=None)
+    assert isinstance(result, VirtualArray)
+    assert result.dtype == virtual_array.dtype
+    assert not result.is_materialized
+    # Check materialized values are correct
+    np.testing.assert_array_equal(result.materialize(), np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_materialized_copy_true(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test materialized VirtualArray with copy=True
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, copy=True)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+    # Should be a copy - modifying result shouldn't affect original
+    result[0] = 999
+    assert virtual_array.materialize()[0] == 1
+
+
+def test_asarray_virtual_array_materialized_copy_false_same_dtype(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test materialized VirtualArray with copy=False and same dtype
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, copy=False)
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5]))
+
+
+def test_asarray_virtual_array_materialized_dtype_conversion(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test materialized VirtualArray with dtype conversion
+    virtual_array.materialize()
+    result = numpy_like.asarray(virtual_array, dtype=np.float64)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5], dtype=np.float64))
+
+
+def test_asarray_virtual_array_complex_dtype_chain(
+    numpy_like, virtual_array, shape_generator_param
+):
+    # Test chaining dtype conversions with VirtualArray
+    float_result = numpy_like.asarray(virtual_array, dtype=np.float32)
+    assert isinstance(float_result, VirtualArray)
+    assert float_result.dtype == np.dtype(np.float32)
+
+    # Further conversion
+    double_result = numpy_like.asarray(float_result, dtype=np.float64)
+    assert isinstance(double_result, VirtualArray)
+    assert double_result.dtype == np.dtype(np.float64)
+
+    # Check final materialized values
+    materialized = double_result.materialize()
+    assert materialized.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        materialized, np.array([1, 2, 3, 4, 5], dtype=np.float64)
+    )
 
 
 def test_ascontiguousarray_unmaterialized(


### PR DESCRIPTION
I realized that `nplike.asarray` does not properly handle `VirtualArray`. A copy should always be created when `copy=True` and that's not the case. The virtual array code branch in `asarray` never cared about copying the underying buffer at all. The codebase often does `nplike.asarray(some object, copy=True)` exactly because it needs a copy to do in-place modifications. This would cause problems if `some object` is a virtual array.

Also very lightly refactoring `reshape` without changing its functionality just to match the general style of other functions that create new virtual arrays.