### PR TITLE
fix: typetracer nplike's `all` function leads to infinite recursion for `axis=None`

### DIFF
--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -1559,7 +1559,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         if axis is None:
             return self.all(
                 cast(TypeTracerArray, self.reshape(x, (-1,))),
-                axis=axis,
+                axis=0,
                 keepdims=keepdims,
                 maybe_out=maybe_out,
             )

--- a/tests/test_3765_typetracer_all_any_infinite_recursion.py
+++ b/tests/test_3765_typetracer_all_any_infinite_recursion.py
@@ -1,0 +1,39 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+
+from awkward._nplikes.typetracer import TypeTracer, TypeTracerArray
+
+
+def test_all():
+    buffer = TypeTracerArray._new(np.dtype("float32"), (4,))
+    nplike = TypeTracer.instance()
+    result = nplike.all(buffer, axis=None)
+    assert isinstance(result, TypeTracerArray)
+    assert result.dtype == np.dtype("bool")
+    assert result.shape == ()
+
+    buffer = TypeTracerArray._new(np.dtype("float32"), (4, 3))
+    nplike = TypeTracer.instance()
+    result = nplike.all(buffer, axis=None)
+    assert isinstance(result, TypeTracerArray)
+    assert result.dtype == np.dtype("bool")
+    assert result.shape == ()
+
+
+def test_any():
+    buffer = TypeTracerArray._new(np.dtype("float32"), (4,))
+    nplike = TypeTracer.instance()
+    result = nplike.any(buffer, axis=None)
+    assert isinstance(result, TypeTracerArray)
+    assert result.dtype == np.dtype("bool")
+    assert result.shape == ()
+
+    buffer = TypeTracerArray._new(np.dtype("float32"), (4, 3))
+    nplike = TypeTracer.instance()
+    result = nplike.any(buffer, axis=None)
+    assert isinstance(result, TypeTracerArray)
+    assert result.dtype == np.dtype("bool")
+    assert result.shape == ()

--- a/tests/test_3765_typetracer_all_any_infinite_recursion.py
+++ b/tests/test_3765_typetracer_all_any_infinite_recursion.py
@@ -6,17 +6,17 @@ import numpy as np
 
 from awkward._nplikes.typetracer import TypeTracer, TypeTracerArray
 
+nplike = TypeTracer.instance()
+
 
 def test_all():
     buffer = TypeTracerArray._new(np.dtype("float32"), (4,))
-    nplike = TypeTracer.instance()
     result = nplike.all(buffer, axis=None)
     assert isinstance(result, TypeTracerArray)
     assert result.dtype == np.dtype("bool")
     assert result.shape == ()
 
     buffer = TypeTracerArray._new(np.dtype("float32"), (4, 3))
-    nplike = TypeTracer.instance()
     result = nplike.all(buffer, axis=None)
     assert isinstance(result, TypeTracerArray)
     assert result.dtype == np.dtype("bool")
@@ -25,14 +25,12 @@ def test_all():
 
 def test_any():
     buffer = TypeTracerArray._new(np.dtype("float32"), (4,))
-    nplike = TypeTracer.instance()
     result = nplike.any(buffer, axis=None)
     assert isinstance(result, TypeTracerArray)
     assert result.dtype == np.dtype("bool")
     assert result.shape == ()
 
     buffer = TypeTracerArray._new(np.dtype("float32"), (4, 3))
-    nplike = TypeTracer.instance()
     result = nplike.any(buffer, axis=None)
     assert isinstance(result, TypeTracerArray)
     assert result.dtype == np.dtype("bool")


### PR DESCRIPTION
The typetracer nplike's `all` function with `axis=None` calls itself again with `axis=None` leading into an infinite recursion naturally. This appears to be a typo. I think the point was when this was implemented to flatten the input with the `self.reshape(x, (-1,)` and then call it on the only existing axis which would be 0.