### PR TITLE
feat: add behavior cls validation hook

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -380,6 +380,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def _update_class(self):
         self._numbaview = None
         self.__class__ = get_array_class(self._layout, self._behavior)
+        if hasattr(self, "__awkward_validation__"):
+            self.__awkward_validation__()
 
     @property
     def attrs(self) -> Attrs:
@@ -1201,15 +1203,15 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             ):
                 raise TypeError("only fields may be assigned in-place (by field name)")
 
-            self._layout = ak.operations.with_field(
-                self._layout,
+            # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
+            self.layout = ak.operations.with_field(
+                self.layout,
                 what,
                 where,
                 highlevel=False,
                 attrs=self._attrs,
                 behavior=self._behavior,
             )
-            self._numbaview = None
 
     def __delitem__(self, where):
         """
@@ -1238,14 +1240,14 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             ):
                 raise TypeError("only fields may be removed in-place (by field name)")
 
-            self._layout = ak.operations.ak_without_field._impl(
-                self._layout,
+            # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
+            self.layout = ak.operations.ak_without_field._impl(
+                self.layout,
                 where,
                 highlevel=False,
                 behavior=self._behavior,
                 attrs=self._attrs,
             )
-            self._numbaview = None
 
     def __getattr__(self, where):
         """
@@ -1917,6 +1919,8 @@ class Record(NDArrayOperatorsMixin):
     def _update_class(self):
         self._numbaview = None
         self.__class__ = get_record_class(self._layout, self._behavior)
+        if hasattr(self, "__awkward_validation__"):
+            self.__awkward_validation__()
 
     @property
     def attrs(self) -> Attrs:
@@ -2157,15 +2161,17 @@ class Record(NDArrayOperatorsMixin):
             ):
                 raise TypeError("only fields may be assigned in-place (by field name)")
 
-            self._layout._array = ak.operations.ak_with_field._impl(
-                self._layout.array,
+            # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
+            layout = self.layout
+            layout._array = ak.operations.ak_with_field._impl(
+                layout._array,
                 what,
                 where,
                 highlevel=False,
                 behavior=self._behavior,
                 attrs=self._attrs,
             )
-            self._numbaview = None
+            self.layout = layout
 
     def __delitem__(self, where):
         """
@@ -2195,14 +2201,14 @@ class Record(NDArrayOperatorsMixin):
             ):
                 raise TypeError("only fields may be removed in-place (by field name)")
 
-            self._layout = ak.operations.ak_without_field._impl(
-                self._layout,
+            # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
+            self.layout = ak.operations.ak_without_field._impl(
+                self.layout,
                 where,
                 highlevel=False,
                 behavior=self._behavior,
                 attrs=self._attrs,
             )
-            self._numbaview = None
 
     def __getattr__(self, where):
         """

--- a/tests/test_3710_behavior_validation.py
+++ b/tests/test_3710_behavior_validation.py
@@ -1,0 +1,75 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_only_floats_validation():
+    class OnlyFloatsError(Exception): ...
+
+    class OnlyFloats(ak.Array):
+        def __awkward_validation__(self) -> None:
+            def _content_only_floats(layout, **kwargs) -> None:
+                del kwargs
+                if layout.is_numpy:
+                    if not np.issubdtype(layout.dtype, np.floating):
+                        raise OnlyFloatsError(
+                            "OnlyFloats arrays can only contain floating-point numbers."
+                        )
+
+            _ = ak.transform(_content_only_floats, self, return_value="none")
+
+    behavior = {
+        "OnlyFloats": OnlyFloats,
+        ("*", "OnlyFloats"): OnlyFloats,
+    }
+
+    # this should pass
+    _ = ak.with_parameter([1.0], "__list__", "OnlyFloats", behavior=behavior)
+
+    # this should fail
+    with pytest.raises(OnlyFloatsError):
+        _ = ak.with_parameter([1], "__list__", "OnlyFloats", behavior=behavior)
+
+
+def test_field_validation():
+    class OnlyAllowedFieldsError(Exception): ...
+
+    class OnlyAllowedFields(ak.Array):
+        _allowed_fields = frozenset({"pt", "eta", "phi", "mass"})
+
+        def __awkward_validation__(self) -> None:
+            fields = set(self.fields)
+            if self._allowed_fields != fields:
+                raise OnlyAllowedFieldsError(
+                    f"OnlyAllowedFields arrays can only have fields: {self._allowed_fields}, "
+                    f"but found fields: {fields}"
+                )
+
+    behavior = {
+        "OnlyAllowedFields": OnlyAllowedFields,
+        ("*", "OnlyAllowedFields"): OnlyAllowedFields,
+    }
+
+    # this should pass
+    _ = ak.with_parameter(
+        [{"pt": 1.0, "eta": 1.0, "phi": 1.0, "mass": 1.0}],
+        "__list__",
+        "OnlyAllowedFields",
+        behavior=behavior,
+    )
+
+    # this should fail
+    with pytest.raises(
+        OnlyAllowedFieldsError, match="OnlyAllowedFields arrays can only have fields"
+    ):
+        _ = ak.with_parameter(
+            [{"pt": 1.0, "eta": 1.0, "phi": 1.0, "mass": 1.0, "energy": 1.0}],
+            "__list__",
+            "OnlyAllowedFields",
+            behavior=behavior,
+        )


### PR DESCRIPTION
This PR adds a way to run a validation method for behaviors, this helps to solve https://github.com/scikit-hep/vector/discussions/660.

A behavior may now implement the `__awkward_validation__` method. It is run everytime awkward wants to update the class type of an highlevel array (which is on every instance creation, or 'in-place' mutation like `__setitem__` or `__delitem__` with fields. This implementation is non-invasive and safe in the sense that `self` is immutable (see its `__setattr__` implementation) and is run right [before the `ak.validity_error` check](https://github.com/scikit-hep/awkward/blob/main/src/awkward/highlevel.py#L365-L368). 

It is meant to be used for fast metadata checks, i.e. are certain fields present or not. This is _not_ the right place to do O(n) array operations! <- I'll make this very explicit in the docs.

Also closes https://github.com/scikit-hep/awkward/issues/1483.

---
Opening this in draft for now as I'm planning to add tests and docs tomorrow.