### PR TITLE
fix: preserve the type when indexed by an empty array

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -730,7 +730,10 @@ class Content(Meta):
             return self._getitem_fields(ak.operations.to_list(where))
 
         elif isinstance(where, ak.contents.EmptyArray):
-            return where.to_NumpyArray(np.int64)
+            return self._carry(
+                Index64.empty(0, self._backend.nplike),
+                allow_lazy=True,
+            )
 
         elif isinstance(where, Content):
             return self._getitem((where,), named_axis)

--- a/tests/test_2377_empty_index.py
+++ b/tests/test_2377_empty_index.py
@@ -63,7 +63,7 @@ EMPTY_INDEXES = (
 
 @pytest.mark.parametrize("a", AWKWARD_ARRAYS)
 @pytest.mark.parametrize("idx", EMPTY_INDEXES)
-def test_non_empty_array(a: ak.Array, idx: Iterable) -> None:
+def test_empty_index(a: ak.Array, idx: Iterable) -> None:
     """Assert indexing with an empty array preserves the type."""
     result = a[idx]
 

--- a/tests/test_2377_empty_index.py
+++ b/tests/test_2377_empty_index.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward.types.numpytype import _primitive_to_dtype_dict
+
+
+def test_issue() -> None:
+    """Assert the GitHub issue #2377 is resolved."""
+    empty = ak.Array([])  # <Array [] type='0 * unknown'>
+
+    # No exception should be raised.
+    result = ak.flatten(empty[empty])
+
+    # The result should be an empty awkward array of the same type.
+    expected_layout = ak.Array([]).layout
+    assert result.layout.is_equal_to(expected_layout, all_parameters=True)
+
+
+# (dtype('bool', dtype='int8', dtype='float16', ...) All supported dtypes
+DTYPES = tuple(_primitive_to_dtype_dict.values())
+
+# (dtype('bool'), dtype('int8'), ...) Only bool and integer types
+INDEXABLE_DTYPES = tuple(d for d in DTYPES if d.kind in ("b", "i", "u"))
+
+
+AWKWARD_ARRAYS = (
+    # Empty array of unknown type
+    ak.Array([]),
+    # Empty arrays of various dtypes
+    *[ak.from_numpy(np.array([], dtype=d)) for d in DTYPES],
+    # Non-empty arrays of specific types
+    ak.Array([1, 2, 3]),
+    ak.Array([[1, 2], [], [3]]),
+    ak.Array([[[1.1, 2.2], []], [[3.3]], []]),
+    ak.Array([1 + 1j, 2 + 2j, 3 + 3j]),
+    ak.Array([datetime(2020, 1, 1), datetime(2021, 1, 1), datetime(2022, 1, 1)]),
+    # Non-empty arrays of mixed types
+    ak.Array([[1, 2], [1.1, 2.2], [1 + 1j, 2 + 2j]]),
+    ak.Array(
+        [
+            [1, 2],
+            [1.1, 2.2],
+            [1 + 1j, 2 + 2j],
+            [datetime(2020, 1, 1), datetime(2021, 1, 1)],
+        ]
+    ),
+)
+
+EMPTY_INDEXES = (
+    # (),  # NOTE: An empty tuple doesn't pass the test.
+    [],
+    ak.Array([]),
+    *[ak.from_numpy(np.array([], dtype=d)) for d in INDEXABLE_DTYPES],
+    *[np.array([], dtype=d) for d in INDEXABLE_DTYPES],
+)
+
+
+@pytest.mark.parametrize("a", AWKWARD_ARRAYS)
+@pytest.mark.parametrize("idx", EMPTY_INDEXES)
+def test_non_empty_array(a: ak.Array, idx: Iterable) -> None:
+    """Assert indexing with an empty array preserves the type."""
+    result = a[idx]
+
+    # Assert an empty array.
+    assert result.to_list() == []
+
+    # Assert the type is preserved
+    # e.g., "0 * complex128", "0 * var * union[complex128, datetime64[us]]"
+    expected_typestr = str(ak.types.ArrayType(a.type.content, 0))
+    assert result.typestr == expected_typestr


### PR DESCRIPTION
This PR is for part of https://github.com/scikit-hep/awkward/issues/2377.
It fixes the problem where indexing with an empty array changes the type.
The PR includes associated tests.