### PR TITLE
fix: make `is_c_contiguous` touch data

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1680,6 +1680,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
 
     def is_c_contiguous(self, x: TypeTracerArray | PlaceholderArray) -> bool:
         assert isinstance(x, TypeTracerArray)
+        try_touch_data(x)
         return True
 
     def memory_ptr(self, x: TypeTracerArray | PlaceholderArray) -> int:


### PR DESCRIPTION
I'm pretty sure that the logic here should be "The code wants to know whether a buffer is contiguous, therefore this buffer should be loaded"