### PR TITLE
fix: typestr respects now limit_cols for .show and _repr_mimebundle_

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1456,6 +1456,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             # it's always the second row (after the array)
             type_line = rows.pop(0)
             out_io.write(type_line)
+            out_io.write("\n")
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_
@@ -2402,6 +2403,7 @@ class Record(NDArrayOperatorsMixin):
             # it's always the second row (after the array)
             type_line = rows.pop(0)
             out_io.write(type_line)
+            out_io.write("\n")
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_

--- a/src/awkward/prettyprint.py
+++ b/src/awkward/prettyprint.py
@@ -487,6 +487,9 @@ def highlevel_array_show_rows(
         array.type.show(stream=typeio)
         type_line = "type: "
         type_line += typeio.getvalue().removesuffix("\n")
+        # crop type line if too long
+        if len(type_line) > limit_cols:
+            type_line = type_line[: limit_cols - 3] + "..."
         rows.append(type_line)
 
     # other info
@@ -495,6 +498,9 @@ def highlevel_array_show_rows(
         named_axis_line += _prettify_named_axes(
             array.named_axis, delimiter=", ", maxlen=None
         )
+        # crop named axis line if too long
+        if len(named_axis_line) > limit_cols:
+            named_axis_line = named_axis_line[: limit_cols - 3] + "..."
         rows.append(named_axis_line)
     if nbytes:
         if array.nbytes is unknown_length:


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3705.

The type string in `.show` and `_repr_mimebundle_` (notebook repr) now respects the `limit_cols` arguments:
```python
import awkward as ak
arr = ak.with_parameter([1,2], "systematics", ["some_name"]*500)

arr.show(all=True)
# type: 2 * int64[parameters={"systematics": ["some_name", "some_name", "some_n...
# nbytes: 16 B
# backend: cpu
# [1,
#  2]
```

and for notebooks:
```python
print(arr._repr_mimebundle_()['text/html'])
# <pre>[1,
#  2]
# ---
# backend: cpu
# nbytes: 16 B
# type: 2 * int64[parameters={&quot;systematics&quot;: [&quot;some_name&quot;, &quot;some_name&quot;, &quot;some_n...</pre>
```
which renders to:
```
[1,
 2]
---
backend: cpu
nbytes: 16 B
type: 2 * int64[parameters={"systematics": ["some_name", "some_name", "some_n...
```

I fixed the same also for `named_axis`, in this PR. 