### PR TITLE
refactor: VirtualArrays

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -8,7 +8,7 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._typing import Callable, TypeAlias, TypeVar, cast
 from awkward._util import UNSET, Sentinel
 
@@ -140,9 +140,9 @@ def find_virtual_backend(obj: type):
     Implements a lookup for finding the backends of virtual arrays.
     This is necessary to avoid calling `isinstance` inside `backend_of_obj` which may cause slowdown.
     """
-    if issubclass(obj, VirtualArray):
+    if issubclass(obj, VirtualNDArray):
 
-        def finder(obj: VirtualArray):
+        def finder(obj: VirtualNDArray):
             if isinstance(obj.nplike, ak._nplikes.numpy.Numpy):
                 return _name_to_backend_cls["cpu"].instance()
             elif isinstance(obj.nplike, ak._nplikes.cupy.Cupy):

--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -8,9 +8,9 @@ import jax
 
 import awkward as ak
 from awkward import _reducers
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem
-from awkward._nplikes.virtual import materialize_if_virtual
 from awkward._reducers import Reducer
 from awkward._typing import Final, Self, TypeVar
 
@@ -149,9 +149,7 @@ class ArgMin(JAXReducer):
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
-        result = segment_argmin(
-            *materialize_if_virtual(array.data, parents.data), outlength
-        )
+        result = segment_argmin(*maybe_materialize(array.data, parents.data), outlength)
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
         corrected_data = apply_positional_corrections(
@@ -211,9 +209,7 @@ class ArgMax(JAXReducer):
         outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
-        result = segment_argmax(
-            *materialize_if_virtual(array.data, parents.data), outlength
-        )
+        result = segment_argmax(*maybe_materialize(array.data, parents.data), outlength)
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
         corrected_data = apply_positional_corrections(
@@ -247,10 +243,10 @@ class Count(JAXReducer):
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
         result = jax.numpy.ones_like(
-            *materialize_if_virtual(array.data), dtype=self.preferred_dtype
+            *maybe_materialize(array.data), dtype=self.preferred_dtype
         )
         result = jax.ops.segment_sum(
-            result, *materialize_if_virtual(parents.data), outlength
+            result, *maybe_materialize(parents.data), outlength
         )
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
 
@@ -306,7 +302,7 @@ class CountNonzero(JAXReducer):
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
         result = segment_count_nonzero(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
 
@@ -341,7 +337,7 @@ class Sum(JAXReducer):
         else:
             input_array = array.data
         result = jax.ops.segment_sum(
-            *materialize_if_virtual(input_array, parents.data), outlength
+            *maybe_materialize(input_array, parents.data), outlength
         )
 
         if array.dtype.kind == "m":
@@ -426,7 +422,7 @@ class Prod(JAXReducer):
         assert isinstance(array, ak.contents.NumpyArray)
         # See issue https://github.com/google/jax/issues/9296
         result = segment_prod_with_negatives(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
 
         if np.issubdtype(array.dtype, np.complexfloating):
@@ -481,7 +477,7 @@ class Any(JAXReducer):
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
         result = jax.ops.segment_max(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
         if array.dtype is not np.dtype(bool):
             result = result.at[result == 0].set(self._max_initial(None, array.dtype))
@@ -516,7 +512,7 @@ class All(JAXReducer):
     ) -> ak.contents.NumpyArray:
         assert isinstance(array, ak.contents.NumpyArray)
         result = jax.ops.segment_min(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
         result = jax.numpy.asarray(result, dtype=bool)
 
@@ -571,7 +567,7 @@ class Min(JAXReducer):
         assert isinstance(array, ak.contents.NumpyArray)
 
         result = jax.ops.segment_min(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
         result = jax.numpy.minimum(result, self._min_initial(self.initial, array.dtype))
 
@@ -634,7 +630,7 @@ class Max(JAXReducer):
         assert isinstance(array, ak.contents.NumpyArray)
 
         result = jax.ops.segment_max(
-            *materialize_if_virtual(array.data, parents.data), outlength
+            *maybe_materialize(array.data, parents.data), outlength
         )
         result = jax.numpy.maximum(result, self._max_initial(self.initial, array.dtype))
 

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -14,7 +14,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import try_touch_data
-from awkward._nplikes.virtual import maybe_materialize
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._typing import Protocol, TypeAlias
 
 KernelKeyType: TypeAlias = tuple  # Tuple[str, Unpack[Tuple[metadata.dtype, ...]]]

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -9,12 +9,12 @@ from typing import Any, Callable
 from packaging.version import parse as parse_version
 
 import awkward as ak
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import try_touch_data
-from awkward._nplikes.array_like import maybe_materialize
 from awkward._typing import Protocol, TypeAlias
 
 KernelKeyType: TypeAlias = tuple  # Tuple[str, Unpack[Tuple[metadata.dtype, ...]]]

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -14,7 +14,7 @@ from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.typetracer import try_touch_data
-from awkward._nplikes.virtual import materialize_if_virtual
+from awkward._nplikes.virtual import maybe_materialize
 from awkward._typing import Protocol, TypeAlias
 
 KernelKeyType: TypeAlias = tuple  # Tuple[str, Unpack[Tuple[metadata.dtype, ...]]]
@@ -91,7 +91,7 @@ class NumpyKernel(BaseKernel):
     def __call__(self, *args) -> None:
         assert len(args) == len(self._impl.argtypes)
 
-        args = materialize_if_virtual(*args)
+        args = maybe_materialize(*args)
 
         return self._impl(
             *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
@@ -138,7 +138,7 @@ class JaxKernel(BaseKernel):
     def __call__(self, *args) -> None:
         assert len(args) == len(self._impl.argtypes)
 
-        args = materialize_if_virtual(*args)
+        args = maybe_materialize(*args)
 
         return self._impl(
             *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
@@ -182,7 +182,7 @@ class CupyKernel(BaseKernel):
     def __call__(self, *args) -> None:
         import awkward._connect.cuda as ak_cuda
 
-        args = materialize_if_virtual(*args)
+        args = maybe_materialize(*args)
 
         cupy = ak_cuda.import_cupy("Awkward Arrays with CUDA")
         maxlength = self.max_length(args)

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -33,7 +33,7 @@ def to_nplike(
     if isinstance(array, awkward._nplikes.virtual.VirtualNDArray):
         if not array.is_materialized and nplike.known_data:
             raise TypeError(
-                "Cannot convert a `VirtualNDArray` to a different `nplike` when its data is not yet materialized. 
+                "Cannot convert a `VirtualNDArray` to a different `nplike` when its data is not yet materialized.
                  Call `ak.materialize(array)` first to load the data before converting."
             )
         else:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -33,8 +33,8 @@ def to_nplike(
     if isinstance(array, awkward._nplikes.virtual.VirtualNDArray):
         if not array.is_materialized and nplike.known_data:
             raise TypeError(
-                "Cannot convert a `VirtualNDArray` to a different `nplike` when its data is not yet materialized.
-                 Call `ak.materialize(array)` first to load the data before converting."
+                "Cannot convert a `VirtualNDArray` to a different `nplike` when its data is not yet materialized."
+                " Call `ak.materialize(array)` first to load the data before converting."
             )
         else:
             if nplike.supports_virtual_arrays:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -30,10 +30,10 @@ def to_nplike(
 
     # We can always convert virtual arrays to typetracers
     # but can only convert virtual arrays to other backends with known data if they are intentionally materialized
-    if isinstance(array, awkward._nplikes.virtual.VirtualArray):
+    if isinstance(array, awkward._nplikes.virtual.VirtualNDArray):
         if not array.is_materialized and nplike.known_data:
             raise TypeError(
-                "Cannot convert a VirtualArray to a different nplike with known data without materializing it first. Use ak.materialize on the array to do so"
+                "Cannot convert a VirtualNDArray to a different nplike with known data without materializing it first. Use ak.materialize on the array to do so"
             )
         else:
             if nplike.supports_virtual_arrays:

--- a/src/awkward/_nplikes/__init__.py
+++ b/src/awkward/_nplikes/__init__.py
@@ -33,7 +33,8 @@ def to_nplike(
     if isinstance(array, awkward._nplikes.virtual.VirtualNDArray):
         if not array.is_materialized and nplike.known_data:
             raise TypeError(
-                "Cannot convert a VirtualNDArray to a different nplike with known data without materializing it first. Use ak.materialize on the array to do so"
+                "Cannot convert a `VirtualNDArray` to a different `nplike` when its data is not yet materialized. 
+                 Call `ak.materialize(array)` first to load the data before converting."
             )
         else:
             if nplike.supports_virtual_arrays:

--- a/src/awkward/_nplikes/array_like.py
+++ b/src/awkward/_nplikes/array_like.py
@@ -142,7 +142,17 @@ class ArrayLike(Protocol):
 
 def maybe_materialize(*args: Any) -> tuple[Any, ...]:
     """
-    A little helper function to materialize all materializable arrays in a list of arrays.
+    Returns a tuple where all `MaterializableArray` arguments have been replaced
+    by the result of calling their `.materialize()` method.
+
+    Other `ArrayLike` or `Any` arguments are returned unchanged.
+
+    Args:
+        *args: Variable length argument list of MaterializableArray or ArrayLike or Any objects.
+
+    Returns:
+        tuple: A tuple where each MaterializableArray is replaced by its materialized form,
+        and other ArrayLike or Any objects are returned unchanged.
     """
     return tuple(
         arg.materialize() if isinstance(arg, MaterializableArray) else arg

--- a/src/awkward/_nplikes/array_like.py
+++ b/src/awkward/_nplikes/array_like.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 from awkward._nplikes.shape import ShapeItem
 from awkward._typing import (
     TYPE_CHECKING,
+    Any,
     DType,
     EllipsisType,
     Protocol,
@@ -31,6 +32,10 @@ class ArrayLike(Protocol):
     @property
     @abstractmethod
     def shape(self) -> tuple[ShapeItem, ...]: ...
+
+    @property
+    @abstractmethod
+    def strides(self) -> tuple[ShapeItem, ...]: ...
 
     @property
     @abstractmethod
@@ -133,3 +138,18 @@ class ArrayLike(Protocol):
 
     @abstractmethod
     def __invert__(self) -> Self: ...
+
+
+def maybe_materialize(*args: Any) -> tuple[Any, ...]:
+    """
+    A little helper function to materialize all materializable arrays in a list of arrays.
+    """
+    return tuple(
+        arg.materialize() if isinstance(arg, MaterializableArray) else arg
+        for arg in args
+    )
+
+
+class MaterializableArray(ArrayLike):
+    @abstractmethod
+    def materialize(self) -> ArrayLike: ...

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -6,6 +6,7 @@ import inspect
 import math
 from functools import lru_cache
 
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.numpy_like import (
     ArrayLike,
     IndexType,
@@ -16,7 +17,7 @@ from awkward._nplikes.numpy_like import (
 )
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._typing import TYPE_CHECKING, Any, DType, Final, Literal, TypeVar, cast
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ ArrayLikeT = TypeVar("ArrayLikeT", bound=ArrayLike)
 class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     """
     Some methods maintain virtualness while others are required to materialize the array.
-    The `materialize_if_virtual` function is used for that purpose.
+    The `maybe_materialize` function is used for that purpose.
     If the input is not a virtual array, it's a zero cost operation.
     """
 
@@ -60,18 +61,18 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         dtype: DTypeLike | None = None,
         copy: bool | None = None,
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray:
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray:
         if isinstance(obj, PlaceholderArray):
             assert obj.dtype == dtype or dtype is None
             return obj
-        if isinstance(obj, VirtualArray):
+        if isinstance(obj, VirtualNDArray):
             if obj.is_materialized:
                 obj = obj.materialize()
             else:
                 if obj.dtype == dtype or dtype is None:
                     return obj
                 else:
-                    return VirtualArray(
+                    return VirtualNDArray(
                         obj._nplike,
                         obj._shape,
                         dtype,
@@ -92,14 +93,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
 
     def ascontiguousarray(
         self, x: ArrayLikeT | PlaceholderArray
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray:
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray:
         if isinstance(x, PlaceholderArray):
             return x
-        elif isinstance(x, VirtualArray):
+        elif isinstance(x, VirtualNDArray):
             if x.is_materialized:
                 return self.ascontiguousarray(x.materialize())  #  type: ignore[arg-type]
             else:
-                return VirtualArray(
+                return VirtualNDArray(
                     x._nplike,
                     x._shape,
                     x._dtype,
@@ -114,7 +115,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     ) -> ArrayLikeT:
         if isinstance(buffer, PlaceholderArray):
             raise TypeError("placeholder arrays are not supported in `frombuffer`")
-        if isinstance(buffer, VirtualArray):
+        if isinstance(buffer, VirtualNDArray):
             raise TypeError("virtual arrays are not supported in `frombuffer`")
         return self._module.frombuffer(buffer, dtype=dtype, count=count)
 
@@ -157,7 +158,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def zeros_like(
         self, x: ArrayLikeT | PlaceholderArray, *, dtype: DTypeLike | None = None
     ) -> ArrayLikeT:
-        if isinstance(x, (PlaceholderArray, VirtualArray)):
+        if isinstance(x, (PlaceholderArray, VirtualNDArray)):
             return self.zeros(x.shape, dtype=dtype or x.dtype)
         else:
             return self._module.zeros_like(x, dtype=dtype)
@@ -165,7 +166,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def ones_like(
         self, x: ArrayLikeT | PlaceholderArray, *, dtype: DTypeLike | None = None
     ) -> ArrayLikeT:
-        if isinstance(x, (PlaceholderArray, VirtualArray)):
+        if isinstance(x, (PlaceholderArray, VirtualNDArray)):
             return self.ones(x.shape, dtype=dtype or x.dtype)
         else:
             return self._module.ones_like(x, dtype=dtype)
@@ -177,7 +178,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         dtype: DTypeLike | None = None,
     ) -> ArrayLikeT:
-        if isinstance(x, (PlaceholderArray, VirtualArray)):
+        if isinstance(x, (PlaceholderArray, VirtualNDArray)):
             return self.full(x.shape, fill_value, dtype=dtype or x.dtype)
         else:
             return self._module.full_like(
@@ -192,27 +193,20 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         dtype: DTypeLike | None = None,
     ) -> ArrayLikeT:
-        start, stop, step = materialize_if_virtual(start, stop, step)
-        assert not isinstance(start, PlaceholderArray)
-        assert not isinstance(stop, PlaceholderArray)
-        assert not isinstance(step, PlaceholderArray)
+        start, stop, step = maybe_materialize(start, stop, step)
         return self._module.arange(start, stop, step, dtype=dtype)
 
     def meshgrid(
         self, *arrays: ArrayLikeT, indexing: Literal["xy", "ij"] = "xy"
     ) -> list[ArrayLikeT]:
-        return self._module.meshgrid(
-            *materialize_if_virtual(*arrays), indexing=indexing
-        )
+        return self._module.meshgrid(*maybe_materialize(*arrays), indexing=indexing)
 
     ############################ testing
 
     def array_equal(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, equal_nan: bool = False
     ) -> bool:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         if equal_nan:
             # Only newer numpy.array_equal supports the equal_nan parameter.
             both_nan = self._module.logical_and(
@@ -231,10 +225,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         side: Literal["left", "right"] = "left",
         sorter: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        x, values, sorter = materialize_if_virtual(x, values, sorter)
-        assert not isinstance(x, PlaceholderArray)
-        assert not isinstance(values, PlaceholderArray)
-        assert not isinstance(sorter, PlaceholderArray)
+        x, values, sorter = maybe_materialize(x, values, sorter)
         return self._module.searchsorted(x, values, side=side, sorter=sorter)
 
     ############################ manipulation
@@ -248,7 +239,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         if method != "__call__" or len(args) == 0:
             raise NotImplementedError
 
-        args = list(materialize_if_virtual(*args))
+        args = list(maybe_materialize(*args))
 
         if hasattr(ufunc, "resolve_dtypes"):
             return self._apply_ufunc_nep_50(ufunc, method, args, kwargs)
@@ -318,8 +309,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         return impl(*non_generic_value_promoted_args, **(kwargs or {}))
 
     def broadcast_arrays(self, *arrays: ArrayLikeT) -> list[ArrayLikeT]:
-        arrays = materialize_if_virtual(*arrays)
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
+        arrays = maybe_materialize(*arrays)
         return self._module.broadcast_arrays(*arrays)
 
     def _compute_compatible_shape(
@@ -345,14 +335,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         shape: tuple[ShapeItem, ...],
         *,
         copy: bool | None = None,
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray:
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray:
         if isinstance(x, PlaceholderArray):
             next_shape = self._compute_compatible_shape(shape, x.shape)
             return PlaceholderArray(self, next_shape, x.dtype, x._field_path)
-        if isinstance(x, VirtualArray):
+        if isinstance(x, VirtualNDArray):
             if not x.is_materialized:
                 next_shape = self._compute_compatible_shape(shape, x.shape)
-                return VirtualArray(
+                return VirtualNDArray(
                     self,
                     next_shape,
                     x.dtype,
@@ -437,23 +427,18 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             raise IndexError(f"index value out of bounds (0, {length}): {index}")
 
     def nonzero(self, x: ArrayLikeT) -> tuple[ArrayLikeT, ...]:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.nonzero(x)
 
     def where(
         self, condition: ArrayLikeT, x1: ArrayLikeT, x2: ArrayLikeT
     ) -> ArrayLikeT:
-        condition, x1, x2 = materialize_if_virtual(condition, x1, x2)
-        assert not isinstance(condition, PlaceholderArray)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        condition, x1, x2 = maybe_materialize(condition, x1, x2)
 
         return self._module.where(condition, x1, x2)
 
     def unique_values(self, x: ArrayLikeT) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         np_unique_accepts_equal_nan = (
             "equal_nan" in inspect.signature(self._module.unique).parameters
         )
@@ -475,8 +460,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             )
 
     def unique_all(self, x: ArrayLikeT) -> UniqueAllResult:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         values, indices, inverse_indices, counts = self._module.unique(
             x, return_counts=True, return_index=True, return_inverse=True
         )
@@ -493,8 +477,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         descending: bool = False,
         stable: bool = True,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         # Note: this keyword argument is different, and the default is different.
         kind = "stable" if stable else "quicksort"
         res = self._module.sort(x, axis=axis, kind=kind)
@@ -509,8 +492,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int | None = 0,
     ) -> ArrayLikeT:
-        arrays = materialize_if_virtual(*arrays)
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
+        arrays = maybe_materialize(*arrays)
         if _nplike_concatenate_has_casting(self._module):
             return self._module.concatenate(arrays, axis=axis, casting="same_kind")
         else:
@@ -523,9 +505,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int | None = None,
     ) -> ArrayLikeT:
-        x, repeats = materialize_if_virtual(x, repeats)
-        assert not isinstance(x, PlaceholderArray)
-        assert not isinstance(repeats, PlaceholderArray)
+        x, repeats = maybe_materialize(x, repeats)
         return self._module.repeat(x, repeats=repeats, axis=axis)
 
     def stack(
@@ -534,8 +514,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         *,
         axis: int = 0,
     ) -> ArrayLikeT:
-        arrays = materialize_if_virtual(*arrays)
-        assert not any(isinstance(x, PlaceholderArray) for x in arrays)
+        arrays = maybe_materialize(*arrays)
         arrays = list(arrays)
         return self._module.stack(arrays, axis=axis)
 
@@ -546,8 +525,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         axis: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.packbits(x, axis=axis, bitorder=bitorder)
 
     def unpackbits(
@@ -558,17 +536,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         count: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.unpackbits(x, axis=axis, count=count, bitorder=bitorder)
 
     def broadcast_to(self, x: ArrayLikeT, shape: tuple[ShapeItem, ...]) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.broadcast_to(x, shape)
 
     def strides(self, x: ArrayLikeT | PlaceholderArray) -> tuple[ShapeItem, ...]:
-        (x,) = materialize_if_virtual(x)
         if isinstance(x, PlaceholderArray):
             # Assume contiguous
             strides: tuple[ShapeItem, ...] = (x.dtype.itemsize,)
@@ -576,57 +551,47 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                 strides = (item * strides[0], *strides)
             return strides
 
-        return x.strides  # type: ignore[attr-defined]
+        (x,) = maybe_materialize(x)
+        return x.strides
 
     ############################ ufuncs
 
     def add(
         self, x1: ArrayLikeT, x2: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.add(x1, x2, out=maybe_out)
 
     def logical_or(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.logical_or(x1, x2, out=maybe_out)
 
     def logical_and(
         self, x1: ArrayLikeT, x2: ArrayLikeT, *, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.logical_and(x1, x2, out=maybe_out)
 
     def logical_not(
         self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.logical_not(x, out=maybe_out)
 
     def sqrt(self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.sqrt(x, out=maybe_out)
 
     def exp(self, x: ArrayLikeT, maybe_out: ArrayLikeT | None = None) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.exp(x, out=maybe_out)
 
     def divide(
         self, x1: ArrayLikeT, x2: ArrayLikeT, maybe_out: ArrayLikeT | None = None
     ) -> ArrayLikeT:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.divide(x1, x2, out=maybe_out)
 
     ############################ almost-ufuncs
@@ -640,8 +605,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         posinf: int | float | None = None,
         neginf: int | float | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.nan_to_num(
             x, copy=copy, nan=nan, posinf=posinf, neginf=neginf
         )
@@ -655,14 +619,11 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         atol: float = 1e-8,
         equal_nan: bool = False,
     ) -> ArrayLikeT:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.isclose(x1, x2, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def isnan(self, x: ArrayLikeT) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.isnan(x)
 
     def all(
@@ -673,8 +634,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.all(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def any(
@@ -685,8 +645,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.any(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def min(
@@ -697,8 +656,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def max(
@@ -709,15 +667,13 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         keepdims: bool = False,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.max(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
     def count_nonzero(
         self, x: ArrayLikeT, *, axis: ShapeItem | tuple[ShapeItem, ...] | None = None
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         assert isinstance(axis, int) or axis is None
         return self._module.count_nonzero(x, axis=axis)
 
@@ -728,32 +684,27 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         axis: int | None = None,
         maybe_out: ArrayLikeT | None = None,
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.cumsum(x, axis=axis, out=maybe_out)
 
     def real(self, x: ArrayLikeT) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         xr = self._module.real(x)
         # For numpy, xr is a view on x, but we don't want to mutate x.
         return self._module.copy(xr)
 
     def imag(self, x: ArrayLikeT) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         xr = self._module.imag(x)
         # For numpy, xr is a view on x, but we don't want to mutate x.
         return self._module.copy(xr)
 
     def angle(self, x: ArrayLikeT, deg: bool = False) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.angle(x, deg)
 
     def round(self, x: ArrayLikeT, decimals: int = 0) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.round(x, decimals=decimals)
 
     def array_str(
@@ -764,11 +715,11 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         precision: int | None = None,
         suppress_small: bool | None = None,
     ):
-        if isinstance(x, VirtualArray) and not x.is_materialized:
+        if isinstance(x, VirtualNDArray) and not x.is_materialized:
             return "[## ... ##]"
-        (x,) = materialize_if_virtual(x)
         if isinstance(x, PlaceholderArray):
             return "[## ... ##]"
+        (x,) = maybe_materialize(x)
         return self._module.array_str(
             x,
             max_line_width=max_line_width,
@@ -779,8 +730,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
     def astype(
         self, x: ArrayLikeT, dtype: DTypeLike, *, copy: bool | None = True
     ) -> ArrayLikeT:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return x.astype(dtype, copy=copy)  # type: ignore[attr-defined]
 
     def can_cast(
@@ -794,10 +744,10 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         # We are required to know if different nplikes own virtual arrays throughout the code
         # and that can only be determined by the underlying nplike of the virtual array
         # as virtual arrays can generate either numpy or cupy ndarrays.
-        # The VirtualArray type is now enough. We need the underlying nplike to determine ownership.
+        # The VirtualNDArray type is now enough. We need the underlying nplike to determine ownership.
         # All nplikes implement an ndarray property so we can can use that.
         # There is an extra isinstance check here but that has to live somewhere in the code either way to determine ownership.
-        if isinstance(obj, VirtualArray):
+        if isinstance(obj, VirtualNDArray):
             return cls.is_own_array_type(obj.nplike.ndarray)
         return cls.is_own_array_type(type(obj))
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -70,8 +70,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                 obj = obj.materialize()
             else:
                 # if we are not copying and the dtype is _exactly_ the dtype of the existing array
-                # or dtype is None, we can return the VirtualArray directly
-                # this avoids unnecessary VirtualArray creation and method-chaining
+                # or dtype is None, we can return the VirtualNDArray directly
+                # this avoids unnecessary VirtualNDArray creation and method-chaining
                 if not copy and (obj.dtype == dtype or dtype is None):
                     return obj
                 else:
@@ -345,8 +345,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         if isinstance(x, VirtualNDArray):
             if not x.is_materialized:
                 next_shape = self._compute_compatible_shape(shape, x.shape)
-                # if the reshape is _exactly_ shaping the array as it is already, we can return the VirtualArray directly
-                # this avoids unnecessary VirtualArray creation and method-chaining
+                # if the reshape is _exactly_ shaping the array as it is already, we can return the VirtualNDArray directly
+                # this avoids unnecessary VirtualNDArray creation and method-chaining
                 if next_shape == x.shape and not copy:
                     return x
                 return VirtualNDArray(

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import numpy
 
 import awkward as ak
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpy_like import ArrayLike
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
@@ -49,17 +50,15 @@ class Cupy(ArrayModuleNumpyLike):
     def frombuffer(
         self, buffer, *, dtype: DTypeLike | None = None, count: ShapeItem = -1
     ) -> ArrayLike:
-        assert not isinstance(buffer, (PlaceholderArray, VirtualArray))
-        assert not isinstance(count, (PlaceholderArray, VirtualArray))
+        assert not isinstance(buffer, (PlaceholderArray, VirtualNDArray))
+        assert not isinstance(count, (PlaceholderArray, VirtualNDArray))
         np_array = numpy.frombuffer(buffer, dtype=dtype, count=count)
         return self._module.asarray(np_array)
 
     def array_equal(
         self, x1: ArrayLike, x2: ArrayLike, *, equal_nan: bool = False
     ) -> bool:
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         if x1.shape != x2.shape:
             return False
         else:
@@ -68,9 +67,7 @@ class Cupy(ArrayModuleNumpyLike):
     def repeat(
         self, x: ArrayLike, repeats: ArrayLike | int, *, axis: int | None = None
     ):
-        x, repeats = materialize_if_virtual(x, repeats)
-        assert not isinstance(x, PlaceholderArray)
-        assert not isinstance(repeats, PlaceholderArray)
+        x, repeats = maybe_materialize(x, repeats)
         if axis is not None:
             raise NotImplementedError(f"repeat for CuPy with axis={axis!r}")
         # https://github.com/cupy/cupy/issues/3849
@@ -94,8 +91,7 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         out = self._module.all(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -110,8 +106,7 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         out = self._module.any(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -121,8 +116,7 @@ class Cupy(ArrayModuleNumpyLike):
     def count_nonzero(
         self, x: ArrayLike, *, axis: ShapeItem | tuple[ShapeItem, ...] | None = None
     ) -> ArrayLike:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         assert isinstance(axis, int) or axis is None
         out = self._module.count_nonzero(x, axis=axis)
         if axis is None and isinstance(out, self._module.ndarray):
@@ -138,8 +132,7 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         out = self._module.min(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -154,8 +147,7 @@ class Cupy(ArrayModuleNumpyLike):
         keepdims: bool = False,
         maybe_out: ArrayLike | None = None,
     ) -> ArrayLike:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         out = self._module.max(x, axis=axis, out=maybe_out)
         if axis is None and isinstance(out, self._module.ndarray):
             return out.item()
@@ -178,10 +170,9 @@ class Cupy(ArrayModuleNumpyLike):
         if isinstance(x, PlaceholderArray):
             return True
         else:
-            (x,) = materialize_if_virtual(x)
+            (x,) = maybe_materialize(x)
             return x.flags["C_CONTIGUOUS"]  # type: ignore[attr-defined]
 
     def memory_ptr(self, x: ArrayLike) -> int:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return x.data.ptr  # type: ignore[attr-defined]

--- a/src/awkward/_nplikes/dispatch.py
+++ b/src/awkward/_nplikes/dispatch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy_like import NumpyLike
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._typing import Any, TypeVar, cast
 from awkward._util import UNSET, Sentinel
 
@@ -49,7 +49,7 @@ def nplike_of_obj(
         # to avoid the isinstance slowdown inside the try block
         # because it's used often for non-virtual arrays
         # TODO: replace this whole function with a more generic lookup registration system
-        if isinstance(obj, VirtualArray):
+        if isinstance(obj, VirtualNDArray):
             return obj.nplike
         for nplike_cls in _nplike_classes:
             if nplike_cls.is_own_array_type(cls):

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import warnings
 
 import awkward as ak
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpy_like import UfuncLike
-from awkward._nplikes.placeholder import PlaceholderArray
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._typing import Final, cast
 
 
@@ -95,7 +94,7 @@ class Jax(ArrayModuleNumpyLike):
         return True
 
     def ascontiguousarray(self, x: ArrayLike) -> ArrayLike:
-        if isinstance(x, VirtualArray) and x.is_materialized:
+        if isinstance(x, VirtualNDArray) and x.is_materialized:
             return x.materialize()
         else:
             return x
@@ -112,59 +111,47 @@ class Jax(ArrayModuleNumpyLike):
         self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.add(x1, x2)
 
     def logical_or(
         self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.logical_or(x1, x2)
 
     def logical_and(
         self, x1: ArrayLike, x2: ArrayLike, *, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.logical_and(x1, x2)
 
     def logical_not(
         self, x: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.logical_not(x)
 
     def sqrt(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
         del maybe_out
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.sqrt(x)
 
     def exp(self, x: ArrayLike, maybe_out: ArrayLike | None = None) -> ArrayLike:
         del maybe_out
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return self._module.exp(x)
 
     def divide(
         self, x1: ArrayLike, x2: ArrayLike, maybe_out: ArrayLike | None = None
     ) -> ArrayLike:
         del maybe_out
-        x1, x2 = materialize_if_virtual(x1, x2)
-        assert not isinstance(x1, PlaceholderArray)
-        assert not isinstance(x2, PlaceholderArray)
+        x1, x2 = maybe_materialize(x1, x2)
         return self._module.divide(x1, x2)
 
     def memory_ptr(self, x: ArrayLike) -> int:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return x.unsafe_buffer_pointer()  # type: ignore[attr-defined]

--- a/src/awkward/_nplikes/numpy.py
+++ b/src/awkward/_nplikes/numpy.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import numpy
 
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.array_module import ArrayModuleNumpyLike
 from awkward._nplikes.dispatch import register_nplike
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
-from awkward._nplikes.virtual import materialize_if_virtual
 from awkward._typing import TYPE_CHECKING, Final, Literal
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ class Numpy(ArrayModuleNumpyLike["NDArray"]):
         if isinstance(x, PlaceholderArray):
             return True
         else:
-            (x,) = materialize_if_virtual(x)
+            (x,) = maybe_materialize(x)
             return x.flags["C_CONTIGUOUS"]  # type: ignore[union-attr]
 
     def packbits(
@@ -63,7 +63,7 @@ class Numpy(ArrayModuleNumpyLike["NDArray"]):
         axis: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ):
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return numpy.packbits(x, axis=axis, bitorder=bitorder)  # type: ignore[arg-type]
 
     def unpackbits(
@@ -74,10 +74,9 @@ class Numpy(ArrayModuleNumpyLike["NDArray"]):
         count: int | None = None,
         bitorder: Literal["big", "little"] = "big",
     ):
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return numpy.unpackbits(x, axis=axis, count=count, bitorder=bitorder)  # type: ignore[arg-type]
 
     def memory_ptr(self, x: NDArray) -> int:
-        (x,) = materialize_if_virtual(x)
-        assert not isinstance(x, PlaceholderArray)
+        (x,) = maybe_materialize(x)
         return x.ctypes.data

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
     from awkward._nplikes.placeholder import PlaceholderArray
-    from awkward._nplikes.virtual import VirtualArray
+    from awkward._nplikes.virtual import VirtualNDArray
 
 
 IndexType: TypeAlias = "int | ArrayLikeT"
@@ -156,14 +156,14 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
         *,
         dtype: DTypeLike | None = None,
         copy: bool | None = None,
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray: ...
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray: ...
 
     # FIXME: find a way to express TypeVar(..., OtherTypeVar(...), FOO) such that
     #        this function preserves the type identity of the input
     @abstractmethod
     def ascontiguousarray(
         self, x: ArrayLikeT | PlaceholderArray
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray: ...
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray: ...
 
     @abstractmethod
     def frombuffer(
@@ -292,7 +292,7 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
         shape: tuple[ShapeItem, ...],
         *,
         copy: bool | None = None,
-    ) -> ArrayLikeT | PlaceholderArray | VirtualArray: ...
+    ) -> ArrayLikeT | PlaceholderArray | VirtualNDArray: ...
 
     @abstractmethod
     def nonzero(self, x: ArrayLikeT) -> tuple[ArrayLikeT, ...]: ...

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -64,8 +64,7 @@ class PlaceholderArray(MaterializableArray):
             " This is unexpected behavior — please open an issue at "
             "https://github.com/scikit-hep/awkward/issues with a minimal example."
         )
-
-    raise RuntimeError(msg)
+        raise RuntimeError(msg)
 
     @property
     def strides(self) -> tuple[ShapeItem, ...]:

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -147,13 +147,13 @@ class PlaceholderArray(MaterializableArray):
         del key
         maybe_materialize(self, value)
 
-    def __bool__(self):
+    def __bool__(self):  # pylint: disable=E0304
         self.materialize()
 
     def __int__(self):
         self.materialize()
 
-    def __index__(self):  # noqa: PLE0305
+    def __index__(self):  # noqa: PLE0305 # pylint: disable=E0305
         self.materialize()
 
     def __len__(self) -> int:

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._nplikes.array_like import MaterializableArray
+from awkward._nplikes.array_like import MaterializableArray, maybe_materialize
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._typing import TYPE_CHECKING, Any, DType, Self
@@ -140,67 +140,69 @@ class PlaceholderArray(MaterializableArray):
                 msg += "please report it to the developers at: https://github.com/scikit-hep/awkward/issues"
             raise TypeError(msg)
 
-    def tolist(self) -> list:
-        raise RuntimeError
+    def tolist(self):
+        self.materialize()
 
     def __setitem__(self, key, value):
-        raise RuntimeError
+        del key
+        maybe_materialize(self, value)
 
-    def __bool__(self) -> bool:
-        raise RuntimeError
+    def __bool__(self):
+        self.materialize()
 
-    def __int__(self) -> int:
-        raise RuntimeError
+    def __int__(self):
+        self.materialize()
 
-    def __index__(self) -> int:
-        raise RuntimeError
+    def __index__(self):  # noqa: PLE0305
+        self.materialize()
 
     def __len__(self) -> int:
         return int(self._shape[0])
 
     def __add__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __and__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __eq__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __floordiv__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __ge__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __gt__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __invert__(self):
-        raise RuntimeError
+        self.materialize()
 
     def __le__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __lt__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __mul__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __or__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __sub__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     def __truediv__(self, other):
-        raise RuntimeError
+        maybe_materialize(self, other)
 
     __iter__: None = None
 
-    def __dlpack_device__(self) -> tuple[int, int]:
-        raise RuntimeError
+    def __dlpack_device__(self):
+        self.materialize()
 
-    def __dlpack__(self, stream: Any = None) -> Any:
-        raise RuntimeError
+    def __dlpack__(self, stream: Any = None):
+        del stream
+        self.materialize()

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import MaterializableArray
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._typing import TYPE_CHECKING, Any, DType, Self
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
 
-class PlaceholderArray(ArrayLike):
+class PlaceholderArray(MaterializableArray):
     def __init__(
         self,
         nplike: NumpyLike,
@@ -52,6 +52,13 @@ class PlaceholderArray(ArrayLike):
     @property
     def nbytes(self) -> int:
         return 0
+
+    def materialize(self):
+        msg = f"{self} should never been encountered. "
+        if self.field_path:
+            msg += f"Awkward-array attempted to access a field '{self.field_path}', but it's only a placeholder. "
+        msg += "Please report it to the developers at: https://github.com/scikit-hep/awkward/issues"
+        raise RuntimeError(msg)
 
     @property
     def strides(self) -> tuple[ShapeItem, ...]:

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -63,7 +63,8 @@ class PlaceholderArray(MaterializableArray):
         msg += (
             " This is unexpected behavior — please open an issue at "
             "https://github.com/scikit-hep/awkward/issues with a minimal example."
-    )
+        )
+
     raise RuntimeError(msg)
 
     @property

--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -54,11 +54,17 @@ class PlaceholderArray(MaterializableArray):
         return 0
 
     def materialize(self):
-        msg = f"{self} should never been encountered. "
+        msg = f"{self} should never have been encountered."
         if self.field_path:
-            msg += f"Awkward-array attempted to access a field '{self.field_path}', but it's only a placeholder. "
-        msg += "Please report it to the developers at: https://github.com/scikit-hep/awkward/issues"
-        raise RuntimeError(msg)
+            msg += (
+                f" Awkward Array tried to access a field '{self.field_path}', "
+                "but it exists only as a placeholder."
+            )
+        msg += (
+            " This is unexpected behavior — please open an issue at "
+            "https://github.com/scikit-hep/awkward/issues with a minimal example."
+    )
+    raise RuntimeError(msg)
 
     @property
     def strides(self) -> tuple[ShapeItem, ...]:

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -320,8 +320,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
 
     @property
     def strides(self):
-        raise AssertionError(
-            "bug in Awkward Array: attempt to get the strides of a TypeTracerArray"
+        raise RuntimeError(
+            "Cannot get the strides of a TypeTracerArray because its not a concrete array"
         )
 
     @property
@@ -397,14 +397,12 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     def __iter__(self):
-        raise AssertionError(
-            "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
+        raise RuntimeError(
+            "Cannot iterate over TypeTracerArray because its not a concrete array"
         )
 
     def __array__(self, dtype=None):
-        raise AssertionError(
-            "bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array"
-        )
+        raise RuntimeError("Cannot convert TypeTracerArray into a concrete array")
 
     class _CTypes:
         data = 0
@@ -414,8 +412,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return self._CTypes
 
     def __len__(self):
-        raise AssertionError(
-            "bug in Awkward Array: attempt to get length of a TypeTracerArray"
+        raise RuntimeError(
+            "Cannot get length of a TypeTracerArray because its not a concrete array"
         )
 
     def __getitem__(
@@ -827,7 +825,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
                         shape.append(len(node))
 
                     if isinstance(node, TypeTracerArray):
-                        raise AssertionError(
+                        raise TypeError(
                             "typetracer arrays inside sequences not currently supported"
                         )
                     # Found leaf!

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -320,8 +320,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
 
     @property
     def strides(self):
-        raise RuntimeError(
-            "Cannot get the strides of a TypeTracerArray because its not a concrete array"
+        raise AssertionError(
+            "Bug in Awkward Array: cannot get the strides of a TypeTracerArray because its not a concrete array"
         )
 
     @property
@@ -397,12 +397,14 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         )
 
     def __iter__(self):
-        raise RuntimeError(
-            "Cannot iterate over TypeTracerArray because its not a concrete array"
+        raise AssertionError(
+            "Bug in Awkward Array: cannot iterate over TypeTracerArray because its not a concrete array"
         )
 
     def __array__(self, dtype=None):
-        raise RuntimeError("Cannot convert TypeTracerArray into a concrete array")
+        raise AssertionError(
+            "Bug in Awkward Array: cannot convert TypeTracerArray into a concrete array"
+        )
 
     class _CTypes:
         data = 0
@@ -412,8 +414,8 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return self._CTypes
 
     def __len__(self):
-        raise RuntimeError(
-            "Cannot get length of a TypeTracerArray because its not a concrete array"
+        raise AssertionError(
+            "Bug in Awkward Array: cannot get length of a TypeTracerArray because its not a concrete array"
         )
 
     def __getitem__(

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -319,6 +319,12 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
         return self._shape
 
     @property
+    def strides(self):
+        raise AssertionError(
+            "bug in Awkward Array: attempt to get the strides of a TypeTracerArray"
+        )
+
+    @property
     def inner_shape(self) -> tuple[ShapeItem, ...]:
         if len(self._shape) > 1:
             self.touch_shape()

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -336,7 +336,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
 
 
 # backward compatibility
-class VirtualArray(NDArrayOperatorsMixin, MaterializableArray):
+class VirtualArray(VirtualNDArray):
     def __init__(self, *args, **kwargs):
         import warnings
 

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -35,7 +35,7 @@ def materialize_if_virtual(*args: Any) -> tuple[Any, ...]:
     A little helper function to materialize all virtual arrays in a list of arrays.
     """
     return tuple(
-        arg.materialize() if isinstance(arg, VirtualArray) else arg for arg in args
+        arg.materialize() if isinstance(arg, VirtualNDArray) else arg for arg in args
     )
 
 
@@ -197,7 +197,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             return self._array.T
 
         # if the existing array is 0D or 1D, we can return self directly
-        # this avoids unnecessary VirtualArray creation and method-chaining
+        # this avoids unnecessary VirtualNDArray creation and method-chaining
         if self.ndim <= 1:
             return self
 
@@ -216,7 +216,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             return self.materialize().view(dtype)  # type: ignore[return-value]
 
         # if the dtype is _exactly_ the dtype of the existing array, we can return self directly
-        # this avoids unnecessary VirtualArray creation and method-chaining
+        # this avoids unnecessary VirtualNDArray creation and method-chaining
         if self._dtype == dtype:
             return self
 
@@ -328,7 +328,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 length = self.shape[0]
                 start, stop, step = index.indices(length)
                 # if the slice is _exactly_ slicing the whole array, we can return self directly
-                # this avoids unnecessary VirtualArray creation and method-chaining
+                # this avoids unnecessary VirtualNDArray creation and method-chaining
                 if start == 0 and step == 1 and stop == length:
                     return self
                 new_length = max(

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -129,7 +129,7 @@ def maybe_shape_of(
     to get the shape of objects without materializing it in the case of virtual arrays.
     Unknown dimensions will be represted as `unknown_length`.
     """
-    if isinstance(obj, ak._nplikes.virtual.VirtualArray):
+    if isinstance(obj, ak._nplikes.virtual.VirtualNDArray):
         return obj._shape
     else:
         return obj.shape

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -10,14 +10,14 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._meta.bitmaskedmeta import BitMaskedMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._regularize import is_integer, is_integer_like
 from awkward._slicing import NO_HEAD
 from awkward._typing import (
@@ -476,7 +476,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._mask.data, VirtualArray)
+            isinstance(self._mask.data, VirtualNDArray)
             and not self._mask.data.is_materialized
         )
         if is_virtual:
@@ -704,7 +704,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         cp = Cupy.instance()._module
 
         assert mask is None  # this class has its own mask
-        (mask,) = materialize_if_virtual(self._mask.data)
+        (mask,) = maybe_materialize(self._mask.data)
         if not self.lsb_order:
             m = cp.flip(cp.packbits(cp.flip(cp.unpackbits(cp.asarray(mask)))))
         else:

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -11,14 +11,14 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.bytemaskedmeta import ByteMaskedMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     parameters_intersect,
 )
@@ -383,7 +383,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._mask.data, VirtualArray)
+            isinstance(self._mask.data, VirtualNDArray)
             and not self._mask.data.is_materialized
         )
         if is_virtual:
@@ -1058,7 +1058,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
         assert mask is None  # this class has its own mask
         m = cp.packbits(
-            cp.asarray(*materialize_if_virtual(self._mask.data)), bitorder="little"
+            cp.asarray(*maybe_materialize(self._mask.data)), bitorder="little"
         )
         if m.nbytes % 64:
             m = cp.resize(m, ((m.nbytes // 64) + 1) * 64)

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -9,13 +9,13 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.indexedmeta import IndexedMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
@@ -296,7 +296,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._index.data, VirtualArray)
+            isinstance(self._index.data, VirtualNDArray)
             and not self._index.data.is_materialized
         )
         if is_virtual:
@@ -1018,7 +1018,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             next = IndexedArray(self._index, self._content, parameters=next_parameters)
             return next._to_arrow(pyarrow, mask_node, validbytes, length, options)
 
-        (index,) = materialize_if_virtual(self._index.raw(numpy))
+        (index,) = maybe_materialize(self._index.raw(numpy))
 
         if self.parameter("__array__") == "categorical":
             dictionary = self._content._to_arrow(
@@ -1161,7 +1161,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         if out is not None:
             return out
 
-        (index,) = materialize_if_virtual(self._index.raw(numpy))
+        (index,) = maybe_materialize(self._index.raw(numpy))
         nextcontent = self._content._carry(ak.index.Index(index), False)
         return nextcontent._to_list(behavior, json_conversions)
 

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -10,14 +10,14 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.indexedoptionmeta import IndexedOptionMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import MaybeNone, TypeTracer
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
@@ -317,7 +317,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._index.data, VirtualArray)
+            isinstance(self._index.data, VirtualNDArray)
             and not self._index.data.is_materialized
         )
         if is_virtual:
@@ -1556,7 +1556,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         length: int,
         options: ToArrowOptions,
     ):
-        (index,) = materialize_if_virtual(numpy.asarray(self._index.data, copy=True))
+        (index,) = maybe_materialize(numpy.asarray(self._index.data, copy=True))
         this_validbytes = self.mask_as_bool(valid_when=True)
         index[~this_validbytes] = 0
 
@@ -1753,7 +1753,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         if out is not None:
             return out
 
-        (index,) = materialize_if_virtual(self._index.raw(numpy))
+        (index,) = maybe_materialize(self._index.raw(numpy))
         not_missing = index >= 0
         content = ak.to_backend(self._content, "cpu", highlevel=False)
         nextcontent = content._carry(ak.index.Index(index[not_missing]), False)

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     parameters_intersect,
     type_parameters_equal,
@@ -329,11 +329,11 @@ class ListArray(ListMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual_starts = (
-            isinstance(self._starts.data, VirtualArray)
+            isinstance(self._starts.data, VirtualNDArray)
             and not self._starts.data.is_materialized
         )
         is_virtual_stops = (
-            isinstance(self._stops.data, VirtualArray)
+            isinstance(self._stops.data, VirtualNDArray)
             and not self._stops.data.is_materialized
         )
         is_virtual = is_virtual_starts or is_virtual_stops

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -9,14 +9,14 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.listoffsetmeta import ListOffsetMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracer, is_unknown_scalar
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     type_parameters_equal,
 )
@@ -316,7 +316,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._offsets.data, VirtualArray)
+            isinstance(self._offsets.data, VirtualNDArray)
             and not self._offsets.data.is_materialized
         )
         return is_virtual or self._content._is_getitem_at_virtual()
@@ -1899,7 +1899,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             downsize = options["bytestring_to32"]
         else:
             downsize = options["list_to32"]
-        (npoffsets,) = materialize_if_virtual(self._offsets.raw(numpy))
+        (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
         akcontent = self._content[npoffsets[0] : npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
@@ -1962,7 +1962,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*materialize_if_virtual(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2003,7 +2003,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         from packaging.version import parse as parse_version
 
         cupy = Cupy.instance()
-        index = materialize_if_virtual(self._offsets.raw(cupy))[0].astype("int32")
+        index = maybe_materialize(self._offsets.raw(cupy))[0].astype("int32")
         buf = cudf.core.buffer.as_buffer(index)
 
         if parse_version(cudf.__version__) >= parse_version("24.10.00"):
@@ -2270,8 +2270,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             raise TypeError("cannot convert typetracer arrays to Python lists")
 
         starts, stops = self.starts, self.stops
-        (starts_data,) = materialize_if_virtual(starts.raw(numpy))
-        (stops_data,) = materialize_if_virtual(stops.raw(numpy)[: len(starts_data)])
+        (starts_data,) = maybe_materialize(starts.raw(numpy))
+        (stops_data,) = maybe_materialize(stops.raw(numpy)[: len(starts_data)])
 
         nonempty = starts_data != stops_data
         if numpy.count_nonzero(nonempty) == 0:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -13,7 +13,7 @@ from awkward._backends.typetracer import TypeTracerBackend
 from awkward._layout import maybe_posaxis
 from awkward._meta.numpymeta import NumpyMeta
 from awkward._nplikes import to_nplike
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -21,7 +21,7 @@ from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import TypeTracerArray
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import (
     parameters_intersect,
     type_parameters_equal,
@@ -319,7 +319,7 @@ class NumpyArray(NumpyMeta, Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual = (
-            isinstance(self._data, VirtualArray) and not self._data.is_materialized
+            isinstance(self._data, VirtualNDArray) and not self._data.is_materialized
         )
         return is_virtual
 
@@ -1206,7 +1206,7 @@ class NumpyArray(NumpyMeta, Content):
                 pyarrow, mask_node, validbytes, length, options
             )
 
-        (nparray,) = materialize_if_virtual(self._raw(numpy))
+        (nparray,) = maybe_materialize(self._raw(numpy))
         storage_type = pyarrow.from_numpy_dtype(nparray.dtype)
 
         if issubclass(nparray.dtype.type, (bool, np.bool_)):
@@ -1235,7 +1235,7 @@ class NumpyArray(NumpyMeta, Content):
         from cudf.core.column.column import as_column
 
         assert self._backend.nplike.known_data
-        data = as_column(*materialize_if_virtual(self._data))
+        data = as_column(*maybe_materialize(self._data))
         if mask is not None:
             m = cupy.packbits(cupy.asarray(mask), bitorder="little")
             if m.nbytes % 64:
@@ -1246,7 +1246,7 @@ class NumpyArray(NumpyMeta, Content):
 
     def _to_backend_array(self, allow_missing, backend):
         return to_nplike(
-            *materialize_if_virtual(self.data),
+            *maybe_materialize(self.data),
             backend.nplike,
             from_nplike=self._backend.nplike,
         )
@@ -1383,20 +1383,20 @@ class NumpyArray(NumpyMeta, Content):
         )
 
     def _materialize(self) -> Self:
-        (out,) = materialize_if_virtual(self._data)
+        (out,) = maybe_materialize(self._data)
         return NumpyArray(out, parameters=self._parameters, backend=self._backend)
 
     @property
     def _is_all_materialized(self) -> bool:
         buffer = self._data
-        if isinstance(buffer, VirtualArray):
+        if isinstance(buffer, VirtualNDArray):
             return buffer.is_materialized
         return True
 
     @property
     def _is_any_materialized(self) -> bool:
         buffer = self._data
-        if isinstance(buffer, VirtualArray):
+        if isinstance(buffer, VirtualNDArray):
             return buffer.is_materialized
         return True
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -9,11 +9,10 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.regularmeta import RegularMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._nplikes.virtual import materialize_if_virtual
 from awkward._parameters import (
     parameters_intersect,
     parameters_union,
@@ -1338,7 +1337,7 @@ class RegularArray(RegularMeta[Content], Content):
                 self.length,
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
-                    pyarrow.py_buffer(akcontent._raw(*materialize_if_virtual(numpy))),
+                    pyarrow.py_buffer(akcontent._raw(*maybe_materialize(numpy))),
                 ],
             )
 

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -11,7 +11,7 @@ import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._layout import maybe_posaxis
 from awkward._meta.unionmeta import UnionMeta
-from awkward._nplikes.array_like import ArrayLike
+from awkward._nplikes.array_like import ArrayLike, maybe_materialize
 from awkward._nplikes.cupy import Cupy
 from awkward._nplikes.jax import Jax
 from awkward._nplikes.numpy import Numpy
@@ -19,7 +19,7 @@ from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.typetracer import OneOf, TypeTracer
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._parameters import parameters_intersect, parameters_union
 from awkward._regularize import is_integer_like
 from awkward._slicing import NO_HEAD
@@ -568,11 +568,11 @@ class UnionArray(UnionMeta[Content], Content):
 
     def _is_getitem_at_virtual(self) -> bool:
         is_virtual_tags = (
-            isinstance(self._tags.data, VirtualArray)
+            isinstance(self._tags.data, VirtualNDArray)
             and not self._tags.data.is_materialized
         )
         is_virtual_index = (
-            isinstance(self._index.data, VirtualArray)
+            isinstance(self._index.data, VirtualNDArray)
             and not self._index.data.is_materialized
         )
         is_virtual = is_virtual_tags or is_virtual_index
@@ -1505,8 +1505,8 @@ class UnionArray(UnionMeta[Content], Content):
         length: int,
         options: ToArrowOptions,
     ):
-        (nptags,) = materialize_if_virtual(self._tags.raw(numpy))
-        (npindex,) = materialize_if_virtual(self._index.raw(numpy))
+        (nptags,) = maybe_materialize(self._tags.raw(numpy))
+        (npindex,) = maybe_materialize(self._index.raw(numpy))
         copied_index = False
 
         values = []
@@ -1713,8 +1713,8 @@ class UnionArray(UnionMeta[Content], Content):
         if out is not None:
             return out
 
-        (tags,) = materialize_if_virtual(self._tags.raw(numpy))
-        (index,) = materialize_if_virtual(self._index.raw(numpy))
+        (tags,) = maybe_materialize(self._tags.raw(numpy))
+        (index,) = maybe_materialize(self._index.raw(numpy))
         contents = [x._to_list(behavior, json_conversions) for x in self._contents]
 
         out = [None] * tags.shape[0]

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -194,7 +194,7 @@ def from_dict(input: Mapping) -> Form:
         )
 
     elif input["class"] == "VirtualNDArray":
-        raise ValueError("Awkward 1.x VirtualArrays are not supported")
+        raise ValueError("Awkward 1.x VirtualNDArrays are not supported")
 
     else:
         raise ValueError(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -193,7 +193,7 @@ def from_dict(input: Mapping) -> Form:
             form_key=form_key,
         )
 
-    elif input["class"] == "VirtualArray":
+    elif input["class"] == "VirtualNDArray":
         raise ValueError("Awkward 1.x VirtualArrays are not supported")
 
     else:

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -15,7 +15,7 @@ from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 from awkward._regularize import is_integer
 from awkward._typing import Callable
 from awkward.forms.form import index_to_dtype, regularize_buffer_key
@@ -87,7 +87,7 @@ def from_buffers(
     If the values of `container` are recognised as arrays by the given backend,
     a view over their existing data will be used, where possible.
     The `container` values are allowed to be callables with no arguments.
-    If that's the case, they will be turned into `VirtualArray` buffers whose generator
+    If that's the case, they will be turned into `VirtualNDArray` buffers whose generator
     function is the callable and is used to materialize the buffer when required.
 
     The `buffer_key` should be the same as the one used in #ak.to_buffers.
@@ -178,20 +178,20 @@ def _from_buffer(
     field_path: tuple,
     shape_generator: Callable | None = None,
 ) -> ArrayLike:
-    if isinstance(buffer, VirtualArray):
+    if isinstance(buffer, VirtualNDArray):
         # This is the case for VirtualArrays
-        # just some checks to make sure the VirtualArray is correctly constructed
+        # just some checks to make sure the VirtualNDArray is correctly constructed
         if nplike != buffer.nplike:
             raise ValueError(
-                f"Mismatch of nplikes. Got {nplike}, but VirtualArray has {buffer.nplike}."
+                f"Mismatch of nplikes. Got {nplike}, but VirtualNDArray has {buffer.nplike}."
             )
         if dtype != buffer.dtype:
             raise ValueError(
-                f"Mismatch of dtypes. Got {dtype}, but VirtualArray has {buffer.dtype}."
+                f"Mismatch of dtypes. Got {dtype}, but VirtualNDArray has {buffer.dtype}."
             )
         if count != buffer._shape[0]:
             raise ValueError(
-                f"Mismatch of lengths. Got {count}, but VirtualArray has {buffer._shape[0]}."
+                f"Mismatch of lengths. Got {count}, but VirtualNDArray has {buffer._shape[0]}."
             )
         return buffer
 
@@ -211,7 +211,7 @@ def _from_buffer(
         # this allows us to access it later again
         generator.__awkward_raw_generator__ = buffer
 
-        return VirtualArray(
+        return VirtualNDArray(
             nplike=nplike,
             shape=(count,),
             dtype=dtype,
@@ -414,7 +414,7 @@ def _reconstitute(
         def _shape_generator():
             return (_adjust_length(index),)
 
-        if isinstance(index, (PlaceholderArray, VirtualArray)):
+        if isinstance(index, (PlaceholderArray, VirtualNDArray)):
             next_length = unknown_length
         else:
             next_length = _adjust_length(index)
@@ -461,7 +461,7 @@ def _reconstitute(
         def _shape_generator():
             return (_adjust_length(index),)
 
-        if isinstance(index, (PlaceholderArray, VirtualArray)):
+        if isinstance(index, (PlaceholderArray, VirtualNDArray)):
             next_length = unknown_length
         else:
             next_length = _adjust_length(index)
@@ -515,8 +515,8 @@ def _reconstitute(
         def _shape_generator():
             return (_adjust_length(starts, stops),)
 
-        if isinstance(starts, (PlaceholderArray, VirtualArray)) or isinstance(
-            stops, (PlaceholderArray, VirtualArray)
+        if isinstance(starts, (PlaceholderArray, VirtualNDArray)) or isinstance(
+            stops, (PlaceholderArray, VirtualNDArray)
         ):
             next_length = unknown_length
         else:
@@ -563,7 +563,7 @@ def _reconstitute(
         def _shape_generator():
             return (_adjust_length(offsets),)
 
-        if isinstance(offsets, (PlaceholderArray, VirtualArray)):
+        if isinstance(offsets, (PlaceholderArray, VirtualNDArray)):
             next_length = unknown_length
         else:
             next_length = _adjust_length(offsets)
@@ -674,8 +674,8 @@ def _reconstitute(
 
             _shape_generators.append(partial(_shape_generator, tag=tag))
 
-        if isinstance(index, (PlaceholderArray, VirtualArray)) or isinstance(
-            tags, (PlaceholderArray, VirtualArray)
+        if isinstance(index, (PlaceholderArray, VirtualNDArray)) or isinstance(
+            tags, (PlaceholderArray, VirtualNDArray)
         ):
             lengths = [unknown_length] * len(form.contents)
         else:

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -179,7 +179,7 @@ def _from_buffer(
     shape_generator: Callable | None = None,
 ) -> ArrayLike:
     if isinstance(buffer, VirtualNDArray):
-        # This is the case for VirtualArrays
+        # This is the case for VirtualNDArrays
         # just some checks to make sure the VirtualNDArray is correctly constructed
         if nplike != buffer.nplike:
             raise ValueError(
@@ -196,7 +196,7 @@ def _from_buffer(
         return buffer
 
     elif callable(buffer):
-        # This is the case where we automatically create VirtualArrays
+        # This is the case where we automatically create VirtualNDArrays
         # We use recursion here to pass down the from_buffer and byteorder transformations to the generator
         assert callable(shape_generator), "shape_generator must be callable"
         cached_shape_generator = lru_cache(maxsize=1)(shape_generator)

--- a/src/awkward/operations/ak_materialize.py
+++ b/src/awkward/operations/ak_materialize.py
@@ -29,7 +29,7 @@ def materialize(
     Traverses the input array and materializes any virtual buffers.
     If the input array is not an #ak.Array or an #ak.contents.Content,
     an error will be raised.
-    The buffers of the returned array are no longer `VirtualArray` objects even if there were any.
+    The buffers of the returned array are no longer `VirtualNDArray` objects even if there were any.
     They will become one of `numpy.ndarray`, `cupy.ndarray`, or `jax.numpy.ndarray` objects,
     depending on the array's backend.
     """

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -908,7 +908,7 @@ def test_generator_error():
         va.materialize()
 
 
-# Test nested VirtualArrays (generator returns another VirtualNDArray)
+# Test nested VirtualNDArrays (generator returns another VirtualNDArray)
 def test_nested_virtual_arrays():
     nplike = Numpy.instance()
 
@@ -1153,7 +1153,7 @@ def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
 
 # Test testing functions with VirtualNDArray
 def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
-    # Create two identical VirtualArrays
+    # Create two identical VirtualNDArrays
     va1 = virtual_array
     va2 = VirtualNDArray(
         numpy_like,
@@ -1224,7 +1224,7 @@ def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
     result = numpy_like.apply_ufunc(np.add, "__call__", [virtual_array, 10])
     np.testing.assert_array_equal(result, np.array([11, 12, 13, 14, 15]))
 
-    # Test apply_ufunc with multiple VirtualArrays
+    # Test apply_ufunc with multiple VirtualNDArrays
     va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
@@ -1238,7 +1238,7 @@ def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
 
 # Test manipulation functions with VirtualNDArray
 def test_broadcast_arrays_with_virtual_arrays(numpy_like, virtual_array):
-    # Test broadcast_arrays with VirtualArrays
+    # Test broadcast_arrays with VirtualNDArrays
     va2 = VirtualNDArray(
         numpy_like,
         shape=(1,),
@@ -1320,7 +1320,7 @@ def test_nonzero_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_where_with_virtual_arrays(numpy_like, virtual_array):
-    # Test where with VirtualArrays
+    # Test where with VirtualNDArrays
     condition = VirtualNDArray(
         numpy_like,
         shape=(5,),
@@ -1398,7 +1398,7 @@ def test_sort_with_virtual_array(numpy_like):
 
 
 def test_concat_with_virtual_arrays(numpy_like, virtual_array):
-    # Test concat with VirtualArrays
+    # Test concat with VirtualNDArrays
     va2 = VirtualNDArray(
         numpy_like,
         shape=(3,),
@@ -1448,7 +1448,7 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_stack_with_virtual_arrays(numpy_like, virtual_array):
-    # Test stack with VirtualArrays
+    # Test stack with VirtualNDArrays
     va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
@@ -1519,7 +1519,7 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
 
 # Test addition and logical operations
 def test_add_with_virtual_arrays(numpy_like, virtual_array):
-    # Test add with VirtualArrays
+    # Test add with VirtualNDArrays
     va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
@@ -1532,7 +1532,7 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array):
 
 
 def test_logical_or_with_virtual_arrays(numpy_like):
-    # Test logical_or with VirtualArrays
+    # Test logical_or with VirtualNDArrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
@@ -1552,7 +1552,7 @@ def test_logical_or_with_virtual_arrays(numpy_like):
 
 
 def test_logical_and_with_virtual_arrays(numpy_like):
-    # Test logical_and with VirtualArrays
+    # Test logical_and with VirtualNDArrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
@@ -1612,7 +1612,7 @@ def test_exp_with_virtual_array(numpy_like):
 
 
 def test_divide_with_virtual_arrays(numpy_like):
-    # Test divide with VirtualArrays
+    # Test divide with VirtualNDArrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
@@ -1650,7 +1650,7 @@ def test_nan_to_num_with_virtual_array(numpy_like):
 
 
 def test_isclose_with_virtual_arrays(numpy_like):
-    # Test isclose with VirtualArrays
+    # Test isclose with VirtualNDArrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
@@ -1972,7 +1972,7 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 def test_materialize_if_virtual_function(numpy_like):
     # Test the maybe_materialize utility function directly
 
-    # Create a mix of VirtualArrays and regular arrays
+    # Create a mix of VirtualNDArrays and regular arrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(3,),
@@ -1996,11 +1996,11 @@ def test_materialize_if_virtual_function(numpy_like):
     np.testing.assert_array_equal(results[1], np.array([4, 5, 6]))
     np.testing.assert_array_equal(results[2], np.array([7, 8, 9]))
 
-    # Check that the VirtualArrays were materialized
+    # Check that the VirtualNDArrays were materialized
     assert va1.is_materialized
     assert va2.is_materialized
 
-    # Test with already materialized VirtualArrays
+    # Test with already materialized VirtualNDArrays
     va3 = VirtualNDArray(
         numpy_like,
         shape=(2,),
@@ -2016,7 +2016,7 @@ def test_materialize_if_virtual_function(numpy_like):
 
 
 def test_operations_with_multiple_virtual_arrays(numpy_like):
-    # Test a complex operation involving multiple VirtualArrays
+    # Test a complex operation involving multiple VirtualNDArrays
     va1 = VirtualNDArray(
         numpy_like,
         shape=(3,),
@@ -2039,14 +2039,14 @@ def test_operations_with_multiple_virtual_arrays(numpy_like):
     )
 
     # Expression: (va1 + va2) * va3
-    # Should materialize all VirtualArrays
+    # Should materialize all VirtualNDArrays
     result = numpy_like.add(va1, va2) * va3
     np.testing.assert_array_equal(
         result,
         np.array([35.0, 56.0, 81.0]),  # (1+4)*7, (2+5)*8, (3+6)*9
     )
 
-    # Check that all VirtualArrays were materialized
+    # Check that all VirtualNDArrays were materialized
     assert va1.is_materialized
     assert va2.is_materialized
     assert va3.is_materialized
@@ -2116,7 +2116,7 @@ def test_virtual_array_with_empty_array(numpy_like):
 
 
 def test_chained_operations_materialization(numpy_like):
-    # Test that chained operations correctly materialize VirtualArrays
+    # Test that chained operations correctly materialize VirtualNDArrays
     va = VirtualNDArray(
         numpy_like,
         shape=(5,),

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -7,10 +7,11 @@ import pytest
 
 import awkward as ak
 from awkward._backends.dispatch import backend_of_obj
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.shape import unknown_length
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 
 
 # Create fixtures for common test setup
@@ -26,7 +27,7 @@ def simple_array_generator():
 
 @pytest.fixture
 def virtual_array(numpy_like, simple_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -41,7 +42,7 @@ def two_dim_array_generator():
 
 @pytest.fixture
 def two_dim_virtual_array(numpy_like, two_dim_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -56,7 +57,7 @@ def scalar_array_generator():
 
 @pytest.fixture
 def scalar_virtual_array(numpy_like, scalar_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like, shape=(), dtype=np.dtype(np.int64), generator=scalar_array_generator
     )
 
@@ -68,7 +69,7 @@ def float_array_generator():
 
 @pytest.fixture
 def float_virtual_array(numpy_like, float_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -93,7 +94,7 @@ def offset_array_generator():
 
 @pytest.fixture
 def virtual_offset_array(numpy_like, offset_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -127,7 +128,7 @@ def starts_array_generator():
 
 @pytest.fixture
 def virtual_starts_array(numpy_like, starts_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
@@ -142,7 +143,7 @@ def stops_array_generator():
 
 @pytest.fixture
 def virtual_stops_array(numpy_like, stops_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
@@ -159,7 +160,7 @@ def content_array_generator():
 
 @pytest.fixture
 def virtual_content_array(numpy_like, content_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -197,7 +198,7 @@ def offsets_array_generator():
 
 @pytest.fixture
 def virtual_offsets_array(numpy_like, offsets_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -214,7 +215,7 @@ def x_content_array_generator():
 
 @pytest.fixture
 def virtual_x_content_array(numpy_like, x_content_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -229,7 +230,7 @@ def y_array_generator():
 
 @pytest.fixture
 def virtual_y_array(numpy_like, y_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -272,7 +273,7 @@ def virtual_recordarray(
 
 # Test initialization
 def test_init_valid(numpy_like, simple_array_generator):
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like, shape=(5,), dtype=np.int64, generator=simple_array_generator
     )
     assert va.shape == (5,)
@@ -286,7 +287,7 @@ def test_init_invalid_shape():
         TypeError,
         match=r"Only shapes of integer dimensions or unknown_length are supported",
     ):
-        VirtualArray(
+        VirtualNDArray(
             nplike,
             shape=("not_an_integer", 5),
             dtype=np.int64,
@@ -350,7 +351,7 @@ def test_materialize_shape_mismatch(numpy_like):
         ValueError,
         match=r"had shape \(5,\) before materialization while the materialized array has shape \(3,\)",
     ):
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.int64,
@@ -365,7 +366,7 @@ def test_materialize_dtype_mismatch(numpy_like):
         ValueError,
         match=r"had dtype int64 before materialization while the materialized array has dtype float64",
     ):
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(3,),
             dtype=np.int64,
@@ -377,7 +378,7 @@ def test_materialize_dtype_mismatch(numpy_like):
 # Test transpose
 def test_T_unmaterialized(two_dim_virtual_array):
     transposed = two_dim_virtual_array.T
-    assert isinstance(transposed, VirtualArray)
+    assert isinstance(transposed, VirtualNDArray)
     assert transposed.shape == (3, 2)
     assert not transposed.is_materialized
 
@@ -392,7 +393,7 @@ def test_T_materialized(two_dim_virtual_array):
 # Test view
 def test_view_unmaterialized(virtual_array):
     view = virtual_array.view(np.float64)
-    assert isinstance(view, VirtualArray)
+    assert isinstance(view, VirtualNDArray)
     assert view.dtype == np.dtype(np.float64)
     assert not view.is_materialized
 
@@ -406,7 +407,7 @@ def test_view_materialized(virtual_array):
 
 def test_view_invalid_size():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=np.int8,
@@ -431,7 +432,7 @@ def test_nplike(virtual_array, numpy_like):
 # Test copy
 def test_copy(virtual_array):
     copy = virtual_array.copy()
-    assert isinstance(copy, VirtualArray)
+    assert isinstance(copy, VirtualNDArray)
     assert copy.shape == virtual_array.shape
     assert copy.dtype == virtual_array.dtype
     assert not copy.is_materialized  # Copy should not be materialized
@@ -457,7 +458,7 @@ def test_tobytes(virtual_array):
 # Test __repr__ and __str__
 def test_repr(virtual_array):
     repr_str = repr(virtual_array)
-    assert "VirtualArray" in repr_str
+    assert "VirtualNDArray" in repr_str
     assert "shape=(5,)" in repr_str
 
 
@@ -467,7 +468,7 @@ def test_str_scalar(scalar_virtual_array):
 
 def test_str_array(virtual_array):
     str_val = str(virtual_array)
-    assert "VirtualArray" in str_val
+    assert "VirtualNDArray" in str_val
 
 
 # Test __getitem__
@@ -479,21 +480,21 @@ def test_getitem_index(virtual_array):
 
 def test_getitem_slice(virtual_array):
     sliced = virtual_array[1:4]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
     assert sliced.shape == (3,)
     np.testing.assert_array_equal(sliced.materialize(), np.array([2, 3, 4]))
 
 
 def test_getitem_slice_with_step(virtual_array):
     sliced = virtual_array[::2]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
     assert sliced.shape == (3,)
     np.testing.assert_array_equal(sliced.materialize(), np.array([1, 3, 5]))
 
 
 def test_getitem_slice_with_unknown_length():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(5,),
         dtype=np.int64,
@@ -520,7 +521,7 @@ def test_bool_scalar(scalar_virtual_array):
 
     # Test with zero value
     nplike = Numpy.instance()
-    va_zero = VirtualArray(
+    va_zero = VirtualNDArray(
         nplike, shape=(), dtype=np.int64, generator=lambda: np.array(0, dtype=np.int64)
     )
     assert bool(va_zero) is False
@@ -565,7 +566,7 @@ def test_len(virtual_array, two_dim_virtual_array):
 def test_len_scalar():
     # Scalar arrays don't have a length
     nplike = Numpy.instance()
-    scalar_va = VirtualArray(
+    scalar_va = VirtualNDArray(
         nplike, shape=(), dtype=np.int64, generator=lambda: np.array(42, dtype=np.int64)
     )
     with pytest.raises(TypeError, match=r"len\(\) of unsized object"):
@@ -602,18 +603,18 @@ def test_array_ufunc(virtual_array, monkeypatch):
     np.testing.assert_array_equal(result, np.array([2, 4, 6, 8, 10]))
 
 
-# Test the helper function materialize_if_virtual
+# Test the helper function maybe_materialize
 def test_materialize_if_virtual():
-    from awkward._nplikes.virtual import materialize_if_virtual
+    from awkward._nplikes.array_like import maybe_materialize
 
     nplike = Numpy.instance()
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=np.int64,
         generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         nplike,
         shape=(2,),
         dtype=np.int64,
@@ -621,7 +622,7 @@ def test_materialize_if_virtual():
     )
     regular_array = np.array([6, 7, 8])
 
-    result = materialize_if_virtual(va1, regular_array, va2)
+    result = maybe_materialize(va1, regular_array, va2)
 
     assert len(result) == 3
     assert isinstance(result[0], np.ndarray)
@@ -634,7 +635,7 @@ def test_materialize_if_virtual():
 
 # Tests for float virtual array
 def test_float_array_init(numpy_like, float_array_generator):
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like, shape=(5,), dtype=np.float64, generator=float_array_generator
     )
     assert va.shape == (5,)
@@ -651,56 +652,56 @@ def test_float_array_materialize(float_virtual_array):
 
 def test_float_array_slicing(numpy_like, float_array_generator):
     # Test basic slice
-    float_virtual_array1 = VirtualArray(
+    float_virtual_array1 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
         generator=float_array_generator,
     )
     sliced = float_virtual_array1[1:4]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
     assert sliced.shape == (3,)
     np.testing.assert_array_almost_equal(
         sliced.materialize(), np.array([2.2, 3.3, 4.4])
     )
 
     # Test step slice
-    float_virtual_array2 = VirtualArray(
+    float_virtual_array2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
         generator=float_array_generator,
     )
     sliced_step = float_virtual_array2[::2]
-    assert isinstance(sliced_step, VirtualArray)
+    assert isinstance(sliced_step, VirtualNDArray)
     assert sliced_step.shape == (3,)
     np.testing.assert_array_almost_equal(
         sliced_step.materialize(), np.array([1.1, 3.3, 5.5])
     )
 
     # Test negative step
-    float_virtual_array3 = VirtualArray(
+    float_virtual_array3 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
         generator=float_array_generator,
     )
     sliced_neg = float_virtual_array3[::-1]
-    assert isinstance(sliced_neg, VirtualArray)
+    assert isinstance(sliced_neg, VirtualNDArray)
     assert sliced_neg.shape == (5,)
     np.testing.assert_array_almost_equal(
         sliced_neg.materialize(), np.array([5.5, 4.4, 3.3, 2.2, 1.1])
     )
 
     # Test complex slice
-    float_virtual_array4 = VirtualArray(
+    float_virtual_array4 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
         generator=float_array_generator,
     )
     sliced_complex = float_virtual_array4[4:1:-2]
-    assert isinstance(sliced_complex, VirtualArray)
+    assert isinstance(sliced_complex, VirtualNDArray)
     assert sliced_complex.shape == (2,)
     np.testing.assert_array_almost_equal(
         sliced_complex.materialize(), np.array([5.5, 3.3])
@@ -729,7 +730,7 @@ def test_float_array_operations(float_virtual_array):
 def test_float_array_view(float_virtual_array):
     # Test view as different float type
     view = float_virtual_array.view(np.float32)
-    assert isinstance(view, VirtualArray)
+    assert isinstance(view, VirtualNDArray)
     assert view.dtype == np.dtype(np.float32)
 
     # Test materialization of view
@@ -760,7 +761,7 @@ def test_float_to_int_comparison(float_virtual_array, virtual_array):
 # Test rounding operations specific to float arrays
 def test_float_array_rounding():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(5,),
         dtype=np.float64,
@@ -783,7 +784,7 @@ def test_float_array_rounding():
 # Test NaN handling
 def test_float_array_nan():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(5,),
         dtype=np.float64,
@@ -808,7 +809,7 @@ def test_multidim_slicing(two_dim_virtual_array):
 
     # Fresh array for next test to avoid materialization effects
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(2, 3),
         dtype=np.int64,
@@ -825,7 +826,7 @@ def test_multidim_slicing(two_dim_virtual_array):
 # Test empty array handling
 def test_empty_array():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(0,),
         dtype=np.int64,
@@ -847,7 +848,7 @@ def test_structured_dtype():
     )
 
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=dtype,
@@ -870,7 +871,7 @@ def test_large_array_memory():
     def large_array_generator():
         return np.ones((1000, 1000), dtype=np.float64)
 
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(1000, 1000),
         dtype=np.float64,
@@ -895,7 +896,7 @@ def test_generator_error():
     def failing_generator():
         raise ValueError("Generator failure test")
 
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(5,),
         dtype=np.int64,
@@ -906,12 +907,12 @@ def test_generator_error():
         va.materialize()
 
 
-# Test nested VirtualArrays (generator returns another VirtualArray)
+# Test nested VirtualArrays (generator returns another VirtualNDArray)
 def test_nested_virtual_arrays():
     nplike = Numpy.instance()
 
     # Inner virtual array
-    inner_va = VirtualArray(
+    inner_va = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=np.int64,
@@ -919,7 +920,7 @@ def test_nested_virtual_arrays():
     )
 
     # Outer virtual array, generator returns inner virtual array
-    outer_va = VirtualArray(
+    outer_va = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=np.int64,
@@ -936,7 +937,7 @@ def test_nested_virtual_arrays():
 # Test with complex numbers
 def test_complex_numbers():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(3,),
         dtype=np.complex128,
@@ -956,7 +957,7 @@ def test_complex_numbers():
 # Test slice with 0 step raises error
 def test_slice_zero_step():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(5,),
         dtype=np.int64,
@@ -987,7 +988,7 @@ def test_slice_length_calculation():
         def create_generator(length):
             return lambda: np.ones(length, dtype=np.int64)
 
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(array_length,),
             dtype=np.int64,
@@ -995,7 +996,7 @@ def test_slice_length_calculation():
         )
 
         sliced = va[slice_obj]
-        assert isinstance(sliced, VirtualArray)
+        assert isinstance(sliced, VirtualNDArray)
         assert sliced.shape[0] == expected_length, f"Failed for slice {slice_obj}"
 
 
@@ -1011,16 +1012,16 @@ def test_backend_of_obj(virtual_array, float_virtual_array):
     assert backend_of_obj(float_virtual_array).name == "cpu"
 
 
-# Test array creation methods with VirtualArray
+# Test array creation methods with VirtualNDArray
 def test_asarray_virtual_array_unmaterialized(numpy_like, virtual_array):
-    # Test with unmaterialized VirtualArray
+    # Test with unmaterialized VirtualNDArray
     result = numpy_like.asarray(virtual_array)
     assert result is virtual_array  # Should return the same object
     assert not virtual_array.is_materialized
 
 
 def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
-    # Test with materialized VirtualArray
+    # Test with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.asarray(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1030,7 +1031,7 @@ def test_asarray_virtual_array_materialized(numpy_like, virtual_array):
 def test_asarray_virtual_array_with_dtype(numpy_like, virtual_array):
     # Test with dtype parameter
     out = numpy_like.asarray(virtual_array, dtype=np.float64)
-    assert isinstance(out, VirtualArray)
+    assert isinstance(out, VirtualNDArray)
     assert out.dtype == np.dtype(np.float64)
     assert not out.is_materialized
     assert out.materialize().dtype == np.dtype(np.float64)
@@ -1048,16 +1049,16 @@ def test_asarray_virtual_array_with_copy(numpy_like, virtual_array):
 
 
 def test_ascontiguousarray_unmaterialized(numpy_like, virtual_array):
-    # Test with unmaterialized VirtualArray
+    # Test with unmaterialized VirtualNDArray
     result = numpy_like.ascontiguousarray(virtual_array)
-    assert isinstance(result, VirtualArray)
+    assert isinstance(result, VirtualNDArray)
     assert not result.is_materialized
     assert result.shape == virtual_array.shape
     assert result.dtype == virtual_array.dtype
 
 
 def test_ascontiguousarray_materialized(numpy_like, virtual_array):
-    # Test with materialized VirtualArray
+    # Test with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.ascontiguousarray(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1065,7 +1066,7 @@ def test_ascontiguousarray_materialized(numpy_like, virtual_array):
 
 
 def test_frombuffer_with_virtual_array(numpy_like, virtual_array):
-    # Test frombuffer with VirtualArray (should raise TypeError)
+    # Test frombuffer with VirtualNDArray (should raise TypeError)
     with pytest.raises(
         TypeError, match="virtual arrays are not supported in `frombuffer`"
     ):
@@ -1074,7 +1075,7 @@ def test_frombuffer_with_virtual_array(numpy_like, virtual_array):
 
 # Test array creation methods using materialization info
 def test_zeros_like_unmaterialized(numpy_like, virtual_array):
-    # Test zeros_like with unmaterialized VirtualArray
+    # Test zeros_like with unmaterialized VirtualNDArray
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1084,7 +1085,7 @@ def test_zeros_like_unmaterialized(numpy_like, virtual_array):
 
 
 def test_zeros_like_materialized(numpy_like, virtual_array):
-    # Test zeros_like with materialized VirtualArray
+    # Test zeros_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1094,7 +1095,7 @@ def test_zeros_like_materialized(numpy_like, virtual_array):
 
 
 def test_ones_like_unmaterialized(numpy_like, virtual_array):
-    # Test ones_like with unmaterialized VirtualArray
+    # Test ones_like with unmaterialized VirtualNDArray
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1104,7 +1105,7 @@ def test_ones_like_unmaterialized(numpy_like, virtual_array):
 
 
 def test_ones_like_materialized(numpy_like, virtual_array):
-    # Test ones_like with materialized VirtualArray
+    # Test ones_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1114,7 +1115,7 @@ def test_ones_like_materialized(numpy_like, virtual_array):
 
 
 def test_full_like_unmaterialized(numpy_like, virtual_array):
-    # Test full_like with unmaterialized VirtualArray
+    # Test full_like with unmaterialized VirtualNDArray
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1124,7 +1125,7 @@ def test_full_like_unmaterialized(numpy_like, virtual_array):
 
 
 def test_full_like_materialized(numpy_like, virtual_array):
-    # Test full_like with materialized VirtualArray
+    # Test full_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
@@ -1133,27 +1134,27 @@ def test_full_like_materialized(numpy_like, virtual_array):
     np.testing.assert_array_equal(result, np.full(5, 7, dtype=np.int64))
 
 
-# Test arange and meshgrid with VirtualArray parameters
+# Test arange and meshgrid with VirtualNDArray parameters
 def test_arange_with_virtual_array_start(numpy_like, scalar_virtual_array):
-    # Test arange with VirtualArray parameter
+    # Test arange with VirtualNDArray parameter
     arange = numpy_like.arange(scalar_virtual_array, 10)
     assert scalar_virtual_array.is_materialized
     np.testing.assert_array_equal(arange, np.arange(42, 10))
 
 
 def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
-    # Test meshgrid with VirtualArray parameter
+    # Test meshgrid with VirtualNDArray parameter
     virtual_array.materialize()
     result = numpy_like.meshgrid(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
 
 
-# Test testing functions with VirtualArray
+# Test testing functions with VirtualNDArray
 def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
     # Create two identical VirtualArrays
     va1 = virtual_array
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1164,8 +1165,8 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
     result = numpy_like.array_equal(va1, va2)
     assert result is True
 
-    # Test with a different VirtualArray
-    va3 = VirtualArray(
+    # Test with a different VirtualNDArray
+    va3 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1179,13 +1180,13 @@ def test_array_equal_with_virtual_arrays(numpy_like, virtual_array):
 
 def test_array_equal_with_equal_nan(numpy_like):
     # Test array_equal with equal_nan=True
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
     )
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -1202,8 +1203,8 @@ def test_array_equal_with_equal_nan(numpy_like):
 
 
 def test_searchsorted_with_virtual_arrays(numpy_like, virtual_array):
-    # Test searchsorted with VirtualArray
-    values = VirtualArray(
+    # Test searchsorted with VirtualNDArray
+    values = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
@@ -1216,14 +1217,14 @@ def test_searchsorted_with_virtual_arrays(numpy_like, virtual_array):
     )  # Indices where values would be inserted
 
 
-# Test ufunc application with VirtualArray
+# Test ufunc application with VirtualNDArray
 def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
     # Test apply_ufunc with add operation
     result = numpy_like.apply_ufunc(np.add, "__call__", [virtual_array, 10])
     np.testing.assert_array_equal(result, np.array([11, 12, 13, 14, 15]))
 
     # Test apply_ufunc with multiple VirtualArrays
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1234,10 +1235,10 @@ def test_apply_ufunc_with_virtual_arrays(numpy_like, virtual_array):
     np.testing.assert_array_equal(result, np.array([10, 40, 90, 160, 250]))
 
 
-# Test manipulation functions with VirtualArray
+# Test manipulation functions with VirtualNDArray
 def test_broadcast_arrays_with_virtual_arrays(numpy_like, virtual_array):
     # Test broadcast_arrays with VirtualArrays
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -1251,21 +1252,21 @@ def test_broadcast_arrays_with_virtual_arrays(numpy_like, virtual_array):
 
 
 def test_reshape_unmaterialized(numpy_like, virtual_array):
-    # Test reshape with unmaterialized VirtualArray
+    # Test reshape with unmaterialized VirtualNDArray
     result = numpy_like.reshape(virtual_array, (5, 1))
-    assert isinstance(result, VirtualArray)
+    assert isinstance(result, VirtualNDArray)
     assert not result.is_materialized
     assert result.shape == (5, 1)
 
     # Test reshape with -1 dimension
     result = numpy_like.reshape(virtual_array, (-1, 1))
-    assert isinstance(result, VirtualArray)
+    assert isinstance(result, VirtualNDArray)
     assert not result.is_materialized
     assert result.shape == (5, 1)
 
 
 def test_reshape_materialized(numpy_like, virtual_array):
-    # Test reshape with materialized VirtualArray
+    # Test reshape with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.reshape(virtual_array, (5, 1))
     assert isinstance(result, np.ndarray)
@@ -1309,7 +1310,7 @@ def test_derive_slice_for_length(numpy_like):
 
 
 def test_nonzero_with_virtual_array(numpy_like, virtual_array):
-    # Test nonzero with VirtualArray
+    # Test nonzero with VirtualNDArray
     result = numpy_like.nonzero(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(
@@ -1319,14 +1320,14 @@ def test_nonzero_with_virtual_array(numpy_like, virtual_array):
 
 def test_where_with_virtual_arrays(numpy_like, virtual_array):
     # Test where with VirtualArrays
-    condition = VirtualArray(
+    condition = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.bool_),
         generator=lambda: np.array([True, False, True, False, True], dtype=np.bool_),
     )
 
-    x1 = VirtualArray(
+    x1 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1338,8 +1339,8 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array):
 
 
 def test_unique_values_with_virtual_array(numpy_like):
-    # Test unique_values with VirtualArray
-    va = VirtualArray(
+    # Test unique_values with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
@@ -1351,8 +1352,8 @@ def test_unique_values_with_virtual_array(numpy_like):
 
 
 def test_unique_all_with_virtual_array(numpy_like):
-    # Test unique_all with VirtualArray
-    va = VirtualArray(
+    # Test unique_all with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(7,),
         dtype=np.dtype(np.int64),
@@ -1367,8 +1368,8 @@ def test_unique_all_with_virtual_array(numpy_like):
 
 
 def test_sort_with_virtual_array(numpy_like):
-    # Test sort with VirtualArray
-    va = VirtualArray(
+    # Test sort with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1384,7 +1385,7 @@ def test_sort_with_virtual_array(numpy_like):
     np.testing.assert_array_equal(result, np.array([5, 4, 3, 2, 1]))
 
     # Test with 2D array and axis
-    va2d = VirtualArray(
+    va2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1397,7 +1398,7 @@ def test_sort_with_virtual_array(numpy_like):
 
 def test_concat_with_virtual_arrays(numpy_like, virtual_array):
     # Test concat with VirtualArrays
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
@@ -1408,14 +1409,14 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
     np.testing.assert_array_equal(result, np.array([1, 2, 3, 4, 5, 6, 7, 8]))
 
     # Test with axis parameter
-    va2d1 = VirtualArray(
+    va2d1 = VirtualNDArray(
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
     )
 
-    va2d2 = VirtualArray(
+    va2d2 = VirtualNDArray(
         numpy_like,
         shape=(2, 2),
         dtype=np.dtype(np.int64),
@@ -1427,12 +1428,12 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array):
 
 
 def test_repeat_with_virtual_array(numpy_like, virtual_array):
-    # Test repeat with VirtualArray
+    # Test repeat with VirtualNDArray
     result = numpy_like.repeat(virtual_array, 2)
     np.testing.assert_array_equal(result, np.array([1, 1, 2, 2, 3, 3, 4, 4, 5, 5]))
 
     # Test with axis parameter
-    va2d = VirtualArray(
+    va2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1447,7 +1448,7 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array):
 
 def test_stack_with_virtual_arrays(numpy_like, virtual_array):
     # Test stack with VirtualArrays
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1465,8 +1466,8 @@ def test_stack_with_virtual_arrays(numpy_like, virtual_array):
 
 
 def test_packbits_with_virtual_array(numpy_like):
-    # Test packbits with VirtualArray of booleans
-    va = VirtualArray(
+    # Test packbits with VirtualNDArray of booleans
+    va = VirtualNDArray(
         numpy_like,
         shape=(8,),
         dtype=np.dtype(np.bool_),
@@ -1480,8 +1481,8 @@ def test_packbits_with_virtual_array(numpy_like):
 
 
 def test_unpackbits_with_virtual_array(numpy_like):
-    # Test unpackbits with VirtualArray of uint8
-    va = VirtualArray(
+    # Test unpackbits with VirtualNDArray of uint8
+    va = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.uint8),
@@ -1495,7 +1496,7 @@ def test_unpackbits_with_virtual_array(numpy_like):
 
 
 def test_broadcast_to_with_virtual_array(numpy_like, virtual_array):
-    # Test broadcast_to with VirtualArray
+    # Test broadcast_to with VirtualNDArray
     result = numpy_like.broadcast_to(virtual_array, (3, 5))
     assert result.shape == (3, 5)
 
@@ -1506,7 +1507,7 @@ def test_broadcast_to_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_strides_with_virtual_array(numpy_like, virtual_array):
-    # Test strides with VirtualArray
+    # Test strides with VirtualNDArray
     # First test without materializing
     assert numpy_like.strides(virtual_array) == (8,)  # 8 bytes per int64
 
@@ -1518,7 +1519,7 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
 # Test addition and logical operations
 def test_add_with_virtual_arrays(numpy_like, virtual_array):
     # Test add with VirtualArrays
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1531,14 +1532,14 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array):
 
 def test_logical_or_with_virtual_arrays(numpy_like):
     # Test logical_or with VirtualArrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
         generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
@@ -1551,14 +1552,14 @@ def test_logical_or_with_virtual_arrays(numpy_like):
 
 def test_logical_and_with_virtual_arrays(numpy_like):
     # Test logical_and with VirtualArrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
         generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
@@ -1570,8 +1571,8 @@ def test_logical_and_with_virtual_arrays(numpy_like):
 
 
 def test_logical_not_with_virtual_array(numpy_like):
-    # Test logical_not with VirtualArray
-    va = VirtualArray(
+    # Test logical_not with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
@@ -1584,8 +1585,8 @@ def test_logical_not_with_virtual_array(numpy_like):
 
 # Test mathematical operations
 def test_sqrt_with_virtual_array(numpy_like):
-    # Test sqrt with VirtualArray
-    va = VirtualArray(
+    # Test sqrt with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1597,8 +1598,8 @@ def test_sqrt_with_virtual_array(numpy_like):
 
 
 def test_exp_with_virtual_array(numpy_like):
-    # Test exp with VirtualArray
-    va = VirtualArray(
+    # Test exp with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -1611,14 +1612,14 @@ def test_exp_with_virtual_array(numpy_like):
 
 def test_divide_with_virtual_arrays(numpy_like):
     # Test divide with VirtualArrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1631,8 +1632,8 @@ def test_divide_with_virtual_arrays(numpy_like):
 
 # Test special operations
 def test_nan_to_num_with_virtual_array(numpy_like):
-    # Test nan_to_num with VirtualArray containing NaN and infinity
-    va = VirtualArray(
+    # Test nan_to_num with VirtualNDArray containing NaN and infinity
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1649,14 +1650,14 @@ def test_nan_to_num_with_virtual_array(numpy_like):
 
 def test_isclose_with_virtual_arrays(numpy_like):
     # Test isclose with VirtualArrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1677,8 +1678,8 @@ def test_isclose_with_virtual_arrays(numpy_like):
 
 
 def test_isnan_with_virtual_array(numpy_like):
-    # Test isnan with VirtualArray
-    va = VirtualArray(
+    # Test isnan with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1691,15 +1692,15 @@ def test_isnan_with_virtual_array(numpy_like):
 
 # Test reduction operations
 def test_all_with_virtual_array(numpy_like):
-    # Test all with VirtualArray
-    va_all_true = VirtualArray(
+    # Test all with VirtualNDArray
+    va_all_true = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
         generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
     )
 
-    va_mixed = VirtualArray(
+    va_mixed = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
@@ -1715,7 +1716,7 @@ def test_all_with_virtual_array(numpy_like):
     assert not result
 
     # Test with axis parameter
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
@@ -1733,15 +1734,15 @@ def test_all_with_virtual_array(numpy_like):
 
 
 def test_any_with_virtual_array(numpy_like):
-    # Test any with VirtualArray
-    va_all_false = VirtualArray(
+    # Test any with VirtualNDArray
+    va_all_false = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
         generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
     )
 
-    va_mixed = VirtualArray(
+    va_mixed = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.bool_),
@@ -1757,7 +1758,7 @@ def test_any_with_virtual_array(numpy_like):
     assert result
 
     # Test with axis parameter
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.bool_),
@@ -1771,8 +1772,8 @@ def test_any_with_virtual_array(numpy_like):
 
 
 def test_min_with_virtual_array(numpy_like):
-    # Test min with VirtualArray
-    va = VirtualArray(
+    # Test min with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1784,7 +1785,7 @@ def test_min_with_virtual_array(numpy_like):
     assert result == 1
 
     # Test with 2D array and axis
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1796,8 +1797,8 @@ def test_min_with_virtual_array(numpy_like):
 
 
 def test_max_with_virtual_array(numpy_like):
-    # Test max with VirtualArray
-    va = VirtualArray(
+    # Test max with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1809,7 +1810,7 @@ def test_max_with_virtual_array(numpy_like):
     assert result == 5
 
     # Test with 2D array and axis
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1821,8 +1822,8 @@ def test_max_with_virtual_array(numpy_like):
 
 
 def test_count_nonzero_with_virtual_array(numpy_like):
-    # Test count_nonzero with VirtualArray
-    va = VirtualArray(
+    # Test count_nonzero with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -1834,7 +1835,7 @@ def test_count_nonzero_with_virtual_array(numpy_like):
     assert result == 3
 
     # Test with 2D array and axis
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1846,8 +1847,8 @@ def test_count_nonzero_with_virtual_array(numpy_like):
 
 
 def test_cumsum_with_virtual_array(numpy_like):
-    # Test cumsum with VirtualArray
-    va = VirtualArray(
+    # Test cumsum with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -1859,7 +1860,7 @@ def test_cumsum_with_virtual_array(numpy_like):
     np.testing.assert_array_equal(result, np.array([1, 3, 6, 10, 15]))
 
     # Test with 2D array and axis
-    va_2d = VirtualArray(
+    va_2d = VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -1871,8 +1872,8 @@ def test_cumsum_with_virtual_array(numpy_like):
 
 
 def test_real_imag_with_complex_virtual_array(numpy_like):
-    # Test real and imag with complex VirtualArray
-    va = VirtualArray(
+    # Test real and imag with complex VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -1889,8 +1890,8 @@ def test_real_imag_with_complex_virtual_array(numpy_like):
 
 
 def test_angle_with_complex_virtual_array(numpy_like):
-    # Test angle with complex VirtualArray
-    va = VirtualArray(
+    # Test angle with complex VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -1911,8 +1912,8 @@ def test_angle_with_complex_virtual_array(numpy_like):
 
 
 def test_round_with_virtual_array(numpy_like):
-    # Test round with VirtualArray
-    va = VirtualArray(
+    # Test round with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1933,20 +1934,20 @@ def test_round_with_virtual_array(numpy_like):
 
 
 def test_array_str_with_virtual_array_unmaterialized(numpy_like, virtual_array):
-    # Test array_str with unmaterialized VirtualArray
+    # Test array_str with unmaterialized VirtualNDArray
     result = numpy_like.array_str(virtual_array)
     assert result == "[## ... ##]"
 
 
 def test_array_str_with_virtual_array_materialized(numpy_like, virtual_array):
-    # Test array_str with materialized VirtualArray
+    # Test array_str with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.array_str(virtual_array)
     assert "[1 2 3 4 5]" in result
 
 
 def test_astype_with_virtual_array(numpy_like, virtual_array):
-    # Test astype with VirtualArray
+    # Test astype with VirtualNDArray
     result = numpy_like.astype(virtual_array, np.float64)
     np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert result.dtype == np.dtype(np.float64)
@@ -1958,7 +1959,7 @@ def test_astype_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
-    # Test can_cast with VirtualArray's dtype
+    # Test can_cast with VirtualNDArray's dtype
     # int64 can be cast to float64 with same_kind casting
     assert numpy_like.can_cast(virtual_array.dtype, np.float64) is True
 
@@ -1968,17 +1969,17 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 
 # Test various combinations and edge cases
 def test_materialize_if_virtual_function(numpy_like):
-    # Test the materialize_if_virtual utility function directly
+    # Test the maybe_materialize utility function directly
 
     # Create a mix of VirtualArrays and regular arrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
@@ -1988,7 +1989,7 @@ def test_materialize_if_virtual_function(numpy_like):
     regular_array = np.array([7, 8, 9])
 
     # Materialize none of them
-    results = materialize_if_virtual(va1, va2, regular_array)
+    results = maybe_materialize(va1, va2, regular_array)
     assert len(results) == 3
     np.testing.assert_array_equal(results[0], np.array([1, 2, 3]))
     np.testing.assert_array_equal(results[1], np.array([4, 5, 6]))
@@ -1999,7 +2000,7 @@ def test_materialize_if_virtual_function(numpy_like):
     assert va2.is_materialized
 
     # Test with already materialized VirtualArrays
-    va3 = VirtualArray(
+    va3 = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
@@ -2007,7 +2008,7 @@ def test_materialize_if_virtual_function(numpy_like):
     )
     va3.materialize()  # Pre-materialize
 
-    results = materialize_if_virtual(va3, regular_array)
+    results = maybe_materialize(va3, regular_array)
     assert len(results) == 2
     np.testing.assert_array_equal(results[0], np.array([10, 11]))
     np.testing.assert_array_equal(results[1], np.array([7, 8, 9]))
@@ -2015,21 +2016,21 @@ def test_materialize_if_virtual_function(numpy_like):
 
 def test_operations_with_multiple_virtual_arrays(numpy_like):
     # Test a complex operation involving multiple VirtualArrays
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
     )
 
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
     )
 
-    va3 = VirtualArray(
+    va3 = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -2051,8 +2052,8 @@ def test_operations_with_multiple_virtual_arrays(numpy_like):
 
 
 def test_is_own_array_with_virtual_array(numpy_like):
-    # Test is_own_array method with VirtualArray
-    va = VirtualArray(
+    # Test is_own_array method with VirtualNDArray
+    va = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
@@ -2061,7 +2062,9 @@ def test_is_own_array_with_virtual_array(numpy_like):
 
     # Before materialization
     result = numpy_like.is_own_array(va)
-    assert result  # Should be True because VirtualArray.nplike.ndarray is numpy.ndarray
+    assert (
+        result
+    )  # Should be True because VirtualNDArray.nplike.ndarray is numpy.ndarray
 
     # After materialization
     va.materialize()
@@ -2070,10 +2073,10 @@ def test_is_own_array_with_virtual_array(numpy_like):
 
 
 def test_virtual_array_with_structured_dtype(numpy_like):
-    # Test VirtualArray with structured dtype
+    # Test VirtualNDArray with structured dtype
     dtype = np.dtype([("name", "U10"), ("age", "i4"), ("weight", "f8")])
 
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=dtype,
@@ -2094,8 +2097,8 @@ def test_virtual_array_with_structured_dtype(numpy_like):
 
 
 def test_virtual_array_with_empty_array(numpy_like):
-    # Test VirtualArray with empty array
-    va = VirtualArray(
+    # Test VirtualNDArray with empty array
+    va = VirtualNDArray(
         numpy_like,
         shape=(0,),
         dtype=np.dtype(np.int64),
@@ -2113,7 +2116,7 @@ def test_virtual_array_with_empty_array(numpy_like):
 
 def test_chained_operations_materialization(numpy_like):
     # Test that chained operations correctly materialize VirtualArrays
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -2124,7 +2127,7 @@ def test_chained_operations_materialization(numpy_like):
     # 1. Add 10
     # 2. Multiply by 2
     # 3. Check if > 25
-    # Each step should materialize the VirtualArray
+    # Each step should materialize the VirtualNDArray
 
     result1 = numpy_like.add(va, 10)  # [11, 12, 13, 14, 15]
     assert va.is_materialized
@@ -2168,7 +2171,7 @@ def test_numpyarray_to_buffers(numpyarray, virtual_numpyarray):
     assert out1[2].keys() == out2[2].keys()
     for key in out1[2]:
         assert isinstance(out1[2][key], np.ndarray)
-        assert isinstance(out2[2][key], VirtualArray)
+        assert isinstance(out2[2][key], VirtualNDArray)
         assert np.all(out1[2][key] == out2[2][key])
 
 
@@ -2382,7 +2385,7 @@ def test_numpyarray_is_none(numpyarray, virtual_numpyarray):
 def test_numpyarray_drop_none(numpy_like):
     array = ak.Array([1, None, 2, 3, None, 4, 5]).layout
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -2390,7 +2393,7 @@ def test_numpyarray_drop_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -2407,7 +2410,7 @@ def test_numpyarray_drop_none(numpy_like):
 def test_numpy_array_pad_none(numpy_like):
     array = ak.Array([1, None, 2, 3, None, 4, 5]).layout
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -2415,7 +2418,7 @@ def test_numpy_array_pad_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -2434,7 +2437,7 @@ def test_numpy_array_pad_none(numpy_like):
 def test_numpyarray_fill_none(numpy_like):
     array = ak.Array([1, None, 2, 3, None, 4, 5]).layout
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -2442,7 +2445,7 @@ def test_numpyarray_fill_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -2469,7 +2472,7 @@ def test_numpyarray_firsts(numpyarray, virtual_numpyarray):
 def test_numpyarray_singletons(numpy_like):
     array = ak.Array([1, 2, 3, 4, 5]).layout
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -2477,7 +2480,7 @@ def test_numpyarray_singletons(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -2552,7 +2555,7 @@ def test_numpyarray_argcombinations(numpyarray, virtual_numpyarray):
 def test_numpyarray_nan_to_none(numpy_like):
     array = ak.Array([1, np.nan, 2, 3, np.nan, 4, 5]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
@@ -2570,7 +2573,7 @@ def test_numpyarray_nan_to_none(numpy_like):
 def test_numpyarray_nan_to_num(numpy_like):
     array = ak.Array([1, np.nan, 2, 3, np.nan, 4, 5]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
@@ -2597,7 +2600,7 @@ def test_numpyarray_local_index(numpyarray, virtual_numpyarray):
 def test_numpyarray_run_lengths(numpy_like):
     array = ak.Array([1, 1, 2, 3, 3, 3, 4, 5]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(8,),
             dtype=np.dtype(np.int64),
@@ -2613,7 +2616,7 @@ def test_numpyarray_run_lengths(numpy_like):
 def test_numpyarray_round(numpy_like):
     array = ak.Array([1.234, 2.567, 3.499, 4.501]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(4,),
             dtype=np.dtype(np.float64),
@@ -2649,7 +2652,7 @@ def test_numpyarray_almost_equal(numpyarray, virtual_numpyarray):
 def test_numpyarray_real(numpy_like):
     array = ak.Array([1 + 2j, 3 + 4j, 5 + 6j]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
@@ -2665,7 +2668,7 @@ def test_numpyarray_real(numpy_like):
 def test_numpyarray_imag(numpy_like):
     array = ak.Array([1 + 2j, 3 + 4j, 5 + 6j]).layout
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
@@ -2749,7 +2752,7 @@ def test_listoffsetarray_to_buffers(listoffsetarray, virtual_listoffsetarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert np.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -2984,14 +2987,14 @@ def test_listoffsetarray_nanargmin(numpy_like):
         ak.index.Index(offsets), ak.contents.NumpyArray(content)
     )
 
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3034,14 +3037,14 @@ def test_listoffsetarray_nanargmax(numpy_like):
         ak.index.Index(offsets), ak.contents.NumpyArray(content)
     )
 
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3106,21 +3109,21 @@ def test_listoffsetarray_drop_none(numpy_like):
     array = ak.contents.ListOffsetArray(ak.index.Index(offsets), indexed_content)
 
     # Create virtual versions
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -3152,14 +3155,14 @@ def test_listoffsetarray_pad_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3196,21 +3199,21 @@ def test_listoffsetarray_fill_none(numpy_like):
     array = ak.contents.ListOffsetArray(ak.index.Index(offsets), indexed_content)
 
     # Create virtual versions
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -3253,14 +3256,14 @@ def test_listoffsetarray_singletons(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -3350,14 +3353,14 @@ def test_listoffsetarray_nan_to_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3388,14 +3391,14 @@ def test_listoffsetarray_nan_to_num(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3435,14 +3438,14 @@ def test_listoffsetarray_run_lengths(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -3469,14 +3472,14 @@ def test_listoffsetarray_round(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -3522,14 +3525,14 @@ def test_listoffsetarray_real(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -3555,14 +3558,14 @@ def test_listoffsetarray_imag(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -3588,14 +3591,14 @@ def test_listoffsetarray_angle(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -3742,7 +3745,7 @@ def test_listarray_to_buffers(listarray, virtual_listarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert np.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -3952,21 +3955,21 @@ def test_listarray_nanargmin(numpy_like):
         ak.index.Index(starts), ak.index.Index(stops), ak.contents.NumpyArray(content)
     )
 
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -4010,21 +4013,21 @@ def test_listarray_nanargmax(numpy_like):
         ak.index.Index(starts), ak.index.Index(stops), ak.contents.NumpyArray(content)
     )
 
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -4094,28 +4097,28 @@ def test_listarray_drop_none(numpy_like):
     )
 
     # Create virtual versions
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -4150,21 +4153,21 @@ def test_listarray_pad_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -4206,28 +4209,28 @@ def test_listarray_fill_none(numpy_like):
     )
 
     # Create virtual versions
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -4273,21 +4276,21 @@ def test_listarray_singletons(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -4380,21 +4383,21 @@ def test_listarray_nan_to_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -4428,21 +4431,21 @@ def test_listarray_nan_to_num(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -4485,21 +4488,21 @@ def test_listarray_run_lengths(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([3, 6], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -4529,21 +4532,21 @@ def test_listarray_round(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -4592,21 +4595,21 @@ def test_listarray_real(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -4635,21 +4638,21 @@ def test_listarray_imag(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -4678,21 +4681,21 @@ def test_listarray_angle(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -4814,7 +4817,7 @@ def test_recordarray_to_buffers(recordarray, virtual_recordarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert np.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -5266,14 +5269,14 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -5283,7 +5286,7 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -5326,14 +5329,14 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -5342,7 +5345,7 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -5546,21 +5549,21 @@ def test_recordarray_run_lengths_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -5601,21 +5604,21 @@ def test_recordarray_run_lengths_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -5656,21 +5659,21 @@ def test_recordarray_round_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -5711,21 +5714,21 @@ def test_recordarray_round_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -5786,21 +5789,21 @@ def test_recordarray_real_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
         generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -5841,20 +5844,20 @@ def test_recordarray_real_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -5895,21 +5898,21 @@ def test_recordarray_imag_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
         generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -5950,21 +5953,21 @@ def test_recordarray_imag_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -6005,14 +6008,14 @@ def test_recordarray_angle_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -6021,7 +6024,7 @@ def test_recordarray_angle_x_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -6062,21 +6065,21 @@ def test_recordarray_angle_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -6115,7 +6118,7 @@ def test_recordarray_with_field(recordarray, virtual_recordarray, numpy_like):
     assert not virtual_recordarray.is_any_materialized
 
     # Create a new field to add
-    new_field = VirtualArray(
+    new_field = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -6174,21 +6177,21 @@ def test_recordarray_with_custom_generator(numpy_like):
         return np.array([np.sin(i) for i in range(5)], dtype=np.float64)
 
     # Create virtual arrays with these generators
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=compute_offsets,
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
         generator=compute_content,
     )
 
-    virtual_y = VirtualArray(
+    virtual_y = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -6270,35 +6273,35 @@ def test_recordarray_with_none_values(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual versions
-    virtual_x_offsets = VirtualArray(
+    virtual_x_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_x_index = VirtualArray(
+    virtual_x_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
-    virtual_y_index = VirtualArray(
+    virtual_y_index = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),

--- a/tests/test_3451_virtualarray_with_jax.py
+++ b/tests/test_3451_virtualarray_with_jax.py
@@ -6,7 +6,7 @@ import pytest
 
 import awkward as ak
 from awkward._nplikes.jax import Jax
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 
 np = pytest.importorskip("jax.numpy")
 ak.jax.register_and_check()
@@ -25,7 +25,7 @@ def simple_array_generator():
 
 @pytest.fixture
 def virtual_array(numpy_like, simple_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -40,7 +40,7 @@ def two_dim_array_generator():
 
 @pytest.fixture
 def two_dim_virtual_array(numpy_like, two_dim_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(2, 3),
         dtype=np.dtype(np.int64),
@@ -55,7 +55,7 @@ def scalar_array_generator():
 
 @pytest.fixture
 def scalar_virtual_array(numpy_like, scalar_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like, shape=(), dtype=np.dtype(np.int64), generator=scalar_array_generator
     )
 
@@ -67,7 +67,7 @@ def float_array_generator():
 
 @pytest.fixture
 def float_virtual_array(numpy_like, float_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -92,7 +92,7 @@ def offset_array_generator():
 
 @pytest.fixture
 def virtual_offset_array(numpy_like, offset_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
@@ -126,7 +126,7 @@ def starts_array_generator():
 
 @pytest.fixture
 def virtual_starts_array(numpy_like, starts_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
@@ -141,7 +141,7 @@ def stops_array_generator():
 
 @pytest.fixture
 def virtual_stops_array(numpy_like, stops_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
@@ -158,7 +158,7 @@ def content_array_generator():
 
 @pytest.fixture
 def virtual_content_array(numpy_like, content_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -196,7 +196,7 @@ def offsets_array_generator():
 
 @pytest.fixture
 def virtual_offsets_array(numpy_like, offsets_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -213,7 +213,7 @@ def x_content_array_generator():
 
 @pytest.fixture
 def virtual_x_content_array(numpy_like, x_content_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -228,7 +228,7 @@ def y_array_generator():
 
 @pytest.fixture
 def virtual_y_array(numpy_like, y_array_generator):
-    return VirtualArray(
+    return VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -305,7 +305,7 @@ def test_numpyarray_to_buffers(numpyarray, virtual_numpyarray):
     assert out1[2].keys() == out2[2].keys()
     for key in out1[2]:
         assert isinstance(out1[2][key], np.ndarray)
-        assert isinstance(out2[2][key], VirtualArray)
+        assert isinstance(out2[2][key], VirtualNDArray)
         assert ak.all(out1[2][key] == out2[2][key])
 
 
@@ -519,7 +519,7 @@ def test_numpyarray_is_none(numpyarray, virtual_numpyarray):
 def test_numpyarray_drop_none(numpy_like):
     array = ak.to_backend(ak.Array([1, None, 2, 3, None, 4, 5]), "jax", highlevel=False)
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -527,7 +527,7 @@ def test_numpyarray_drop_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -544,7 +544,7 @@ def test_numpyarray_drop_none(numpy_like):
 def test_numpy_array_pad_none(numpy_like):
     array = ak.to_backend(ak.Array([1, None, 2, 3, None, 4, 5]), "jax", highlevel=False)
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -552,7 +552,7 @@ def test_numpy_array_pad_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -571,7 +571,7 @@ def test_numpy_array_pad_none(numpy_like):
 def test_numpyarray_fill_none(numpy_like):
     array = ak.to_backend(ak.Array([1, None, 2, 3, None, 4, 5]), "jax", highlevel=False)
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.int64),
@@ -579,7 +579,7 @@ def test_numpyarray_fill_none(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -606,7 +606,7 @@ def test_numpyarray_firsts(numpyarray, virtual_numpyarray):
 def test_numpyarray_singletons(numpy_like):
     array = ak.to_backend(ak.Array([1, 2, 3, 4, 5]), "jax", highlevel=False)
     virtual_index = ak.index.Index(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -614,7 +614,7 @@ def test_numpyarray_singletons(numpy_like):
         )
     )
     virtual_content = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(5,),
             dtype=np.dtype(np.int64),
@@ -691,7 +691,7 @@ def test_numpyarray_nan_to_none(numpy_like):
         ak.Array([1, np.nan, 2, 3, np.nan, 4, 5]), "jax", highlevel=False
     )
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
@@ -711,7 +711,7 @@ def test_numpyarray_nan_to_num(numpy_like):
         ak.Array([1, np.nan, 2, 3, np.nan, 4, 5]), "jax", highlevel=False
     )
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(7,),
             dtype=np.dtype(np.float64),
@@ -738,7 +738,7 @@ def test_numpyarray_local_index(numpyarray, virtual_numpyarray):
 def test_numpyarray_run_lengths(numpy_like):
     array = ak.to_backend(ak.Array([1, 1, 2, 3, 3, 3, 4, 5]), "jax", highlevel=False)
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(8,),
             dtype=np.dtype(np.int64),
@@ -756,7 +756,7 @@ def test_numpyarray_round(numpy_like):
         ak.Array([1.234, 2.567, 3.499, 4.501]), "jax", highlevel=False
     )
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(4,),
             dtype=np.dtype(np.float64),
@@ -792,7 +792,7 @@ def test_numpyarray_almost_equal(numpyarray, virtual_numpyarray):
 def test_numpyarray_real(numpy_like):
     array = ak.to_backend(ak.Array([1 + 2j, 3 + 4j, 5 + 6j]), "jax", highlevel=False)
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
@@ -808,7 +808,7 @@ def test_numpyarray_real(numpy_like):
 def test_numpyarray_imag(numpy_like):
     array = ak.to_backend(ak.Array([1 + 2j, 3 + 4j, 5 + 6j]), "jax", highlevel=False)
     virtual_array = ak.contents.NumpyArray(
-        VirtualArray(
+        VirtualNDArray(
             numpy_like,
             shape=(3,),
             dtype=np.dtype(np.complex128),
@@ -893,7 +893,7 @@ def test_listoffsetarray_to_buffers(listoffsetarray, virtual_listoffsetarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert ak.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -1131,14 +1131,14 @@ def test_listoffsetarray_nanargmin(numpy_like):
         ak.index.Index(offsets), ak.contents.NumpyArray(content)
     )
 
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -1181,14 +1181,14 @@ def test_listoffsetarray_nanargmax(numpy_like):
         ak.index.Index(offsets), ak.contents.NumpyArray(content)
     )
 
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -1253,21 +1253,21 @@ def test_listoffsetarray_drop_none(numpy_like):
     array = ak.contents.ListOffsetArray(ak.index.Index(offsets), indexed_content)
 
     # Create virtual versions
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -1299,14 +1299,14 @@ def test_listoffsetarray_pad_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -1343,21 +1343,21 @@ def test_listoffsetarray_fill_none(numpy_like):
     array = ak.contents.ListOffsetArray(ak.index.Index(offsets), indexed_content)
 
     # Create virtual versions
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -1400,14 +1400,14 @@ def test_listoffsetarray_singletons(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 1, 2, 3, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1497,14 +1497,14 @@ def test_listoffsetarray_nan_to_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -1535,14 +1535,14 @@ def test_listoffsetarray_nan_to_num(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -1582,14 +1582,14 @@ def test_listoffsetarray_run_lengths(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -1616,14 +1616,14 @@ def test_listoffsetarray_round(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -1669,14 +1669,14 @@ def test_listoffsetarray_real(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -1702,14 +1702,14 @@ def test_listoffsetarray_imag(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -1735,14 +1735,14 @@ def test_listoffsetarray_angle(numpy_like):
     )
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -1892,7 +1892,7 @@ def test_listarray_to_buffers(listarray, virtual_listarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert ak.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -2105,21 +2105,21 @@ def test_listarray_nanargmin(numpy_like):
         ak.index.Index(starts), ak.index.Index(stops), ak.contents.NumpyArray(content)
     )
 
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -2163,21 +2163,21 @@ def test_listarray_nanargmax(numpy_like):
         ak.index.Index(starts), ak.index.Index(stops), ak.contents.NumpyArray(content)
     )
 
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -2247,28 +2247,28 @@ def test_listarray_drop_none(numpy_like):
     )
 
     # Create virtual versions
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -2303,21 +2303,21 @@ def test_listarray_pad_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -2359,28 +2359,28 @@ def test_listarray_fill_none(numpy_like):
     )
 
     # Create virtual versions
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_index = VirtualArray(
+    virtual_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -2426,21 +2426,21 @@ def test_listarray_singletons(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 1, 2, 3], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1, 2, 3, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -2533,21 +2533,21 @@ def test_listarray_nan_to_none(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -2581,21 +2581,21 @@ def test_listarray_nan_to_num(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -2638,21 +2638,21 @@ def test_listarray_run_lengths(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([3, 6], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
@@ -2682,21 +2682,21 @@ def test_listarray_round(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
@@ -2745,21 +2745,21 @@ def test_listarray_real(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -2788,21 +2788,21 @@ def test_listarray_imag(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 3], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -2831,21 +2831,21 @@ def test_listarray_angle(numpy_like):
     )
 
     # Create virtual version
-    virtual_starts = VirtualArray(
+    virtual_starts = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2], dtype=np.int64),
     )
 
-    virtual_stops = VirtualArray(
+    virtual_stops = VirtualNDArray(
         numpy_like,
         shape=(2,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([2, 4], dtype=np.int64),
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -2967,7 +2967,7 @@ def test_recordarray_to_buffers(recordarray, virtual_recordarray):
     # container
     assert set(out1[2].keys()) == set(out2[2].keys())
     for key in out1[2]:
-        if isinstance(out2[2][key], VirtualArray):
+        if isinstance(out2[2][key], VirtualNDArray):
             assert not out2[2][key].is_materialized
             assert ak.all(out1[2][key] == out2[2][key])
             assert out2[2][key].is_materialized
@@ -3422,14 +3422,14 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3439,7 +3439,7 @@ def test_recordarray_nan_to_none_x_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -3482,14 +3482,14 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10, 10], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
@@ -3498,7 +3498,7 @@ def test_recordarray_nan_to_none_y_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -3702,21 +3702,21 @@ def test_recordarray_run_lengths_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([1, 1, 2, 3, 3, 3], dtype=np.int64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -3757,21 +3757,21 @@ def test_recordarray_run_lengths_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 3, 6, 6], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
@@ -3812,21 +3812,21 @@ def test_recordarray_round_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -3867,21 +3867,21 @@ def test_recordarray_round_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -3942,21 +3942,21 @@ def test_recordarray_real_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
         generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -3997,20 +3997,20 @@ def test_recordarray_real_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -4051,21 +4051,21 @@ def test_recordarray_imag_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
         generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -4106,21 +4106,21 @@ def test_recordarray_imag_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -4161,14 +4161,14 @@ def test_recordarray_angle_x_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 4], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.complex128),
@@ -4177,7 +4177,7 @@ def test_recordarray_angle_x_field(numpy_like):
         ),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
@@ -4218,21 +4218,21 @@ def test_recordarray_angle_y_field(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual version
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(4,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 3, 3], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3], dtype=np.float64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.complex128),
@@ -4271,7 +4271,7 @@ def test_recordarray_with_field(recordarray, virtual_recordarray, numpy_like):
     assert not virtual_recordarray.is_any_materialized
 
     # Create a new field to add
-    new_field = VirtualArray(
+    new_field = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -4330,21 +4330,21 @@ def test_recordarray_with_custom_generator(numpy_like):
         return np.array([np.sin(i) for i in range(5)], dtype=np.float64)
 
     # Create virtual arrays with these generators
-    virtual_offsets = VirtualArray(
+    virtual_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=compute_offsets,
     )
 
-    virtual_content = VirtualArray(
+    virtual_content = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.float64),
         generator=compute_content,
     )
 
-    virtual_y = VirtualArray(
+    virtual_y = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.float64),
@@ -4426,35 +4426,35 @@ def test_recordarray_with_none_values(numpy_like):
     array = ak.contents.RecordArray([x_field, y_field], ["x", "y"])
 
     # Create virtual versions
-    virtual_x_offsets = VirtualArray(
+    virtual_x_offsets = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, 2, 4, 7, 10], dtype=np.int64),
     )
 
-    virtual_x_index = VirtualArray(
+    virtual_x_index = VirtualNDArray(
         numpy_like,
         shape=(10,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2, 3, -1, 4, 5, -1], dtype=np.int64),
     )
 
-    virtual_x_content = VirtualArray(
+    virtual_x_content = VirtualNDArray(
         numpy_like,
         shape=(6,),
         dtype=np.dtype(np.float64),
         generator=lambda: np.array([1.1, 2.2, 3.3, 4.4, 5.5, 6.6], dtype=np.float64),
     )
 
-    virtual_y_index = VirtualArray(
+    virtual_y_index = VirtualNDArray(
         numpy_like,
         shape=(5,),
         dtype=np.dtype(np.int64),
         generator=lambda: np.array([0, -1, 1, -1, 2], dtype=np.int64),
     )
 
-    virtual_y_content = VirtualArray(
+    virtual_y_content = VirtualNDArray(
         numpy_like,
         shape=(3,),
         dtype=np.dtype(np.float64),

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -4,10 +4,11 @@ import numpy as np
 import pytest
 
 from awkward._backends.dispatch import backend_of_obj
+from awkward._nplikes.array_like import maybe_materialize
 from awkward._nplikes.dispatch import nplike_of_obj
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.shape import unknown_length
-from awkward._nplikes.virtual import VirtualArray, materialize_if_virtual
+from awkward._nplikes.virtual import VirtualNDArray
 
 
 @pytest.fixture
@@ -33,14 +34,14 @@ def simple_array_generator():
 @pytest.fixture
 def virtual_array(numpy_like, simple_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=simple_array_generator,
         )
     else:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -57,14 +58,14 @@ def two_dim_array_generator():
 @pytest.fixture
 def two_dim_virtual_array(numpy_like, two_dim_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=two_dim_array_generator,
         )
     else:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -81,14 +82,14 @@ def scalar_array_generator():
 @pytest.fixture
 def scalar_virtual_array(numpy_like, scalar_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(),
             dtype=np.dtype(np.int64),
             generator=scalar_array_generator,
         )
     else:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(),
             dtype=np.dtype(np.int64),
@@ -105,14 +106,14 @@ def float_array_generator():
 @pytest.fixture
 def float_virtual_array(numpy_like, float_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=float_array_generator,
         )
     else:
-        return VirtualArray(
+        return VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -124,14 +125,14 @@ def float_virtual_array(numpy_like, float_array_generator, shape_generator_param
 # Test initialization
 def test_init_valid(numpy_like, simple_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.int64,
             generator=simple_array_generator,
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -155,7 +156,7 @@ def test_init_invalid_shape():
         TypeError,
         match=r"Only shapes of integer dimensions or unknown_length are supported",
     ):
-        VirtualArray(
+        VirtualNDArray(
             nplike,
             shape=("not_an_integer", 5),
             dtype=np.int64,
@@ -237,7 +238,7 @@ def test_is_materialized(virtual_array):
 
 def test_materialize_shape(numpy_like):
     # Generator returns array with different shape than declared
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -249,7 +250,7 @@ def test_materialize_shape(numpy_like):
 
 def test_materialize_shape_mismatch(numpy_like):
     # Generator returns array with different shape than declared
-    va = VirtualArray(
+    va = VirtualNDArray(
         numpy_like,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -270,7 +271,7 @@ def test_materialize_dtype_mismatch(numpy_like):
         ValueError,
         match=r"had dtype int64 before materialization while the materialized array has dtype float64",
     ):
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -282,7 +283,7 @@ def test_materialize_dtype_mismatch(numpy_like):
 # Test transpose
 def test_T_unmaterialized(two_dim_virtual_array, shape_generator_param):
     transposed = two_dim_virtual_array.T
-    assert isinstance(transposed, VirtualArray)
+    assert isinstance(transposed, VirtualNDArray)
 
     assert transposed._shape == (3, unknown_length)
     assert transposed.shape == (3, 2)
@@ -299,7 +300,7 @@ def test_T_materialized(two_dim_virtual_array):
 # Test view
 def test_view_unmaterialized(virtual_array):
     view = virtual_array.view(np.float64)
-    assert isinstance(view, VirtualArray)
+    assert isinstance(view, VirtualNDArray)
     assert view.dtype == np.dtype(np.float64)
     assert not view.is_materialized
 
@@ -313,7 +314,7 @@ def test_view_materialized(virtual_array):
 
 def test_view_invalid_size():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int8,
@@ -360,7 +361,7 @@ def test_shape_generator(virtual_array, shape_generator_param):
 # Test copy
 def test_copy(virtual_array, shape_generator_param):
     copy = virtual_array.copy()
-    assert isinstance(copy, VirtualArray)
+    assert isinstance(copy, VirtualNDArray)
     assert copy._shape == virtual_array._shape
     assert copy.shape == virtual_array.shape
     assert copy.dtype == virtual_array.dtype
@@ -391,7 +392,7 @@ def test_tobytes(virtual_array):
 # Test __repr__ and __str__
 def test_repr(virtual_array, shape_generator_param):
     repr_str = repr(virtual_array)
-    assert "VirtualArray" in repr_str
+    assert "VirtualNDArray" in repr_str
     assert "shape=(awkward._nplikes.shape.unknown_length,)" in repr_str
 
 
@@ -401,7 +402,7 @@ def test_str_scalar(scalar_virtual_array):
 
 def test_str_array(virtual_array):
     str_val = str(virtual_array)
-    assert "VirtualArray" in str_val
+    assert "VirtualNDArray" in str_val
 
 
 # Test __getitem__
@@ -415,7 +416,7 @@ def test_getitem_index(virtual_array):
 
 def test_getitem_slice(virtual_array, shape_generator_param):
     sliced = virtual_array[1:4]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced.shape == (3,)
@@ -429,7 +430,7 @@ def test_getitem_slice(virtual_array, shape_generator_param):
 
 def test_getitem_slice_with_step(virtual_array, shape_generator_param):
     sliced = virtual_array[::2]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced.shape == (3,)
@@ -443,7 +444,7 @@ def test_getitem_slice_with_step(virtual_array, shape_generator_param):
 
 def test_getitem_slice_with_unknown_length():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -470,7 +471,7 @@ def test_bool_scalar(scalar_virtual_array):
 
     # Test with zero value
     nplike = Numpy.instance()
-    va_zero = VirtualArray(
+    va_zero = VirtualNDArray(
         nplike, shape=(), dtype=np.int64, generator=lambda: np.array(0, dtype=np.int64)
     )
     assert bool(va_zero) is False
@@ -522,7 +523,7 @@ def test_len(virtual_array, two_dim_virtual_array, shape_generator_param):
 def test_len_scalar():
     # Scalar arrays don't have a length
     nplike = Numpy.instance()
-    scalar_va = VirtualArray(
+    scalar_va = VirtualNDArray(
         nplike, shape=(), dtype=np.int64, generator=lambda: np.array(42, dtype=np.int64)
     )
     with pytest.raises(TypeError, match=r"len\(\) of unsized object"):
@@ -561,16 +562,16 @@ def test_array_ufunc(virtual_array, monkeypatch):
     np.testing.assert_array_equal(result, np.array([2, 4, 6, 8, 10]))
 
 
-# Test the helper function materialize_if_virtual
+# Test the helper function maybe_materialize
 def test_materialize_if_virtual():
     nplike = Numpy.instance()
-    va1 = VirtualArray(
+    va1 = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int64,
         generator=lambda: np.array([1, 2, 3], dtype=np.int64),
     )
-    va2 = VirtualArray(
+    va2 = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -578,7 +579,7 @@ def test_materialize_if_virtual():
     )
     regular_array = np.array([6, 7, 8])
 
-    result = materialize_if_virtual(va1, regular_array, va2)
+    result = maybe_materialize(va1, regular_array, va2)
 
     assert len(result) == 3
     assert isinstance(result[0], np.ndarray)
@@ -592,14 +593,14 @@ def test_materialize_if_virtual():
 # Tests for float virtual array
 def test_float_array_init(numpy_like, float_array_generator, shape_generator_param):
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.float64,
             generator=float_array_generator,
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.float64,
@@ -630,14 +631,14 @@ def test_float_array_materialize(float_virtual_array):
 def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_param):
     # Test basic slice
     if shape_generator_param is None:
-        float_virtual_array1 = VirtualArray(
+        float_virtual_array1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=float_array_generator,
         )
     else:
-        float_virtual_array1 = VirtualArray(
+        float_virtual_array1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -646,7 +647,7 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
         )
 
     sliced = float_virtual_array1[1:4]
-    assert isinstance(sliced, VirtualArray)
+    assert isinstance(sliced, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced.shape == (3,)
@@ -661,14 +662,14 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
 
     # Test step slice
     if shape_generator_param is None:
-        float_virtual_array2 = VirtualArray(
+        float_virtual_array2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=float_array_generator,
         )
     else:
-        float_virtual_array2 = VirtualArray(
+        float_virtual_array2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -677,7 +678,7 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
         )
 
     sliced_step = float_virtual_array2[::2]
-    assert isinstance(sliced_step, VirtualArray)
+    assert isinstance(sliced_step, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced_step.shape == (3,)
@@ -692,14 +693,14 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
 
     # Test negative step
     if shape_generator_param is None:
-        float_virtual_array3 = VirtualArray(
+        float_virtual_array3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=float_array_generator,
         )
     else:
-        float_virtual_array3 = VirtualArray(
+        float_virtual_array3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -708,7 +709,7 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
         )
 
     sliced_neg = float_virtual_array3[::-1]
-    assert isinstance(sliced_neg, VirtualArray)
+    assert isinstance(sliced_neg, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced_neg.shape == (5,)
@@ -723,14 +724,14 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
 
     # Test complex slice
     if shape_generator_param is None:
-        float_virtual_array4 = VirtualArray(
+        float_virtual_array4 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=float_array_generator,
         )
     else:
-        float_virtual_array4 = VirtualArray(
+        float_virtual_array4 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -739,7 +740,7 @@ def test_float_array_slicing(numpy_like, float_array_generator, shape_generator_
         )
 
     sliced_complex = float_virtual_array4[4:1:-2]
-    assert isinstance(sliced_complex, VirtualArray)
+    assert isinstance(sliced_complex, VirtualNDArray)
 
     if shape_generator_param is None:
         assert sliced_complex.shape == (2,)
@@ -775,7 +776,7 @@ def test_float_array_operations(float_virtual_array):
 def test_float_array_view(float_virtual_array):
     # Test view as different float type
     view = float_virtual_array.view(np.float32)
-    assert isinstance(view, VirtualArray)
+    assert isinstance(view, VirtualNDArray)
     assert view.dtype == np.dtype(np.float32)
 
     # Test materialization of view
@@ -808,14 +809,14 @@ def test_float_array_rounding(shape_generator_param):
     nplike = Numpy.instance()
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.float64,
             generator=lambda: np.array([1.1, 2.5, 3.7, 4.2, 5.9], dtype=np.float64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.float64,
@@ -841,7 +842,7 @@ def test_float_array_nan(shape_generator_param):
     nplike = Numpy.instance()
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.float64,
@@ -850,7 +851,7 @@ def test_float_array_nan(shape_generator_param):
             ),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.float64,
@@ -878,7 +879,7 @@ def test_multidim_slicing(two_dim_virtual_array):
 
     # Fresh array for next test to avoid materialization effects
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(unknown_length, 3),
         dtype=np.int64,
@@ -897,14 +898,14 @@ def test_empty_array(shape_generator_param):
     nplike = Numpy.instance()
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
             generator=lambda: np.array([], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -933,14 +934,14 @@ def test_structured_dtype(shape_generator_param):
     nplike = Numpy.instance()
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=dtype,
             generator=lambda: data,
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=dtype,
@@ -965,14 +966,14 @@ def test_large_array_memory(shape_generator_param):
         return np.ones((1000, 1000), dtype=np.float64)
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length, 1000),
             dtype=np.float64,
             generator=large_array_generator,
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length, 1000),
             dtype=np.float64,
@@ -1002,7 +1003,7 @@ def test_generator_error():
     def failing_generator():
         raise ValueError("Generator failure test")
 
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -1013,20 +1014,20 @@ def test_generator_error():
         va.get_shape()
 
 
-# Test nested VirtualArrays (generator returns another VirtualArray)
+# Test nested VirtualArrays (generator returns another VirtualNDArray)
 def test_nested_virtual_arrays(shape_generator_param):
     nplike = Numpy.instance()
 
     # Inner virtual array
     if shape_generator_param is None:
-        inner_va = VirtualArray(
+        inner_va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
             generator=lambda: np.array([10, 20, 30], np.int64),
         )
     else:
-        inner_va = VirtualArray(
+        inner_va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -1036,14 +1037,14 @@ def test_nested_virtual_arrays(shape_generator_param):
 
     # Outer virtual array, generator returns inner virtual array
     if shape_generator_param is None:
-        outer_va = VirtualArray(
+        outer_va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
             generator=lambda: inner_va,
         )
     else:
-        outer_va = VirtualArray(
+        outer_va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -1063,14 +1064,14 @@ def test_complex_numbers(shape_generator_param):
     nplike = Numpy.instance()
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.complex128,
             generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.complex128,
@@ -1091,7 +1092,7 @@ def test_complex_numbers(shape_generator_param):
 # Test slice with 0 step raises error
 def test_slice_zero_step():
     nplike = Numpy.instance()
-    va = VirtualArray(
+    va = VirtualNDArray(
         nplike,
         shape=(unknown_length,),
         dtype=np.int64,
@@ -1122,7 +1123,7 @@ def test_slice_length_calculation():
         def create_generator(length):
             return lambda: np.ones(length, dtype=np.int64)
 
-        va = VirtualArray(
+        va = VirtualNDArray(
             nplike,
             shape=(unknown_length,),
             dtype=np.int64,
@@ -1133,7 +1134,7 @@ def test_slice_length_calculation():
 
         if shape_generator_param is None:
             # Without shape_generator, we can check the shape directly
-            assert isinstance(sliced, VirtualArray)
+            assert isinstance(sliced, VirtualNDArray)
             assert sliced.shape[0] == expected_length, f"Failed for slice {slice_obj}"
         else:
             # With shape_generator, need to materialize to check shape
@@ -1155,11 +1156,11 @@ def test_backend_of_obj(virtual_array, float_virtual_array, shape_generator_para
     assert backend_of_obj(float_virtual_array).name == "cpu"
 
 
-# Test array creation methods with VirtualArray
+# Test array creation methods with VirtualNDArray
 def test_asarray_virtual_array_unmaterialized(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test with unmaterialized VirtualArray
+    # Test with unmaterialized VirtualNDArray
     result = numpy_like.asarray(virtual_array)
     assert result is virtual_array  # Should return the same object
     assert not virtual_array.is_materialized
@@ -1168,7 +1169,7 @@ def test_asarray_virtual_array_unmaterialized(
 def test_asarray_virtual_array_materialized(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test with materialized VirtualArray
+    # Test with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.asarray(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1180,7 +1181,7 @@ def test_asarray_virtual_array_with_dtype(
 ):
     # Test with dtype parameter
     out = numpy_like.asarray(virtual_array, dtype=np.float64)
-    assert isinstance(out, VirtualArray)
+    assert isinstance(out, VirtualNDArray)
     assert out.dtype == np.dtype(np.float64)
     assert not out.is_materialized
     assert out.materialize().dtype == np.dtype(np.float64)
@@ -1202,9 +1203,9 @@ def test_asarray_virtual_array_with_copy(
 def test_ascontiguousarray_unmaterialized(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test with unmaterialized VirtualArray
+    # Test with unmaterialized VirtualNDArray
     result = numpy_like.ascontiguousarray(virtual_array)
-    assert isinstance(result, VirtualArray)
+    assert isinstance(result, VirtualNDArray)
     assert not result.is_materialized
     assert result.shape == virtual_array.shape
     assert result.dtype == virtual_array.dtype
@@ -1213,7 +1214,7 @@ def test_ascontiguousarray_unmaterialized(
 def test_ascontiguousarray_materialized(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test with materialized VirtualArray
+    # Test with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.ascontiguousarray(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1223,7 +1224,7 @@ def test_ascontiguousarray_materialized(
 def test_frombuffer_with_virtual_array(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test frombuffer with VirtualArray (should raise TypeError)
+    # Test frombuffer with VirtualNDArray (should raise TypeError)
     with pytest.raises(
         TypeError, match="virtual arrays are not supported in `frombuffer`"
     ):
@@ -1232,7 +1233,7 @@ def test_frombuffer_with_virtual_array(
 
 # Test array creation methods using materialization info
 def test_zeros_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
-    # Test zeros_like with unmaterialized VirtualArray
+    # Test zeros_like with unmaterialized VirtualNDArray
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1245,7 +1246,7 @@ def test_zeros_like_unmaterialized(numpy_like, virtual_array, shape_generator_pa
 
 
 def test_zeros_like_materialized(numpy_like, virtual_array, shape_generator_param):
-    # Test zeros_like with materialized VirtualArray
+    # Test zeros_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.zeros_like(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1255,7 +1256,7 @@ def test_zeros_like_materialized(numpy_like, virtual_array, shape_generator_para
 
 
 def test_ones_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
-    # Test ones_like with unmaterialized VirtualArray
+    # Test ones_like with unmaterialized VirtualNDArray
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1268,7 +1269,7 @@ def test_ones_like_unmaterialized(numpy_like, virtual_array, shape_generator_par
 
 
 def test_ones_like_materialized(numpy_like, virtual_array, shape_generator_param):
-    # Test ones_like with materialized VirtualArray
+    # Test ones_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.ones_like(virtual_array)
     assert isinstance(result, np.ndarray)
@@ -1278,7 +1279,7 @@ def test_ones_like_materialized(numpy_like, virtual_array, shape_generator_param
 
 
 def test_full_like_unmaterialized(numpy_like, virtual_array, shape_generator_param):
-    # Test full_like with unmaterialized VirtualArray
+    # Test full_like with unmaterialized VirtualNDArray
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
     assert result.shape == (5,)
@@ -1291,7 +1292,7 @@ def test_full_like_unmaterialized(numpy_like, virtual_array, shape_generator_par
 
 
 def test_full_like_materialized(numpy_like, virtual_array):
-    # Test full_like with materialized VirtualArray
+    # Test full_like with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.full_like(virtual_array, 7)
     assert isinstance(result, np.ndarray)
@@ -1300,37 +1301,37 @@ def test_full_like_materialized(numpy_like, virtual_array):
     np.testing.assert_array_equal(result, np.full(5, 7, dtype=np.int64))
 
 
-# Test arange and meshgrid with VirtualArray parameters
+# Test arange and meshgrid with VirtualNDArray parameters
 def test_arange_with_virtual_array_start(numpy_like, scalar_virtual_array):
-    # Test arange with VirtualArray parameter
+    # Test arange with VirtualNDArray parameter
     arange = numpy_like.arange(scalar_virtual_array, 10)
     assert scalar_virtual_array.is_materialized
     np.testing.assert_array_equal(arange, np.arange(42, 10))
 
 
 def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
-    # Test meshgrid with VirtualArray parameter
+    # Test meshgrid with VirtualNDArray parameter
     virtual_array.materialize()
     result = numpy_like.meshgrid(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(result[0], np.array([1, 2, 3, 4, 5]))
 
 
-# Test testing functions with VirtualArray
+# Test testing functions with VirtualNDArray
 def test_array_equal_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
     # Create two identical VirtualArrays
     va1 = virtual_array
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1342,9 +1343,9 @@ def test_array_equal_with_virtual_arrays(
     result = numpy_like.array_equal(va1, va2)
     assert result is True
 
-    # Test with a different VirtualArray
+    # Test with a different VirtualNDArray
     if shape_generator_param is None:
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1353,7 +1354,7 @@ def test_array_equal_with_virtual_arrays(
             ),  # Different last value
         )
     else:
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1370,27 +1371,27 @@ def test_array_equal_with_virtual_arrays(
 def test_array_equal_with_equal_nan(numpy_like, shape_generator_param):
     # Test array_equal with equal_nan=True
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, np.nan, 3.0], dtype=np.float64),
             shape_generator=lambda: (3,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -1410,16 +1411,16 @@ def test_array_equal_with_equal_nan(numpy_like, shape_generator_param):
 def test_searchsorted_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test searchsorted with VirtualArray
+    # Test searchsorted with VirtualNDArray
     if shape_generator_param is None:
-        values = VirtualArray(
+        values = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([0, 3, 6], dtype=np.int64),
         )
     else:
-        values = VirtualArray(
+        values = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1433,7 +1434,7 @@ def test_searchsorted_with_virtual_arrays(
     )  # Indices where values would be inserted
 
 
-# Test ufunc application with VirtualArray
+# Test ufunc application with VirtualNDArray
 def test_apply_ufunc_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
@@ -1443,14 +1444,14 @@ def test_apply_ufunc_with_virtual_arrays(
 
     # Test apply_ufunc with multiple VirtualArrays
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1462,20 +1463,20 @@ def test_apply_ufunc_with_virtual_arrays(
     np.testing.assert_array_equal(result, np.array([10, 40, 90, 160, 250]))
 
 
-# Test manipulation functions with VirtualArray
+# Test manipulation functions with VirtualNDArray
 def test_broadcast_arrays_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
     # Test broadcast_arrays with VirtualArrays
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([10], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1490,9 +1491,9 @@ def test_broadcast_arrays_with_virtual_arrays(
 
 
 def test_reshape_unmaterialized(numpy_like, virtual_array, shape_generator_param):
-    # Test reshape with unmaterialized VirtualArray
+    # Test reshape with unmaterialized VirtualNDArray
     result = numpy_like.reshape(virtual_array, (5, 1))
-    assert isinstance(result, VirtualArray)
+    assert isinstance(result, VirtualNDArray)
     assert not result.is_materialized
     assert result.shape == (5, 1)
 
@@ -1502,13 +1503,13 @@ def test_reshape_unmaterialized(numpy_like, virtual_array, shape_generator_param
         assert isinstance(result, np.ndarray)
         assert virtual_array.is_materialized
     else:
-        assert isinstance(result, VirtualArray)
+        assert isinstance(result, VirtualNDArray)
         assert not virtual_array.is_materialized
     assert result.shape == (5, 1)
 
 
 def test_reshape_materialized(numpy_like, virtual_array):
-    # Test reshape with materialized VirtualArray
+    # Test reshape with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.reshape(virtual_array, (5, 1))
     assert isinstance(result, np.ndarray)
@@ -1552,7 +1553,7 @@ def test_derive_slice_for_length(numpy_like):
 
 
 def test_nonzero_with_virtual_array(numpy_like, virtual_array):
-    # Test nonzero with VirtualArray
+    # Test nonzero with VirtualNDArray
     result = numpy_like.nonzero(virtual_array)
     assert len(result) == 1
     np.testing.assert_array_equal(
@@ -1563,7 +1564,7 @@ def test_nonzero_with_virtual_array(numpy_like, virtual_array):
 def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
     # Test where with VirtualArrays
     if shape_generator_param is None:
-        condition = VirtualArray(
+        condition = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1571,14 +1572,14 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_pa
                 [True, False, True, False, True], dtype=np.bool_
             ),
         )
-        x1 = VirtualArray(
+        x1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
         )
     else:
-        condition = VirtualArray(
+        condition = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1587,7 +1588,7 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_pa
             ),
             shape_generator=lambda: (5,),
         )
-        x1 = VirtualArray(
+        x1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1600,16 +1601,16 @@ def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_pa
 
 
 def test_unique_values_with_virtual_array(numpy_like, shape_generator_param):
-    # Test unique_values with VirtualArray
+    # Test unique_values with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1622,16 +1623,16 @@ def test_unique_values_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_unique_all_with_virtual_array(numpy_like, shape_generator_param):
-    # Test unique_all with VirtualArray
+    # Test unique_all with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 2, 3, 3, 3, 1], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1647,16 +1648,16 @@ def test_unique_all_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_sort_with_virtual_array(numpy_like, shape_generator_param):
-    # Test sort with VirtualArray
+    # Test sort with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1674,14 +1675,14 @@ def test_sort_with_virtual_array(numpy_like, shape_generator_param):
 
     # Test with 2D array and axis
     if shape_generator_param is None:
-        va2d = VirtualArray(
+        va2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
         )
     else:
-        va2d = VirtualArray(
+        va2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -1696,14 +1697,14 @@ def test_sort_with_virtual_array(numpy_like, shape_generator_param):
 def test_concat_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
     # Test concat with VirtualArrays
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([6, 7, 8], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1716,27 +1717,27 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array, shape_generator_p
 
     # Test with axis parameter
     if shape_generator_param is None:
-        va2d1 = VirtualArray(
+        va2d1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 2),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
         )
-        va2d2 = VirtualArray(
+        va2d2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 2),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[5, 6], [7, 8]], dtype=np.int64),
         )
     else:
-        va2d1 = VirtualArray(
+        va2d1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 2),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[1, 2], [3, 4]], dtype=np.int64),
             shape_generator=lambda: (2, 2),
         )
-        va2d2 = VirtualArray(
+        va2d2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 2),
             dtype=np.dtype(np.int64),
@@ -1749,20 +1750,20 @@ def test_concat_with_virtual_arrays(numpy_like, virtual_array, shape_generator_p
 
 
 def test_repeat_with_virtual_array(numpy_like, virtual_array, shape_generator_param):
-    # Test repeat with VirtualArray
+    # Test repeat with VirtualNDArray
     result = numpy_like.repeat(virtual_array, 2)
     np.testing.assert_array_equal(result, np.array([1, 1, 2, 2, 3, 3, 4, 4, 5, 5]))
 
     # Test with axis parameter
     if shape_generator_param is None:
-        va2d = VirtualArray(
+        va2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
         )
     else:
-        va2d = VirtualArray(
+        va2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -1779,14 +1780,14 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array, shape_generator_pa
 def test_stack_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
     # Test stack with VirtualArrays
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([6, 7, 8, 9, 10], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1805,16 +1806,16 @@ def test_stack_with_virtual_arrays(numpy_like, virtual_array, shape_generator_pa
 
 
 def test_packbits_with_virtual_array(numpy_like, shape_generator_param):
-    # Test packbits with VirtualArray of booleans
+    # Test packbits with VirtualNDArray of booleans
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([1, 0, 1, 0, 1, 0, 1, 0], dtype=bool),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1829,16 +1830,16 @@ def test_packbits_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_unpackbits_with_virtual_array(numpy_like, shape_generator_param):
-    # Test unpackbits with VirtualArray of uint8
+    # Test unpackbits with VirtualNDArray of uint8
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.uint8),
             generator=lambda: np.array([170], dtype=np.uint8),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.uint8),
@@ -1853,7 +1854,7 @@ def test_unpackbits_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_broadcast_to_with_virtual_array(numpy_like, virtual_array):
-    # Test broadcast_to with VirtualArray
+    # Test broadcast_to with VirtualNDArray
     result = numpy_like.broadcast_to(virtual_array, (3, 5))
     assert result.shape == (3, 5)
 
@@ -1864,7 +1865,7 @@ def test_broadcast_to_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_strides_with_virtual_array(numpy_like, virtual_array):
-    # Test strides with VirtualArray
+    # Test strides with VirtualNDArray
     # First test without materializing
     assert numpy_like.strides(virtual_array) == (8,)  # 8 bytes per int64
 
@@ -1877,14 +1878,14 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
 def test_add_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
     # Test add with VirtualArrays
     if shape_generator_param is None:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([10, 20, 30, 40, 50], dtype=np.int64),
         )
     else:
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -1899,27 +1900,27 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array, shape_generator_para
 def test_logical_or_with_virtual_arrays(numpy_like, shape_generator_param):
     # Test logical_or with VirtualArrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1934,27 +1935,27 @@ def test_logical_or_with_virtual_arrays(numpy_like, shape_generator_param):
 def test_logical_and_with_virtual_arrays(numpy_like, shape_generator_param):
     # Test logical_and with VirtualArrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, True, False, False], dtype=np.bool_),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1967,16 +1968,16 @@ def test_logical_and_with_virtual_arrays(numpy_like, shape_generator_param):
 
 
 def test_logical_not_with_virtual_array(numpy_like, shape_generator_param):
-    # Test logical_not with VirtualArray
+    # Test logical_not with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, False], dtype=np.bool_),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
@@ -1990,16 +1991,16 @@ def test_logical_not_with_virtual_array(numpy_like, shape_generator_param):
 
 # Test mathematical operations
 def test_sqrt_with_virtual_array(numpy_like, shape_generator_param):
-    # Test sqrt with VirtualArray
+    # Test sqrt with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([4.0, 9.0, 16.0, 25.0], dtype=np.float64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2012,16 +2013,16 @@ def test_sqrt_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_exp_with_virtual_array(numpy_like, shape_generator_param):
-    # Test exp with VirtualArray
+    # Test exp with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([0.0, 1.0, 2.0], dtype=np.float64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2036,27 +2037,27 @@ def test_exp_with_virtual_array(numpy_like, shape_generator_param):
 def test_divide_with_virtual_arrays(numpy_like, shape_generator_param):
     # Test divide with VirtualArrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([2.0, 4.0, 5.0, 8.0], dtype=np.float64),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64),
             shape_generator=lambda: (4,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2070,9 +2071,9 @@ def test_divide_with_virtual_arrays(numpy_like, shape_generator_param):
 
 # Test special operations
 def test_nan_to_num_with_virtual_array(numpy_like, shape_generator_param):
-    # Test nan_to_num with VirtualArray containing NaN and infinity
+    # Test nan_to_num with VirtualNDArray containing NaN and infinity
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2081,7 +2082,7 @@ def test_nan_to_num_with_virtual_array(numpy_like, shape_generator_param):
             ),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2102,27 +2103,27 @@ def test_nan_to_num_with_virtual_array(numpy_like, shape_generator_param):
 def test_isclose_with_virtual_arrays(numpy_like, shape_generator_param):
     # Test isclose with VirtualArrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0001, 2.0, 3.1, np.nan], dtype=np.float64),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, 2.0, 3.0, np.nan], dtype=np.float64),
             shape_generator=lambda: (4,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2144,16 +2145,16 @@ def test_isclose_with_virtual_arrays(numpy_like, shape_generator_param):
 
 
 def test_isnan_with_virtual_array(numpy_like, shape_generator_param):
-    # Test isnan with VirtualArray
+    # Test isnan with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, np.nan, 3.0, np.nan], dtype=np.float64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2167,21 +2168,21 @@ def test_isnan_with_virtual_array(numpy_like, shape_generator_param):
 
 # Test reduction operations
 def test_all_with_virtual_array(numpy_like, shape_generator_param):
-    # Test all with VirtualArray
+    # Test all with VirtualNDArray
     if shape_generator_param is None:
-        va_all_true = VirtualArray(
+        va_all_true = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
         )
-        va_mixed = VirtualArray(
+        va_mixed = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.bool_),
@@ -2190,21 +2191,21 @@ def test_all_with_virtual_array(numpy_like, shape_generator_param):
             ),
         )
     else:
-        va_all_true = VirtualArray(
+        va_all_true = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, True, True, True], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va_mixed = VirtualArray(
+        va_mixed = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([True, False, True, True], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.bool_),
@@ -2232,21 +2233,21 @@ def test_all_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_any_with_virtual_array(numpy_like, shape_generator_param):
-    # Test any with VirtualArray
+    # Test any with VirtualNDArray
     if shape_generator_param is None:
-        va_all_false = VirtualArray(
+        va_all_false = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
         )
-        va_mixed = VirtualArray(
+        va_mixed = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.bool_),
@@ -2255,21 +2256,21 @@ def test_any_with_virtual_array(numpy_like, shape_generator_param):
             ),
         )
     else:
-        va_all_false = VirtualArray(
+        va_all_false = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([False, False, False, False], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va_mixed = VirtualArray(
+        va_mixed = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.bool_),
             generator=lambda: np.array([False, False, True, False], dtype=np.bool_),
             shape_generator=lambda: (4,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.bool_),
@@ -2293,29 +2294,29 @@ def test_any_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_min_with_virtual_array(numpy_like, shape_generator_param):
-    # Test min with VirtualArray
+    # Test min with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
             shape_generator=lambda: (5,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -2333,29 +2334,29 @@ def test_min_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_max_with_virtual_array(numpy_like, shape_generator_param):
-    # Test max with VirtualArray
+    # Test max with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[3, 1, 2], [6, 4, 5]], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([5, 3, 1, 4, 2], dtype=np.int64),
             shape_generator=lambda: (5,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -2373,29 +2374,29 @@ def test_max_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_count_nonzero_with_virtual_array(numpy_like, shape_generator_param):
-    # Test count_nonzero with VirtualArray
+    # Test count_nonzero with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[1, 0, 2], [0, 4, 0]], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 0, 3, 0, 5, 0], dtype=np.int64),
             shape_generator=lambda: (6,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -2413,29 +2414,29 @@ def test_count_nonzero_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_cumsum_with_virtual_array(numpy_like, shape_generator_param):
-    # Test cumsum with VirtualArray
+    # Test cumsum with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
             shape_generator=lambda: (5,),
         )
-        va_2d = VirtualArray(
+        va_2d = VirtualNDArray(
             numpy_like,
             shape=(unknown_length, 3),
             dtype=np.dtype(np.int64),
@@ -2453,16 +2454,16 @@ def test_cumsum_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_real_imag_with_complex_virtual_array(numpy_like, shape_generator_param):
-    # Test real and imag with complex VirtualArray
+    # Test real and imag with complex VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.complex128),
             generator=lambda: np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.complex128),
@@ -2480,9 +2481,9 @@ def test_real_imag_with_complex_virtual_array(numpy_like, shape_generator_param)
 
 
 def test_angle_with_complex_virtual_array(numpy_like, shape_generator_param):
-    # Test angle with complex VirtualArray
+    # Test angle with complex VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.complex128),
@@ -2491,7 +2492,7 @@ def test_angle_with_complex_virtual_array(numpy_like, shape_generator_param):
             ),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.complex128),
@@ -2513,16 +2514,16 @@ def test_angle_with_complex_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_round_with_virtual_array(numpy_like, shape_generator_param):
-    # Test round with VirtualArray
+    # Test round with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.234, 2.567, 3.499, 4.501], dtype=np.float64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2544,20 +2545,20 @@ def test_round_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_array_str_with_virtual_array_unmaterialized(numpy_like, virtual_array):
-    # Test array_str with unmaterialized VirtualArray
+    # Test array_str with unmaterialized VirtualNDArray
     result = numpy_like.array_str(virtual_array)
     assert result == "[## ... ##]"
 
 
 def test_array_str_with_virtual_array_materialized(numpy_like, virtual_array):
-    # Test array_str with materialized VirtualArray
+    # Test array_str with materialized VirtualNDArray
     virtual_array.materialize()
     result = numpy_like.array_str(virtual_array)
     assert "[1 2 3 4 5]" in result
 
 
 def test_astype_with_virtual_array(numpy_like, virtual_array):
-    # Test astype with VirtualArray
+    # Test astype with VirtualNDArray
     result = numpy_like.astype(virtual_array, np.float64)
     np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
     assert result.dtype == np.dtype(np.float64)
@@ -2569,7 +2570,7 @@ def test_astype_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
-    # Test can_cast with VirtualArray's dtype
+    # Test can_cast with VirtualNDArray's dtype
     # int64 can be cast to float64 with same_kind casting
     assert numpy_like.can_cast(virtual_array.dtype, np.float64) is True
 
@@ -2579,31 +2580,31 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 
 # Test various combinations and edge cases
 def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
-    # Test the materialize_if_virtual utility function directly
+    # Test the maybe_materialize utility function directly
 
     # Create a mix of VirtualArrays and regular arrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3], dtype=np.int64),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([4, 5, 6], dtype=np.int64),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3], dtype=np.int64),
             shape_generator=lambda: (3,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -2614,7 +2615,7 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
     regular_array = np.array([7, 8, 9])
 
     # Materialize none of them
-    results = materialize_if_virtual(va1, va2, regular_array)
+    results = maybe_materialize(va1, va2, regular_array)
     assert len(results) == 3
     np.testing.assert_array_equal(results[0], np.array([1, 2, 3]))
     np.testing.assert_array_equal(results[1], np.array([4, 5, 6]))
@@ -2626,14 +2627,14 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
 
     # Test with already materialized VirtualArrays
     if shape_generator_param is None:
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([10, 11], dtype=np.int64),
         )
     else:
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -2643,7 +2644,7 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
 
     va3.materialize()  # Pre-materialize
 
-    results = materialize_if_virtual(va3, regular_array)
+    results = maybe_materialize(va3, regular_array)
     assert len(results) == 2
     np.testing.assert_array_equal(results[0], np.array([10, 11]))
     np.testing.assert_array_equal(results[1], np.array([7, 8, 9]))
@@ -2652,40 +2653,40 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
 def test_operations_with_multiple_virtual_arrays(numpy_like, shape_generator_param):
     # Test a complex operation involving multiple VirtualArrays
     if shape_generator_param is None:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
         )
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([7.0, 8.0, 9.0], dtype=np.float64),
         )
     else:
-        va1 = VirtualArray(
+        va1 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([1.0, 2.0, 3.0], dtype=np.float64),
             shape_generator=lambda: (3,),
         )
-        va2 = VirtualArray(
+        va2 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
             generator=lambda: np.array([4.0, 5.0, 6.0], dtype=np.float64),
             shape_generator=lambda: (3,),
         )
-        va3 = VirtualArray(
+        va3 = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.float64),
@@ -2708,16 +2709,16 @@ def test_operations_with_multiple_virtual_arrays(numpy_like, shape_generator_par
 
 
 def test_is_own_array_with_virtual_array(numpy_like, shape_generator_param):
-    # Test is_own_array method with VirtualArray
+    # Test is_own_array method with VirtualNDArray
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -2727,7 +2728,9 @@ def test_is_own_array_with_virtual_array(numpy_like, shape_generator_param):
 
     # Before materialization
     result = numpy_like.is_own_array(va)
-    assert result  # Should be True because VirtualArray.nplike.ndarray is numpy.ndarray
+    assert (
+        result
+    )  # Should be True because VirtualNDArray.nplike.ndarray is numpy.ndarray
 
     # After materialization
     va.materialize()
@@ -2736,11 +2739,11 @@ def test_is_own_array_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_virtual_array_with_structured_dtype(numpy_like, shape_generator_param):
-    # Test VirtualArray with structured dtype
+    # Test VirtualNDArray with structured dtype
     dtype = np.dtype([("name", "U10"), ("age", "i4"), ("weight", "f8")])
 
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=dtype,
@@ -2749,7 +2752,7 @@ def test_virtual_array_with_structured_dtype(numpy_like, shape_generator_param):
             ),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=dtype,
@@ -2772,16 +2775,16 @@ def test_virtual_array_with_structured_dtype(numpy_like, shape_generator_param):
 
 
 def test_virtual_array_with_empty_array(numpy_like, shape_generator_param):
-    # Test VirtualArray with empty array
+    # Test VirtualNDArray with empty array
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -2798,14 +2801,14 @@ def test_virtual_array_with_empty_array(numpy_like, shape_generator_param):
 def test_chained_operations_materialization(numpy_like, shape_generator_param):
     # Test that chained operations correctly materialize VirtualArrays
     if shape_generator_param is None:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
             generator=lambda: np.array([1, 2, 3, 4, 5], dtype=np.int64),
         )
     else:
-        va = VirtualArray(
+        va = VirtualNDArray(
             numpy_like,
             shape=(unknown_length,),
             dtype=np.dtype(np.int64),
@@ -2817,7 +2820,7 @@ def test_chained_operations_materialization(numpy_like, shape_generator_param):
     # 1. Add 10
     # 2. Multiply by 2
     # 3. Check if > 25
-    # Each step should materialize the VirtualArray
+    # Each step should materialize the VirtualNDArray
 
     result1 = numpy_like.add(va, 10)  # [11, 12, 13, 14, 15]
     assert va.is_materialized

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -1014,7 +1014,7 @@ def test_generator_error():
         va.get_shape()
 
 
-# Test nested VirtualArrays (generator returns another VirtualNDArray)
+# Test nested VirtualNDArrays (generator returns another VirtualNDArray)
 def test_nested_virtual_arrays(shape_generator_param):
     nplike = Numpy.instance()
 
@@ -1321,7 +1321,7 @@ def test_meshgrid_with_virtual_array(numpy_like, virtual_array):
 def test_array_equal_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Create two identical VirtualArrays
+    # Create two identical VirtualNDArrays
     va1 = virtual_array
     if shape_generator_param is None:
         va2 = VirtualNDArray(
@@ -1442,7 +1442,7 @@ def test_apply_ufunc_with_virtual_arrays(
     result = numpy_like.apply_ufunc(np.add, "__call__", [virtual_array, 10])
     np.testing.assert_array_equal(result, np.array([11, 12, 13, 14, 15]))
 
-    # Test apply_ufunc with multiple VirtualArrays
+    # Test apply_ufunc with multiple VirtualNDArrays
     if shape_generator_param is None:
         va2 = VirtualNDArray(
             numpy_like,
@@ -1467,7 +1467,7 @@ def test_apply_ufunc_with_virtual_arrays(
 def test_broadcast_arrays_with_virtual_arrays(
     numpy_like, virtual_array, shape_generator_param
 ):
-    # Test broadcast_arrays with VirtualArrays
+    # Test broadcast_arrays with VirtualNDArrays
     if shape_generator_param is None:
         va2 = VirtualNDArray(
             numpy_like,
@@ -1562,7 +1562,7 @@ def test_nonzero_with_virtual_array(numpy_like, virtual_array):
 
 
 def test_where_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
-    # Test where with VirtualArrays
+    # Test where with VirtualNDArrays
     if shape_generator_param is None:
         condition = VirtualNDArray(
             numpy_like,
@@ -1695,7 +1695,7 @@ def test_sort_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_concat_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
-    # Test concat with VirtualArrays
+    # Test concat with VirtualNDArrays
     if shape_generator_param is None:
         va2 = VirtualNDArray(
             numpy_like,
@@ -1778,7 +1778,7 @@ def test_repeat_with_virtual_array(numpy_like, virtual_array, shape_generator_pa
 
 
 def test_stack_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
-    # Test stack with VirtualArrays
+    # Test stack with VirtualNDArrays
     if shape_generator_param is None:
         va2 = VirtualNDArray(
             numpy_like,
@@ -1876,7 +1876,7 @@ def test_strides_with_virtual_array(numpy_like, virtual_array):
 
 # Test addition and logical operations
 def test_add_with_virtual_arrays(numpy_like, virtual_array, shape_generator_param):
-    # Test add with VirtualArrays
+    # Test add with VirtualNDArrays
     if shape_generator_param is None:
         va2 = VirtualNDArray(
             numpy_like,
@@ -1898,7 +1898,7 @@ def test_add_with_virtual_arrays(numpy_like, virtual_array, shape_generator_para
 
 
 def test_logical_or_with_virtual_arrays(numpy_like, shape_generator_param):
-    # Test logical_or with VirtualArrays
+    # Test logical_or with VirtualNDArrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -1933,7 +1933,7 @@ def test_logical_or_with_virtual_arrays(numpy_like, shape_generator_param):
 
 
 def test_logical_and_with_virtual_arrays(numpy_like, shape_generator_param):
-    # Test logical_and with VirtualArrays
+    # Test logical_and with VirtualNDArrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -2035,7 +2035,7 @@ def test_exp_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_divide_with_virtual_arrays(numpy_like, shape_generator_param):
-    # Test divide with VirtualArrays
+    # Test divide with VirtualNDArrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -2101,7 +2101,7 @@ def test_nan_to_num_with_virtual_array(numpy_like, shape_generator_param):
 
 
 def test_isclose_with_virtual_arrays(numpy_like, shape_generator_param):
-    # Test isclose with VirtualArrays
+    # Test isclose with VirtualNDArrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -2582,7 +2582,7 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
     # Test the maybe_materialize utility function directly
 
-    # Create a mix of VirtualArrays and regular arrays
+    # Create a mix of VirtualNDArrays and regular arrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -2621,11 +2621,11 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
     np.testing.assert_array_equal(results[1], np.array([4, 5, 6]))
     np.testing.assert_array_equal(results[2], np.array([7, 8, 9]))
 
-    # Check that the VirtualArrays were materialized
+    # Check that the VirtualNDArrays were materialized
     assert va1.is_materialized
     assert va2.is_materialized
 
-    # Test with already materialized VirtualArrays
+    # Test with already materialized VirtualNDArrays
     if shape_generator_param is None:
         va3 = VirtualNDArray(
             numpy_like,
@@ -2651,7 +2651,7 @@ def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
 
 
 def test_operations_with_multiple_virtual_arrays(numpy_like, shape_generator_param):
-    # Test a complex operation involving multiple VirtualArrays
+    # Test a complex operation involving multiple VirtualNDArrays
     if shape_generator_param is None:
         va1 = VirtualNDArray(
             numpy_like,
@@ -2695,14 +2695,14 @@ def test_operations_with_multiple_virtual_arrays(numpy_like, shape_generator_par
         )
 
     # Expression: (va1 + va2) * va3
-    # Should materialize all VirtualArrays
+    # Should materialize all VirtualNDArrays
     result = numpy_like.add(va1, va2) * va3
     np.testing.assert_array_equal(
         result,
         np.array([35.0, 56.0, 81.0]),  # (1+4)*7, (2+5)*8, (3+6)*9
     )
 
-    # Check that all VirtualArrays were materialized
+    # Check that all VirtualNDArrays were materialized
     assert va1.is_materialized
     assert va2.is_materialized
     assert va3.is_materialized
@@ -2799,7 +2799,7 @@ def test_virtual_array_with_empty_array(numpy_like, shape_generator_param):
 
 
 def test_chained_operations_materialization(numpy_like, shape_generator_param):
-    # Test that chained operations correctly materialize VirtualArrays
+    # Test that chained operations correctly materialize VirtualNDArrays
     if shape_generator_param is None:
         va = VirtualNDArray(
             numpy_like,

--- a/tests/test_3611_avoid_noop_recursion_virtualarray.py
+++ b/tests/test_3611_avoid_noop_recursion_virtualarray.py
@@ -7,12 +7,12 @@ import sys
 import numpy as np
 
 from awkward._nplikes.numpy import Numpy
-from awkward._nplikes.virtual import VirtualArray
+from awkward._nplikes.virtual import VirtualNDArray
 
 
 def test_getitem():
     numpy_like = Numpy.instance()
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -25,7 +25,7 @@ def test_getitem():
 
 def test_view():
     numpy_like = Numpy.instance()
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -38,7 +38,7 @@ def test_view():
 
 def test_transpose():
     numpy_like = Numpy.instance()
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -51,7 +51,7 @@ def test_transpose():
 
 def test_reshape():
     numpy_like = Numpy.instance()
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -66,7 +66,7 @@ def test_asarray():
     numpy_like = Numpy.instance()
 
     # copy=False
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),
@@ -77,7 +77,7 @@ def test_asarray():
     assert vc.materialize()
 
     # copy=None
-    vc = VirtualArray(
+    vc = VirtualNDArray(
         numpy_like,
         shape=(1,),
         dtype=np.dtype(np.int64),


### PR DESCRIPTION
This PR does some refactoring for VirtualArrays:
- `VirtualArray` -> `VirtualNDArray` (closes https://github.com/scikit-hep/awkward/issues/3604)
- add new base class: `MaterializeableArray`
- `PlaceholderArray` implements its own `materialize` function that raises with a much better error than before; also we get rid of _many_ assertions extra for `PlaceholderArrays`
- `materialize_if_virtual` -> `maybe_materialize` (because now any `MaterializableArray` can materialize, not just `VirtualNDArrays`
- add `strides` to the `ArrayLike` protocol, this solves also some previous typing issues that we ignored with `type: ignore`

This PR does not touch the `TypetracerArray` on purpose. _If_ someone wants to add `def materialize(self)` with touching-behavior to them at some point it could be possible, but I'd prefer to not touch this code path as it is carefully optimized.