### PR TITLE
chore: Remove CUDA 11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,6 @@ jobs:
       fail-fast: false
       matrix:
         cuda-version:
-          - 11
           - 12
           - 13
 

--- a/dev/cuda-tests/cuda-tests-entrypoint
+++ b/dev/cuda-tests/cuda-tests-entrypoint
@@ -27,7 +27,7 @@ fi
   python3 -m pip install wheel build;
 
   # Install awkward and dependencies
-  python3 -m pip install -v --only-binary "numpy" . ./awkward-cpp cupy-cuda11x pytest>=6;
+  python3 -m pip install -v --only-binary "numpy" . ./awkward-cpp cupy-cuda12x pytest>=6;
 } || gh issue create --title "GPU Tests Setup Failed" --body "The test-runner for the GPU tests failed before hitting pytest." -R scikit-hep/awkward;
 
 # Test

--- a/dev/cuda-tests/cuda-tests.Dockerfile
+++ b/dev/cuda-tests/cuda-tests.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu20.04
+FROM nvidia/cuda:12.6.3-devel-ubuntu22.04
 WORKDIR /app
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -1,6 +1,6 @@
 # The CI installs cudf and cupy using conda
 # If you are using this file manually uncomment the following lines and
-# set the cuda version matching your system.
+# set the cuda version matching your system (currently supporting CUDA 12 and 13).
 # cudf-cu12
 # cupy-cuda12x
 fsspec>=2022.11.0


### PR DESCRIPTION
In https://github.com/scikit-hep/awkward/pull/3750#discussion_r2578936195 it was determined that CUDA 11 can be dropped from the support matrix given that the driver versions are past EOL.