### PR TITLE
fix: incorrect type passed down for the `mergeastable` argument

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -1265,7 +1265,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         nulls_index_content = ak.contents.NumpyArray(
             nulls_index.data, parameters=None, backend=self._backend
         )
-        if out._mergeable_next(nulls_index_content, True, True):
+        if out._mergeable_next(nulls_index_content, True, "same_kind"):
             out = out._mergemany([nulls_index_content])
             nulls_merged = True
 


### PR DESCRIPTION
In https://github.com/scikit-hep/awkward/pull/3773, when I switched `mergecastable` to be a string instead of a bool, I missed this one instance. Fixing it here.