### PR TITLE
fix: `ArrayBuilder.__bool__ ` raises `TypeError` when builder length is 1

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2929,7 +2929,7 @@ class ArrayBuilder(Sized):
 
     def __bool__(self):
         if len(self) == 1:
-            return bool(self[0])
+            return bool(self.snapshot()[0])
         else:
             raise ValueError(
                 "the truth value of an array whose length is not 1 is ambiguous; "


### PR DESCRIPTION
Closes #3732 

The implementation explicitly checks `len(self) == 1`, but then attempts to access `self[0]`, even though `ArrayBuilder` does not implement `__getitem__`. Change it to fetch the value from the snapshot instead.