### PR TITLE
fix: `VirtualArray`'s `.copy()` method should be a deep copy

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -209,7 +209,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
         return self._nplike
 
     def copy(self) -> VirtualArray:
-        return copy.copy(self)
+        return copy.deepcopy(self)
 
     def tolist(self) -> list:
         return self.materialize().tolist()  # type: ignore[attr-defined]

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -436,6 +436,7 @@ def test_copy(virtual_array):
     assert copy.dtype == virtual_array.dtype
     assert not copy.is_materialized  # Copy should not be materialized
     assert id(copy) != id(virtual_array)  # Different objects
+    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -367,7 +367,7 @@ def test_copy(virtual_array, shape_generator_param):
     if shape_generator_param is None:
         assert copy.is_materialized
     assert id(copy) != id(virtual_array)  # Different objects
-    assert copy._generator is virtual_array._generator
+    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist


### PR DESCRIPTION
While adding tests for https://github.com/scikit-hep/awkward/pull/3599, I found this bug/typo. `.copy()` of an `ndarray` is a deep copy. It should be like that for `VirtualArray` too. This is semi-critical too. It's probably not being hit often but I just hit it while writing tests and was getting wrong results.