### PR TITLE
test: test the virtual array generator before calling `.shape` in copy test

### DIFF
--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -432,11 +432,11 @@ def test_nplike(virtual_array, numpy_like):
 def test_copy(virtual_array):
     copy = virtual_array.copy()
     assert isinstance(copy, VirtualArray)
+    assert copy._generator is not virtual_array._generator
     assert copy.shape == virtual_array.shape
     assert copy.dtype == virtual_array.dtype
     assert not copy.is_materialized  # Copy should not be materialized
     assert id(copy) != id(virtual_array)  # Different objects
-    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -361,13 +361,13 @@ def test_shape_generator(virtual_array, shape_generator_param):
 def test_copy(virtual_array, shape_generator_param):
     copy = virtual_array.copy()
     assert isinstance(copy, VirtualArray)
+    assert copy._generator is not virtual_array._generator
     assert copy._shape == virtual_array._shape
     assert copy.shape == virtual_array.shape
     assert copy.dtype == virtual_array.dtype
     if shape_generator_param is None:
         assert copy.is_materialized
     assert id(copy) != id(virtual_array)  # Different objects
-    assert copy._generator is not virtual_array._generator
 
 
 # Test tolist


### PR DESCRIPTION
As pointed out by @ariostas, the order of the recently merged PRs combined with not rebasing before merging broke a test.
This fixes it. We test the generator before calling  `.shape` as that will call the generator if there is no shape generator and change it to `assert_never`.