### PR TITLE
feat: consider unions of ints and floats as valid layouts

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1504,7 +1504,9 @@ class UnionArray(UnionMeta[Content], Content):
         for i, content_i in enumerate(self._contents):
             for j in range(i):
                 content_j = self._contents[j]
-                if ak._do.mergeable(content_i, content_j, mergebool=False):
+                if ak._do.mergeable(
+                    content_i, content_j, mergebool=False, mergecastable="family"
+                ):
                     return f"at {path}: content({i}) is mergeable with content({j})"
 
         for i, content in enumerate(self._contents):


### PR DESCRIPTION
As suggested by @ariostas in https://github.com/scikit-hep/awkward/pull/3773#pullrequestreview-3600102854, I also don't think unions of floats and ints should be considered invalid. Usually, there is a very good reason to keep ints and floats separate and it's not just for fun. This PR changes just that.

Before:
```
In [3]: array = ak.contents.UnionArray(
   ...:     ak.index.Index8([0, 1, 1, 0]),
   ...:     ak.index.Index64([0, 1, 1, 0]),
   ...:     [
   ...:         ak.contents.NumpyArray(np.array([1.0, 2.0], dtype=np.float64)),
   ...:         ak.contents.NumpyArray(np.array([1, 2], dtype=np.int64)),
   ...:     ],
   ...: )

In [4]: ak.validity_error(array)
Out[4]: 'at highlevel: content(1) is mergeable with content(0)'
```
With this PR:
```
In [3]: array = ak.contents.UnionArray(
   ...:     ak.index.Index8([0, 1, 1, 0]),
   ...:     ak.index.Index64([0, 1, 1, 0]),
   ...:     [
   ...:         ak.contents.NumpyArray(np.array([1.0, 2.0], dtype=np.float64)),
   ...:         ak.contents.NumpyArray(np.array([1, 2], dtype=np.int64)),
   ...:     ],
   ...: )

In [4]: ak.validity_error(array)
Out[4]: ''
```

@ianna @ariostas, what do you think about this?