### PR TITLE
feat: Make `ak.combinations` faster on GPU by using `cp.searchsorted` to compute output list indexes

### DIFF
--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_combinations.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_ListArray_combinations.cu
@@ -22,14 +22,15 @@
 //     )
 //     # Inclusive scan (device-only)
 //     scan_in_array_offsets = cupy.cumsum(scan_in_array_offsets)
-//     # Allocate parents/local_indices (device-only), sized to total outputs
+//     # Compute total outputs and allocate local_indices
 //     total = int(scan_in_array_offsets[length])
-//     scan_in_array_parents = cupy.zeros(total, dtype=cupy.int64)
 //     scan_in_array_local_indices = cupy.zeros(total, dtype=cupy.int64)
-//     # Fill parents as a run-length expansion of [0..length-1]
-//     # (pure device write in a trivial loop would be another kernel; your original loop is fine)
-//     for i in range(1, length + 1):
-//         scan_in_array_parents[scan_in_array_offsets[i - 1]:scan_in_array_offsets[i]] = i - 1
+//     # Compute parents as a run-length expansion of [0..length-1]
+//     # using cp.searchsorted
+//     if total > 0:
+//         scan_in_array_parents = cupy.searchsorted(scan_in_array_offsets[1:], cupy.arange(total), side='right').astype(cupy.int64)
+//     else:
+//         scan_in_array_parents = cupy.zeros(0, dtype=cupy.int64)
 //     # Choose launch for passes B and C
 //     block_size = min(1024, total) if total > 0 else 1
 //     grid_size = (total + block_size - 1)//block_size if block_size > 0 else 1


### PR DESCRIPTION
By far the bottleneck in `ak.combinations` for the GPU is the Python loop for computing the output list indexes. This can be done in a vectorized fashion using `cp.searchsorted`. As written, this does multiple `memset` operations in a loop which can be slow.

The improvement is massive.

Before:

```
lists=100,000 total_values=1,000,668 mean_len≈10
estimated total_pairs=5,009,024
Time taken for ak.combinations: 2.16 seconds
```

After:

```
lists=100,000 total_values=1,000,668 mean_len≈10
estimated total_pairs=5,009,024
Time taken for ak.combinations: 0.0015 seconds
```

Benchmarking script used:

```python
import numpy as np
import cupy as cp
import awkward as ak
import timeit


# Create random jagged data
np.random.seed(42)
num_lists = 100_000
mean_len = 10
max_len = 40

# Generate random lengths and build offsets
lengths = np.random.poisson(lam=mean_len, size=num_lists).astype(np.int64)
lengths = np.clip(lengths, 0, max_len)
offsets = np.empty(num_lists + 1, dtype=np.int64)
offsets[0] = 0
np.cumsum(lengths, out=offsets[1:])

total_values = int(offsets[-1])
values = np.arange(total_values, dtype=np.int64)

# Build awkward array
layout = ak.contents.ListOffsetArray(
    ak.index.Index64(offsets),
    ak.contents.NumpyArray(values)
)
arr = ak.Array(layout)

# Estimate total pairs
total_pairs = sum(n * (n - 1) // 2 for n in lengths)
print(f"lists={num_lists:,} total_values={total_values:,} mean_len≈{mean_len}")
print(f"estimated total_pairs={total_pairs:,}")

# Move to CUDA
gpu_arr = ak.to_backend(arr, "cuda")
cp.cuda.get_current_stream().synchronize()

# Benchmark using timeit
# warmup:
ak.combinations(gpu_arr, n=2)
result = timeit.timeit(lambda: ak.combinations(gpu_arr, n=2), number=10)
print(f"Time taken for ak.combinations: {result / 10:.4f} seconds")
```