### PR TITLE
chore: update requirements files for latest possible python versions

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,9 +1,9 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-jax[cpu]>=0.2.15;sys_platform != "win32" and python_version < "3.13"
-numba>=0.50.0;sys_platform != "win32" and python_version < "3.13"
-numexpr>=2.7; python_version < "3.14"
-pandas>=0.24.0;sys_platform != "win32" and python_version < "3.14"
-pyarrow>=12.0.0;sys_platform != "win32" and python_version < "3.14"
+jax[cpu]>=0.2.15;sys_platform != "win32"
+numba>=0.50.0;sys_platform != "win32" and python_version < "3.14"
+numexpr>=2.7
+pandas>=0.24.0;sys_platform != "win32"
+pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
As far as I'm aware, jax, numexpr, pandas, and pyarrow all have 3.14 wheels. Numba only has them in pre-release at the time of writing. The requirements files should be updated accordingly