### PR TITLE
fix: incorrect passing of `Index` inside nplike function in `to_IndexedOptionArray64`

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -269,7 +269,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return self
         else:
             return IndexedOptionArray(
-                self._index.to64()
+                self._index.to64(),
                 self._content,
                 parameters=self._parameters,
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -269,9 +269,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return self
         else:
             return IndexedOptionArray(
-                ak.index.Index64(
-                    self._backend.nplike.astype(self._index.data, dtype=np.int64)
-                ),
+                self._index.to64()
                 self._content,
                 parameters=self._parameters,
             )

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -269,7 +269,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return self
         else:
             return IndexedOptionArray(
-                self._backend.nplike.astype(self._index, dtype=np.int64),
+                ak.index.Index64(
+                    self._backend.nplike.astype(self._index.data, dtype=np.int64)
+                ),
                 self._content,
                 parameters=self._parameters,
             )

--- a/tests/test_3727_to_indexedoptionarray64_with_int32_index.py
+++ b/tests/test_3727_to_indexedoptionarray64_with_int32_index.py
@@ -10,10 +10,9 @@ import awkward as ak
 def test():
     index32 = ak.index.Index(np.array([0, 1, -1], dtype=np.int32))
     content = ak.contents.NumpyArray(np.array([10, 20, 30]))
-
     arr = ak.contents.IndexedOptionArray(index32, content)
-
     new_arr = arr.to_IndexedOptionArray64()
+
     assert arr.index.dtype == np.dtype("int32")
     assert new_arr.index.dtype == np.dtype("int64")
     assert arr.to_list() == new_arr.to_list()

--- a/tests/test_3727_to_indexedoptionarray64_with_int32_index.py
+++ b/tests/test_3727_to_indexedoptionarray64_with_int32_index.py
@@ -1,0 +1,19 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test():
+    index32 = ak.index.Index(np.array([0, 1, -1], dtype=np.int32))
+    content = ak.contents.NumpyArray(np.array([10, 20, 30]))
+
+    arr = ak.contents.IndexedOptionArray(index32, content)
+
+    new_arr = arr.to_IndexedOptionArray64()
+    assert arr.index.dtype == np.dtype("int32")
+    assert new_arr.index.dtype == np.dtype("int64")
+    assert arr.to_list() == new_arr.to_list()


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/3726

The index's data should be passed into the nplike function. Not the index itself. It's just a typo.