### PR TITLE
ci: move job to deploy doc preview to a separte workflow

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,77 @@
+name: Docs Preview
+on:
+  workflow_run:
+    workflows: [Docs]
+    types:
+      - completed
+
+concurrency:
+  group: 'docs-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+jobs:
+  branch-preview:
+    runs-on: ubuntu-24.04
+    name: Deploy Branch Preview
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      S3_BUCKET: "preview.awkward-array.org"
+      DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
+    environment:
+      name: docs
+      url: "${{ env.DEPLOY_URL }}/${{ github.head_ref }}"
+    steps:
+    # - name: Configure AWS credentials
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     aws-region: eu-west-2
+    #     role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+    - name: Download rendered docs
+      uses: actions/github-script@v7
+      with:
+        script: |
+          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+          });
+          let docsArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "docs"
+          })[0];
+          let PRNumberArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr_number"
+          })[0];
+          let downloadDocs = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: docsArtifact.id,
+              archive_format: 'zip',
+          });
+          let downloadPRNumber = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: PRNumberArtifact.id,
+              archive_format: 'zip',
+          });
+          const fs = require('fs');
+          const path = require('path');
+          const temp = '${{ runner.temp }}/artifacts';
+          if (!fs.existsSync(temp)){
+            fs.mkdirSync(temp);
+          }
+          fs.writeFileSync(path.join(temp, 'docs.zip'), Buffer.from(downloadDocs.data));
+          fs.writeFileSync(path.join(temp, 'pr_number.zip'), Buffer.from(downloadPRNumber.data));
+    - name: Unzip artifacts
+      run: |
+        unzip docs.zip -d "${{ runner.temp }}/artifacts"
+        unzip pr_number.zip -d "${{ runner.temp }}/artifacts"
+    - name: Read PR number
+      run: |
+        echo "PR_NUMBER=$(cat ${{ runner.temp }}/artifacts/pr_number.txt)" >> $GITHUB_ENV
+        rm ${{ runner.temp }}/artifacts/pr_number.txt
+    - name: Sync artifacts
+      run: |
+        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ env.PR_NUMBER }}"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -19,7 +19,7 @@ jobs:
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
     environment:
       name: docs
-      url: "${{ env.DEPLOY_URL }}/PR$${{ steps.pr_number.outputs.pr_number }}"
+      url: "${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}"
     steps:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -9,7 +9,7 @@ jobs:
   branch-preview:
     runs-on: ubuntu-24.04
     name: Deploy Branch Preview
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -75,6 +75,20 @@ jobs:
         rm "${{ runner.temp }}/artifacts/pr_number.txt"
         rm "${{ runner.temp }}/artifacts/docs.zip"
         rm "${{ runner.temp }}/artifacts/pr_number.zip"
-    - name: Sync artifacts
-      run: |
-        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"
+    # - name: Sync artifacts
+    #   run: |
+    #     aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"
+    - name: Try to find previous bot comment
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ steps.pr_number.outputs.pr_number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: The documentation preview is ready to be viewed
+    - name: Create comment with preview link
+      if: steps.fc.outputs.comment-id == ''
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ steps.pr_number.outputs.pr_number }}
+        body: |
+          The documentation preview is ready to be viewed at <${{ env.DEPLOY_URL }}/PR$${{ steps.pr_number.outputs.pr_number }}>

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -22,7 +22,7 @@ jobs:
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
     environment:
       name: docs
-      url: "${{ env.DEPLOY_URL }}/${{ github.head_ref }}"
+      url: "${{ env.DEPLOY_URL }}/PR$${{ steps.pr_number.outputs.pr_number }}"
     steps:
     # - name: Configure AWS credentials
     #   uses: aws-actions/configure-aws-credentials@v4
@@ -66,12 +66,15 @@ jobs:
           fs.writeFileSync(path.join(temp, 'pr_number.zip'), Buffer.from(downloadPRNumber.data));
     - name: Unzip artifacts
       run: |
-        unzip docs.zip -d "${{ runner.temp }}/artifacts"
-        unzip pr_number.zip -d "${{ runner.temp }}/artifacts"
+        unzip "${{ runner.temp }}/artifacts/docs.zip" -d "${{ runner.temp }}/artifacts"
+        unzip "${{ runner.temp }}/artifacts/pr_number.zip" -d "${{ runner.temp }}/artifacts"
     - name: Read PR number
+      id: pr_number
       run: |
-        echo "PR_NUMBER=$(cat ${{ runner.temp }}/artifacts/pr_number.txt)" >> $GITHUB_ENV
-        rm ${{ runner.temp }}/artifacts/pr_number.txt
+        echo "pr_number=$(cat ${{ runner.temp }}/artifacts/pr_number.txt)" >> $GITHUB_OUTPUT
+        rm "${{ runner.temp }}/artifacts/pr_number.txt"
+        rm "${{ runner.temp }}/artifacts/docs.zip"
+        rm "${{ runner.temp }}/artifacts/pr_number.zip"
     - name: Sync artifacts
       run: |
-        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ env.PR_NUMBER }}"
+        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     env:
       S3_BUCKET: "preview.awkward-array.org"
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -91,4 +91,4 @@ jobs:
       with:
         issue-number: ${{ steps.pr_number.outputs.pr_number }}
         body: |
-          The documentation preview is ready to be viewed at <${{ env.DEPLOY_URL }}/PR$${{ steps.pr_number.outputs.pr_number }}>
+          The documentation preview is ready to be viewed at <${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}>

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -5,10 +5,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: 'docs-${{ github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 jobs:
   branch-preview:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -25,11 +25,11 @@ jobs:
       name: docs
       url: "${{ env.DEPLOY_URL }}/PR$${{ steps.pr_number.outputs.pr_number }}"
     steps:
-    # - name: Configure AWS credentials
-    #   uses: aws-actions/configure-aws-credentials@v4
-    #   with:
-    #     aws-region: eu-west-2
-    #     role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: eu-west-2
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
     - name: Download rendered docs
       uses: actions/github-script@v7
       with:
@@ -76,9 +76,9 @@ jobs:
         rm "${{ runner.temp }}/artifacts/pr_number.txt"
         rm "${{ runner.temp }}/artifacts/docs.zip"
         rm "${{ runner.temp }}/artifacts/pr_number.zip"
-    # - name: Sync artifacts
-    #   run: |
-    #     aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"
+    - name: Sync artifacts
+      run: |
+        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"
     - name: Try to find previous bot comment
       uses: peter-evans/find-comment@v3
       id: fc


### PR DESCRIPTION
This PR works alongside #3625 to be able to deploy doc previews for PRs from forks.

This PR needs to be merged first, and then #3625 right after.

I tested this in https://github.com/ariostas-talks/awkward-test/pull/1 to verify that it works properly.