### PR TITLE
feat: add axis=None reducer specializations

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -230,7 +230,7 @@ def reduce(
 
     if axis is None:
         del original_reducer  # not used below this point
-        
+
         parts = remove_structure(
             layout,
             flatten_records=False,

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -227,7 +227,7 @@ def reduce(
     reducer = layout.backend.prepare_reducer(reducer)
 
     # a flat array can only be reduced with axis=None
-    if isinstance(layout, ak.contents.NumpyArray) and layout.data.ndim <= 1:
+    if layout.purelist_depth <= 1:
         axis = None
 
     if axis is None:

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -304,7 +304,7 @@ def reduce(
 
             # a flat array can be fully reduced with axis=None or axis=0 or axis=-1,
             # so we treat them as equivalent and recurse to the axis=None specialization
-            if depth <= 1 and negaxis in {0, 1}:
+            if depth == negaxis == 1:
                 return reduce(
                     layout=layout,
                     reducer=original_reducer,

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -665,6 +665,28 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         (x,) = maybe_materialize(x)
         return self._module.min(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
+    def sum(
+        self,
+        x: ArrayLikeT,
+        *,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLikeT | None = None,
+    ) -> ArrayLikeT:
+        (x,) = maybe_materialize(x)
+        return self._module.sum(x, axis=axis, keepdims=keepdims, out=maybe_out)
+
+    def prod(
+        self,
+        x: ArrayLikeT,
+        *,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLikeT | None = None,
+    ) -> ArrayLikeT:
+        (x,) = maybe_materialize(x)
+        return self._module.prod(x, axis=axis, keepdims=keepdims, out=maybe_out)
+
     def max(
         self,
         x: ArrayLikeT,

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -676,17 +676,6 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         (x,) = maybe_materialize(x)
         return self._module.sum(x, axis=axis, keepdims=keepdims, out=maybe_out)
 
-    def prod(
-        self,
-        x: ArrayLikeT,
-        *,
-        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
-        keepdims: bool = False,
-        maybe_out: ArrayLikeT | None = None,
-    ) -> ArrayLikeT:
-        (x,) = maybe_materialize(x)
-        return self._module.prod(x, axis=axis, keepdims=keepdims, out=maybe_out)
-
     def max(
         self,
         x: ArrayLikeT,

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -139,6 +139,36 @@ class Cupy(ArrayModuleNumpyLike):
         else:
             return out
 
+    def sum(
+        self,
+        x: ArrayLike,
+        *,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLike | None = None,
+    ) -> ArrayLike:
+        (x,) = maybe_materialize(x)
+        out = self._module.sum(x, axis=axis, out=maybe_out)
+        if axis is None and isinstance(out, self._module.ndarray):
+            return out.item()
+        else:
+            return out
+
+    def prod(
+        self,
+        x: ArrayLike,
+        *,
+        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLike | None = None,
+    ) -> ArrayLike:
+        (x,) = maybe_materialize(x)
+        out = self._module.prod(x, axis=axis, out=maybe_out)
+        if axis is None and isinstance(out, self._module.ndarray):
+            return out.item()
+        else:
+            return out
+
     def max(
         self,
         x: ArrayLike,

--- a/src/awkward/_nplikes/cupy.py
+++ b/src/awkward/_nplikes/cupy.py
@@ -154,21 +154,6 @@ class Cupy(ArrayModuleNumpyLike):
         else:
             return out
 
-    def prod(
-        self,
-        x: ArrayLike,
-        *,
-        axis: ShapeItem | tuple[ShapeItem, ...] | None = None,
-        keepdims: bool = False,
-        maybe_out: ArrayLike | None = None,
-    ) -> ArrayLike:
-        (x,) = maybe_materialize(x)
-        out = self._module.prod(x, axis=axis, out=maybe_out)
-        if axis is None and isinstance(out, self._module.ndarray):
-            return out.item()
-        else:
-            return out
-
     def max(
         self,
         x: ArrayLike,

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -478,16 +478,6 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
     ) -> ArrayLikeT: ...
 
     @abstractmethod
-    def prod(
-        self,
-        x: ArrayLikeT,
-        *,
-        axis: int | tuple[int, ...] | None = None,
-        keepdims: bool = False,
-        maybe_out: ArrayLikeT | None = None,
-    ) -> ArrayLikeT: ...
-
-    @abstractmethod
     def count_nonzero(
         self, x: ArrayLikeT, *, axis: int | tuple[int, ...] | None = None
     ) -> ArrayLikeT: ...

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -468,6 +468,26 @@ class NumpyLike(PublicSingleton, Protocol[ArrayLikeT]):
     ) -> ArrayLikeT: ...
 
     @abstractmethod
+    def sum(
+        self,
+        x: ArrayLikeT,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLikeT | None = None,
+    ) -> ArrayLikeT: ...
+
+    @abstractmethod
+    def prod(
+        self,
+        x: ArrayLikeT,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: ArrayLikeT | None = None,
+    ) -> ArrayLikeT: ...
+
+    @abstractmethod
     def count_nonzero(
         self, x: ArrayLikeT, *, axis: int | tuple[int, ...] | None = None
     ) -> ArrayLikeT: ...

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1646,6 +1646,26 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
     ) -> TypeTracerArray:
         return self.min(x, axis=axis, keepdims=keepdims, maybe_out=maybe_out)
 
+    def sum(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        return self.min(x, axis=axis, keepdims=keepdims, maybe_out=maybe_out)
+
+    def prod(
+        self,
+        x: TypeTracerArray,
+        *,
+        axis: int | tuple[int, ...] | None = None,
+        keepdims: bool = False,
+        maybe_out: TypeTracerArray | None = None,
+    ) -> TypeTracerArray:
+        return self.min(x, axis=axis, keepdims=keepdims, maybe_out=maybe_out)
+
     def array_str(
         self,
         x: TypeTracerArray,

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1656,16 +1656,6 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
     ) -> TypeTracerArray:
         return self.min(x, axis=axis, keepdims=keepdims, maybe_out=maybe_out)
 
-    def prod(
-        self,
-        x: TypeTracerArray,
-        *,
-        axis: int | tuple[int, ...] | None = None,
-        keepdims: bool = False,
-        maybe_out: TypeTracerArray | None = None,
-    ) -> TypeTracerArray:
-        return self.min(x, axis=axis, keepdims=keepdims, maybe_out=maybe_out)
-
     def array_str(
         self,
         x: TypeTracerArray,

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -468,10 +468,6 @@ class Prod(KernelReducer):
     preferred_dtype: Final = np.float64
     needs_position: Final = False
 
-    @classmethod
-    def axis_none_reducer(cls) -> Reducer | None:
-        return AxisNoneProd()
-
     def apply(
         self,
         array: ak.contents.NumpyArray,
@@ -556,25 +552,6 @@ class Prod(KernelReducer):
                 result.view(self._promote_integer_rank(array.dtype)),
                 backend=array.backend,
             )
-
-
-class AxisNoneProd(Prod):
-    def apply(
-        self,
-        array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
-        starts: ak.index.Index,
-        shifts: ak.index.Index | None,
-        outlength: ShapeItem,
-    ) -> ak.contents.NumpyArray:
-        del parents, starts, shifts, outlength  # Unused
-        assert isinstance(array, ak.contents.NumpyArray)
-        if array.dtype.kind.upper() == "M":
-            raise ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
-        reduce_fn = getattr(array.backend.nplike, self.name)
-        return ak.contents.NumpyArray(
-            [reduce_fn(array.data, axis=None)], backend=array.backend
-        )
 
 
 class Any(KernelReducer):

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -33,6 +33,11 @@ class Reducer(Protocol):
     def highlevel_function(cls):
         return getattr(ak.operations, cls.name)
 
+    @classmethod
+    def axis_none_reducer(cls) -> Reducer | None:
+        """A specialized version for axis=None reductions, or None if there is none."""
+        return None
+
     @abstractmethod
     def apply(
         self,
@@ -336,6 +341,10 @@ class Sum(KernelReducer):
     preferred_dtype: Final = np.float64
     needs_position: Final = False
 
+    @classmethod
+    def axis_none_reducer(cls):
+        return AxisNoneSum()
+
     def apply(
         self,
         array: ak.contents.NumpyArray,
@@ -435,10 +444,33 @@ class Sum(KernelReducer):
             )
 
 
+class AxisNoneSum(Sum):
+    def apply(
+        self,
+        array: ak.contents.NumpyArray,
+        parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
+        outlength: ShapeItem,
+    ) -> ak.contents.NumpyArray:
+        del parents, starts, shifts, outlength  # Unused
+        assert isinstance(array, ak.contents.NumpyArray)
+        if array.dtype.kind == "M":
+            raise ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
+        reduce_fn = getattr(array.backend.nplike, self.name)
+        return ak.contents.NumpyArray(
+            [reduce_fn(array.data, axis=None)], backend=array.backend
+        )
+
+
 class Prod(KernelReducer):
     name: Final = "prod"
     preferred_dtype: Final = np.float64
     needs_position: Final = False
+
+    @classmethod
+    def axis_none_reducer(cls) -> Reducer | None:
+        return AxisNoneProd()
 
     def apply(
         self,
@@ -524,6 +556,25 @@ class Prod(KernelReducer):
                 result.view(self._promote_integer_rank(array.dtype)),
                 backend=array.backend,
             )
+
+
+class AxisNoneProd(Prod):
+    def apply(
+        self,
+        array: ak.contents.NumpyArray,
+        parents: ak.index.Index,
+        starts: ak.index.Index,
+        shifts: ak.index.Index | None,
+        outlength: ShapeItem,
+    ) -> ak.contents.NumpyArray:
+        del parents, starts, shifts, outlength  # Unused
+        assert isinstance(array, ak.contents.NumpyArray)
+        if array.dtype.kind.upper() == "M":
+            raise ValueError(f"cannot compute the product (ak.prod) of {array.dtype!r}")
+        reduce_fn = getattr(array.backend.nplike, self.name)
+        return ak.contents.NumpyArray(
+            [reduce_fn(array.data, axis=None)], backend=array.backend
+        )
 
 
 class Any(KernelReducer):


### PR DESCRIPTION
This PR adds `axis=None` reducer specializations. Should fix https://github.com/scikit-hep/awkward/issues/1250.

A reducer may now implement a specialization of itself that is used in the `axis=None` case (and `axis=0` or `axis=-1` case for 1D rectangular arrays). With this PR the specialization makes use of the underlying nplike implementation for the reducer, i.e. `np.sum`, which implements a sum algorithm that takes care of compensation due to floating point precision. In order for this interface to work I extended the nplike interface to also implement `sum`.

@ikrommyd and @valsdav could you give this a try?

@ianna what do you think about these specializations? Unfortunately this is not getting rid of intermediate arrays, that would be a much more invasive change in the codebase. However, I noticed that `ak.sum(..., axis=None)` is now quite a bit faster than before (due to the numpy kernel).

~(I might need some help regarding the cuda issue here @ianna :D)~