### PR TITLE
chore(ci): use macOS to test ML dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,8 @@ jobs:
             runs-on: ubuntu-latest
             dependencies-kind: pypy
           - python-version: '3.11'
-            python-architecture: x64
-            runs-on: ubuntu-latest
+            python-architecture: arm64
+            runs-on: macos-14
             dependencies-kind: ml
           - python-version: '3.14t'
             python-architecture: x64

--- a/requirements-test-ml.txt
+++ b/requirements-test-ml.txt
@@ -2,6 +2,5 @@ fsspec>=2022.11.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist
-tensorflow >= 2.12;sys_platform != "linux" or platform_machine != "x86_64"
-tensorflow-cpu >= 2.12;sys_platform == "linux" and platform_machine == "x86_64"
+tensorflow >= 2.12
 torch >= 2.4.0

--- a/requirements-test-ml.txt
+++ b/requirements-test-ml.txt
@@ -2,5 +2,6 @@ fsspec>=2022.11.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist
-tensorflow-cpu >= 2.12
+tensorflow >= 2.12;sys_platform != "linux"
+tensorflow-cpu >= 2.12;sys_platform == "linux"
 torch >= 2.4.0

--- a/requirements-test-ml.txt
+++ b/requirements-test-ml.txt
@@ -2,6 +2,6 @@ fsspec>=2022.11.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist
-tensorflow >= 2.12;sys_platform != "linux"
-tensorflow-cpu >= 2.12;sys_platform == "linux"
+tensorflow >= 2.12;sys_platform != "linux" or platform_machine != "x86_64"
+tensorflow-cpu >= 2.12;sys_platform == "linux" and platform_machine == "x86_64"
 torch >= 2.4.0


### PR DESCRIPTION
We changed the ML requirements to use `tensorflow-cpu` instead of `tensorflow` since it was downloading a bunch of extra stuff and running out of storage. However, `tensorflow-cpu` doesn't build wheels for macOS, so the integration tests are failing. Since this requirement file could be used for people as a guideline, it's good to fix it here. Thanks to @ikrommyd for pointing this out.