### PR TITLE
chore: small inconsistency/typo with the non-jax case below

### DIFF
--- a/src/awkward/operations/ak_merge_union_of_records.py
+++ b/src/awkward/operations/ak_merge_union_of_records.py
@@ -116,7 +116,9 @@ def _impl(array, axis, highlevel, behavior, attrs):
                     tagged_content.length + 1, dtype=np.int64
                 )
                 if isinstance(nplike, Jax):
-                    indexedoption_index = indexedoption_index.at[-1].set(-1)
+                    indexedoption_index = indexedoption_index.at[
+                        nplike.shape_item_as_index(tagged_content.length)
+                    ].set(-1)
                 else:
                     indexedoption_index[
                         nplike.shape_item_as_index(tagged_content.length)


### PR DESCRIPTION
Something I accidentally introduced in https://github.com/scikit-hep/awkward/pull/3596
To be fair, it's correct either way because `indexedoption_index` is
```py
                indexedoption_index = nplike.arange(
                    tagged_content.length + 1, dtype=np.int64
                )
```
Which means that it has length `tagged_content.length ` so setting the item at `nplike.shape_item_as_index(tagged_content.length)` is just setting it at `-1`. It's just that I don't like seeing it be different from the non-jax case right below :smile:.