### PR TITLE
fix: do not force LE data-order in form.py

### DIFF
--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -373,11 +373,11 @@ def regularize_buffer_key(buffer_key: str | Callable) -> Callable[[Form, str], s
 
 
 index_to_dtype: Final[dict[str, DType]] = {
-    "i8": np.dtype("<i1"),
-    "u8": np.dtype("<u1"),
-    "i32": np.dtype("<i4"),
-    "u32": np.dtype("<u4"),
-    "i64": np.dtype("<i8"),
+    "i8": np.dtype("i1"),
+    "u8": np.dtype("u1"),
+    "i32": np.dtype("i4"),
+    "u32": np.dtype("u4"),
+    "i64": np.dtype("i8"),
 }
 
 

--- a/src/awkward/operations/ak_to_buffers.py
+++ b/src/awkward/operations/ak_to_buffers.py
@@ -21,7 +21,7 @@ def to_buffers(
     *,
     id_start=0,
     backend=None,
-    byteorder="<",
+    byteorder=ak._util.native_byteorder,
 ):
     """
     Args:


### PR DESCRIPTION
Hi, on big endian (s390x) a simple array create fails as follows. This seems to stem from the fact that byte order is hard-coded. The same is also seen in debian CI, see [here](https://ci.debian.net/packages/p/python-awkward/testing/s390x/62151756/).

It should instead use the (native) byte order of the build machine.

```
% python
Python 3.13.7 (main, Aug 20 2025, 22:17:40) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import awkward
>>> array = awkward.Array([[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}], [], [{"x": 4.4, "y": [1, 2, 3, \
4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]])
Traceback (most recent call last):
   File "<python-input-1>", line 1, in <module>
     array = awkward.Array([[{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}], [], [{"x": 4.4, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}]])
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/highlevel.py", line 325, in __init__
     layout = ak.operations.to_layout(
         data, allow_record=False, regulararray=False, primitive_policy="error"
     )
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/_dispatch.py", line 41, in dispatch
     with OperationErrorContext(name, args, kwargs):
          ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/_errors.py", line 80, in __exit__
     raise self.decorate_exception(exception_type, exception_value)
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/_dispatch.py", line 67, in dispatch
     next(gen_or_result)
     ~~~~^^^^^^^^^^^^^^^
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_to_layout.py", line 80, in to_layout
     return _impl(
         array,
     ...<6 lines>...
         string_policy,
     )
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_to_layout.py", line 280, in _impl
     return ak.operations.from_iter(
            ~~~~~~~~~~~~~~~~~~~~~~~^
         obj, highlevel=False, allow_record=allow_record
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/_dispatch.py", line 42, in dispatch
     gen_or_result = func(*args, **kwargs)
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_iter.py", line 70, in from_iter
     return _impl(iterable, highlevel, behavior, allow_record, initial, resize, attrs)
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_iter.py", line 105, in _impl
     return ak.operations.ak_from_buffers._impl(
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         form,
         ^^^^^
     ...<8 lines>...
         attrs=attrs,
         ^^^^^^^^^^^^
     )[0]
     ^
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_buffers.py", line 157, in _impl
     out = _reconstitute(
         form,
     ...<7 lines>...
         shape_generator=lambda: (length,),
     )
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_buffers.py", line 571, in _reconstitute
     content = _reconstitute(
         form.content,
     ...<7 lines>...
         _shape_generator,
     )
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_buffers.py", line 549, in _reconstitute
     offsets = _from_buffer(
         backend.nplike,
     ...<5 lines>...
         shape_generator=_shape_generator,
     )
   File "/home/nilesh/venv/lib/python3.13/site-packages/awkward/operations/ak_from_buffers.py", line 241, in _from_buffer
     raise TypeError(
         f"size of array ({array.size}) is less than size of form ({count})"
     )
TypeError: size of array (4) is less than size of form (216172782113783809)

This error occurred while calling

     ak.to_layout(
         [[{'x': 1.1, 'y': [1]}, {'x': 2.2, 'y': [1, 2]}, {'x': 3.3, 'y': [1, ...
         allow_record = False
         regulararray = False
         primitive_policy = 'error'
     )
```