### PR TITLE
fix: avoid unnecessary recursion if not needed

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -352,11 +352,15 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         if isinstance(x, VirtualArray):
             if not x.is_materialized:
                 next_shape = self._compute_compatible_shape(shape, x.shape)
+                # if the reshape is _exactly_ shaping the array as it is already, we can return self directly
+                # this avoids unnecessary VirtualArray creation and method-chaining
+                if next_shape == x.shape and not copy:
+                    return x
                 return VirtualArray(
                     self,
                     next_shape,
                     x.dtype,
-                    lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[union-attr]
+                    lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[union-attr]
                     lambda: next_shape,
                 )
             else:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -68,19 +68,17 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             if obj.is_materialized:
                 obj = obj.materialize()
             else:
-                if obj.dtype == dtype or dtype is None:
+                # if we are not copying and the dtype is _exactly_ the dtype of the existing array
+                # or dtype is None, we can return the VirtualArray directly
+                # this avoids unnecessary VirtualArray creation and method-chaining
+                if not copy and (obj.dtype == dtype or dtype is None):
                     return obj
                 else:
-                    # if we are not copying and the dtype is _exactly_ the dtype of the existing array
-                    # or dtype is None, we can return the VirtualArray directly
-                    # this avoids unnecessary VirtualArray creation and method-chaining
-                    if not copy and (obj.dtype == dtype or dtype is None):
-                        return obj
                     return VirtualArray(
                         obj._nplike,
                         obj._shape,
                         dtype,
-                        lambda: self.asarray(obj.materialize(), dtype=dtype),
+                        lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
                         lambda: obj.shape,
                     )
         if copy:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -71,6 +71,11 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                 if obj.dtype == dtype or dtype is None:
                     return obj
                 else:
+                    # if we are not copying and the dtype is _exactly_ the dtype of the existing array
+                    # or dtype is None, we can return the VirtualArray directly
+                    # this avoids unnecessary VirtualArray creation and method-chaining
+                    if not copy and (obj.dtype == dtype or dtype is None):
+                        return obj
                     return VirtualArray(
                         obj._nplike,
                         obj._shape,

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -352,7 +352,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         if isinstance(x, VirtualArray):
             if not x.is_materialized:
                 next_shape = self._compute_compatible_shape(shape, x.shape)
-                # if the reshape is _exactly_ shaping the array as it is already, we can return self directly
+                # if the reshape is _exactly_ shaping the array as it is already, we can return the VirtualArray directly
                 # this avoids unnecessary VirtualArray creation and method-chaining
                 if next_shape == x.shape and not copy:
                     return x

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -35,7 +35,7 @@ def materialize_if_virtual(*args: Any) -> tuple[Any, ...]:
     )
 
 
-def _wrap_generator_asarray(
+def _lazy_asarray(
     nplike: NumpyLike, generator: Callable[[], ArrayLike]
 ) -> Callable[[], ArrayLike]:
     """
@@ -88,7 +88,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
 
         # this ensures that the generator returns an array-like object according to the nplike
         if __wrap_generator_asarray__:
-            generator = _wrap_generator_asarray(nplike, generator)
+            generator = _lazy_asarray(nplike, generator)
 
         self._generator = generator
         self._shape_generator = shape_generator
@@ -154,7 +154,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
 
     def materialize(self) -> ArrayLike:
         if self._array is UNMATERIALIZED:
-            array = _wrap_generator_asarray(self._nplike, self._generator)()
+            array = _lazy_asarray(self._nplike, self._generator)()
             if len(self._shape) != len(array.shape):
                 raise ValueError(
                     f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {array.shape}"

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -170,6 +170,8 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                 )
             self._shape = array.shape
             self._array = array
+            self._shape_generator = assert_never
+            self._generator = assert_never
         return self._array  # type: ignore[return-value]
 
     def dematerialize(self) -> None:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -174,9 +174,6 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
             self._generator = assert_never
         return self._array  # type: ignore[return-value]
 
-    def dematerialize(self) -> None:
-        self._array = UNMATERIALIZED
-
     @property
     def is_materialized(self) -> bool:
         return self._array is not UNMATERIALIZED

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -217,6 +217,7 @@ def _from_buffer(
             dtype=dtype,
             generator=generator,
             shape_generator=cached_shape_generator,
+            __wrap_generator_asarray__=True,
         )
     # Unknown-length information implies that we didn't load shape-buffers (offsets, etc)
     # for the parent of this node. Thus, this node and its children *must* only

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -6,12 +6,11 @@ import sys
 
 import numpy as np
 
-import awkward as ak
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.virtual import VirtualArray
 
 
-def test():
+def test_getitem():
     numpy_like = Numpy.instance()
     vc = VirtualArray(
         numpy_like,
@@ -19,9 +18,32 @@ def test():
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1], dtype=np.int64),
     )
-    v = ak.contents.NumpyArray(vc)
-
     for _ in range(sys.getrecursionlimit() + 1):
-        v = v[:]
+        vc = vc[:]
+    assert vc.materialize()
 
-    assert ak.materialize(v)
+
+def test_view():
+    numpy_like = Numpy.instance()
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    for _ in range(sys.getrecursionlimit() + 1):
+        vc = vc.view(np.dtype(np.int64))
+    assert vc.materialize()
+
+
+def test_transpose():
+    numpy_like = Numpy.instance()
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    for _ in range(sys.getrecursionlimit() + 1):
+        vc = vc.T
+    assert vc.materialize()

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -47,3 +47,16 @@ def test_transpose():
     for _ in range(sys.getrecursionlimit() + 1):
         vc = vc.T
     assert vc.materialize()
+
+
+def test_reshape():
+    numpy_like = Numpy.instance()
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    for _ in range(sys.getrecursionlimit() + 1):
+        vc = numpy_like.reshape(vc, (1,), copy=False)
+    assert vc.materialize()

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -1,0 +1,25 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+#
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.numpy import Numpy
+import sys
+
+
+def test():
+    numpy_like = Numpy.instance()
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    v = ak.contents.NumpyArray(vc)
+
+    for _ in range(sys.getrecursionlimit() + 1):
+        v = v[:]
+
+    assert ak.materialize(v)

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -60,3 +60,29 @@ def test_reshape():
     for _ in range(sys.getrecursionlimit() + 1):
         vc = numpy_like.reshape(vc, (1,), copy=False)
     assert vc.materialize()
+
+
+def test_asarray():
+    numpy_like = Numpy.instance()
+
+    # copy=False
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    for _ in range(sys.getrecursionlimit() + 1):
+        vc = numpy_like.asarray(vc, dtype=np.dtype(np.int64), copy=False)
+    assert vc.materialize()
+
+    # copy=None
+    vc = VirtualArray(
+        numpy_like,
+        shape=(1,),
+        dtype=np.dtype(np.int64),
+        generator=lambda: np.array([1], dtype=np.int64),
+    )
+    for _ in range(sys.getrecursionlimit() + 1):
+        vc = numpy_like.asarray(vc, dtype=np.dtype(np.int64), copy=None)
+    assert vc.materialize()

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -2,11 +2,13 @@
 #
 from __future__ import annotations
 
-import awkward as ak
-import numpy as np
-from awkward._nplikes.virtual import VirtualArray
-from awkward._nplikes.numpy import Numpy
 import sys
+
+import numpy as np
+
+import awkward as ak
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.virtual import VirtualArray
 
 
 def test():


### PR DESCRIPTION
This PR avoids unnecessary recursion for VirtualArray transformations in case they are no-ops. Otherwise in rare cases we may descend down the call stack hell and discover circles of hell that even Dante Alighieri didn't know about...

There are _no_ infinity recursions here; but because Python has a limit on the recursion depth we try to avoid them as much as possible. This wouldn't be an issue if Python would have had tail recursion optimization (but it doesn't). This issue is a language limitation...

To completely avoid recursion we could use a FIFO stack to track all operations and run them in order in the materialization, but that turns out to be harder to implement _and_ will be very much unreadable, harder to maintain, and harder to reason about, which is why this PR doesn't do that now.

If anyone runs into this ever again (and that should be really weird edge cases), one can always increase Pythons recursion depth limit with `sys.setrecursionlimit(some_large_value)`. (Or we can revise the stack approach.)