### PR TITLE
fix: prevent teardown from crashing GPU test suite

### DIFF
--- a/tests-cuda/test_2922a_new_cuda_kernels.py
+++ b/tests-cuda/test_2922a_new_cuda_kernels.py
@@ -20,8 +20,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0184_concatenate_operation_records():

--- a/tests-cuda/test_2922b_new_cuda_kernels.py
+++ b/tests-cuda/test_2922b_new_cuda_kernels.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_2651_parameter_union():

--- a/tests-cuda/test_3065a_cuda_kernels.py
+++ b/tests-cuda/test_3065a_cuda_kernels.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0449_merge_many_arrays_in_one_pass_concatenate():

--- a/tests-cuda/test_3065b_cuda_kernels.py
+++ b/tests-cuda/test_3065b_cuda_kernels.py
@@ -14,8 +14,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0582_propagate_context_in_broadcast_and_apply_firsts():

--- a/tests-cuda/test_3065c_cuda_kernels.py
+++ b/tests-cuda/test_3065c_cuda_kernels.py
@@ -14,8 +14,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0546_fill_none_replacement_value_type():

--- a/tests-cuda/test_3086_cuda_concatenate.py
+++ b/tests-cuda/test_3086_cuda_concatenate.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0184_concatenate_number():

--- a/tests-cuda/test_3130_cuda_listarray_getitem_next.py
+++ b/tests-cuda/test_3130_cuda_listarray_getitem_next.py
@@ -22,8 +22,11 @@ offsets2 = ak.index.IndexU32(np.array([0, 2, 3, 3, 5], np.uint32))
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def tests_0020_support_unsigned_indexes_listarray_ellipsis():

--- a/tests-cuda/test_3136_cuda_argmin_and_argmax.py
+++ b/tests-cuda/test_3136_cuda_argmin_and_argmax.py
@@ -11,8 +11,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0835_argmin_argmax_axis_None():

--- a/tests-cuda/test_3136_cuda_reducers.py
+++ b/tests-cuda/test_3136_cuda_reducers.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def prod(xs):

--- a/tests-cuda/test_3140_cuda_jagged_and_masked_getitem.py
+++ b/tests-cuda/test_3140_cuda_jagged_and_masked_getitem.py
@@ -12,8 +12,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0111_jagged_and_masked_getitem_bitmaskedarray2b():

--- a/tests-cuda/test_3140_cuda_slicing.py
+++ b/tests-cuda/test_3140_cuda_slicing.py
@@ -12,8 +12,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0315_integerindex_null_more():

--- a/tests-cuda/test_3141_cuda_misc.py
+++ b/tests-cuda/test_3141_cuda_misc.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0150_ByteMaskedArray_flatten():

--- a/tests-cuda/test_3149_complex_reducers.py
+++ b/tests-cuda/test_3149_complex_reducers.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0652_tests_of_complex_numbers_reducers():

--- a/tests-cuda/test_3150_combinations_n_equal_2.py
+++ b/tests-cuda/test_3150_combinations_n_equal_2.py
@@ -12,8 +12,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_0079_argchoose_and_choose_ListOffsetArray():

--- a/tests-cuda/test_3162_block_boundary_reducers.py
+++ b/tests-cuda/test_3162_block_boundary_reducers.py
@@ -12,8 +12,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 def test_block_boundary_sum():

--- a/tests-cuda/test_3162_cuda_generic_reducer_operation.py
+++ b/tests-cuda/test_3162_cuda_generic_reducer_operation.py
@@ -13,8 +13,11 @@ to_list = ak.operations.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 primes = [x for x in range(2, 1000) if all(x % n != 0 for n in range(2, x))]

--- a/tests-cuda/test_3260_combinations_n_equal_3.py
+++ b/tests-cuda/test_3260_combinations_n_equal_3.py
@@ -12,7 +12,10 @@ to_list = ak.to_list
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
-    cp.cuda.Device().synchronize()
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
 
 

--- a/tests-cuda/test_3459_virtualarray_with_cuda.py
+++ b/tests-cuda/test_3459_virtualarray_with_cuda.py
@@ -13,8 +13,11 @@ from awkward._nplikes.virtual import VirtualNDArray
 @pytest.fixture(scope="function", autouse=True)
 def cleanup_cuda():
     yield
+    try:
+        cp.cuda.Device().synchronize()  # wait for all kernels
+    except cp.cuda.runtime.CUDARuntimeError as e:
+        print("GPU error during sync:", e)
     cp._default_memory_pool.free_all_blocks()
-    cp.cuda.Device().synchronize()
 
 
 # Create fixtures for common test setup


### PR DESCRIPTION
First synchronize, then free memory. This avoids freeing memory still in use by the GPU.