### PR TITLE
fix: make `ak.enforce_type` work with typetracers

### DIFF
--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -13,7 +13,6 @@ from glob import escape as escape_glob
 import awkward as ak
 from awkward._backends.dispatch import regularize_backend
 from awkward._backends.numpy import NumpyBackend
-from awkward._backends.typetracer import TypeTracerBackend
 from awkward._meta.meta import Meta
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._nplikes.shape import ShapeItem, unknown_length
@@ -530,7 +529,7 @@ class Form(Meta):
                 "The `highlevel=True` variant of `Form.length_zero_array` has been removed. "
                 "Please use `ak.Array(form.length_zero_array(...), behavior=...)` if an `ak.Array` is required.",
             )
-        if isinstance(regularize_backend(backend), TypeTracerBackend):
+        if not regularize_backend(backend).nplike.known_data:
             return self.length_zero_array(
                 backend=numpy_backend, highlevel=highlevel, behavior=behavior
             ).to_typetracer()
@@ -557,7 +556,7 @@ class Form(Meta):
                 "The `highlevel=True` variant of `Form.length_one_array` has been removed. "
                 "Please use `ak.Array(form.length_one_array(...), behavior=...)` if an `ak.Array` is required.",
             )
-        if isinstance(regularize_backend(backend), TypeTracerBackend):
+        if not regularize_backend(backend).nplike.known_data:
             return self.length_one_array(
                 backend=numpy_backend, highlevel=highlevel, behavior=behavior
             ).to_typetracer()

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -532,7 +532,7 @@ class Form(Meta):
             )
         if isinstance(regularize_backend(backend), TypeTracerBackend):
             return self.length_zero_array(
-                backend=numpy_backend, highlevel=False, behavior=behavior
+                backend=numpy_backend, highlevel=highlevel, behavior=behavior
             ).to_typetracer()
 
         return ak.operations.ak_from_buffers._impl(
@@ -559,7 +559,7 @@ class Form(Meta):
             )
         if isinstance(regularize_backend(backend), TypeTracerBackend):
             return self.length_one_array(
-                backend=numpy_backend, highlevel=False, behavior=behavior
+                backend=numpy_backend, highlevel=highlevel, behavior=behavior
             ).to_typetracer()
 
         # The naive implementation of a length-1 array requires that we have a sufficiently

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -665,7 +665,7 @@ def _recurse_option_any(
                     new_index[~is_none] = nplike.arange(
                         layout.length - num_none
                         if layout.length is not unknown_length
-                        else unknown_length,
+                        else num_none,
                         dtype=new_index.dtype,
                     )
                 return ak.contents.IndexedOptionArray(

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -680,7 +680,9 @@ def _recurse_option_any(
         # Check that we can build the content
         content_enforceable = _type_is_enforceable(layout.content, type_)
 
-        if layout.backend.nplike.any(layout.mask_as_bool(False)):
+        if layout.backend.nplike.known_data and layout.backend.nplike.any(
+            layout.mask_as_bool(False)
+        ):
             raise ValueError(
                 "option types can only be removed if there are no missing values"
             )

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -608,7 +608,9 @@ def _recurse_unknown_any(
     layout: ak.contents.EmptyArray, type_: ak.types.Type
 ) -> ak.contents.Content:
     type_form = ak.forms.from_type(type_)
-    return type_form.length_zero_array().copy(parameters=type_._parameters)
+    return type_form.length_zero_array(backend=layout.backend).copy(
+        parameters=type_._parameters
+    )
 
 
 def _recurse_any_unknown(layout: ak.contents.Content, type_: ak.types.UnknownType):

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -663,7 +663,9 @@ def _recurse_option_any(
                 else:
                     new_index[is_none] = -1
                     new_index[~is_none] = nplike.arange(
-                        layout.length - num_none,
+                        layout.length - num_none
+                        if layout.length is not unknown_length
+                        else unknown_length,
                         dtype=new_index.dtype,
                     )
                 return ak.contents.IndexedOptionArray(

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -145,7 +145,7 @@ def _impl(
     enable_virtualarray_caching,
 ):
     backend = regularize_backend(backend)
-    if isinstance(backend, ak._backends.typetracer.TypeTracerBackend):
+    if not backend.nplike.known_data:
         msg = (
             "Typetacer backend is not supported in 'ak.from_buffers'. "
             "Typetracer-backed arrays can be constructed only from the form as they do not hold any data. "

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -145,6 +145,14 @@ def _impl(
     enable_virtualarray_caching,
 ):
     backend = regularize_backend(backend)
+    if isinstance(backend, ak._backends.typetracer.TypeTracerBackend):
+        msg = (
+            "Typetacer backend is not supported in 'ak.from_buffers'. "
+            "Typetracer-backed arrays can be constructed only from the form as they do not hold any data. "
+            "Use highlevel functions like 'ak.typetracer.typetracer_from_form' or 'ak.typetracer.typetracer_with_report' "
+            "to construct such arrays."
+        )
+        raise TypeError(msg)
 
     if isinstance(form, str):
         if ak.types.numpytype.is_primitive(form):

--- a/tests/test_3764_enforce_type_with_typetracers.py
+++ b/tests/test_3764_enforce_type_with_typetracers.py
@@ -739,3 +739,126 @@ def test_union(forget_length):
         ],
     ).to_typetracer(forget_length)
     assert result.layout.is_equal_to(expected)
+
+
+@pytest.mark.parametrize("forget_length", [False, True])
+def test_string(forget_length):
+    ## string -> bytestring
+    original = ak.to_layout(["hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("bytes", highlevel=False))
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "byte"},
+        ),
+        parameters={"__array__": "bytestring"},
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## bytestring -> string
+    original = ak.to_layout([b"hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("string", highlevel=False))
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "char"},
+        ),
+        parameters={"__array__": "string"},
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## string -> string
+    original = ak.to_layout(["hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("string", highlevel=False))
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "char"},
+        ),
+        parameters={"__array__": "string"},
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## bytestring -> bytestring
+    original = ak.to_layout([b"hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("bytes", highlevel=False))
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "byte"},
+        ),
+        parameters={"__array__": "bytestring"},
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## bytestring -> list of byte
+    original = ak.to_layout([b"hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("var * byte", highlevel=False)
+    )
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "byte"},
+        ),
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## bytestring -> list of int64
+    original = ak.to_layout([b"hello world"])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("var * int64", highlevel=False)
+    )
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.int64,
+            )
+        ),
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## list of int64 -> string
+    original = ak.without_parameters([b"hello world"])
+    array = original.layout.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("string", highlevel=False))
+    expected = ak.contents.ListOffsetArray(
+        offsets=ak.index.Index64([0, 11]),
+        content=ak.contents.NumpyArray(
+            numpy.array(
+                [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+                dtype=numpy.uint8,
+            ),
+            parameters={"__array__": "char"},
+        ),
+        parameters={"__array__": "string"},
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)

--- a/tests/test_3764_enforce_type_with_typetracers.py
+++ b/tests/test_3764_enforce_type_with_typetracers.py
@@ -1,0 +1,267 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy
+import pytest
+
+import awkward as ak
+from awkward._nplikes.shape import unknown_length
+from awkward._nplikes.typetracer import TypeTracerArray
+
+# tests taken from tests/test_2365_enforce_type.py and adapted for typetracer arrays
+
+
+@pytest.mark.parametrize("forget_length", [False, True])
+def test_record(forget_length):
+    ## record → record
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("{x: var * int64}", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 2], dtype=numpy.int64)),
+            )
+        ],
+        ["x"],
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## record → record
+    original = ak.to_layout([{"x": [1, 0]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("{x: var * bool}", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 0], dtype=numpy.bool_)),
+            )
+        ],
+        ["x"],
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## record → different tuple
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    with pytest.raises(ValueError, match=r"converted between records and tuples"):
+        ak.enforce_type(
+            array, ak.types.from_datashape("(var * float64)", highlevel=False)
+        )
+
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    with pytest.raises(
+        TypeError, match=r"can only add new fields to a record if they are option types"
+    ):
+        ak.enforce_type(
+            array, ak.types.from_datashape("{y: var * float64}", highlevel=False)
+        )
+
+    ## record → totally different record
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("{y: ?var * float64}", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.IndexedOptionArray(
+                ak.index.Index64([-1]),
+                ak.contents.ListOffsetArray(
+                    ak.index.Index(numpy.array([0], dtype=numpy.int64)),
+                    ak.contents.NumpyArray(numpy.array([], dtype=numpy.float64)),
+                ),
+            )
+        ],
+        ["y"],
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## record → extended record
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array,
+        ak.types.from_datashape("{x: var * int64, y: ?int64}", highlevel=False),
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 2], dtype=numpy.int64)),
+            ),
+            ak.contents.IndexedOptionArray(
+                ak.index.Index64([-1]),
+                ak.contents.NumpyArray(numpy.array([], dtype=numpy.int64)),
+            ),
+        ],
+        ["x", "y"],
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## record → empty record
+    original = ak.to_layout([{"x": [1, 2]}], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("{}", highlevel=False))
+    expected = ak.contents.RecordArray([], [], length=1).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ############
+
+    ## tuple → tuple
+    original = ak.to_layout([([1, 2],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("(var * int64)", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 2], dtype=numpy.int64)),
+            )
+        ],
+        None,
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## tuple → tuple
+    original = ak.to_layout([([1, 0],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("(var * bool)", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 0], dtype=numpy.bool_)),
+            )
+        ],
+        None,
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## tuple → different record
+    original = ak.to_layout([([1, 2],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    with pytest.raises(ValueError, match=r"converted between records and tuples"):
+        ak.enforce_type(
+            array, ak.types.from_datashape("{x: var * float64}", highlevel=False)
+        )
+
+    original = ak.to_layout([([1, 2],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    with pytest.raises(
+        TypeError, match=r"can only add new slots to a tuple if they are option types"
+    ):
+        ak.enforce_type(
+            array, ak.types.from_datashape("(var * int64, float32)", highlevel=False)
+        )
+
+    ## tuple → extended tuple
+    original = ak.to_layout([([1, 2],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("(var * int64, ?float32)", highlevel=False)
+    )
+    expected = ak.contents.RecordArray(
+        [
+            ak.contents.ListOffsetArray(
+                ak.index.Index(numpy.array([0, 2], dtype=numpy.int64)),
+                ak.contents.NumpyArray(numpy.array([1, 2], dtype=numpy.int64)),
+            ),
+            ak.contents.IndexedOptionArray(
+                ak.index.Index64([-1]),
+                ak.contents.NumpyArray(numpy.array([], dtype=numpy.float32)),
+            ),
+        ],
+        None,
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## tuple → empty tuple
+    original = ak.to_layout([([1, 2],)], regulararray=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(array, ak.types.from_datashape("()", highlevel=False))
+    expected = ak.contents.RecordArray([], None, length=1).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+
+@pytest.mark.parametrize("forget_length", [False, True])
+def test_list(forget_length):
+    original = ak.to_layout([[1, 2, 3]])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("var * int64", highlevel=False)
+    )
+    expected = ak.contents.ListOffsetArray(
+        ak.index.Index(numpy.array([0, 3], dtype=numpy.int64)),
+        ak.contents.NumpyArray(numpy.array([1, 2, 3], dtype=numpy.int64)),
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    original = ak.to_layout([[1, 2, 3]])
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("3 * int64", highlevel=False)
+    )
+    expected = ak.contents.RegularArray(
+        ak.contents.NumpyArray(numpy.array([1, 2, 3], dtype=numpy.int64)), size=3
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    ## Empty list to regular shape
+    original = ak.to_layout([[]])[:0]
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("3 * int64", highlevel=False)
+    )
+    expected = ak.contents.RegularArray(
+        ak.contents.NumpyArray(numpy.array([], dtype=numpy.int64)), size=3
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    original = ak.to_layout([[1, 2, 3]])
+    array = original.to_typetracer(forget_length)
+    expected = ak.contents.RegularArray(
+        ak.contents.NumpyArray(
+            TypeTracerArray._new(numpy.dtype("int64"), (unknown_length,))
+        ),
+        size=unknown_length,
+    )
+    assert result.layout.is_equal_to(expected)
+
+    original = ak.to_regular([[1, 2, 3]], axis=-1, highlevel=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("var * int64", highlevel=False)
+    )
+    expected = ak.contents.ListOffsetArray(
+        ak.index.Index(numpy.array([0, 3], dtype=numpy.int64)),
+        ak.contents.NumpyArray(numpy.array([1, 2, 3], dtype=numpy.int64)),
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    original = ak.to_regular([[1, 2, 3]], axis=-1, highlevel=False)
+    array = original.to_typetracer(forget_length)
+    result = ak.enforce_type(
+        array, ak.types.from_datashape("3 * int64", highlevel=False)
+    )
+    expected = ak.contents.RegularArray(
+        ak.contents.NumpyArray(numpy.array([1, 2, 3], dtype=numpy.int64)), size=3
+    ).to_typetracer(forget_length)
+    assert result.layout.is_equal_to(expected)
+
+    original = ak.to_regular([[1, 2, 3]], axis=-1, highlevel=False)
+    array = original.to_typetracer(forget_length)
+    with pytest.raises(ValueError, match=r"different size"):
+        ak.enforce_type(array, ak.types.from_datashape("4 * int64", highlevel=False))


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3736

As the title says, this makes `ak.enforce_type` work with typetracers. This is needed in order to make `dak.enforce_type` work in dask-awkward.