### PR TITLE
fix: only check length against empty form in `ak.from_buffers` if it is known

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -266,7 +266,7 @@ def _reconstitute(
     shape_generator,
 ):
     if isinstance(form, ak.forms.EmptyForm):
-        if length != 0:
+        if length is not unknown_length and length != 0:
             raise ValueError(f"EmptyForm node, but the expected length is {length}")
         return ak.contents.EmptyArray(backend=backend)
 


### PR DESCRIPTION
We cannot check if the length is zero in the case of `EmptyForm` if the recursion earlier set it to unknown length. We skip the check in that case.