### PR TITLE
perf: avoid method chaining for some shape_generators

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -357,7 +357,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     next_shape,
                     x.dtype,
                     lambda: self.reshape(x.materialize(), next_shape),  # type: ignore[union-attr]
-                    lambda: next_shape,
+                    None,
                 )
             else:
                 x = x.materialize()  # type: ignore[assignment]

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -197,7 +197,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
             shape,
             dtype,
             lambda: self.materialize().view(dtype),
-            lambda: shape,
+            None,
         )
 
     @property
@@ -295,7 +295,7 @@ class VirtualArray(NDArrayOperatorsMixin, ArrayLike):
                 (new_length, *self.shape[1:]),
                 self._dtype,
                 lambda: self.materialize()[index],
-                lambda: (new_length, *self.shape[1:]),
+                None,
             )
         else:
             return self.materialize().__getitem__(index)


### PR DESCRIPTION
this PR improves performance by avoiding creation of unnecessary shape_generators where the actual shape is already known. This can become noticeable in cases where trivial getitems (or similar) are chained _many_ times in very _large_ layouts, i.e. coffea's NanoEvents data structure.