### PR TITLE
chore: mac os 13 hosted runner image is closing down

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -71,7 +71,7 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-14, macos-15]
         arch: [auto64]
         build: ["cp", "pp"]
 

--- a/.github/workflows/header-only-test.yml
+++ b/.github/workflows/header-only-test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Run Tests"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-13, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         runs-on:
           - windows-latest
           - ubuntu-latest
-          - macos-13
+          - macos-latest
         python-version:
           - '3.14'
           - '3.13'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         include:
           - runs-on: macos-14
             python-architecture: arm64
+            dependencies-kind: full
           - python-version: '3.9'
             python-architecture: x86
             runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         runs-on:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
+          - macos-14
         python-version:
           - '3.14'
           - '3.13'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,12 @@ jobs:
           - x64
         dependencies-kind:
           - full
+        exclude:
+          - runs-on: macos-14
+            python-architecture: x64
         include:
+          - runs-on: macos-14
+            python-architecture: arm64
           - python-version: '3.9'
             python-architecture: x86
             runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,30 +84,6 @@ jobs:
             python-architecture: x64
             runs-on: windows-latest
             dependencies-kind: nogil
-          - python-version: '3.14'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
-          - python-version: '3.13'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
-          - python-version: '3.12'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
-          - python-version: '3.11'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
-          - python-version: '3.10'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
-          - python-version: '3.9'
-            runs-on: macos-14
-            python-architecture: arm64
-            dependencies-kind: full
 
     runs-on: ${{ matrix.runs-on }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,30 @@ jobs:
             python-architecture: x64
             runs-on: windows-latest
             dependencies-kind: nogil
+          - python-version: '3.14'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
+          - python-version: '3.13'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
+          - python-version: '3.12'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
+          - python-version: '3.11'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
+          - python-version: '3.10'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
+          - python-version: '3.9'
+            runs-on: macos-14
+            python-architecture: arm64
+            dependencies-kind: full
 
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:

    November 4, 14:00 UTC - November 5, 00:00 UTC
    November 11, 14:00 UTC - November 12, 00:00 UTC
    November 18, 14:00 UTC - November 19, 00:00 UTC
    November 25, 14:00 UTC - November 26, 00:00 UTC

This deprecation includes the following labels:

    macos-13
    macos-13-large
    macos-13-xlarge