### PR TITLE
chore: request for tensorflow in requirements only if python < 3.14

### DIFF
--- a/requirements-test-ml.txt
+++ b/requirements-test-ml.txt
@@ -2,5 +2,5 @@ fsspec>=2022.11.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist
-tensorflow >= 2.12
+tensorflow >= 2.12;python_version < "3.14"
 torch >= 2.4.0


### PR DESCRIPTION
Tensorflow does not support python 3.14 and given the project's status, they will probably not support it for like a year.
We should only ask for it in requirements if python < 3.14