### PR TITLE
perf: detect & fastpath no-op range slices in all layout types

### DIFF
--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -413,7 +413,6 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -411,10 +411,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return ByteMaskedArray(

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -409,6 +409,15 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return ByteMaskedArray(
             self._mask[start:stop],
             self._content._getitem_range(start, stop),

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -319,6 +319,15 @@ class IndexedArray(IndexedMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return IndexedArray(
             self._index[start:stop], self._content, parameters=self._parameters
         )

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -323,7 +323,6 @@ class IndexedArray(IndexedMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -321,10 +321,7 @@ class IndexedArray(IndexedMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return IndexedArray(

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -346,7 +346,6 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -342,6 +342,15 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return IndexedOptionArray(
             self._index[start:stop], self._content, parameters=self._parameters
         )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -344,10 +344,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return IndexedOptionArray(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -358,10 +358,7 @@ class ListArray(ListMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return ListArray(

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -356,6 +356,15 @@ class ListArray(ListMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return ListArray(
             self._starts[start:stop],
             self._stops[start:stop],

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -360,7 +360,6 @@ class ListArray(ListMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -343,10 +343,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         offsets = self._offsets[start : stop + 1]

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -345,7 +345,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -341,6 +341,15 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         offsets = self._offsets[start : stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -339,6 +339,15 @@ class NumpyArray(NumpyMeta, Content):
             return out
 
     def _getitem_range(self, start: IndexType, stop: IndexType) -> Content:
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         try:
             out = self._data[start:stop]
         except IndexError as err:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -341,11 +341,7 @@ class NumpyArray(NumpyMeta, Content):
     def _getitem_range(self, start: IndexType, stop: IndexType) -> Content:
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and self.length is not unknown_length
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         try:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -17,7 +17,6 @@ from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
-from awkward._nplikes.typetracer import TypeTracerArray
 from awkward._parameters import (
     parameters_intersect,
     type_parameters_equal,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -454,9 +454,8 @@ class RecordArray(RecordMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == length == self.length)
+        if self._backend.nplike.known_data and (
+            start == 0 and stop == length == self.length
         ):
             return self
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -17,6 +17,7 @@ from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
+from awkward._nplikes.typetracer import TypeTracerArray
 from awkward._parameters import (
     parameters_intersect,
     type_parameters_equal,
@@ -451,6 +452,11 @@ class RecordArray(RecordMeta[Content], Content):
         start, stop, _, length = self._backend.nplike.derive_slice_for_length(
             slice(start, stop), self.length
         )
+
+        # in non-typetracer mode we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
+            return self
 
         if len(self._contents) == 0:
             return RecordArray(

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -452,9 +452,14 @@ class RecordArray(RecordMeta[Content], Content):
             slice(start, stop), self.length
         )
 
-        # in non-typetracer mode we can check if the slice is a no-op
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
+        if (
+            self._backend.nplike.known_data
+            and length is not unknown_length
+            and self.length is not unknown_length
+            and (start == 0 and stop == length == self.length)
+        ):
             return self
 
         if len(self._contents) == 0:

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -456,8 +456,6 @@ class RecordArray(RecordMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and length is not unknown_length
-            and self.length is not unknown_length
             and (start == 0 and stop == length == self.length)
         ):
             return self

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -604,7 +604,6 @@ class UnionArray(UnionMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -602,10 +602,7 @@ class UnionArray(UnionMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return UnionArray(

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -600,6 +600,15 @@ class UnionArray(UnionMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return UnionArray(
             self._tags[start:stop],
             self._index[start:stop],

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -256,6 +256,15 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             self._touch_shape(recursive=False)
             return self
 
+        # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+        # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+        if (
+            self._backend.nplike.known_data
+            and self.length is not unknown_length
+            and (start == 0 and stop == self.length)
+        ):
+            return self
+
         return UnmaskedArray(
             self._content._getitem_range(start, stop),
             parameters=self._parameters,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -260,7 +260,6 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
         if (
             self._backend.nplike.known_data
-            and self.length is not unknown_length
             and (start == 0 and stop == self.length)
         ):
             return self

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -258,10 +258,7 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
 
         # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
         # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
-        if (
-            self._backend.nplike.known_data
-            and (start == 0 and stop == self.length)
-        ):
+        if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
         return UnmaskedArray(

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -239,6 +239,13 @@ class Index:
         if isinstance(where, slice):
             where = normalize_slice(where, nplike=self.nplike)
 
+            # in non-typetracer mode (and if all lengths are known) we can check if the slice is a no-op
+            # (i.e. slicing the full array) and shortcut to avoid noticeable python overhead
+            if self._nplike.known_data and (
+                where.step == 1 and where.start == 0 and where.stop == self.length
+            ):
+                return self
+
         out = self._data[where]
 
         if hasattr(out, "shape") and len(out.shape) != 0:


### PR DESCRIPTION
This PR checks for trivial no-op slices in all layout types that essentially do nothing. If that's the case we can directly return `self` instead of constructing new python classes (and loosing their cached_properties), doing plenty of unnecessary repetitive checks, etc.

The most common operation that benefits from this improvement are `__setitem__` calls on RecordArrays, see the following:
```python
from coffea.nanoevents import NanoEventsFactory

events = NanoEventsFactory.from_root({"nanoaod.root": "Events"}, mode="eager").events()

# before this PR
%timeit events["Jet"] = events["Jet"]
10.4 ms ± 14.8 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# after this PR -> 32x speedup
%timeit events["Jet"] = events["Jet"]
327 μs ± 1.79 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# or nested:
# before this PR
%timeit events["Jet", "pt"] = events["Jet", "pt"]
11.2 ms ± 250 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# after this PR -> 16x speedup
%timeit events["Jet", "pt"] = events["Jet", "pt"]
700 μs ± 5.31 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
Similar speedups are seen for VirtualNDArrays. 

I expect this to speedup multiple other operations that traverse layouts as well. 

Adding this to TypeTracerArrays is maybe possible (?) but much more complicated as the slices can be TypeTracerArrays themselves and thus need special & careful handling. I tried this, but the full logic turned out to be a bit complicated, and needs more thoughts -> maybe something for a future PR.

This improvement should become pretty noticeable in coffea analysis as it is highly common to store new fields on `events`, and currently that's one of the most expensive operations - even more expensive than running awkward kernels. And that should _not_ be the case given that this is a metadata only operation.

---
This PR is reducing the total number of python allocations (new instances, etc) for a _single_ `events["Jet", "pt"] = events["Jet", "pt"]` setitem from `8049` to `1692`.