### PR TITLE
fix: do not materialize before custom pickling

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1666,13 +1666,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         return numba.typeof(self._numbaview)
 
     def __reduce_ex__(self, protocol: int) -> tuple:
-        materialized = wrap_layout(
-            self._layout.materialize(),
-            self._behavior,
-            attrs=self._attrs,
-            highlevel=True,
-        )
-        result = custom_reduce(materialized, protocol)
+        result = custom_reduce(self, protocol)
         if result is not NotImplemented:
             return result
 
@@ -2506,13 +2500,7 @@ class Record(NDArrayOperatorsMixin):
 
     def __reduce_ex__(self, protocol: int) -> tuple:
         # Allow third-party libraries to customise pickling
-        materialized = wrap_layout(
-            self._layout.materialize(),
-            self._behavior,
-            attrs=self._attrs,
-            highlevel=True,
-        )
-        result = custom_reduce(materialized, protocol)
+        result = custom_reduce(self, protocol)
         if result is not NotImplemented:
             return result
 


### PR DESCRIPTION
In hindsight I’m regretting my decision to materialize for others before pickling using a custom registered pickler. It's the responsibility of the person who's implementing a custom pickler to be able to handle ALL of awkward layouts. It's not awkward's job to materialize for them nor do we want to enforce that. Let other libraries handle virtual arrays if they are implementing a custom pickler (i.e. dask-awkward).