### PR TITLE
refactor: add jax `DeprecationWarning`

### DIFF
--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import awkward_cpp
 
 import awkward as ak
@@ -28,6 +30,12 @@ class JaxBackend(Backend):
         return self._jax
 
     def __init__(self):
+        warnings.warn(
+            "The JAX backend is deprecated and will be removed in a future release of Awkward Array. "
+            "Please plan to migrate your code accordingly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._jax = Jax.instance()
 
     def __getitem__(self, index: KernelKeyType) -> JaxKernel:

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import awkward as ak
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
@@ -19,6 +21,12 @@ class Jax(ArrayModuleNumpyLike):
     supports_virtual_arrays: Final = True
 
     def __init__(self):
+        warnings.warn(
+            "The JAX backend is deprecated and will be removed in a future release of Awkward Array. "
+            "Please plan to migrate your code accordingly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         jax = ak.jax.import_jax()
         self._module = jax.numpy
 


### PR DESCRIPTION
**Description:**

This PR adds a `DeprecationWarning` to the Jax nplike backend, notifying users that JAX support in Awkward Array will be deprecated and removed in a future release.

**Changes:**

   * Imported warnings and added a DeprecationWarning in Jax.__init__.
   * Warning message encourages users to migrate away from the JAX backend.

**Rationale:**
The JAX backend in Awkward Array is no longer actively maintained and is planned for removal in an upcoming release. Adding an explicit deprecation warning will ensure that downstream users are aware of this change before it happens, giving them time to adapt their code.

Note: `ak.to_jax` and `ak.from_jax` will continue to be maintained for interoperability with JAX, even after the backend is removed.

**Example Warning Output:**

```python
DeprecationWarning: The JAX backend is deprecated and will be removed in a future release of Awkward Array. Please plan to migrate your code accordingly.
```
**Next Steps:**

   * Update documentation to reflect the planned removal.
   * Announce the deprecation in release notes and communication channels.

If there are any comments or suggestions, please add them to the ongoing discussion: https://github.com/scikit-hep/awkward/discussions/3603