### PR TITLE
feat: make `ak.combinations` faster on GPU by using `cp.searchsorted` to compute output list indexes

### DIFF
--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_RegularArray_combinations_64.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_RegularArray_combinations_64.cu
@@ -15,7 +15,6 @@
 //         scan_in_array_parents = cupy.searchsorted(scan_in_array_offsets[1:], cupy.arange(total), side='right').astype(cupy.int64)
 //     else:
 //         scan_in_array_parents = cupy.zeros(0, dtype=cupy.int64)
-// 
 //     if int(scan_in_array_offsets[length]) < 1024:
 //         block_size = int(scan_in_array_offsets[length])
 //     else:

--- a/src/awkward/_connect/cuda/cuda_kernels/awkward_RegularArray_combinations_64.cu
+++ b/src/awkward/_connect/cuda/cuda_kernels/awkward_RegularArray_combinations_64.cu
@@ -6,10 +6,16 @@
 //     scan_in_array_offsets = cupy.zeros(length + 1, dtype=cupy.int64)
 //     cuda_kernel_templates.get_function(fetch_specialization(["awkward_RegularArray_combinations_64_a", tocarry[0].dtype, toindex.dtype, fromindex.dtype]))(grid, block, (tocarry, toindex, fromindex, n, replacement, size, length, scan_in_array_offsets, invocation_index, err_code))
 //     scan_in_array_offsets = cupy.cumsum(scan_in_array_offsets)
-//     scan_in_array_parents = cupy.zeros(int(scan_in_array_offsets[length]), dtype=cupy.int64)
-//     scan_in_array_local_indices = cupy.zeros(int(scan_in_array_offsets[length]), dtype=cupy.int64)
-//     for i in range(1, length + 1):
-//         scan_in_array_parents[scan_in_array_offsets[i - 1]:scan_in_array_offsets[i]] = i - 1
+//     # Compute total outputs and allocate local_indices
+//     total = int(scan_in_array_offsets[length])
+//     scan_in_array_local_indices = cupy.zeros(total, dtype=cupy.int64)
+//     # Compute parents as a run-length expansion of [0..length-1]
+//     # using cp.searchsorted
+//     if total > 0:
+//         scan_in_array_parents = cupy.searchsorted(scan_in_array_offsets[1:], cupy.arange(total), side='right').astype(cupy.int64)
+//     else:
+//         scan_in_array_parents = cupy.zeros(0, dtype=cupy.int64)
+// 
 //     if int(scan_in_array_offsets[length]) < 1024:
 //         block_size = int(scan_in_array_offsets[length])
 //     else:


### PR DESCRIPTION
The GPU bottleneck in `ak.combinations` came from a Python loop computing output list indexes with repeated `memset` calls. Replacing it with a vectorized `cp.searchsorted` implementation removes the loop and dramatically improves performance.

This PR extends the existing approach to the `RegularArray` layout and improves uniformity between `ListOffsetArray` and `RegularArray` handling.

This work is inspired by @shwina’s PR #3795. Thanks to @shwina for the original work and guidance.


Before:

```python
regular_layout = ak.contents.RegularArray(ak.contents.NumpyArray(values),size=6)
reg_arr = ak.Array(regular_layout)
reg_gpu_arr = ak.to_backend(reg_arr, "cuda")
cp.cuda.get_current_stream().synchronize()
ak.combinations(reg_gpu_arr, n=2)
result = timeit.timeit(lambda: ak.combinations(reg_gpu_arr, n=2),  number=10)
print(f"Time taken for ak.combinations: {result / 10:.4f} seconds")

Time taken for ak.combinations: 7.9204 seconds

```

After:

```python
regular_layout = ak.contents.RegularArray(ak.contents.NumpyArray(values),size=6)
reg_arr = ak.Array(regular_layout)
reg_gpu_arr = ak.to_backend(reg_arr, "cuda")
cp.cuda.get_current_stream().synchronize()
ak.combinations(reg_gpu_arr, n=2)
result = timeit.timeit(lambda: ak.combinations(reg_gpu_arr, n=2),  number=10)
print(f"Time taken for ak.combinations: {result / 10:.4f} seconds")
Time taken for ak.combinations: 0.0013 seconds

```

This change reduces the runtime of `ak.combinations` on CUDA-backed `RegularArrays` by several orders of magnitude, bringing performance in line with expectations for regular, fixed-size layouts.
