### PR TITLE
feat: add to_/from_safetensors

### DIFF
--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -38,6 +38,8 @@
     generated/ak.from_feather
     generated/ak.to_feather
     generated/ak.from_avro_file
+    generated/ak.to_safetensors
+    generated/ak.from_safetensors
 
 .. toctree::
     :caption: Conversions for machine learning

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -7,4 +7,5 @@ pyarrow>=12.0.0;sys_platform != "win32" and python_version < "3.14"
 pytest>=6
 pytest-cov
 pytest-xdist
+safetensors>=0.6.2
 uproot>=5

--- a/src/awkward/operations/__init__.py
+++ b/src/awkward/operations/__init__.py
@@ -47,6 +47,7 @@ from awkward.operations.ak_from_parquet import *
 from awkward.operations.ak_from_raggedtensor import *
 from awkward.operations.ak_from_rdataframe import *
 from awkward.operations.ak_from_regular import *
+from awkward.operations.ak_from_safetensors import *
 from awkward.operations.ak_from_tensorflow import *
 from awkward.operations.ak_from_torch import *
 from awkward.operations.ak_full_like import *
@@ -105,6 +106,7 @@ from awkward.operations.ak_to_parquet_row_groups import *
 from awkward.operations.ak_to_raggedtensor import *
 from awkward.operations.ak_to_rdataframe import *
 from awkward.operations.ak_to_regular import *
+from awkward.operations.ak_to_safetensors import *
 from awkward.operations.ak_to_tensorflow import *
 from awkward.operations.ak_to_torch import *
 from awkward.operations.ak_transform import *

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -43,8 +43,7 @@ def from_safetensors(
         buffer_key (str, optional): Template for buffer names, with placeholders
            `{form_key}` and `{attribute}`. Defaults to "{form_key}-{attribute}".
         backend (str, optional): Backend identifier (e.g., "cpu"). Defaults to "cpu".
-        byteorder (str): Byte order to assume when interpreting raw tensor bytes.
-            Use "<" for little-endian (default) or ">" for big-endian.
+        byteorder (str, optional): Byte order, "<" (little-endian, default) or ">".
         allow_noncanonical_form (bool): If True, attempt to convert non-canonical
             safetensors forms into a canonical Awkward form. If False, raise when
             a direct mapping is not possible. Defaults to False.

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -123,7 +123,7 @@ or
         ) from err
 
     buffers = {}
-    wrap = lambda x: (lambda: x) if virtual else x
+    wrap = lambda x: (lambda: x) if virtual else x  # noqa: E731
     with safetensors.safe_open(source, framework="np") as f:
         metadata = f.metadata()
         for k in f.offset_keys():

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -26,10 +26,10 @@ def from_safetensors(
 
     Ref: https://huggingface.co/docs/safetensors/.
 
-    This function reads data serialized in the safetensors format and constructs an
-    Awkward Array (or low-level layout) from it. Buffers in the safetensors
-    file are mapped to Awkward buffers using the `buffer_key` template, and optional
-    behavior/attributes can be attached to the returned array.
+    This function reads data serialized in the safetensors format and reconstructs
+    an Awkward Array (or low-level layout) from it. Buffers in the safetensors file
+    are mapped to Awkward buffers according to the `buffer_key` template, and
+    optional behavior or attributes can be attached to the returned array.
 
     Optionally the result can be "virtual" (lazily referencing buffers rather than materializing them immediately).
 

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -70,7 +70,7 @@ def from_safetensors(
         RuntimeError: If the safetensors data is malformed or tensors cannot be mapped to
             Awkward forms and `allow_noncanonical_form` is False.
 
-    Here is a simple example:
+    Example:
 
         >>> import awkward as ak
         >>> arr = ak.from_safetensors("out.safetensors")

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import awkward as ak
 from awkward._dispatch import high_level_function
 
@@ -107,9 +110,6 @@ def _impl(
 or
         conda install -c huggingface safetensors"""
         ) from err
-
-    import os
-    from pathlib import Path
 
     if isinstance(source, Path):
         source = os.fspath(source)

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 import awkward as ak
 from awkward._dispatch import high_level_function
 
@@ -10,7 +9,7 @@ __all__ = ("from_safetensors",)
 
 
 @high_level_function()
-def from_safetensors( 
+def from_safetensors(
     source,
     *,
     virtual=False,
@@ -29,9 +28,9 @@ def from_safetensors(
 
     This function reads data serialized in the safetensors format and constructs an
     Awkward Array (or low-level layout) from it. Buffers in the safetensors
-    file are mapped to Awkward buffers using the `buffer_key` template, and optional 
-    behavior/attributes can be attached to the returned array. 
-    
+    file are mapped to Awkward buffers using the `buffer_key` template, and optional
+    behavior/attributes can be attached to the returned array.
+
     Optionally the result can be "virtual" (lazily referencing buffers rather than materializing them immediately).
 
     Args:
@@ -101,7 +100,6 @@ def from_safetensors(
     )
 
 
-
 def _impl(
     source,
     virtual,
@@ -123,7 +121,7 @@ def _impl(
 or
         conda install -c huggingface safetensors"""
         ) from err
-    
+
     buffers = {}
     wrap = lambda x: (lambda: x) if virtual else x
     with safetensors.safe_open(source, framework="np") as f:

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -128,7 +128,10 @@ or
         metadata = f.metadata()
         for k in f.offset_keys():
             buffers[k] = wrap(f.get_tensor(k))
-
+    if "form" not in metadata or "length" not in metadata:
+        raise RuntimeError(
+            "Missing required metadata in safetensors file: 'form' and 'length' are required."
+        )
     form = ak.forms.from_json(metadata["form"])
     length = int(metadata["length"])
 

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -40,10 +40,8 @@ def from_safetensors(
             read/seek.
         virtual (bool, optional): If True, create a virtual (lazy) Awkward Array
            that references buffers without materializing them. Defaults to False.
-        buffer_key (str): Template used to construct buffer names for ak.from_buffers.
-            The template may include the placeholders "{form_key}" (the safetensors form
-            key) and "{attribute}" (the tensor attribute, e.g. "data" or a named field).
-            Defaults to "{form_key}-{attribute}".
+        buffer_key (str, optional): Template for buffer names, with placeholders
+           `{form_key}` and `{attribute}`. Defaults to "{form_key}-{attribute}".
         backend (str): Backend identifier used to interpret raw buffers (for example
             "cpu" or a GPU backend string). Defaults to "cpu".
         byteorder (str): Byte order to assume when interpreting raw tensor bytes.

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -44,16 +44,12 @@ def from_safetensors(
            `{form_key}` and `{attribute}`. Defaults to "{form_key}-{attribute}".
         backend (str, optional): Backend identifier (e.g., "cpu"). Defaults to "cpu".
         byteorder (str, optional): Byte order, "<" (little-endian, default) or ">".
-        allow_noncanonical_form (bool): If True, attempt to convert non-canonical
-            safetensors forms into a canonical Awkward form. If False, raise when
-            a direct mapping is not possible. Defaults to False.
-        highlevel (bool): If True, return a high-level ak.Array. If False, return the
-            low-level Awkward layout object. Defaults to True.
-        behavior (Mapping | None): Optional behavior mapping applied to the returned
-            high-level array (see Awkward's behavior mechanism). If None, the default
-            behavior is used.
-        attrs (Mapping | None): Optional dictionary of attributes (metadata) to attach
-            to the returned array; useful for preserving safetensors file metadata.
+        allow_noncanonical_form (bool, optional): If True, normalize
+            safetensors forms that do not directly match Awkward. Defaults to False.
+         highlevel (bool, optional): If True, return a high-level ak.Array. If False,
+             return the low-level layout. Defaults to True.
+         behavior (Mapping | None, optional): Optional Awkward behavior mapping.
+         attrs (Mapping | None, optional): Optional metadata to attach to the array.
 
     Returns:
         ak.Array or ak.layout.Content: An Awkward Array (or layout) reconstructed

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -31,7 +31,8 @@ def from_safetensors(
     are mapped to Awkward buffers according to the `buffer_key` template, and
     optional behavior or attributes can be attached to the returned array.
 
-    Optionally the result can be "virtual" (lazily referencing buffers rather than materializing them immediately).
+   The safetensors file **must contain** `form` and `length` entries in its
+   metadata, which define the structure and length of the reconstructed array.
 
     Args:
         source (str | os.PathLike | bytes | file-like): Path to a .safetensors file,

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -123,7 +123,7 @@ or
         ) from err
 
     buffers = {}
-    wrap = lambda x: (lambda: x) if virtual else x  # noqa: E731
+    wrap = lambda x: (lambda: x) if virtual else x  # noqa: E731 # pylint: disable=C3001
     with safetensors.safe_open(source, framework="np") as f:
         metadata = f.metadata()
         for k in f.offset_keys():

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -38,8 +38,8 @@ def from_safetensors(
         source (str | os.PathLike | bytes | file-like): Path to a .safetensors file,
             raw bytes containing safetensors data, or a file-like object supporting
             read/seek.
-        virtual (bool): If True, create a virtual (lazy) Awkward Array that references
-            buffers without immediately materializing them. Defaults to False.
+        virtual (bool, optional): If True, create a virtual (lazy) Awkward Array
+           that references buffers without materializing them. Defaults to False.
         buffer_key (str): Template used to construct buffer names for ak.from_buffers.
             The template may include the placeholders "{form_key}" (the safetensors form
             key) and "{attribute}" (the tensor attribute, e.g. "data" or a named field).

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -60,9 +60,8 @@ def from_safetensors(
             to the returned array; useful for preserving safetensors file metadata.
 
     Returns:
-        ak.Array or ak.layout.Content: A high-level Awkward Array if `highlevel` is True,
-        otherwise the corresponding low-level Awkward layout object. The array contains
-        data reconstructed from the safetensors tensors; buffer names follow `buffer_key`.
+        ak.Array or ak.layout.Content: An Awkward Array (or layout) reconstructed
+        from the safetensors buffers.
 
     Raises:
         ValueError: If `byteorder` is not one of "<" or ">".

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -1,0 +1,149 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+
+import awkward as ak
+from awkward._dispatch import high_level_function
+
+__all__ = ("from_safetensors",)
+
+
+@high_level_function()
+def from_safetensors( 
+    source,
+    *,
+    virtual=False,
+    # ak.from_buffers kwargs
+    buffer_key="{form_key}-{attribute}",
+    backend="cpu",
+    byteorder="<",
+    allow_noncanonical_form=False,
+    highlevel=True,
+    behavior=None,
+    attrs=None,
+):
+    """Load a safetensors file as an Awkward Array.
+
+    Ref: https://huggingface.co/docs/safetensors/.
+
+    This function reads data serialized in the safetensors format and constructs an
+    Awkward Array (or low-level layout) from it. Buffers in the safetensors
+    file are mapped to Awkward buffers using the `buffer_key` template, and optional 
+    behavior/attributes can be attached to the returned array. 
+    
+    Optionally the result can be "virtual" (lazily referencing buffers rather than materializing them immediately).
+
+    Args:
+        source (str | os.PathLike | bytes | file-like): Path to a .safetensors file,
+            raw bytes containing safetensors data, or a file-like object supporting
+            read/seek.
+        virtual (bool): If True, create a virtual (lazy) Awkward Array that references
+            buffers without immediately materializing them. Defaults to False.
+        buffer_key (str): Template used to construct buffer names for ak.from_buffers.
+            The template may include the placeholders "{form_key}" (the safetensors form
+            key) and "{attribute}" (the tensor attribute, e.g. "data" or a named field).
+            Defaults to "{form_key}-{attribute}".
+        backend (str): Backend identifier used to interpret raw buffers (for example
+            "cpu" or a GPU backend string). Defaults to "cpu".
+        byteorder (str): Byte order to assume when interpreting raw tensor bytes.
+            Use "<" for little-endian (default) or ">" for big-endian.
+        allow_noncanonical_form (bool): If True, attempt to convert non-canonical
+            safetensors forms into a canonical Awkward form. If False, raise when
+            a direct mapping is not possible. Defaults to False.
+        highlevel (bool): If True, return a high-level ak.Array. If False, return the
+            low-level Awkward layout object. Defaults to True.
+        behavior (Mapping | None): Optional behavior mapping applied to the returned
+            high-level array (see Awkward's behavior mechanism). If None, the default
+            behavior is used.
+        attrs (Mapping | None): Optional dictionary of attributes (metadata) to attach
+            to the returned array; useful for preserving safetensors file metadata.
+
+    Returns:
+        ak.Array or ak.layout.Content: A high-level Awkward Array if `highlevel` is True,
+        otherwise the corresponding low-level Awkward layout object. The array contains
+        data reconstructed from the safetensors tensors; buffer names follow `buffer_key`.
+
+    Raises:
+        ValueError: If `byteorder` is not one of "<" or ">".
+        FileNotFoundError: If `source` is a path that does not exist.
+        TypeError: If `source` is not a supported type (neither path/bytes nor file-like).
+        RuntimeError: If the safetensors data is malformed or tensors cannot be mapped to
+            Awkward forms and `allow_noncanonical_form` is False.
+
+    Here is a simple example:
+
+        >>> import awkward as ak
+        >>> arr = ak.from_safetensors("out.safetensors")
+        >>> arr  # doctest: +SKIP
+        <Array [[1, 2, 3], [], [4]] type='3 * var * int64'>
+
+        Create a virtual (lazy) array that references buffers without materializing them:
+
+        >>> virtual_arr = ak.from_safetensors("out.safetensors", virtual=True)
+        >>> virtual_arr  # doctest: +SKIP
+        <Array [??, ??, ??] type='3 * var * int64'>
+
+
+    See also #ak.to_safetensors.
+    """
+    # Implementation
+    return _impl(
+        source,
+        virtual,
+        buffer_key,
+        backend,
+        byteorder,
+        allow_noncanonical_form,
+        highlevel,
+        behavior,
+        attrs,
+    )
+
+
+
+def _impl(
+    source,
+    virtual,
+    buffer_key,
+    backend,
+    byteorder,
+    allow_noncanonical_form,
+    highlevel,
+    behavior,
+    attrs,
+):
+    try:
+        import safetensors
+    except ImportError as err:
+        raise ImportError(
+            """to use ak.from_tensorflow, you must install the 'safetensors' package with:
+
+        pip install safetensors
+or
+        conda install -c huggingface safetensors"""
+        ) from err
+    
+    buffers = {}
+    wrap = lambda x: (lambda: x) if virtual else x
+    with safetensors.safe_open(source, framework="np") as f:
+        metadata = f.metadata()
+        for k in f.offset_keys():
+            buffers[k] = wrap(f.get_tensor(k))
+
+    form = ak.forms.from_json(metadata["form"])
+    length = int(metadata["length"])
+
+    # reconstruct array
+    return ak.ak_from_buffers._impl(
+        form,
+        length,
+        buffers,
+        buffer_key=buffer_key,
+        backend=backend,
+        byteorder=byteorder,
+        simplify=allow_noncanonical_form,
+        highlevel=highlevel,
+        behavior=behavior,
+        attrs=attrs,
+    )

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -42,8 +42,7 @@ def from_safetensors(
            that references buffers without materializing them. Defaults to False.
         buffer_key (str, optional): Template for buffer names, with placeholders
            `{form_key}` and `{attribute}`. Defaults to "{form_key}-{attribute}".
-        backend (str): Backend identifier used to interpret raw buffers (for example
-            "cpu" or a GPU backend string). Defaults to "cpu".
+        backend (str, optional): Backend identifier (e.g., "cpu"). Defaults to "cpu".
         byteorder (str): Byte order to assume when interpreting raw tensor bytes.
             Use "<" for little-endian (default) or ">" for big-endian.
         allow_noncanonical_form (bool): If True, attempt to convert non-canonical

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -52,9 +52,9 @@ def to_safetensors(
             system’s native byte order.
 
     Returns:
-        None: The function writes the safetensors file to `destination`. If a
-        `container` was provided, it will be populated with the generated buffer
-        bytes and can be inspected or reused by the caller.
+        None
+            This function writes the safetensors file to `destination`. If
+        `container` is provided, it will be populated with the raw buffer bytes.
 
     Raises:
         ValueError: If `destination` is not writable or otherwise invalid.

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -66,7 +66,7 @@ def to_safetensors(
         TypeError: If `array` is not an Awkward Array or an object convertible to one.
         RuntimeError: If an error occurs while serializing buffers or writing the file.
 
-    Here is a simple example:
+    Example:
 
         >>> import awkward as ak
         >>> arr = ak.Array([[1, 2, 3], [], [4]])

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -35,26 +35,21 @@ def to_safetensors(
      array `length`, which are required for `ak.from_safetensors` to reconstruct the array.
     Args:
         array: An Awkward Array or array-like object to serialize.
-        destination (str or pathlib.Path or file-like): Path to write the resulting
-            safetensors file, or a writable binary file-like object.
-        container (dict, optional): A mapping to receive the raw buffers produced by
-            ak.to_buffers. If provided, the function will populate this dict with
-            {buffer_key: bytes} entries. If None (the default), a temporary container
-            is used for writing and discarded after the file is created.
-        buffer_key (str, optional): A format string used to name each buffer in the
-            safetensors container. May include placeholders such as
-            "{form_key}" and "{attribute}" (default: "{form_key}-{attribute}").
-        form_key (str, optional): A format string used to name node forms when
-            generating buffer keys; typically contains an "{id}" placeholder
-            (default: "node{id}").
-        id_start (int, optional): Starting index for node numbering used by `form_key`
-            (default: 0).
-        backend (str or object, optional): Backend selection passed through to
-            ak.to_buffers for converting array data to raw buffers (e.g., numpy
-            backend or an Awkward array backend object). If None, the library's
-            default backend is used.
-        byteorder (str, optional): Byte order to use when encoding numeric buffers.
-            Defaults to the system native byteorder.
+        destination (str | pathlib.Path | file-like): Path or writable binary stream
+            where the safetensors file will be written.
+        container (dict, optional): Optional mapping to receive the generated buffer
+            bytes. If None (default), a temporary container is used and discarded
+            after writing.
+        buffer_key (str, optional): Format string for naming buffers. May include
+            `{form_key}` and `{attribute}` placeholders. Defaults to
+            `"{form_key}-{attribute}"`.
+        form_key (str, optional): Format string for node forms when generating buffer
+            keys. Typically includes `"{id}"`. Defaults to `"node{id}"`.
+        id_start (int, optional): Starting index for node numbering. Defaults to `0`.
+        backend (str | object, optional): Backend used to convert array data into
+            buffers. If None, the default backend is used.
+        byteorder (str, optional): Byte order for numeric buffers. Defaults to the
+            system’s native byte order.
 
     Returns:
         None: The function writes the safetensors file to `destination`. If a

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import awkward as ak
 from awkward._dispatch import high_level_function
 
@@ -23,16 +21,7 @@ def to_safetensors(
     backend=None,
     byteorder=ak._util.native_byteorder,
 ):
-    """Serialize an Awkward Array to the safetensors format and write it to `destination`.
-
-    Ref: https://huggingface.co/docs/safetensors/.
-
-    This function converts the provided Awkward Array (or array-like object) into raw
-    buffers via `ak.to_buffers` and stores them in the safetensors format. Buffer names
-    are generated from `buffer_key` and `form_key` templates, allowing downstream
-    compatibility or layout reuse.
-     The resulting safetensors file includes metadata containing the Awkward `form` and
-     array `length`, which are required for `ak.from_safetensors` to reconstruct the array.
+    """
     Args:
         array: An Awkward Array or array-like object to serialize.
         destination (str | pathlib.Path | file-like): Path or writable binary stream
@@ -49,17 +38,23 @@ def to_safetensors(
         backend (str | object, optional): Backend used to convert array data into
             buffers. If None, the default backend is used.
         byteorder (str, optional): Byte order for numeric buffers. Defaults to the
-            system’s native byte order.
+            system's native byte order.
 
     Returns:
         None
             This function writes the safetensors file to `destination`. If
         `container` is provided, it will be populated with the raw buffer bytes.
 
-    Raises:
-        ValueError: If `destination` is not writable or otherwise invalid.
-        TypeError: If `array` is not an Awkward Array or an object convertible to one.
-        RuntimeError: If an error occurs while serializing buffers or writing the file.
+    Serialize an Awkward Array to the safetensors format and write it to `destination`.
+
+    Ref: https://huggingface.co/docs/safetensors/.
+
+    This function converts the provided Awkward Array (or array-like object) into raw
+    buffers via `ak.to_buffers` and stores them in the safetensors format. Buffer names
+    are generated from `buffer_key` and `form_key` templates, allowing downstream
+    compatibility or layout reuse.
+    The resulting safetensors file includes metadata containing the Awkward `form` and
+    array `length`, which are required for `ak.from_safetensors` to reconstruct the array.
 
     Example:
 
@@ -68,8 +63,7 @@ def to_safetensors(
         >>> ak.to_safetensors(arr, "out.safetensors")
 
 
-    See also:
-        ak.from_safetensors
+    See also #ak.from_safetensors.
     """
     # Implementation
     return _impl(
@@ -105,6 +99,12 @@ or
         conda install -c huggingface safetensors"""
         ) from err
 
+    import os
+    from pathlib import Path
+
+    if isinstance(destination, Path):
+        destination = os.fspath(destination)
+
     form, length, buffers = ak.ak_to_buffers._impl(
         array,
         container=container,
@@ -121,8 +121,8 @@ or
     }
     # save
     try:
-      save_file(buffers, destination, metadata)
+        save_file(buffers, destination, metadata)
     except Exception as err:
-      raise RuntimeError(
-          f"Failed to write safetensors file to '{destination}': {err}"
-      ) from err
+        raise RuntimeError(
+            f"Failed to write safetensors file to '{destination}': {err}"
+        ) from err

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -117,7 +117,7 @@ or
 
     metadata = {
         "form": form.to_json(),
-        "length": json.dumps(length),
+        "length": str(length),
     }
     # save
     try:

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -73,7 +73,8 @@ def to_safetensors(
         >>> ak.to_safetensors(arr, "out.safetensors")
 
 
-    See also #ak.from_safetensors.
+    See also:
+        ak.from_safetensors
     """
     # Implementation
     return _impl(

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -31,7 +31,8 @@ def to_safetensors(
     buffers (via ak.to_buffers) and stores them in the safetensors layout. Buffer
     names are generated from `buffer_key` and `form_key` and can be controlled to
     match downstream consumers or to allow reuse of existing serialization layouts.
-
+     The resulting safetensors file includes metadata containing the Awkward `form` and
+     array `length`, which are required for `ak.from_safetensors` to reconstruct the array.
     Args:
         array: An Awkward Array or array-like object to serialize.
         destination (str or pathlib.Path or file-like): Path to write the resulting

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -28,9 +28,9 @@ def to_safetensors(
     Ref: https://huggingface.co/docs/safetensors/.
 
     This function converts the provided Awkward Array (or array-like object) into raw
-    buffers (via ak.to_buffers) and stores them in the safetensors layout. Buffer
-    names are generated from `buffer_key` and `form_key` and can be controlled to
-    match downstream consumers or to allow reuse of existing serialization layouts.
+    buffers via `ak.to_buffers` and stores them in the safetensors format. Buffer names
+    are generated from `buffer_key` and `form_key` templates, allowing downstream
+    compatibility or layout reuse.
      The resulting safetensors file includes metadata containing the Awkward `form` and
      array `length`, which are required for `ak.from_safetensors` to reconstruct the array.
     Args:

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -11,7 +11,7 @@ __all__ = ("to_safetensors",)
 
 
 @high_level_function()
-def to_safetensors( 
+def to_safetensors(
     array,
     destination,
     *,
@@ -71,7 +71,7 @@ def to_safetensors(
         >>> arr = ak.Array([[1, 2, 3], [], [4]])
         >>> ak.to_safetensors(arr, "out.safetensors")
 
-    
+
     See also #ak.from_safetensors.
     """
     # Implementation
@@ -87,7 +87,6 @@ def to_safetensors(
     )
 
 
-
 def _impl(
     array,
     destination,
@@ -96,7 +95,7 @@ def _impl(
     form_key,
     id_start,
     backend,
-    byteorder,  
+    byteorder,
 ):
     try:
         from safetensors.numpy import save_file
@@ -108,7 +107,7 @@ def _impl(
 or
         conda install -c huggingface safetensors"""
         ) from err
-    
+
     form, length, buffers = ak.ak_to_buffers._impl(
         array,
         container=container,

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -1,0 +1,127 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import json
+
+import awkward as ak
+from awkward._dispatch import high_level_function
+
+__all__ = ("to_safetensors",)
+
+
+@high_level_function()
+def to_safetensors( 
+    array,
+    destination,
+    *,
+    # ak.to_buffers kwargs
+    container=None,
+    buffer_key="{form_key}-{attribute}",
+    form_key="node{id}",
+    id_start=0,
+    backend=None,
+    byteorder=ak._util.native_byteorder,
+):
+    """Serialize an Awkward Array to the safetensors format and write it to `destination`.
+
+    Ref: https://huggingface.co/docs/safetensors/.
+
+    This function converts the provided Awkward Array (or array-like object) into raw
+    buffers (via ak.to_buffers) and stores them in the safetensors layout. Buffer
+    names are generated from `buffer_key` and `form_key` and can be controlled to
+    match downstream consumers or to allow reuse of existing serialization layouts.
+
+    Args:
+        array: An Awkward Array or array-like object to serialize.
+        destination (str or pathlib.Path or file-like): Path to write the resulting
+            safetensors file, or a writable binary file-like object.
+        container (dict, optional): A mapping to receive the raw buffers produced by
+            ak.to_buffers. If provided, the function will populate this dict with
+            {buffer_key: bytes} entries. If None (the default), a temporary container
+            is used for writing and discarded after the file is created.
+        buffer_key (str, optional): A format string used to name each buffer in the
+            safetensors container. May include placeholders such as
+            "{form_key}" and "{attribute}" (default: "{form_key}-{attribute}").
+        form_key (str, optional): A format string used to name node forms when
+            generating buffer keys; typically contains an "{id}" placeholder
+            (default: "node{id}").
+        id_start (int, optional): Starting index for node numbering used by `form_key`
+            (default: 0).
+        backend (str or object, optional): Backend selection passed through to
+            ak.to_buffers for converting array data to raw buffers (e.g., numpy
+            backend or an Awkward array backend object). If None, the library's
+            default backend is used.
+        byteorder (str, optional): Byte order to use when encoding numeric buffers.
+            Defaults to the system native byteorder.
+
+    Returns:
+        None: The function writes the safetensors file to `destination`. If a
+        `container` was provided, it will be populated with the generated buffer
+        bytes and can be inspected or reused by the caller.
+
+    Raises:
+        ValueError: If `destination` is not writable or otherwise invalid.
+        TypeError: If `array` is not an Awkward Array or an object convertible to one.
+        RuntimeError: If an error occurs while serializing buffers or writing the file.
+
+    Here is a simple example:
+
+        >>> import awkward as ak
+        >>> arr = ak.Array([[1, 2, 3], [], [4]])
+        >>> ak.to_safetensors(arr, "out.safetensors")
+
+    
+    See also #ak.from_safetensors.
+    """
+    # Implementation
+    return _impl(
+        array,
+        destination,
+        container,
+        buffer_key,
+        form_key,
+        id_start,
+        backend,
+        byteorder,
+    )
+
+
+
+def _impl(
+    array,
+    destination,
+    container,
+    buffer_key,
+    form_key,
+    id_start,
+    backend,
+    byteorder,  
+):
+    try:
+        from safetensors.numpy import save_file
+    except ImportError as err:
+        raise ImportError(
+            """to use ak.to_safetensors, you must install the 'safetensors' package with:
+
+        pip install safetensors
+or
+        conda install -c huggingface safetensors"""
+        ) from err
+    
+    form, length, buffers = ak.ak_to_buffers._impl(
+        array,
+        container=container,
+        buffer_key=buffer_key,
+        form_key=form_key,
+        id_start=id_start,
+        backend=backend,
+        byteorder=byteorder,
+    )
+
+    metadata = {
+        "form": form.to_json(),
+        "length": json.dumps(length),
+    }
+    # save
+    save_file(buffers, destination, metadata)

--- a/src/awkward/operations/ak_to_safetensors.py
+++ b/src/awkward/operations/ak_to_safetensors.py
@@ -120,4 +120,9 @@ or
         "length": json.dumps(length),
     }
     # save
-    save_file(buffers, destination, metadata)
+    try:
+      save_file(buffers, destination, metadata)
+    except Exception as err:
+      raise RuntimeError(
+          f"Failed to write safetensors file to '{destination}': {err}"
+      ) from err

--- a/tests/test_3685_to_from_safetensors.py
+++ b/tests/test_3685_to_from_safetensors.py
@@ -1,0 +1,28 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+#
+from __future__ import annotations
+
+import os
+
+import pytest
+
+safetensors = pytest.importorskip("safetensors")
+
+
+def test_roundtrip():
+    import awkward as ak
+
+    array = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
+
+    path = "./test.safetensors"
+    ak.to_safetensors(array, path)
+
+    loaded = ak.from_safetensors(path)
+    virtual_loaded = ak.from_safetensors(path, virtual=True)
+
+    os.remove(path)
+
+    assert array.layout.is_equal_to(loaded.layout, all_parameters=True)
+    assert array.layout.is_equal_to(
+        virtual_loaded.layout.materialize(), all_parameters=True
+    )

--- a/tests/test_3685_to_from_safetensors.py
+++ b/tests/test_3685_to_from_safetensors.py
@@ -26,3 +26,24 @@ def test_roundtrip():
     assert array.layout.is_equal_to(
         virtual_loaded.layout.materialize(), all_parameters=True
     )
+
+
+def test_virtual_array_to_safetensors():
+    import awkward as ak
+
+    array = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
+
+    path = "./test_virtual{}.safetensors".format
+
+    ak.to_safetensors(array, path(0))
+    virtual_loaded = ak.from_safetensors(path(0), virtual=True)
+
+    ak.to_safetensors(virtual_loaded, path(1))
+    loaded = ak.from_safetensors(path(1), virtual=False)
+
+    os.remove(path(0))
+    os.remove(path(1))
+
+    assert virtual_loaded.layout.materialize().is_equal_to(
+        loaded.layout, all_parameters=True
+    )


### PR DESCRIPTION
This PR adds to and from [safetensors](https://huggingface.co/docs/safetensors/index) conversions. They're extremely fast at the cost of file size because they to not include any compression.  The idea is that all buffers are saved as a long sequence of uncompressed bytes along with metadata that remembers where each buffers starts and stops (similar to an awkward array). Loading it mmaps the file and accessing individual buffers loads only the corresponding slice into memory. This is basically what zarr does but with a dynamic chunk size instead of a static one (which is good for us, because we don't have rectangular arrays) and when one turns off compression.