### PR TITLE
ci: xfail failing cudf tests until fixed

### DIFF
--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -8,6 +8,7 @@ cudf = pytest.importorskip("cudf", exc_type=ImportError)
 cupy = pytest.importorskip("cupy")
 
 
+@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
 def test_jagged():
     arr = ak.Array([[[1, 2, 3], [], [3, 4]], []])
     out = ak.to_cudf(arr)
@@ -15,6 +16,7 @@ def test_jagged():
     assert out.to_arrow().tolist() == [[[1, 2, 3], [], [3, 4]], []]
 
 
+@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
 def test_nested():
     arr = ak.Array(
         [{"a": 0, "b": 1.0, "c": {"d": 0}}, {"a": 1, "b": 0.0, "c": {"d": 1}}]
@@ -47,6 +49,7 @@ def test_null():
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
+@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
 def test_strings():
     arr = ak.Array(["hey", "hi", "hum"])
     out = ak.to_cudf(arr)


### PR DESCRIPTION
In the latest cudf release, the internal column constructors have changed and we've been getting 3 failing tests consistently for GPU every single time. Even though the GPU tests are not required in ci to merge, it's still hard to see if those are the tests that failed every or if a PR breaks other GPU tests until we actually go and look inside the actions log.
I think it's the safest to xfail these tests until we have a fix so that we can easily know if GPU ci is broken or not. Also it will be immediately seen if these tests start passing unexpectedly or in the PR that aims to fix them.