### PR TITLE
fix: `ArrayBuilder.show()` formatter forwarding

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -44,7 +44,7 @@ from awkward._pickle import (
 from awkward._regularize import is_non_string_like_iterable
 from awkward._typing import Any, TypeVar
 from awkward._util import STDOUT
-from awkward.prettyprint import Formatter, highlevel_array_show_rows
+from awkward.prettyprint import highlevel_array_show_rows
 from awkward.prettyprint import valuestr as prettyprint_valuestr
 
 __all__ = ("Array", "ArrayBuilder", "Record")
@@ -84,7 +84,7 @@ def _awkward_1_rewrite_partition_form(form, partition: int, template: str = "par
     part_prefix = f"{template.format(partition)}-"
 
     def rename_form_key(key: str) -> str:
-        suffix = key[len(default_prefix):]
+        suffix = key[len(default_prefix) :]
 
         return f"{part_prefix}{suffix}"
 
@@ -314,8 +314,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                         f"of equal length ({length} vs {_arrays[-1].layout.length}). "
                         "For automatic broadcasting use 'ak.zip' instead. "
                     )
-            layout = ak.contents.RecordArray(
-                [arr.layout for arr in _arrays], fields)
+            layout = ak.contents.RecordArray([arr.layout for arr in _arrays], fields)
             attrs = attrs_of(*_arrays, attrs=attrs)
             behavior = behavior_of(*_arrays, behavior=behavior)
 
@@ -1112,8 +1111,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
             NamedAxis.mapping = named_axis
 
-            indexed_layout = prepare_layout(
-                self._layout._getitem(where, NamedAxis))
+            indexed_layout = prepare_layout(self._layout._getitem(where, NamedAxis))
 
             if NamedAxis.mapping:
                 return ak.operations.ak_with_named_axis._impl(
@@ -1203,8 +1201,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError(
-                    "only fields may be assigned in-place (by field name)")
+                raise TypeError("only fields may be assigned in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.with_field(
@@ -1241,8 +1238,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError(
-                    "only fields may be removed in-place (by field name)")
+                raise TypeError("only fields may be removed in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.ak_without_field._impl(
@@ -1377,15 +1373,13 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         axisstr = ""
         if self.named_axis:
             # we reserve at maximum 20 characters for the named axis string
-            axisstr = _prettify_named_axes(
-                self.named_axis, delimiter=",", maxlen=20)
+            axisstr = _prettify_named_axes(self.named_axis, delimiter=",", maxlen=20)
             axisstr = f" {axisstr}"
         # subtract the reserved space from the limit_cols
         limit_cols -= len(axisstr)
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:
-            strwidth = limit_cols - \
-                (len(typestr) + len(pytype) + len(" type=''") + 3)
+            strwidth = limit_cols - (len(typestr) + len(pytype) + len(" type=''") + 3)
         else:
             strwidth = max(
                 0,
@@ -1396,8 +1390,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             )
         valuestr = valuestr + " " + prettyprint_valuestr(self, 1, strwidth)
 
-        length = max(3, limit_cols - len(pytype) -
-                     len("type='...'") - len(valuestr))
+        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
@@ -1469,8 +1462,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_
-        sorted_rows = sorted([r for r in rows if r],
-                             key=lambda x: len(x.split(":")[0]))
+        sorted_rows = sorted([r for r in rows if r], key=lambda x: len(x.split(":")[0]))
 
         if sorted_rows:
             out_io.write("\n".join(sorted_rows))
@@ -1565,8 +1557,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(
-            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {
-                "type": type}
+            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {"type": type}
         ):
             from awkward._connect.pyarrow import convert_to_array
 
@@ -1672,8 +1663,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         ak.numba.register_and_check()
 
         if self._numbaview is None:
-            self._numbaview = ak._connect.numba.arrayview.ArrayView.fromarray(
-                self)
+            self._numbaview = ak._connect.numba.arrayview.ArrayView.fromarray(self)
         import numba
 
         return numba.typeof(self._numbaview)
@@ -1693,8 +1683,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         # For pickle >= 5, we can avoid copying the buffers
         if protocol >= 5:
-            container = {k: pickle.PickleBuffer(
-                v) for k, v in container.items()}
+            container = {k: pickle.PickleBuffer(v) for k, v in container.items()}
 
         if self._behavior is ak.behavior:
             behavior = None
@@ -1875,8 +1864,7 @@ class Record(NDArrayOperatorsMixin):
                 else:
                     contents.append(Array([v]).layout)
 
-            layout = ak.record.Record(
-                ak.contents.RecordArray(contents, fields), at=0)
+            layout = ak.record.Record(ak.contents.RecordArray(contents, fields), at=0)
 
         elif isinstance(data, Iterable):
             raise TypeError(
@@ -1890,8 +1878,7 @@ class Record(NDArrayOperatorsMixin):
             raise TypeError("could not convert data into an ak.Record")
 
         if with_name is not None:
-            layout = ak.operations.with_name(
-                layout, with_name, highlevel=False)
+            layout = ak.operations.with_name(layout, with_name, highlevel=False)
 
         if not (backend is None or backend == layout.backend.name):
             layout = ak.operations.to_backend(layout, backend, highlevel=False)
@@ -2174,8 +2161,7 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError(
-                    "only fields may be assigned in-place (by field name)")
+                raise TypeError("only fields may be assigned in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             layout = self.layout
@@ -2215,8 +2201,7 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError(
-                    "only fields may be removed in-place (by field name)")
+                raise TypeError("only fields may be removed in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.ak_without_field._impl(
@@ -2340,15 +2325,13 @@ class Record(NDArrayOperatorsMixin):
         axisstr = ""
         if self.named_axis:
             # we reserve at maximum 20 characters for the named axis string
-            axisstr = _prettify_named_axes(
-                self.named_axis, delimiter=",", maxlen=20)
+            axisstr = _prettify_named_axes(self.named_axis, delimiter=",", maxlen=20)
             axisstr = f" {axisstr}"
         # subtract the reserved space from the limit_cols
         limit_cols -= len(axisstr)
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:
-            strwidth = limit_cols - \
-                (len(typestr) + len(pytype) + len(" type=''") + 3)
+            strwidth = limit_cols - (len(typestr) + len(pytype) + len(" type=''") + 3)
         else:
             strwidth = max(
                 0,
@@ -2359,8 +2342,7 @@ class Record(NDArrayOperatorsMixin):
             )
         valuestr = valuestr + " " + prettyprint_valuestr(self, 1, strwidth)
 
-        length = max(3, limit_cols - len(pytype) -
-                     len("type='...'") - len(valuestr))
+        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
@@ -2432,8 +2414,7 @@ class Record(NDArrayOperatorsMixin):
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_
-        sorted_rows = sorted([r for r in rows if r],
-                             key=lambda x: len(x.split(":")[0]))
+        sorted_rows = sorted([r for r in rows if r], key=lambda x: len(x.split(":")[0]))
 
         if sorted_rows:
             out_io.write("\n".join(sorted_rows))
@@ -2521,8 +2502,7 @@ class Record(NDArrayOperatorsMixin):
         ak.numba.register_and_check()
 
         if self._numbaview is None:
-            self._numbaview = ak._connect.numba.arrayview.RecordView.fromrecord(
-                self)
+            self._numbaview = ak._connect.numba.arrayview.RecordView.fromrecord(self)
         import numba
 
         return numba.typeof(self._numbaview)
@@ -2543,8 +2523,7 @@ class Record(NDArrayOperatorsMixin):
 
         # For pickle >= 5, we can avoid copying the buffers
         if protocol >= 5:
-            container = {k: pickle.PickleBuffer(
-                v) for k, v in container.items()}
+            container = {k: pickle.PickleBuffer(v) for k, v in container.items()}
 
         if self._behavior is ak.behavior:
             behavior = None
@@ -2872,19 +2851,19 @@ class ArrayBuilder(Sized):
         return f"<ArrayBuilder type={typestr}>"
 
     def show(
-    self,
-    limit_rows=20,
-    limit_cols=80,
-    *,
-    type=False,
-    named_axis=False,
-    nbytes=False,
-    backend=False,
-    all=False,
-    stream=STDOUT,
-    formatter=None,
-    precision=3,
-):
+        self,
+        limit_rows=20,
+        limit_cols=80,
+        *,
+        type=False,
+        named_axis=False,
+        nbytes=False,
+        backend=False,
+        all=False,
+        stream=STDOUT,
+        formatter=None,
+        precision=3,
+    ):
         """
         Display the contents of the ArrayBuilder by taking a snapshot and
         delegating to ak.Array.show.
@@ -2950,8 +2929,7 @@ class ArrayBuilder(Sized):
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(
-            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {
-                "type": type}
+            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {"type": type}
         ):
             from awkward._connect.pyarrow import convert_to_array
 
@@ -3396,6 +3374,3 @@ def find_lowlevel_backend(obj: type):
             return NumpyBackend.instance()
 
         return numpy_lookup
-
-
-

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -84,7 +84,7 @@ def _awkward_1_rewrite_partition_form(form, partition: int, template: str = "par
     part_prefix = f"{template.format(partition)}-"
 
     def rename_form_key(key: str) -> str:
-        suffix = key[len(default_prefix) :]
+        suffix = key[len(default_prefix):]
 
         return f"{part_prefix}{suffix}"
 
@@ -314,7 +314,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                         f"of equal length ({length} vs {_arrays[-1].layout.length}). "
                         "For automatic broadcasting use 'ak.zip' instead. "
                     )
-            layout = ak.contents.RecordArray([arr.layout for arr in _arrays], fields)
+            layout = ak.contents.RecordArray(
+                [arr.layout for arr in _arrays], fields)
             attrs = attrs_of(*_arrays, attrs=attrs)
             behavior = behavior_of(*_arrays, behavior=behavior)
 
@@ -1111,7 +1112,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
             NamedAxis.mapping = named_axis
 
-            indexed_layout = prepare_layout(self._layout._getitem(where, NamedAxis))
+            indexed_layout = prepare_layout(
+                self._layout._getitem(where, NamedAxis))
 
             if NamedAxis.mapping:
                 return ak.operations.ak_with_named_axis._impl(
@@ -1201,7 +1203,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError("only fields may be assigned in-place (by field name)")
+                raise TypeError(
+                    "only fields may be assigned in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.with_field(
@@ -1238,7 +1241,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError("only fields may be removed in-place (by field name)")
+                raise TypeError(
+                    "only fields may be removed in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.ak_without_field._impl(
@@ -1373,13 +1377,15 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         axisstr = ""
         if self.named_axis:
             # we reserve at maximum 20 characters for the named axis string
-            axisstr = _prettify_named_axes(self.named_axis, delimiter=",", maxlen=20)
+            axisstr = _prettify_named_axes(
+                self.named_axis, delimiter=",", maxlen=20)
             axisstr = f" {axisstr}"
         # subtract the reserved space from the limit_cols
         limit_cols -= len(axisstr)
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:
-            strwidth = limit_cols - (len(typestr) + len(pytype) + len(" type=''") + 3)
+            strwidth = limit_cols - \
+                (len(typestr) + len(pytype) + len(" type=''") + 3)
         else:
             strwidth = max(
                 0,
@@ -1390,7 +1396,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             )
         valuestr = valuestr + " " + prettyprint_valuestr(self, 1, strwidth)
 
-        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
+        length = max(3, limit_cols - len(pytype) -
+                     len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
@@ -1462,7 +1469,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_
-        sorted_rows = sorted([r for r in rows if r], key=lambda x: len(x.split(":")[0]))
+        sorted_rows = sorted([r for r in rows if r],
+                             key=lambda x: len(x.split(":")[0]))
 
         if sorted_rows:
             out_io.write("\n".join(sorted_rows))
@@ -1557,7 +1565,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(
-            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {"type": type}
+            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {
+                "type": type}
         ):
             from awkward._connect.pyarrow import convert_to_array
 
@@ -1663,7 +1672,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         ak.numba.register_and_check()
 
         if self._numbaview is None:
-            self._numbaview = ak._connect.numba.arrayview.ArrayView.fromarray(self)
+            self._numbaview = ak._connect.numba.arrayview.ArrayView.fromarray(
+                self)
         import numba
 
         return numba.typeof(self._numbaview)
@@ -1683,7 +1693,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         # For pickle >= 5, we can avoid copying the buffers
         if protocol >= 5:
-            container = {k: pickle.PickleBuffer(v) for k, v in container.items()}
+            container = {k: pickle.PickleBuffer(
+                v) for k, v in container.items()}
 
         if self._behavior is ak.behavior:
             behavior = None
@@ -1864,7 +1875,8 @@ class Record(NDArrayOperatorsMixin):
                 else:
                     contents.append(Array([v]).layout)
 
-            layout = ak.record.Record(ak.contents.RecordArray(contents, fields), at=0)
+            layout = ak.record.Record(
+                ak.contents.RecordArray(contents, fields), at=0)
 
         elif isinstance(data, Iterable):
             raise TypeError(
@@ -1878,7 +1890,8 @@ class Record(NDArrayOperatorsMixin):
             raise TypeError("could not convert data into an ak.Record")
 
         if with_name is not None:
-            layout = ak.operations.with_name(layout, with_name, highlevel=False)
+            layout = ak.operations.with_name(
+                layout, with_name, highlevel=False)
 
         if not (backend is None or backend == layout.backend.name):
             layout = ak.operations.to_backend(layout, backend, highlevel=False)
@@ -2161,7 +2174,8 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError("only fields may be assigned in-place (by field name)")
+                raise TypeError(
+                    "only fields may be assigned in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             layout = self.layout
@@ -2201,7 +2215,8 @@ class Record(NDArrayOperatorsMixin):
                 isinstance(where, str)
                 or (isinstance(where, tuple) and all(isinstance(x, str) for x in where))
             ):
-                raise TypeError("only fields may be removed in-place (by field name)")
+                raise TypeError(
+                    "only fields may be removed in-place (by field name)")
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             self.layout = ak.operations.ak_without_field._impl(
@@ -2325,13 +2340,15 @@ class Record(NDArrayOperatorsMixin):
         axisstr = ""
         if self.named_axis:
             # we reserve at maximum 20 characters for the named axis string
-            axisstr = _prettify_named_axes(self.named_axis, delimiter=",", maxlen=20)
+            axisstr = _prettify_named_axes(
+                self.named_axis, delimiter=",", maxlen=20)
             axisstr = f" {axisstr}"
         # subtract the reserved space from the limit_cols
         limit_cols -= len(axisstr)
 
         if len(typestr) + len(pytype) + len(" type=''") + 3 < limit_cols // 2:
-            strwidth = limit_cols - (len(typestr) + len(pytype) + len(" type=''") + 3)
+            strwidth = limit_cols - \
+                (len(typestr) + len(pytype) + len(" type=''") + 3)
         else:
             strwidth = max(
                 0,
@@ -2342,7 +2359,8 @@ class Record(NDArrayOperatorsMixin):
             )
         valuestr = valuestr + " " + prettyprint_valuestr(self, 1, strwidth)
 
-        length = max(3, limit_cols - len(pytype) - len("type='...'") - len(valuestr))
+        length = max(3, limit_cols - len(pytype) -
+                     len("type='...'") - len(valuestr))
         if len(typestr) > length:
             typestr = "'" + typestr[: length - 3] + "...'"
         else:
@@ -2414,7 +2432,8 @@ class Record(NDArrayOperatorsMixin):
 
         # the rest of the rows we sort by the length of their '<prefix>:'
         # but we sort it from shortest to longest contrary to _repr_mimebundle_
-        sorted_rows = sorted([r for r in rows if r], key=lambda x: len(x.split(":")[0]))
+        sorted_rows = sorted([r for r in rows if r],
+                             key=lambda x: len(x.split(":")[0]))
 
         if sorted_rows:
             out_io.write("\n".join(sorted_rows))
@@ -2502,7 +2521,8 @@ class Record(NDArrayOperatorsMixin):
         ak.numba.register_and_check()
 
         if self._numbaview is None:
-            self._numbaview = ak._connect.numba.arrayview.RecordView.fromrecord(self)
+            self._numbaview = ak._connect.numba.arrayview.RecordView.fromrecord(
+                self)
         import numba
 
         return numba.typeof(self._numbaview)
@@ -2523,7 +2543,8 @@ class Record(NDArrayOperatorsMixin):
 
         # For pickle >= 5, we can avoid copying the buffers
         if protocol >= 5:
-            container = {k: pickle.PickleBuffer(v) for k, v in container.items()}
+            container = {k: pickle.PickleBuffer(
+                v) for k, v in container.items()}
 
         if self._behavior is ak.behavior:
             behavior = None
@@ -2851,45 +2872,66 @@ class ArrayBuilder(Sized):
         return f"<ArrayBuilder type={typestr}>"
 
     def show(
-        self,
-        limit_rows=20,
-        limit_cols=80,
-        type=False,
-        stream=STDOUT,
-        *,
-        formatter=None,
-        precision=3,
-    ):
+    self,
+    limit_rows=20,
+    limit_cols=80,
+    *,
+    type=False,
+    named_axis=False,
+    nbytes=False,
+    backend=False,
+    all=False,
+    stream=STDOUT,
+    formatter=None,
+    precision=3,
+):
         """
+        Display the contents of the ArrayBuilder by taking a snapshot and
+        delegating to ak.Array.show.
+
         Args:
             limit_rows (int): Maximum number of rows (lines) to use in the output.
             limit_cols (int): Maximum number of columns (characters wide).
             type (bool): If True, print the type as well. (Doesn't count toward number
                 of rows/lines limit.)
+            named_axis (bool): If True, print the named axis as well. (Doesn't count toward number
+                of rows/lines limit.)
+            nbytes (bool): If True, print the number of bytes as well. (Doesn't count toward number
+                of rows/lines limit.)
+            backend (bool): If True, print the backend of the array as well. (Doesn't count toward number
+                of rows/lines limit.)
+            all (bool): If True, print the 'type', 'named axis', 'nbytes', and 'backend' of the array.
+                (Doesn't count toward number of rows/lines limit.)
             stream (object with a ``write(str)`` method or None): Stream to write the
                 output to. If None, return a string instead of writing to a stream.
             formatter (Mapping or None): Mapping of types/type-classes to string formatters.
                 If None, use the default formatter.
+            precision (int): Floating-point precision.
 
-        Display the contents of the array within `limit_rows` and `limit_cols`, using
-        ellipsis (`...`) for hidden nested data.
+        Display the contents of the array within ``limit_rows`` and ``limit_cols``, using
+        ellipsis (``...``) for hidden nested data.
 
-        The `formatter` argument controls the formatting of individual values, c.f.
+        The ``formatter`` argument controls the formatting of individual values, c.f.
         https://numpy.org/doc/stable/reference/generated/numpy.set_printoptions.html
-        As Awkward Array does not implement strings as a NumPy dtype, the `numpystr`
-        key is ignored; instead, a `"bytes"` and/or `"str"` key is considered when formatting
-        string values, falling back upon `"str_kind"`.
 
-        This method takes a snapshot of the data and calls show on it, and a snapshot
+        As Awkward Array does not implement strings as a NumPy dtype, the ``numpystr``
+        key is ignored; instead, a ``"bytes"`` and/or ``"str"`` key is considered when
+        formatting string values, falling back upon ``"str_kind"``.
+
+        This method takes a snapshot of the data and calls ``show`` on it, and a snapshot
         copies data.
         """
-        formatter_impl = Formatter(formatter, precision=precision)
         return self.snapshot().show(
             limit_rows=limit_rows,
             limit_cols=limit_cols,
             type=type,
+            named_axis=named_axis,
+            nbytes=nbytes,
+            backend=backend,
+            all=all,
             stream=stream,
-            formatter=formatter_impl,
+            formatter=formatter,
+            precision=precision,
         )
 
     def __array__(self, dtype=None, copy=None):
@@ -2908,7 +2950,8 @@ class ArrayBuilder(Sized):
 
     def __arrow_array__(self, type=None):
         with ak._errors.OperationErrorContext(
-            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {"type": type}
+            f"{builtins.type(self).__name__}.__arrow_array__", (self,), {
+                "type": type}
         ):
             from awkward._connect.pyarrow import convert_to_array
 
@@ -3353,3 +3396,6 @@ def find_lowlevel_backend(obj: type):
             return NumpyBackend.instance()
 
         return numpy_lookup
+
+
+

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -2383,7 +2383,7 @@ class Record(NDArrayOperatorsMixin):
             formatter (Mapping or None): Mapping of types/type-classes to string formatters.
                 If None, use the default formatter.
 
-        Display the contents of the array within `limit_rows` and `limit_cols`, using
+        Display the contents of the record within `limit_rows` and `limit_cols`, using
         ellipsis (`...`) for hidden nested data.
 
         The `formatter` argument controls the formatting of individual values, c.f.
@@ -2865,9 +2865,6 @@ class ArrayBuilder(Sized):
         precision=3,
     ):
         """
-        Display the contents of the ArrayBuilder by taking a snapshot and
-        delegating to ak.Array.show.
-
         Args:
             limit_rows (int): Maximum number of rows (lines) to use in the output.
             limit_cols (int): Maximum number of columns (characters wide).
@@ -2879,25 +2876,23 @@ class ArrayBuilder(Sized):
                 of rows/lines limit.)
             backend (bool): If True, print the backend of the array as well. (Doesn't count toward number
                 of rows/lines limit.)
-            all (bool): If True, print the 'type', 'named axis', 'nbytes', and 'backend' of the array.
-                (Doesn't count toward number of rows/lines limit.)
+            all (bool): If True, print the 'type', 'named axis', 'nbytes', and 'backend' of the array. (Doesn't count toward number
+                of rows/lines limit.)
             stream (object with a ``write(str)`` method or None): Stream to write the
                 output to. If None, return a string instead of writing to a stream.
             formatter (Mapping or None): Mapping of types/type-classes to string formatters.
                 If None, use the default formatter.
-            precision (int): Floating-point precision.
 
-        Display the contents of the array within ``limit_rows`` and ``limit_cols``, using
-        ellipsis (``...``) for hidden nested data.
+        Display the contents of the array builder within `limit_rows` and `limit_cols`, using
+        ellipsis (`...`) for hidden nested data.
 
-        The ``formatter`` argument controls the formatting of individual values, c.f.
+        The `formatter` argument controls the formatting of individual values, c.f.
         https://numpy.org/doc/stable/reference/generated/numpy.set_printoptions.html
+        As Awkward Array does not implement strings as a NumPy dtype, the `numpystr`
+        key is ignored; instead, a `"bytes"` and/or `"str"` key is considered when formatting
+        string values, falling back upon `"str_kind"`.
 
-        As Awkward Array does not implement strings as a NumPy dtype, the ``numpystr``
-        key is ignored; instead, a ``"bytes"`` and/or ``"str"`` key is considered when
-        formatting string values, falling back upon ``"str_kind"``.
-
-        This method takes a snapshot of the data and calls ``show`` on it, and a snapshot
+        This method takes a snapshot of the data and calls show on it, and a snapshot
         copies data.
         """
         return self.snapshot().show(

--- a/tests/test_2055_array_builder_check.py
+++ b/tests/test_2055_array_builder_check.py
@@ -53,6 +53,7 @@ def test_no_field_name():
         result,
         ak.contents.RecordArray(
             fields=["time"],
-            contents=[ak.contents.NumpyArray(np.array([0, 2], dtype=np.float64))],
+            contents=[ak.contents.NumpyArray(
+                np.array([0, 2], dtype=np.float64))],
         ),
     )

--- a/tests/test_2055_array_builder_check.py
+++ b/tests/test_2055_array_builder_check.py
@@ -53,7 +53,6 @@ def test_no_field_name():
         result,
         ak.contents.RecordArray(
             fields=["time"],
-            contents=[ak.contents.NumpyArray(
-                np.array([0, 2], dtype=np.float64))],
+            contents=[ak.contents.NumpyArray(np.array([0, 2], dtype=np.float64))],
         ),
     )

--- a/tests/test_3724_arraybuilder_show.py
+++ b/tests/test_3724_arraybuilder_show.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import io
+
 import awkward as ak
 
 

--- a/tests/test_3724_arraybuilder_show.py
+++ b/tests/test_3724_arraybuilder_show.py
@@ -1,0 +1,49 @@
+import io
+import awkward as ak
+
+
+def _capture_show_output(obj):
+    stream = io.StringIO()
+    obj.show(stream=stream)
+    return stream.getvalue()
+
+
+def test_arraybuilder_show_simple_list():
+    builder = ak.ArrayBuilder()
+    builder.begin_list()
+    builder.real(1.2)
+    builder.real(3.4)
+    builder.end_list()
+
+    out_builder = _capture_show_output(builder)
+    out_snapshot = _capture_show_output(builder.snapshot())
+
+    assert out_builder == out_snapshot
+
+
+def test_arraybuilder_show_record():
+    builder = ak.ArrayBuilder()
+    builder.begin_record()
+    builder.field("x").real(1.2)
+    builder.field("y").integer(3)
+    builder.end_record()
+
+    out_builder = _capture_show_output(builder)
+    out_snapshot = _capture_show_output(builder.snapshot())
+
+    assert out_builder == out_snapshot
+
+
+def test_arraybuilder_show_nested_list():
+    builder = ak.ArrayBuilder()
+    builder.begin_list()
+    builder.begin_list()
+    builder.integer(1)
+    builder.integer(2)
+    builder.end_list()
+    builder.end_list()
+
+    out_builder = _capture_show_output(builder)
+    out_snapshot = _capture_show_output(builder.snapshot())
+
+    assert out_builder == out_snapshot


### PR DESCRIPTION
ArrayBuilder.show is documented to forward arguments unchanged to
snapshot().show, but currently wraps the formatter argument in a
Formatter instance. This causes Array.show to receive a non-mapping
formatter and raises a TypeError.

This change forwards formatter unchanged and adds a regression test
ensuring ArrayBuilder.show behaves identically to snapshot().show.

Fixes #3724
