### PR TITLE
chore: remove `materialize_if_virtual` 

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -30,15 +30,6 @@ def assert_never():
     raise AssertionError("this shape_generator should never be run!")
 
 
-def materialize_if_virtual(*args: Any) -> tuple[Any, ...]:
-    """
-    A little helper function to materialize all virtual arrays in a list of arrays.
-    """
-    return tuple(
-        arg.materialize() if isinstance(arg, VirtualNDArray) else arg for arg in args
-    )
-
-
 def _lazy_asarray(
     nplike: NumpyLike, generator: Callable[[], ArrayLike]
 ) -> Callable[[], ArrayLike]:

--- a/tests/test_3364_virtualarray.py
+++ b/tests/test_3364_virtualarray.py
@@ -605,7 +605,7 @@ def test_array_ufunc(virtual_array, monkeypatch):
 
 
 # Test the helper function maybe_materialize
-def test_materialize_if_virtual():
+def test_maybe_materialize():
     from awkward._nplikes.array_like import maybe_materialize
 
     nplike = Numpy.instance()
@@ -2111,7 +2111,7 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 
 
 # Test various combinations and edge cases
-def test_materialize_if_virtual_function(numpy_like):
+def test_maybe_materialize_function(numpy_like):
     # Test the maybe_materialize utility function directly
 
     # Create a mix of VirtualNDArrays and regular arrays

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -563,7 +563,7 @@ def test_array_ufunc(virtual_array, monkeypatch):
 
 
 # Test the helper function maybe_materialize
-def test_materialize_if_virtual():
+def test_maybe_materialize():
     nplike = Numpy.instance()
     va1 = VirtualNDArray(
         nplike,
@@ -2741,7 +2741,7 @@ def test_can_cast_with_virtual_array_dtype(numpy_like, virtual_array):
 
 
 # Test various combinations and edge cases
-def test_materialize_if_virtual_function(numpy_like, shape_generator_param):
+def test_maybe_materialize_function(numpy_like, shape_generator_param):
     # Test the maybe_materialize utility function directly
 
     # Create a mix of VirtualNDArrays and regular arrays


### PR DESCRIPTION
In https://github.com/scikit-hep/awkward/pull/3620, `materialize_if_virtual` was changed to `maybe_materialize`. However, the function wasn't removed and the tests weren't renamed. This PR fixes that.