### PR TITLE
fix: virtual array deep copy generator reference + better error message for `assert_never`

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -27,13 +27,11 @@ UNMATERIALIZED = Sentinel("UNMATERIALIZED", None)
 
 
 def assert_never():
-    msg = "This generator should never have been encountered."
-    msg += (
-        " Awkward Array tried to use a generator function, "
-        "but this generator function should never be run."
-    )
-    msg += (
-        " This is unexpected behavior — please open an issue at "
+    msg = (
+        "This generator should never have been encountered. "
+        "Awkward Array tried to use a generator function, "
+        "but this generator function should never be run. "
+        "This is unexpected behavior — please open an issue at "
         "https://github.com/scikit-hep/awkward/issues with a minimal example."
     )
     raise RuntimeError(msg)

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -27,7 +27,16 @@ UNMATERIALIZED = Sentinel("UNMATERIALIZED", None)
 
 
 def assert_never():
-    raise AssertionError("this shape_generator should never be run!")
+    msg = "This generator should never have been encountered."
+    msg += (
+        " Awkward Array tried to use a generator function, "
+        "but this generator function should never be run."
+    )
+    msg += (
+        " This is unexpected behavior — please open an issue at "
+        "https://github.com/scikit-hep/awkward/issues with a minimal example."
+    )
+    raise RuntimeError(msg)
 
 
 def _lazy_asarray(
@@ -273,11 +282,12 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
         return new_virtual
 
     def __deepcopy__(self, memo) -> VirtualNDArray:
+        current_generator = self._generator
         new_virtual = type(self)(
             self._nplike,
             self._shape,
             self._dtype,
-            lambda: copy.deepcopy(self._generator(), memo),
+            lambda: copy.deepcopy(current_generator(), memo),
             self._shape_generator,
         )
         new_virtual._array = (

--- a/tests/test_3475_virtualarray_unknown_length.py
+++ b/tests/test_3475_virtualarray_unknown_length.py
@@ -353,7 +353,7 @@ def test_shape_generator(virtual_array, shape_generator_param):
         assert virtual_array._shape == (5,)
         assert not virtual_array.is_materialized
         with pytest.raises(
-            AssertionError, match="this shape_generator should never be run!"
+            RuntimeError, match="this generator function should never be run"
         ):
             assert virtual_array._shape_generator() == (5,)
 

--- a/tests/test_3644_virtual_array_deepcopy_generator_reference.py
+++ b/tests/test_3644_virtual_array_deepcopy_generator_reference.py
@@ -1,0 +1,31 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+#
+from __future__ import annotations
+
+import numpy as np
+
+from awkward._nplikes.numpy import Numpy
+from awkward._nplikes.virtual import VirtualNDArray
+
+
+def test():
+    numpy_like = Numpy.instance()
+    v1 = VirtualNDArray(
+        numpy_like,
+        shape=(10,),
+        dtype=np.dtype(np.float32),
+        generator=lambda: np.arange(10, dtype=np.float32),
+    )
+    v2 = v1.copy()
+    np.testing.assert_array_equal(v1.materialize(), np.arange(10, dtype=np.float32))
+    np.testing.assert_array_equal(v2.materialize(), np.arange(10, dtype=np.float32))
+
+    v1 = VirtualNDArray(
+        numpy_like,
+        shape=(10,),
+        dtype=np.dtype(np.float32),
+        generator=lambda: np.arange(10, dtype=np.float32),
+    )
+    v2 = v1.copy()
+    np.testing.assert_array_equal(v2.materialize(), np.arange(10, dtype=np.float32))
+    np.testing.assert_array_equal(v1.materialize(), np.arange(10, dtype=np.float32))


### PR DESCRIPTION
While deep copying virtual arrays, we used to do `lambda: copy.deepcopy(self._generator(), memo)` as the new generator.
The problem is that this apparently keeps a reference to `self` and not to `self._generator`. So when you make a copy and materialize the parent array first, its generator is set to `assert_never` in `materialize`, which effectively changes the generator of `self`. Therefore you cannot materialize the copy anymore because `self._generator` is now `assert_never`.
By extracting `self._generator` into a variable first, this keeps the right reference to the original generator and now you can materialize both the parent and the copied array in any order you want.

While we're at it, we add a better error message for `assert_never`, similar to the one for placeholder materialization.