### PR TITLE
fix: catch off-by-one out of bound error

### DIFF
--- a/awkward-cpp/src/cpu-kernels/awkward_ListArray_getitem_jagged_apply.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_ListArray_getitem_jagged_apply.cpp
@@ -39,7 +39,7 @@ ERROR awkward_ListArray_getitem_jagged_apply(
       int64_t count = stop - start;
       for (int64_t j = slicestart;  j < slicestop;  j++) {
         int64_t index = (int64_t) sliceindex[j];
-        if (index < -count || index > count) {
+        if (index < -count || index >= count) {
           return failure("index out of range", i, index, FILENAME(__LINE__));
         }
         if (index < 0) {

--- a/tests/test_3619_fancy_indexing_with_awkward_arrays.py
+++ b/tests/test_3619_fancy_indexing_with_awkward_arrays.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+#
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+
+def test():
+    # taking the array directly from the issue: https://github.com/scikit-hep/awkward/issues/3619
+    a = ak.Array([[1, 5], [3], [4]])
+
+    # this is a valid case, where the index is not out of bounds
+    c_valid = ak.Array([[1, 1], [0], [0]])
+    assert a[c_valid].tolist() == [[5, 5], [3], [4]]
+
+    # this is an invalid case, where the index for the second element `[1]` is out of bounds
+    c_oob = ak.Array([[1, 1], [1], [0]])
+    with pytest.raises(IndexError):
+        a[c_oob]


### PR DESCRIPTION
Closes #2619 

@pfackeldey https://github.com/scikit-hep/awkward/issues/3619#issuecomment-3189510009 pointed out the location, I just made the patch.
