### PR TITLE
perf: add slots to virtual array to reduce instance alloc size

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -49,6 +49,15 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
     Subsequent virtual arrays that originate from some virtual array will hit the cache of their parents if there is any.
     """
 
+    __slots__ = (
+        "_array",
+        "_dtype",
+        "_generator",
+        "_nplike",
+        "_shape",
+        "_shape_generator",
+    )
+
     def __init__(
         self,
         nplike: NumpyLike,


### PR DESCRIPTION
This PR adds `__slots__` to `VirtualArray` which reduces a few bytes of the instance allocation. This piles up for large complex structures such as `coffea.NanoEvents` and can reduce memory footprint for many delayed operations on the full layout noticeably.