### PR TITLE
feat: ability to optionally disable the caching of virtual arrays on themselves

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -80,6 +80,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     obj._dtype if dtype is None else dtype,
                     lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
                     lambda: obj.shape,
+                    __disable_caching__=obj.__disable_caching__,
                 )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
@@ -108,6 +109,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     x._dtype,
                     lambda: self.ascontiguousarray(x.materialize()),  # type: ignore[arg-type]
                     lambda: x.shape,
+                    __disable_caching__=x.__disable_caching__,
                 )
         else:
             return self._module.ascontiguousarray(x)
@@ -356,6 +358,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     x.dtype,
                     lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[arg-type]
                     None,
+                    __disable_caching__=x.__disable_caching__,
                 )
 
         if copy is None:

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -80,7 +80,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     obj._dtype if dtype is None else dtype,
                     lambda: self.asarray(obj.materialize(), dtype=dtype, copy=copy),
                     lambda: obj.shape,
-                    __disable_caching__=obj.__disable_caching__,
+                    __enable_caching__=obj.__enable_caching__,
                 )
         if copy:
             return self._module.array(obj, dtype=dtype, copy=True)
@@ -109,7 +109,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     x._dtype,
                     lambda: self.ascontiguousarray(x.materialize()),  # type: ignore[arg-type]
                     lambda: x.shape,
-                    __disable_caching__=x.__disable_caching__,
+                    __enable_caching__=x.__enable_caching__,
                 )
         else:
             return self._module.ascontiguousarray(x)
@@ -358,7 +358,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
                     x.dtype,
                     lambda: self.reshape(x.materialize(), next_shape, copy=copy),  # type: ignore[arg-type]
                     None,
-                    __disable_caching__=x.__disable_caching__,
+                    __enable_caching__=x.__enable_caching__,
                 )
 
         if copy is None:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -81,7 +81,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
         generator: Callable[[], ArrayLike],
         shape_generator: Callable[[], tuple[ShapeItem, ...]] | None = None,
         __wrap_generator_asarray__: bool = False,
-        __disable_caching__: bool = False,
+        __enable_caching__: bool = True,
     ) -> None:
         if not nplike.supports_virtual_arrays:
             raise TypeError(
@@ -105,7 +105,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
         self._generator = generator
         self._shape_generator = shape_generator
 
-        self.__disable_caching__ = __disable_caching__
+        self.__enable_caching__ = __enable_caching__
 
     @property
     def dtype(self) -> DType:
@@ -183,7 +183,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                     f"{type(self).__name__} had dtype {self._dtype} before materialization while the materialized array has dtype {array.dtype}"
                 )
             self._shape = array.shape
-            if not self.__disable_caching__:
+            if self.__enable_caching__:
                 self._array = array
                 self._shape_generator = assert_never
                 self._generator = assert_never
@@ -210,7 +210,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: self.materialize().T,
             lambda: self.shape[::-1],
-            __disable_caching__=self.__disable_caching__,
+            __enable_caching__=self.__enable_caching__,
         )
 
     def view(self, dtype: DTypeLike) -> Self:
@@ -243,7 +243,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             dtype,
             lambda: self.materialize().view(dtype),
             None,
-            __disable_caching__=self.__disable_caching__,
+            __enable_caching__=self.__enable_caching__,
         )
 
     @property
@@ -270,7 +270,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: self.materialize().byteswap(inplace=inplace),
             lambda: self.shape,
-            __disable_caching__=self.__disable_caching__,
+            __enable_caching__=self.__enable_caching__,
         )
 
     def tobytes(self, order="C") -> bytes:
@@ -283,7 +283,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             self._generator,
             self._shape_generator,
-            __disable_caching__=self.__disable_caching__,
+            __enable_caching__=self.__enable_caching__,
         )
         new_virtual._array = self._array
         return new_virtual
@@ -296,7 +296,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: copy.deepcopy(current_generator(), memo),
             self._shape_generator,
-            __disable_caching__=self.__disable_caching__,
+            __enable_caching__=self.__enable_caching__,
         )
         new_virtual._array = (
             copy.deepcopy(self._array, memo)
@@ -350,7 +350,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 self._dtype,
                 lambda: self.materialize()[index],
                 None,
-                __disable_caching__=self.__disable_caching__,
+                __enable_caching__=self.__enable_caching__,
             )
         else:
             return self.materialize().__getitem__(index)

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -81,6 +81,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
         generator: Callable[[], ArrayLike],
         shape_generator: Callable[[], tuple[ShapeItem, ...]] | None = None,
         __wrap_generator_asarray__: bool = False,
+        __disable_caching__: bool = False,
     ) -> None:
         if not nplike.supports_virtual_arrays:
             raise TypeError(
@@ -103,6 +104,8 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
 
         self._generator = generator
         self._shape_generator = shape_generator
+
+        self.__disable_caching__ = __disable_caching__
 
     @property
     def dtype(self) -> DType:
@@ -180,9 +183,11 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                     f"{type(self).__name__} had dtype {self._dtype} before materialization while the materialized array has dtype {array.dtype}"
                 )
             self._shape = array.shape
-            self._array = array
-            self._shape_generator = assert_never
-            self._generator = assert_never
+            if not self.__disable_caching__:
+                self._array = array
+                self._shape_generator = assert_never
+                self._generator = assert_never
+            return array
         return self._array  # type: ignore[return-value]
 
     @property
@@ -205,6 +210,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: self.materialize().T,
             lambda: self.shape[::-1],
+            __disable_caching__=self.__disable_caching__,
         )
 
     def view(self, dtype: DTypeLike) -> Self:
@@ -237,6 +243,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             dtype,
             lambda: self.materialize().view(dtype),
             None,
+            __disable_caching__=self.__disable_caching__,
         )
 
     @property
@@ -263,6 +270,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: self.materialize().byteswap(inplace=inplace),
             lambda: self.shape,
+            __disable_caching__=self.__disable_caching__,
         )
 
     def tobytes(self, order="C") -> bytes:
@@ -275,6 +283,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             self._generator,
             self._shape_generator,
+            __disable_caching__=self.__disable_caching__,
         )
         new_virtual._array = self._array
         return new_virtual
@@ -287,6 +296,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
             self._dtype,
             lambda: copy.deepcopy(current_generator(), memo),
             self._shape_generator,
+            __disable_caching__=self.__disable_caching__,
         )
         new_virtual._array = (
             copy.deepcopy(self._array, memo)
@@ -340,6 +350,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 self._dtype,
                 lambda: self.materialize()[index],
                 None,
+                __disable_caching__=self.__disable_caching__,
             )
         else:
             return self.materialize().__getitem__(index)

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -65,6 +65,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
     """
 
     __slots__ = (
+        "__enable_caching__",
         "_array",
         "_dtype",
         "_generator",

--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -115,7 +115,7 @@ def unpickle_array_schema_1(
         buffer_key="{form_key}-{attribute}",
         byteorder="<",
         simplify=False,
-        disable_virtualarray_caching=False,
+        enable_virtualarray_caching=True,
     )
 
 
@@ -142,7 +142,7 @@ def unpickle_record_schema_1(
         buffer_key="{form_key}-{attribute}",
         byteorder="<",
         simplify=False,
-        disable_virtualarray_caching=False,
+        enable_virtualarray_caching=True,
     )
     layout = LowLevelRecord(array_layout, at)
     return Record(layout, behavior=behavior, attrs=attrs)

--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -115,6 +115,7 @@ def unpickle_array_schema_1(
         buffer_key="{form_key}-{attribute}",
         byteorder="<",
         simplify=False,
+        disable_virtualarray_caching=False,
     )
 
 
@@ -141,6 +142,7 @@ def unpickle_record_schema_1(
         buffer_key="{form_key}-{attribute}",
         byteorder="<",
         simplify=False,
+        disable_virtualarray_caching=False,
     )
     layout = LowLevelRecord(array_layout, at)
     return Record(layout, behavior=behavior, attrs=attrs)

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -540,6 +540,7 @@ class Form(Meta):
             behavior=behavior,
             attrs=None,
             simplify=False,
+            disable_virtualarray_caching=False,
         )
 
     def length_one_array(
@@ -696,6 +697,7 @@ class Form(Meta):
             behavior=behavior,
             attrs=None,
             simplify=False,
+            disable_virtualarray_caching=False,
         )
 
     def _expected_from_buffers(

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -540,7 +540,7 @@ class Form(Meta):
             behavior=behavior,
             attrs=None,
             simplify=False,
-            disable_virtualarray_caching=False,
+            enable_virtualarray_caching=True,
         )
 
     def length_one_array(
@@ -697,7 +697,7 @@ class Form(Meta):
             behavior=behavior,
             attrs=None,
             simplify=False,
-            disable_virtualarray_caching=False,
+            enable_virtualarray_caching=True,
         )
 
     def _expected_from_buffers(

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2953,6 +2953,7 @@ class ArrayBuilder(Sized):
                 backend="cpu",
                 byteorder=ak._util.native_byteorder,
                 simplify=True,
+                disable_virtualarray_caching=False,
                 highlevel=True,
                 behavior=self._behavior,
                 attrs=self._attrs,

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2953,7 +2953,7 @@ class ArrayBuilder(Sized):
                 backend="cpu",
                 byteorder=ak._util.native_byteorder,
                 simplify=True,
-                disable_virtualarray_caching=False,
+                enable_virtualarray_caching=True,
                 highlevel=True,
                 behavior=self._behavior,
                 attrs=self._attrs,

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -73,6 +73,6 @@ def _impl(form, length, container, highlevel, behavior, attrs):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
-        disable_virtualarray_caching=False,
+        enable_virtualarray_caching=True,
         attrs=attrs,
     )

--- a/src/awkward/operations/ak_from_avro_file.py
+++ b/src/awkward/operations/ak_from_avro_file.py
@@ -73,5 +73,6 @@ def _impl(form, length, container, highlevel, behavior, attrs):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
+        disable_virtualarray_caching=False,
         attrs=attrs,
     )

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -157,7 +157,7 @@ def _impl(
 
     if isinstance(disable_virtualarray_caching, bool):
 
-        def disable_caching_function(attribute):
+        def disable_caching_function(attribute, form_key):
             return disable_virtualarray_caching
     elif callable(disable_virtualarray_caching):
         disable_caching_function = disable_virtualarray_caching
@@ -297,7 +297,8 @@ def _reconstitute(
 
     elif isinstance(form, ak.forms.NumpyForm):
         dtype = ak.types.numpytype.primitive_to_dtype(form.primitive)
-        raw_array = container[getkey(form, "data")]
+        form_key = getkey(form, "data")
+        raw_array = container[form_key]
 
         def _adjust_length(length):
             return length * math.prod(form.inner_shape)
@@ -316,7 +317,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("data"),
+            disable_virtualarray_caching=disable_virtualarray_caching("data", form_key),
         )
         if form.inner_shape != ():
             data = backend.nplike.reshape(data, (length, *form.inner_shape))
@@ -345,7 +346,8 @@ def _reconstitute(
         return make(content, parameters=form._parameters)
 
     elif isinstance(form, ak.forms.BitMaskedForm):
-        raw_array = container[getkey(form, "mask")]
+        form_key = getkey(form, "mask")
+        raw_array = container[form_key]
 
         def _adjust_length(length):
             return math.ceil(length / 8.0)
@@ -367,7 +369,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("mask"),
+            disable_virtualarray_caching=disable_virtualarray_caching("mask", form_key),
         )
         content = _reconstitute(
             form.content,
@@ -398,7 +400,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ByteMaskedForm):
-        raw_array = container[getkey(form, "mask")]
+        form_key = getkey(form, "mask")
+        raw_array = container[form_key]
         mask = _from_buffer(
             backend.nplike,
             raw_array,
@@ -407,7 +410,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("mask"),
+            disable_virtualarray_caching=disable_virtualarray_caching("mask", form_key),
         )
         content = _reconstitute(
             form.content,
@@ -433,7 +436,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.IndexedOptionForm):
-        raw_array = container[getkey(form, "index")]
+        form_key = getkey(form, "index")
+        raw_array = container[form_key]
         index = _from_buffer(
             backend.nplike,
             raw_array,
@@ -442,7 +446,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("index"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "index", form_key
+            ),
         )
 
         def _adjust_length(index):
@@ -478,7 +484,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.IndexedForm):
-        raw_array = container[getkey(form, "index")]
+        form_key = getkey(form, "index")
+        raw_array = container[form_key]
         index = _from_buffer(
             backend.nplike,
             raw_array,
@@ -487,7 +494,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("index"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "index", form_key
+            ),
         )
 
         def _adjust_length(index):
@@ -527,8 +536,10 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ListForm):
-        raw_array1 = container[getkey(form, "starts")]
-        raw_array2 = container[getkey(form, "stops")]
+        form_key1 = getkey(form, "starts")
+        form_key2 = getkey(form, "stops")
+        raw_array1 = container[form_key1]
+        raw_array2 = container[form_key2]
         starts = _from_buffer(
             backend.nplike,
             raw_array1,
@@ -537,7 +548,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("starts"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "starts", form_key1
+            ),
         )
         stops = _from_buffer(
             backend.nplike,
@@ -547,7 +560,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("stops"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "stops", form_key2
+            ),
         )
 
         def _adjust_length(starts, stops):
@@ -583,7 +598,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ListOffsetForm):
-        raw_array = container[getkey(form, "offsets")]
+        form_key = getkey(form, "offsets")
+        raw_array = container[form_key]
 
         def _shape_generator():
             (first,) = shape_generator()
@@ -597,7 +613,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("offsets"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "offsets", form_key
+            ),
         )
 
         # next length
@@ -685,8 +703,10 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.UnionForm):
-        raw_array1 = container[getkey(form, "tags")]
-        raw_array2 = container[getkey(form, "index")]
+        form_key1 = getkey(form, "tags")
+        form_key2 = getkey(form, "index")
+        raw_array1 = container[form_key1]
+        raw_array2 = container[form_key2]
         tags = _from_buffer(
             backend.nplike,
             raw_array1,
@@ -695,7 +715,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("tags"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "tags", form_key1
+            ),
         )
         index = _from_buffer(
             backend.nplike,
@@ -705,7 +727,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("index"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                "index", form_key2
+            ),
         )
 
         def _adjust_length(index, tags, tag):

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -36,6 +36,7 @@ def from_buffers(
     backend="cpu",
     byteorder="<",
     allow_noncanonical_form=False,
+    disable_virtual_array_caching=False,
     highlevel=True,
     behavior=None,
     attrs=None,
@@ -107,6 +108,8 @@ def from_buffers(
 
     See #ak.to_buffers for examples.
     """
+    global __disable_virtual_array_caching__
+    __disable_virtual_array_caching__ = disable_virtual_array_caching
     return _impl(
         form,
         length,
@@ -222,6 +225,7 @@ def _from_buffer(
             generator=generator,
             shape_generator=cached_shape_generator,
             __wrap_generator_asarray__=True,
+            __disable_caching__=__disable_virtual_array_caching__,
         )
     # Unknown-length information implies that we didn't load shape-buffers (offsets, etc)
     # for the parent of this node. Thus, this node and its children *must* only

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -64,6 +64,14 @@ def from_buffers(
         allow_noncanonical_form (bool): If True, non-canonical forms will be
             simplified to produce arrays with canonical layouts; otherwise,
             an exception will be thrown for such forms.
+        disavle_virtualarray_caching (bool or callable): If True, all VirtualNDArray
+            buffers that get created will not cache their materialized buffers
+            on themselves when they get materialized. If a callable is given, it
+            must accept two arguments, `form_key` and `attribute`, and return a
+            boolean indicating whether caching should be disabled for the given
+            buffer. The `form_key` and `attribute` are the same as those passed to
+            the `buffer_key` function. If False, all VirtualNDArrays will cache their
+            materialized buffers on themselves (default behavior).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -305,8 +305,7 @@ def _reconstitute(
 
     elif isinstance(form, ak.forms.NumpyForm):
         dtype = ak.types.numpytype.primitive_to_dtype(form.primitive)
-        form_key = getkey(form, "data")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "data")]
 
         def _adjust_length(length):
             return length * math.prod(form.inner_shape)
@@ -325,7 +324,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "data"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                form.form_key, "data"
+            ),
         )
         if form.inner_shape != ():
             data = backend.nplike.reshape(data, (length, *form.inner_shape))
@@ -354,8 +355,7 @@ def _reconstitute(
         return make(content, parameters=form._parameters)
 
     elif isinstance(form, ak.forms.BitMaskedForm):
-        form_key = getkey(form, "mask")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "mask")]
 
         def _adjust_length(length):
             return math.ceil(length / 8.0)
@@ -377,7 +377,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "mask"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                form.form_key, "mask"
+            ),
         )
         content = _reconstitute(
             form.content,
@@ -408,8 +410,7 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ByteMaskedForm):
-        form_key = getkey(form, "mask")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "mask")]
         mask = _from_buffer(
             backend.nplike,
             raw_array,
@@ -418,7 +419,9 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "mask"),
+            disable_virtualarray_caching=disable_virtualarray_caching(
+                form.form_key, "mask"
+            ),
         )
         content = _reconstitute(
             form.content,
@@ -444,8 +447,7 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.IndexedOptionForm):
-        form_key = getkey(form, "index")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "index")]
         index = _from_buffer(
             backend.nplike,
             raw_array,
@@ -455,7 +457,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key, "index"
+                form.form_key, "index"
             ),
         )
 
@@ -492,8 +494,7 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.IndexedForm):
-        form_key = getkey(form, "index")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "index")]
         index = _from_buffer(
             backend.nplike,
             raw_array,
@@ -503,7 +504,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key, "index"
+                form.form_key, "index"
             ),
         )
 
@@ -544,10 +545,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ListForm):
-        form_key1 = getkey(form, "starts")
-        form_key2 = getkey(form, "stops")
-        raw_array1 = container[form_key1]
-        raw_array2 = container[form_key2]
+        raw_array1 = container[getkey(form, "starts")]
+        raw_array2 = container[getkey(form, "stops")]
         starts = _from_buffer(
             backend.nplike,
             raw_array1,
@@ -557,7 +556,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key1, "starts"
+                form.form_key, "starts"
             ),
         )
         stops = _from_buffer(
@@ -569,7 +568,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key2, "stops"
+                form.form_key, "stops"
             ),
         )
 
@@ -606,8 +605,7 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.ListOffsetForm):
-        form_key = getkey(form, "offsets")
-        raw_array = container[form_key]
+        raw_array = container[getkey(form, "offsets")]
 
         def _shape_generator():
             (first,) = shape_generator()
@@ -622,7 +620,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=_shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key, "offsets"
+                form.form_key, "offsets"
             ),
         )
 
@@ -711,10 +709,8 @@ def _reconstitute(
         )
 
     elif isinstance(form, ak.forms.UnionForm):
-        form_key1 = getkey(form, "tags")
-        form_key2 = getkey(form, "index")
-        raw_array1 = container[form_key1]
-        raw_array2 = container[form_key2]
+        raw_array1 = container[getkey(form, "tags")]
+        raw_array2 = container[getkey(form, "index")]
         tags = _from_buffer(
             backend.nplike,
             raw_array1,
@@ -724,7 +720,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key1, "tags"
+                form.form_key, "tags"
             ),
         )
         index = _from_buffer(
@@ -736,7 +732,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                form_key2, "index"
+                form.form_key, "index"
             ),
         )
 

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -157,7 +157,7 @@ def _impl(
 
     if isinstance(disable_virtualarray_caching, bool):
 
-        def disable_caching_function(attribute, form_key):
+        def disable_caching_function(form_key, attribute):
             return disable_virtualarray_caching
     elif callable(disable_virtualarray_caching):
         disable_caching_function = disable_virtualarray_caching
@@ -317,7 +317,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("data", form_key),
+            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "data"),
         )
         if form.inner_shape != ():
             data = backend.nplike.reshape(data, (length, *form.inner_shape))
@@ -369,7 +369,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=_shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("mask", form_key),
+            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "mask"),
         )
         content = _reconstitute(
             form.content,
@@ -410,7 +410,7 @@ def _reconstitute(
             byteorder=byteorder,
             field_path=field_path,
             shape_generator=shape_generator,
-            disable_virtualarray_caching=disable_virtualarray_caching("mask", form_key),
+            disable_virtualarray_caching=disable_virtualarray_caching(form_key, "mask"),
         )
         content = _reconstitute(
             form.content,
@@ -447,7 +447,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "index", form_key
+                form_key, "index"
             ),
         )
 
@@ -495,7 +495,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "index", form_key
+                form_key, "index"
             ),
         )
 
@@ -549,7 +549,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "starts", form_key1
+                form_key1, "starts"
             ),
         )
         stops = _from_buffer(
@@ -561,7 +561,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "stops", form_key2
+                form_key2, "stops"
             ),
         )
 
@@ -614,7 +614,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=_shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "offsets", form_key
+                form_key, "offsets"
             ),
         )
 
@@ -716,7 +716,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "tags", form_key1
+                form_key1, "tags"
             ),
         )
         index = _from_buffer(
@@ -728,7 +728,7 @@ def _reconstitute(
             field_path=field_path,
             shape_generator=shape_generator,
             disable_virtualarray_caching=disable_virtualarray_caching(
-                "index", form_key2
+                form_key2, "index"
             ),
         )
 

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -112,6 +112,6 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize, attrs):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
-        disable_virtualarray_caching=False,
+        enable_virtualarray_caching=True,
         attrs=attrs,
     )[0]

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -112,5 +112,6 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize, attrs):
         highlevel=highlevel,
         behavior=behavior,
         simplify=True,
+        disable_virtualarray_caching=False,
         attrs=attrs,
     )[0]

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -145,6 +145,7 @@ or
         backend=backend,
         byteorder=byteorder,
         simplify=allow_noncanonical_form,
+        disable_virtualarray_caching=False,
         highlevel=highlevel,
         behavior=behavior,
         attrs=attrs,

--- a/src/awkward/operations/ak_from_safetensors.py
+++ b/src/awkward/operations/ak_from_safetensors.py
@@ -145,7 +145,7 @@ or
         backend=backend,
         byteorder=byteorder,
         simplify=allow_noncanonical_form,
-        disable_virtualarray_caching=False,
+        enable_virtualarray_caching=True,
         highlevel=highlevel,
         behavior=behavior,
         attrs=attrs,

--- a/tests/test_3741_virtualarray_caching.py
+++ b/tests/test_3741_virtualarray_caching.py
@@ -1,0 +1,79 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+
+
+@pytest.mark.parametrize("offsets_length", [5, unknown_length])
+@pytest.mark.parametrize("content_length", [9, unknown_length])
+def test(offsets_length, content_length):
+    offset_generator = lambda: np.array([0, 2, 4, 5, 6], dtype=np.int64)  # noqa: E731
+    data_generator = lambda: np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.int64)  # noqa: E731
+    buffers = {"node0-offsets": offset_generator, "node1-data": data_generator}
+    form = ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("int64", form_key="node1"), form_key="node0"
+    )
+
+    array = ak.from_buffers(form, 4, buffers, enable_virtualarray_caching=True)
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert array.layout.is_all_materialized
+
+    array = ak.from_buffers(form, 4, buffers, enable_virtualarray_caching=False)
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert not array.layout.is_any_materialized
+
+    array = ak.from_buffers(
+        form, 4, buffers, enable_virtualarray_caching=lambda form_key, attribute: True
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert array.layout.is_all_materialized
+
+    array = ak.from_buffers(
+        form, 4, buffers, enable_virtualarray_caching=lambda form_key, attribute: False
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert not array.layout.is_any_materialized
+
+    array = ak.from_buffers(
+        form,
+        4,
+        buffers,
+        enable_virtualarray_caching=lambda form_key, attribute: attribute != "data",
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert array.layout.offsets.is_all_materialized
+    assert not array.layout.content.is_any_materialized
+
+    array = ak.from_buffers(
+        form,
+        4,
+        buffers,
+        enable_virtualarray_caching=lambda form_key, attribute: attribute == "data",
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert not array.layout.offsets.is_any_materialized
+    assert array.layout.content.is_all_materialized
+
+    array = ak.from_buffers(
+        form,
+        4,
+        buffers,
+        enable_virtualarray_caching=lambda form_key, attribute: attribute != "offsets",
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert not array.layout.offsets.is_any_materialized
+    assert array.layout.content.is_all_materialized
+
+    array = ak.from_buffers(
+        form,
+        4,
+        buffers,
+        enable_virtualarray_caching=lambda form_key, attribute: attribute == "offsets",
+    )
+    assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
+    assert array.layout.offsets.is_all_materialized

--- a/tests/test_3741_virtualarray_caching.py
+++ b/tests/test_3741_virtualarray_caching.py
@@ -22,22 +22,26 @@ def test(offsets_length, content_length):
     array = ak.from_buffers(form, 4, buffers, enable_virtualarray_caching=True)
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert array.layout.is_all_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(form, 4, buffers, enable_virtualarray_caching=False)
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert not array.layout.is_any_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form, 4, buffers, enable_virtualarray_caching=lambda form_key, attribute: True
     )
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert array.layout.is_all_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form, 4, buffers, enable_virtualarray_caching=lambda form_key, attribute: False
     )
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert not array.layout.is_any_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form,
@@ -48,6 +52,7 @@ def test(offsets_length, content_length):
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert array.layout.offsets.is_all_materialized
     assert not array.layout.content.is_any_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form,
@@ -58,6 +63,7 @@ def test(offsets_length, content_length):
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert not array.layout.offsets.is_any_materialized
     assert array.layout.content.is_all_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form,
@@ -68,6 +74,7 @@ def test(offsets_length, content_length):
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert not array.layout.offsets.is_any_materialized
     assert array.layout.content.is_all_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]
 
     array = ak.from_buffers(
         form,
@@ -77,3 +84,4 @@ def test(offsets_length, content_length):
     )
     assert array.to_list() == [[1, 2], [3, 4], [5], [6]]
     assert array.layout.offsets.is_all_materialized
+    assert ak.materialize(array).to_list() == [[1, 2], [3, 4], [5], [6]]


### PR DESCRIPTION
This allows us to disable the caching of the materialized array on the virtual array object.
The virtual arrays will still be aware of their generators and be able to materialize again (they just need to call the generator again).
The option is passed through `from_buffers` which is currently the only publicly exposed way to create virtual arrays.
We also have the freedom with this PR to disable the caching only for specific types of buffers. You may want to keep it for offsets only for example but disable it for all the contents. This PR lets you do that.
The reason for this PR is to enable us the ability to handle caching outside of awkward and be able to handle memory and clean up loaded arrays if we want to. This becomes important in low memory workers where you may have needed to materialize some branches at the beginning of the analyses to do a couple of cuts but you don't need them anymore and want to "dematerialize" them to free up memory.

@pfackeldey this is in line with what we discussed regarding what options to allow and what not.