### PR TITLE
fix: convert integer-like objects to python integers in shapes

### DIFF
--- a/src/awkward/_nplikes/placeholder.py
+++ b/src/awkward/_nplikes/placeholder.py
@@ -22,7 +22,7 @@ class PlaceholderArray(MaterializableArray):
         field_path: tuple[str, ...] = (),
     ):
         self._nplike = nplike
-        self._shape = shape
+        self._shape = tuple(dim if dim is unknown_length else int(dim) for dim in shape)
         self._dtype = np.dtype(dtype)
         self._field_path = field_path
 

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -280,7 +280,7 @@ class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
                 raise TypeError("typetracer shape must be integers or unknown-length")
             if not isinstance(dtype, np.dtype):
                 raise TypeError("typetracer dtype must be an instance of np.dtype")
-        self._shape = shape
+        self._shape = tuple(dim if dim is unknown_length else int(dim) for dim in shape)
         self._dtype = dtype
 
         return self

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -93,7 +93,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
 
         # array metadata
         self._nplike = nplike
-        self._shape = shape
+        self._shape = tuple(dim if dim is unknown_length else int(dim) for dim in shape)
         self._dtype = np.dtype(dtype)
         self._array: Sentinel | ArrayLike = UNMATERIALIZED
 


### PR DESCRIPTION
The shape of an array should always be composed of python integers in order to avoid problems in `shape_item_as_index`.
You can construct an array in numpy from numpy integers like `array=np.empty(shape=(np.int32(2), np.int32(3)))` but `array.shape` is going to always give you python integers back.
In awkward we can construct arrays with shapes that are numpy integers for example when we get the shape from the last element of the offsets like `offsets[-1]`. That's going to be a `np.integer` as it is an element of an array. We should internally force the shapes to be python integers like numpy does when you do `.shape` on an array.

This PR solves a problem that I ran into from a very complicated dask-awkward workflow with `np.integer` placeholder shapes and `shape_item_as_index`:
```
﻿  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/_broadcasting.py", line 1197, in apply_step
    return continuation()
  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/_broadcasting.py", line 1166, in continuation
    return broadcast_any_list()
  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/_broadcasting.py", line 721, in broadcast_any_list
    next_content = broadcast_to_offsets_avoiding_carry(x, offsets)
  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/_broadcasting.py", line 405, in broadcast_to_offsets_avoiding_carry
    my_offsets = list_content._compact_offsets64(True)
  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/contents/regulararray.py", line 422, in _compact_offsets64
    nplike.shape_item_as_index(self.length * self._size) + 1,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iason/Dropbox/work/coffea_dev/awkward/src/awkward/_nplikes/array_module.py", line 379, in shape_item_as_index
    raise TypeError(f"expected None or int type, received {x1}")
TypeError: expected None or int type, received 2000

This error occurred while calling

    ak.cartesian(
        {'tag': <ElectronArray [[Electron, ...], ...] type='1000 * var * Elec...
        axis = 1
        nested = None
        parameters = None
        with_name = None
        highlevel = True
        behavior = None
        attrs = None
    )
```