### PR TITLE
fix: `VirtualArray`'s deep copy + accidental `.data` access

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -209,7 +209,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
         return self._nplike
 
     def copy(self) -> VirtualArray:
-        return copy.copy(self)
+        return copy.deepcopy(self)
 
     def tolist(self) -> list:
         return self.materialize().tolist()  # type: ignore[attr-defined]

--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -90,8 +90,8 @@ def _impl(array, axis, highlevel, behavior, attrs):
         # Build unions for each field
         outer_field_contents = []
         for field in all_fields:
-            field_tags = nplike.asarray(tags.data, copy=True)
-            field_index = nplike.asarray(index.data, copy=True)
+            field_tags = nplike.asarray(tags, copy=True)
+            field_index = nplike.asarray(index, copy=True)
 
             # Build contents for union representing current field
             field_contents = [c.content(field) for c in contents if c.has_field(field)]

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -436,6 +436,7 @@ def test_copy(virtual_array):
     assert copy.dtype == virtual_array.dtype
     assert not copy.is_materialized  # Copy should not be materialized
     assert id(copy) != id(virtual_array)  # Different objects
+    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -367,7 +367,7 @@ def test_copy(virtual_array, shape_generator_param):
     if shape_generator_param is None:
         assert copy.is_materialized
     assert id(copy) != id(virtual_array)  # Different objects
-    assert copy._generator is virtual_array._generator
+    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist

--- a/tests/test_3599_remove_accidental_data_attr_in_merge_union_of_records.py
+++ b/tests/test_3599_remove_accidental_data_attr_in_merge_union_of_records.py
@@ -1,0 +1,260 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import copy
+
+import numpy as np  # noqa: F401
+
+import awkward as ak
+
+
+def virtualize(array):
+    form, length, container = ak.to_buffers(array)
+    new_container = {k: lambda v=v: v for k, v in container.items()}
+    return ak.from_buffers(copy.deepcopy(form), length, new_container)
+
+
+def test_merge_union_of_records():
+    a1 = ak.Array([{"a": 1, "b": 2}])
+    a2 = ak.Array([{"b": 3.3, "c": 4.4}])
+    c = ak.concatenate((a1, a2))
+    c = virtualize(c)
+
+    assert c.tolist() == [{"a": 1, "b": 2}, {"b": 3.3, "c": 4.4}]
+
+    assert str(c.type) == "2 * union[{a: int64, b: int64}, {b: float64, c: float64}]"
+
+    d = ak.merge_union_of_records(c)
+
+    assert d.tolist() == [{"a": 1, "b": 2, "c": None}, {"a": None, "b": 3.3, "c": 4.4}]
+
+    assert str(d.type) == "2 * {a: ?int64, b: float64, c: ?float64}"
+
+
+def test_merge_union_of_records_2():
+    a1 = ak.Array([{"a": 1, "b": 2}])
+    a2 = ak.Array([{"b": 3.3, "c": 4.4}, {"b": None, "c": None}])
+    c = ak.concatenate((a1, a2))
+    c = virtualize(c)
+
+    assert c.tolist() == [
+        {"a": 1, "b": 2},
+        {"b": 3.3, "c": 4.4},
+        {"b": None, "c": None},
+    ]
+
+    assert str(c.type) == "3 * union[{a: int64, b: int64}, {b: ?float64, c: ?float64}]"
+
+    d = ak.merge_union_of_records(c)
+
+    assert d.tolist() == [
+        {"a": 1, "b": 2, "c": None},
+        {"a": None, "b": 3.3, "c": 4.4},
+        {"a": None, "b": None, "c": None},
+    ]
+
+    assert str(d.type) == "3 * {a: ?int64, b: ?float64, c: ?float64}"
+
+
+def test_merge_union_of_records_3():
+    a1 = ak.Array([[[[{"a": 1, "b": 2}]]]])
+    a2 = ak.Array([[[[{"b": 3.3, "c": 4.4}]]]])
+    c = ak.concatenate((a1, a2), axis=-1)
+    c = virtualize(c)
+
+    assert c.tolist() == [[[[{"a": 1, "b": 2}, {"b": 3.3, "c": 4.4}]]]]
+
+    assert (
+        str(c.type)
+        == "1 * var * var * var * union[{a: int64, b: int64}, {b: float64, c: float64}]"
+    )
+
+    d = ak.merge_union_of_records(c, axis=-1)
+
+    assert d.tolist() == [
+        [[[{"a": 1, "b": 2, "c": None}, {"a": None, "b": 3.3, "c": 4.4}]]]
+    ]
+
+    assert str(d.type) == "1 * var * var * var * {a: ?int64, b: float64, c: ?float64}"
+
+
+def test_merge_option_of_records():
+    a = ak.Array([None, {"a": 1, "b": 2}])
+    a = virtualize(a)
+
+    assert str(a.type) == "2 * ?{a: int64, b: int64}"
+
+    b = ak.merge_option_of_records(a)
+
+    assert b.tolist() == [{"a": None, "b": None}, {"a": 1, "b": 2}]
+
+    assert str(b.type) == "2 * {a: ?int64, b: ?int64}"
+
+
+def test_merge_option_of_records_2():
+    a = ak.Array([None, {"a": 1, "b": 2}, {"a": None, "b": None}])
+    a = virtualize(a)
+
+    assert str(a.type) == "3 * ?{a: ?int64, b: ?int64}"
+
+    b = ak.merge_option_of_records(a)
+
+    assert b.tolist() == [
+        {"a": None, "b": None},
+        {"a": 1, "b": 2},
+        {"a": None, "b": None},
+    ]
+
+    assert str(b.type) == "3 * {a: ?int64, b: ?int64}"
+
+
+def test_merge_option_of_records_3():
+    a = ak.Array([[[[None, {"a": 1, "b": 2}]]]])
+    a = virtualize(a)
+
+    assert str(a.type) == "1 * var * var * var * ?{a: int64, b: int64}"
+
+    b = ak.merge_option_of_records(a, axis=-1)
+
+    assert b.tolist() == [[[[{"a": None, "b": None}, {"a": 1, "b": 2}]]]]
+
+    assert str(b.type) == "1 * var * var * var * {a: ?int64, b: ?int64}"
+
+
+def test_indexed():
+    x = ak.to_layout([{"a": 1, "b": 2}])
+    y = ak.contents.IndexedArray(
+        ak.index.Index64([1]), ak.to_layout([{"c": 13, "b": 15}, {"c": 3, "b": 5}])
+    )
+
+    z = ak.concatenate((x, y))
+    z = virtualize(z)
+
+    assert z.tolist() == [
+        {"a": 1, "b": 2},
+        {"c": 3, "b": 5},
+    ]
+    assert z.type == ak.types.ArrayType(
+        ak.types.UnionType(
+            [
+                ak.types.RecordType(
+                    [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                    ["a", "b"],
+                ),
+                ak.types.RecordType(
+                    [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                    ["c", "b"],
+                ),
+            ]
+        ),
+        2,
+    )
+
+    w = ak.merge_union_of_records(z)
+    assert w.type == ak.types.ArrayType(
+        ak.types.RecordType(
+            [
+                ak.types.OptionType(ak.types.NumpyType("int64")),
+                ak.types.NumpyType("int64"),
+                ak.types.OptionType(ak.types.NumpyType("int64")),
+            ],
+            ["a", "b", "c"],
+        ),
+        2,
+    )
+    assert w.tolist() == [{"a": 1, "b": 2, "c": None}, {"a": None, "b": 5, "c": 3}]
+
+
+def test_option():
+    x = ak.to_layout([{"a": 1, "b": 2}])
+    y = ak.to_layout([{"c": 3, "b": 5}, None])
+
+    z = ak.concatenate((x, y))
+    z = virtualize(z)
+
+    assert z.tolist() == [{"a": 1, "b": 2}, {"c": 3, "b": 5}, None]
+    assert z.type == ak.types.ArrayType(
+        ak.types.UnionType(
+            [
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["a", "b"],
+                    )
+                ),
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["c", "b"],
+                    )
+                ),
+            ]
+        ),
+        3,
+    )
+
+    w = ak.merge_union_of_records(z)
+    assert w.type == ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.RecordType(
+                [
+                    ak.types.OptionType(ak.types.NumpyType("int64")),
+                    ak.types.NumpyType("int64"),
+                    ak.types.OptionType(ak.types.NumpyType("int64")),
+                ],
+                ["a", "b", "c"],
+            )
+        ),
+        3,
+    )
+    assert w.tolist() == [
+        {"a": 1, "b": 2, "c": None},
+        {"a": None, "b": 5, "c": 3},
+        None,
+    ]
+
+
+def test_option_unmasked():
+    x = ak.to_layout([{"a": 1, "b": 2}])
+    y = ak.contents.UnmaskedArray(ak.to_layout([{"c": 3, "b": 5}]))
+
+    z = ak.concatenate((x, y))
+    z = virtualize(z)
+
+    assert z.tolist() == [{"a": 1, "b": 2}, {"c": 3, "b": 5}]
+    assert z.type == ak.types.ArrayType(
+        ak.types.UnionType(
+            [
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["a", "b"],
+                    )
+                ),
+                ak.types.OptionType(
+                    ak.types.RecordType(
+                        [ak.types.NumpyType("int64"), ak.types.NumpyType("int64")],
+                        ["c", "b"],
+                    )
+                ),
+            ]
+        ),
+        2,
+    )
+
+    w = ak.merge_union_of_records(z)
+    assert w.type == ak.types.ArrayType(
+        ak.types.OptionType(
+            ak.types.RecordType(
+                [
+                    ak.types.OptionType(ak.types.NumpyType("int64")),
+                    ak.types.NumpyType("int64"),
+                    ak.types.OptionType(ak.types.NumpyType("int64")),
+                ],
+                ["a", "b", "c"],
+            )
+        ),
+        2,
+    )
+    assert w.tolist() == [{"a": 1, "b": 2, "c": None}, {"a": None, "b": 5, "c": 3}]

--- a/tests/test_3599_remove_accidental_data_attr_in_merge_union_of_records.py
+++ b/tests/test_3599_remove_accidental_data_attr_in_merge_union_of_records.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import copy
-
-import numpy as np  # noqa: F401
-
 import awkward as ak
 
 
 def virtualize(array):
     form, length, container = ak.to_buffers(array)
     new_container = {k: lambda v=v: v for k, v in container.items()}
-    return ak.from_buffers(copy.deepcopy(form), length, new_container)
+    return ak.from_buffers(form, length, new_container)
 
 
 def test_merge_union_of_records():


### PR DESCRIPTION
`.copy()` of an `ndarray` is a deep copy. It should be like that for `VirtualArray` too.
Also `ak.merge_union_of_records` asks for `.data` in two lines when the objects it asks for the `.data` attribute are already buffers (not `ak.contents.Content` or `ak.index.Index`). This accidentally returns a `memoryview` object which numpy and cupy can handle in `asarray`, but It doesn't look intended. Also the buffers of other backends don't implement a `.data` property which means this won't work for virtual and typetracer arrays.

- [x] VirtualArray's .copy() should be a deep copy
- [x] handle VirtualArray correctly by removing accidental .data access in ak.merge_union_of_records