### PR TITLE
feat: drop Python 3.9

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
 
     env:
       PIP_ONLY_BINARY: cmake
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.10"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/packaging-test.yml
+++ b/.github/workflows/packaging-test.yml
@@ -71,14 +71,7 @@ jobs:
     - uses: pypa/cibuildwheel@v3.3
       env:
         CIBW_ARCHS_MACOS: universal2
-        CIBW_BUILD: cp39-win_amd64 cp310-manylinux_x86_64 cp39-macosx_universal2
-      with:
-        package-dir: awkward-cpp
-
-    - uses: pypa/cibuildwheel@v3.3
-      if: matrix.os == 'ubuntu-latest'
-      env:
-        CIBW_BUILD: cp312-manylinux_x86_64
+        CIBW_BUILD: cp310-win_amd64 cp310-macosx_universal2 cp310-manylinux_x86_64 cp312-manylinux_x86_64
       with:
         package-dir: awkward-cpp
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           - macos-latest
         python-version:
           - '3.14'
-          - '3.9'
+          - '3.10'
         python-architecture:
           - '' # use default arch
         dependencies-kind:
@@ -55,19 +55,19 @@ jobs:
             python-architecture: x64
             runs-on: macos-15-intel
             dependencies-kind: basic
-          - python-version: '3.9'
+          - python-version: '3.10'
             python-architecture: x86
             runs-on: windows-latest
             dependencies-kind: full
-          - python-version: '3.9'
+          - python-version: '3.10'
             python-architecture: x86
             runs-on: windows-latest
             dependencies-kind: numpy1
-          - python-version: '3.9'
+          - python-version: '3.10'
             python-architecture: x64
             runs-on: ubuntu-latest
             dependencies-kind: minimal
-          - python-version: 'pypy3.9'
+          - python-version: 'pypy3.10'
             python-architecture: x64
             runs-on: ubuntu-latest
             dependencies-kind: pypy
@@ -176,7 +176,7 @@ jobs:
           python -m pytest -vv -rs tests --parallel-threads 4 --ignore=tests/test_3364_virtualarray.py --ignore=tests/test_3451_virtualarray_with_jax.py --ignore=tests/test_3475_virtualarray_unknown_length.py
 
       - name: Upload Codecov results
-        if: (matrix.python-version == '3.9') && (matrix.runs-on == 'ubuntu-latest')
+        if: (matrix.python-version == '3.10') && (matrix.runs-on == 'ubuntu-latest')
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -298,9 +298,9 @@ jobs:
           # Cache invalidates daily by default
           cache-environment: true
           environment-name: awkward
-          # Need Python 3.9 for the cached wheels
+          # Need Python 3.10 for the cached wheels
           create-args: >-
-            python=3.9
+            python=3.10
             numpy
             root
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.9‒3.14](https://img.shields.io/badge/python-3.9%E2%80%923.14-blue)](https://www.python.org)
+[![Python 3.9‒3.14](https://img.shields.io/badge/python-3.10%E2%80%923.14-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/test.yml)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://badge.fury.io/py/awkward.svg)](https://pypi.org/project/awkward)
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
-[![Python 3.9‒3.14](https://img.shields.io/badge/python-3.10%E2%80%923.14-blue)](https://www.python.org)
+[![Python 3.10‒3.14](https://img.shields.io/badge/python-3.10%E2%80%923.14-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/test.yml)
 

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -46,7 +45,7 @@ classifiers = [
 ]
 license = "BSD-3-Clause AND MIT"
 license-files = ["LICENSE", "rapidjson/license.txt"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://github.com/scikit-hep/awkward-1.0"
@@ -110,7 +109,7 @@ UV_ONLY_BINARY = "cmake,numpy"
 select = "*pyodide*"
 build-frontend = {name = "build", args = ["--exports", "whole_archive"]}
 
-# Use older manylinux for Python 3.9 and 3.10
+# Use older manylinux for Python 3.10
 [[tool.cibuildwheel.overrides]]
-select = "cp3{9,10}-manylinux*"
+select = "cp310-manylinux*"
 manylinux-x86_64-image = "manylinux2014"

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 name = "awkward_cpp"
 version = "51"
 dependencies = [
-    "numpy>=1.18.0"
+    "numpy>=1.21.3"
 ]
 readme = "README.md"
 description = "CPU kernels and compiled extensions for Awkward Array"

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -159,12 +159,12 @@ class Specification:
             temp = []
             for arg in instancedict[name]:
                 temp.append(funcpassdict[arg])
-            combinations.append(zip(*temp, strict=False))
+            combinations.append(zip(*temp, strict=True))
 
         for x in product(*combinations):
             origtemp = OrderedDict()
-            for groupName, t in zip(instancedictlist, x, strict=False):
-                for key, value in zip(instancedict[groupName], t, strict=False):
+            for groupName, t in zip(instancedictlist, x, strict=True):
+                for key, value in zip(instancedict[groupName], t, strict=True):
                     origtemp[key] = value
 
             temp = copy.deepcopy(origtemp)

--- a/dev/generate-tests.py
+++ b/dev/generate-tests.py
@@ -159,12 +159,12 @@ class Specification:
             temp = []
             for arg in instancedict[name]:
                 temp.append(funcpassdict[arg])
-            combinations.append(zip(*temp))
+            combinations.append(zip(*temp, strict=False))
 
         for x in product(*combinations):
             origtemp = OrderedDict()
-            for groupName, t in zip(instancedictlist, x):
-                for key, value in zip(instancedict[groupName], t):
+            for groupName, t in zip(instancedictlist, x, strict=False):
+                for key, value in zip(instancedict[groupName], t, strict=False):
                     origtemp[key] = value
 
             temp = copy.deepcopy(origtemp)

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def tests(session):
     Run the unit and regular tests.
     """
     session.install("-r", "requirements-test-full.txt", "--only-binary=:all:")
-    session.install("./awkward-cpp", ".")
+    session.install("./awkward-cpp", "-e.")
     session.run("pytest", *session.posargs if session.posargs else ["tests"])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 dependencies = [
     "awkward_cpp==51",
     "importlib_metadata>=4.13.0;python_version < \"3.12\"",
-    "numpy>=1.18.0",
+    "numpy>=1.21.3",
     "packaging",
     "typing_extensions>=4.1.0; python_version < \"3.11\"",
     "fsspec>=2022.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "2.8.12"
 description = "Manipulate JSON-like data with NumPy-like idioms."
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Jim Pivarski", email = "jpivarski@gmail.com" },
 ]
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -141,7 +140,7 @@ log_level = "INFO"
 testpaths = ["tests", "tests-cuda", "tests-cuda-kernels", "tests-cuda-kernels-explicit"]
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 jobs = "0"
 ignore-paths = [
     "src/awkward/_typeparser/generated_parser.py",

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,6 +1,6 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-numpy==1.19.3
-pandas==1.1.3
+numpy==1.21.3
+pandas==1.3.4
 pyarrow==14.0.0
 pytest>=6
 pytest-cov

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -122,7 +122,7 @@ def find_ufunc(behavior: Mapping | None, signature: tuple) -> UfuncLike | None:
             and all(
                 k == s
                 or (isinstance(k, type) and isinstance(s, type) and issubclass(s, k))
-                for k, s in zip(key[1:], signature[1:])
+                for k, s in zip(key[1:], signature[1:], strict=False)
             )
         ):
             return custom

--- a/src/awkward/_behavior.py
+++ b/src/awkward/_behavior.py
@@ -122,7 +122,7 @@ def find_ufunc(behavior: Mapping | None, signature: tuple) -> UfuncLike | None:
             and all(
                 k == s
                 or (isinstance(k, type) and isinstance(s, type) and issubclass(s, k))
-                for k, s in zip(key[1:], signature[1:], strict=False)
+                for k, s in zip(key[1:], signature[1:], strict=True)
             )
         ):
             return custom

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -450,7 +450,7 @@ def apply_step(
             named_axes_with_ndims = depth_context[NAMED_AXIS_KEY]
             seen_named_axes = lateral_context[NAMED_AXIS_KEY]
             for i, ((named_axis, ndim), o) in enumerate(
-                zip(named_axes_with_ndims, inputs, strict=False)
+                zip(named_axes_with_ndims, inputs, strict=True)
             ):
                 if isinstance(o, Content):
                     # rightbroadcast
@@ -472,7 +472,7 @@ def apply_step(
                 else:
                     nextinputs.append(o)
             # Did a broadcast take place?
-            if any(x is not y for x, y in zip(inputs, nextinputs, strict=False)):
+            if any(x is not y for x, y in zip(inputs, nextinputs, strict=True)):
                 return apply_step(
                     backend,
                     nextinputs,
@@ -622,7 +622,7 @@ def apply_step(
             nextinputs = []
             nextparameters = []
             for i, ((named_axis, ndim), x, x_is_string) in enumerate(
-                zip(named_axes_with_ndims, inputs, inputs_are_strings, strict=False)
+                zip(named_axes_with_ndims, inputs, inputs_are_strings, strict=True)
             ):
                 if isinstance(x, RegularArray) and not x_is_string:
                     content_size_maybe_one = (
@@ -681,7 +681,7 @@ def apply_step(
 
             return tuple(
                 RegularArray(x, dim_size, length, parameters=p)
-                for x, p in zip(outcontent, parameters, strict=False)
+                for x, p in zip(outcontent, parameters, strict=True)
             )
         # General list-handling case: the offsets of each list may be different.
         else:
@@ -757,7 +757,7 @@ def apply_step(
 
             return tuple(
                 ListOffsetArray(offsets, x, parameters=p)
-                for x, p in zip(outcontent, parameters, strict=False)
+                for x, p in zip(outcontent, parameters, strict=True)
             )
 
     def broadcast_any_option_all_UnmaskedArray():
@@ -788,7 +788,7 @@ def apply_step(
 
         return tuple(
             UnmaskedArray(x, parameters=p)
-            for x, p in zip(outcontent, parameters, strict=False)
+            for x, p in zip(outcontent, parameters, strict=True)
         )
 
     def broadcast_any_option():
@@ -856,7 +856,7 @@ def apply_step(
 
         return tuple(
             IndexedOptionArray.simplified(index, x, parameters=p)
-            for x, p in zip(outcontent, parameters, strict=False)
+            for x, p in zip(outcontent, parameters, strict=True)
         )
 
     def broadcast_any_option_akwhere():

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -450,7 +450,7 @@ def apply_step(
             named_axes_with_ndims = depth_context[NAMED_AXIS_KEY]
             seen_named_axes = lateral_context[NAMED_AXIS_KEY]
             for i, ((named_axis, ndim), o) in enumerate(
-                zip(named_axes_with_ndims, inputs)
+                zip(named_axes_with_ndims, inputs, strict=False)
             ):
                 if isinstance(o, Content):
                     # rightbroadcast
@@ -472,7 +472,7 @@ def apply_step(
                 else:
                     nextinputs.append(o)
             # Did a broadcast take place?
-            if any(x is not y for x, y in zip(inputs, nextinputs)):
+            if any(x is not y for x, y in zip(inputs, nextinputs, strict=False)):
                 return apply_step(
                     backend,
                     nextinputs,
@@ -622,7 +622,7 @@ def apply_step(
             nextinputs = []
             nextparameters = []
             for i, ((named_axis, ndim), x, x_is_string) in enumerate(
-                zip(named_axes_with_ndims, inputs, inputs_are_strings)
+                zip(named_axes_with_ndims, inputs, inputs_are_strings, strict=False)
             ):
                 if isinstance(x, RegularArray) and not x_is_string:
                     content_size_maybe_one = (
@@ -681,7 +681,7 @@ def apply_step(
 
             return tuple(
                 RegularArray(x, dim_size, length, parameters=p)
-                for x, p in zip(outcontent, parameters)
+                for x, p in zip(outcontent, parameters, strict=False)
             )
         # General list-handling case: the offsets of each list may be different.
         else:
@@ -715,7 +715,7 @@ def apply_step(
             nextinputs = []
             nextparameters = []
             for i, ((named_axis, ndim), x, x_is_string) in enumerate(
-                zip(named_axes_with_ndims, inputs, input_is_string)
+                zip(named_axes_with_ndims, inputs, input_is_string, strict=False)
             ):
                 if isinstance(x, listtypes) and not x_is_string:
                     next_content = broadcast_to_offsets_avoiding_carry(x, offsets)
@@ -757,7 +757,7 @@ def apply_step(
 
             return tuple(
                 ListOffsetArray(offsets, x, parameters=p)
-                for x, p in zip(outcontent, parameters)
+                for x, p in zip(outcontent, parameters, strict=False)
             )
 
     def broadcast_any_option_all_UnmaskedArray():
@@ -787,7 +787,8 @@ def apply_step(
         parameters = parameters_factory(nextparameters, len(outcontent))
 
         return tuple(
-            UnmaskedArray(x, parameters=p) for x, p in zip(outcontent, parameters)
+            UnmaskedArray(x, parameters=p)
+            for x, p in zip(outcontent, parameters, strict=False)
         )
 
     def broadcast_any_option():
@@ -855,7 +856,7 @@ def apply_step(
 
         return tuple(
             IndexedOptionArray.simplified(index, x, parameters=p)
-            for x, p in zip(outcontent, parameters)
+            for x, p in zip(outcontent, parameters, strict=False)
         )
 
     def broadcast_any_option_akwhere():

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -1366,7 +1366,9 @@ class RecordGenerator(Generator, ak._lookup.RecordLookup):
             else:
                 fieldnames = self.fields
             getfields = []
-            for i, (fieldname, content) in enumerate(zip(fieldnames, self.contents)):
+            for i, (fieldname, content) in enumerate(
+                zip(fieldnames, self.contents, strict=False)
+            ):
                 if re.match("^[A-Za-z_][A-Za-z_0-9]*$", fieldname) is not None:
                     getfields.append(
                         f"""

--- a/src/awkward/_connect/cling.py
+++ b/src/awkward/_connect/cling.py
@@ -1367,7 +1367,7 @@ class RecordGenerator(Generator, ak._lookup.RecordLookup):
                 fieldnames = self.fields
             getfields = []
             for i, (fieldname, content) in enumerate(
-                zip(fieldnames, self.contents, strict=False)
+                zip(fieldnames, self.contents, strict=True)
             ):
                 if re.match("^[A-Za-z_][A-Za-z_0-9]*$", fieldname) is not None:
                     getfields.append(

--- a/src/awkward/_connect/hist.py
+++ b/src/awkward/_connect/hist.py
@@ -19,7 +19,7 @@ def unpack(array: ak.Array) -> dict[str, ak.Array] | None:
     if not ak.fields(array):
         return None
     else:
-        return dict(zip(ak.fields(array), ak.unzip(array), strict=False))
+        return dict(zip(ak.fields(array), ak.unzip(array), strict=True))
 
 
 def broadcast_and_flatten(args: Sequence[Any]) -> tuple[np.ndarray]:

--- a/src/awkward/_connect/hist.py
+++ b/src/awkward/_connect/hist.py
@@ -19,7 +19,7 @@ def unpack(array: ak.Array) -> dict[str, ak.Array] | None:
     if not ak.fields(array):
         return None
     else:
-        return dict(zip(ak.fields(array), ak.unzip(array)))
+        return dict(zip(ak.fields(array), ak.unzip(array), strict=False))
 
 
 def broadcast_and_flatten(args: Sequence[Any]) -> tuple[np.ndarray]:

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -9,11 +9,11 @@ from awkward import contents, highlevel, record
 from awkward._backends.jax import JaxBackend
 from awkward._layout import HighLevelContext
 from awkward._nplikes.numpy_like import NumpyMetadata
-from awkward._typing import Generic, TypeVar, Union
+from awkward._typing import Generic, TypeVar
 from awkward.contents import Content
 
 T = TypeVar(
-    "T", bound=Union[highlevel.Array, highlevel.Record, contents.Content, record.Record]
+    "T", bound=highlevel.Array | highlevel.Record | contents.Content | record.Record
 )
 
 np = NumpyMetadata.instance()
@@ -72,7 +72,7 @@ class AuxData(Generic[T]):
         data_buffers, other_buffers = split_buffers(buffers)
 
         # now we need to flatten the data buffers
-        data_buffer_keys, data_flat_buffers = zip(*data_buffers.items())
+        data_buffer_keys, data_flat_buffers = zip(*data_buffers.items(), strict=False)
         return data_flat_buffers, AuxData(
             data_buffer_keys=data_buffer_keys,
             other_buffers=other_buffers,
@@ -95,7 +95,7 @@ class AuxData(Generic[T]):
                 )
 
         # reconstitute data buffers
-        data_buffers = dict(zip(self._data_buffer_keys, data_buffers))
+        data_buffers = dict(zip(self._data_buffer_keys, data_buffers, strict=False))
 
         # combine data buffers with other buffers
         buffers = {**self._other_buffers, **data_buffers}

--- a/src/awkward/_connect/jax/trees.py
+++ b/src/awkward/_connect/jax/trees.py
@@ -72,7 +72,7 @@ class AuxData(Generic[T]):
         data_buffers, other_buffers = split_buffers(buffers)
 
         # now we need to flatten the data buffers
-        data_buffer_keys, data_flat_buffers = zip(*data_buffers.items(), strict=False)
+        data_buffer_keys, data_flat_buffers = zip(*data_buffers.items(), strict=True)
         return data_flat_buffers, AuxData(
             data_buffer_keys=data_buffer_keys,
             other_buffers=other_buffers,
@@ -95,7 +95,7 @@ class AuxData(Generic[T]):
                 )
 
         # reconstitute data buffers
-        data_buffers = dict(zip(self._data_buffer_keys, data_buffers, strict=False))
+        data_buffers = dict(zip(self._data_buffer_keys, data_buffers, strict=True))
 
         # combine data buffers with other buffers
         buffers = {**self._other_buffers, **data_buffers}

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -918,7 +918,7 @@ def overload_contains(obj, element):
                         add_statement(indent, name + "[" + repr(fi) + "]", ft, False)
                 else:
                     for fn, ft in zip(
-                        arraytype.fields, arraytype.contenttypes, strict=False
+                        arraytype.fields, arraytype.contenttypes, strict=True
                     ):
                         add_statement(indent, name + "[" + repr(fn) + "]", ft, False)
 

--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -917,7 +917,9 @@ def overload_contains(obj, element):
                     for fi, ft in enumerate(arraytype.contenttypes):
                         add_statement(indent, name + "[" + repr(fi) + "]", ft, False)
                 else:
-                    for fn, ft in zip(arraytype.fields, arraytype.contenttypes):
+                    for fn, ft in zip(
+                        arraytype.fields, arraytype.contenttypes, strict=False
+                    ):
                         add_statement(indent, name + "[" + repr(fn) + "]", ft, False)
 
             elif arraytype.ndim == 1 and not arraytype.is_recordtype:

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -120,7 +120,7 @@ def evaluate(
                 ak.contents.NumpyArray(
                     numexpr.evaluate(
                         expression,
-                        dict(zip(names, input_primitives, strict=False)),
+                        dict(zip(names, input_primitives, strict=True)),
                         {},
                         order=order,
                         casting=casting,
@@ -188,7 +188,7 @@ def re_evaluate(local_dict=None):
             return (
                 ak.contents.NumpyArray(
                     numexpr.re_evaluate(
-                        dict(zip(names, input_primitives, strict=False))
+                        dict(zip(names, input_primitives, strict=True))
                     )
                 ),
             )

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -187,9 +187,7 @@ def re_evaluate(local_dict=None):
             ]
             return (
                 ak.contents.NumpyArray(
-                    numexpr.re_evaluate(
-                        dict(zip(names, input_primitives, strict=True))
-                    )
+                    numexpr.re_evaluate(dict(zip(names, input_primitives, strict=True)))
                 ),
             )
         else:

--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -120,7 +120,7 @@ def evaluate(
                 ak.contents.NumpyArray(
                     numexpr.evaluate(
                         expression,
-                        dict(zip(names, input_primitives)),
+                        dict(zip(names, input_primitives, strict=False)),
                         {},
                         order=order,
                         casting=casting,
@@ -187,7 +187,9 @@ def re_evaluate(local_dict=None):
             ]
             return (
                 ak.contents.NumpyArray(
-                    numexpr.re_evaluate(dict(zip(names, input_primitives)))
+                    numexpr.re_evaluate(
+                        dict(zip(names, input_primitives, strict=False))
+                    )
                 ),
             )
         else:

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -143,7 +143,7 @@ def native_arrow_field_to_akarraytype(
             awkwardized_fields = [
                 native_arrow_field_to_akarraytype(field, meta)  # Recurse
                 for field, meta in zip(
-                    fields, metadata["subfield_metadata"], strict=False
+                    fields, metadata["subfield_metadata"], strict=True
                 )
             ]
         elif len(fields) < len(sub_meta):
@@ -235,7 +235,7 @@ def replace_schema(table: pyarrow.Table, new_schema: pyarrow.Schema) -> pyarrow.
     new_batches = []
     for batch in table.to_batches():
         columns = []
-        for col, new_field in zip(batch.columns, new_schema, strict=False):
+        for col, new_field in zip(batch.columns, new_schema, strict=True):
             columns.append(array_with_replacement_type(col, new_field.type))
         new_batches.append(
             pyarrow.RecordBatch.from_arrays(arrays=columns, schema=new_schema)
@@ -259,7 +259,7 @@ def array_with_replacement_type(
         )
     children_new = [
         array_with_replacement_type(child, new_child_type.type)
-        for child, new_child_type in zip(children_orig, new_fields, strict=False)
+        for child, new_child_type in zip(children_orig, new_fields, strict=True)
     ]
     own_buffers = orig_array.buffers()[: orig_array.type.num_buffers]
     if isinstance(native_type, pyarrow.lib.DictionaryType):

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -142,7 +142,9 @@ def native_arrow_field_to_akarraytype(
         if len(sub_meta) == len(fields):
             awkwardized_fields = [
                 native_arrow_field_to_akarraytype(field, meta)  # Recurse
-                for field, meta in zip(fields, metadata["subfield_metadata"])
+                for field, meta in zip(
+                    fields, metadata["subfield_metadata"], strict=False
+                )
             ]
         elif len(fields) < len(sub_meta):
             # If a user has read a partial column, we can have fewer Arrow fields than the original.
@@ -233,7 +235,7 @@ def replace_schema(table: pyarrow.Table, new_schema: pyarrow.Schema) -> pyarrow.
     new_batches = []
     for batch in table.to_batches():
         columns = []
-        for col, new_field in zip(batch.columns, new_schema):
+        for col, new_field in zip(batch.columns, new_schema, strict=False):
             columns.append(array_with_replacement_type(col, new_field.type))
         new_batches.append(
             pyarrow.RecordBatch.from_arrays(arrays=columns, schema=new_schema)
@@ -257,7 +259,7 @@ def array_with_replacement_type(
         )
     children_new = [
         array_with_replacement_type(child, new_child_type.type)
-        for child, new_child_type in zip(children_orig, new_fields)
+        for child, new_child_type in zip(children_orig, new_fields, strict=False)
     ]
     own_buffers = orig_array.buffers()[: orig_array.type.num_buffers]
     if isinstance(native_type, pyarrow.lib.DictionaryType):

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -96,7 +96,7 @@ class NumpyKernel(BaseKernel):
         args = maybe_materialize(*args)
 
         return self._impl(
-            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=False))
+            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=True))
         )
 
 
@@ -143,7 +143,7 @@ class JaxKernel(BaseKernel):
         args = maybe_materialize(*args)
 
         return self._impl(
-            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=False))
+            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=True))
         )
 
 
@@ -198,7 +198,7 @@ class CupyKernel(BaseKernel):
             )
         assert len(args) == len(self._impl.is_ptr)
 
-        args = [self._cast(x, t) for x, t in zip(args, self._impl.is_ptr, strict=False)]
+        args = [self._cast(x, t) for x, t in zip(args, self._impl.is_ptr, strict=True)]
 
         # The first arg is the invocation index which raises itself by 8 in the kernel if there was no error before.
         # The second arg is the error_code.

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import ctypes
 from abc import abstractmethod
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from packaging.version import parse as parse_version
 
@@ -95,7 +96,7 @@ class NumpyKernel(BaseKernel):
         args = maybe_materialize(*args)
 
         return self._impl(
-            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
+            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=False))
         )
 
 
@@ -142,7 +143,7 @@ class JaxKernel(BaseKernel):
         args = maybe_materialize(*args)
 
         return self._impl(
-            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes))
+            *(self._cast(x, t) for x, t in zip(args, self._impl.argtypes, strict=False))
         )
 
 
@@ -197,7 +198,7 @@ class CupyKernel(BaseKernel):
             )
         assert len(args) == len(self._impl.is_ptr)
 
-        args = [self._cast(x, t) for x, t in zip(args, self._impl.is_ptr)]
+        args = [self._cast(x, t) for x, t in zip(args, self._impl.is_ptr, strict=False)]
 
         # The first arg is the invocation index which raises itself by 8 in the kernel if there was no error before.
         # The second arg is the error_code.

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -667,7 +667,7 @@ class NamedAxesWithDims:
             )
 
     def __iter__(self) -> tp.Iterator[tuple[AxisMapping, int | None]]:
-        yield from zip(self.named_axis, self.ndims, strict=False)
+        yield from zip(self.named_axis, self.ndims, strict=True)
 
     @classmethod
     def prepare_contexts(

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -667,7 +667,7 @@ class NamedAxesWithDims:
             )
 
     def __iter__(self) -> tp.Iterator[tuple[AxisMapping, int | None]]:
-        yield from zip(self.named_axis, self.ndims)
+        yield from zip(self.named_axis, self.ndims, strict=False)
 
     @classmethod
     def prepare_contexts(
@@ -710,7 +710,7 @@ class NamedAxesWithDims:
 
 
 # Define a type alias for a slice or int (can be a single axis or a sequence of axes)
-AxisSlice: tp.TypeAlias = tp.Union[tuple, slice, int, tp.EllipsisType, None]
+AxisSlice: tp.TypeAlias = tuple | slice | int | tp.EllipsisType | None
 NamedAxisSlice: tp.TypeAlias = tp.Dict[AxisName, AxisSlice]
 
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -279,7 +279,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         # Interpret the arguments under these dtypes, converting scalars to length-1 arrays
         resolved_args = [
             cast("ArrayLikeT", self.asarray(arg, dtype=dtype))
-            for arg, dtype in zip(args, resolved_dtypes)
+            for arg, dtype in zip(args, resolved_dtypes, strict=False)
         ]
         # Broadcast to ensure all-scalar or all-nd-array
         broadcasted_args = self.broadcast_arrays(*resolved_args)
@@ -307,7 +307,8 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         broadcasted_args = self.broadcast_arrays(*resolved_args)
         # Choose the broadcasted argument if it wasn't a Python scalar
         non_generic_value_promoted_args = [
-            y if hasattr(x, "ndim") else x for x, y in zip(args, broadcasted_args)
+            y if hasattr(x, "ndim") else x
+            for x, y in zip(args, broadcasted_args, strict=False)
         ]
         # Allow other nplikes to replace implementation
         impl = self.prepare_ufunc(ufunc)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -279,7 +279,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         # Interpret the arguments under these dtypes, converting scalars to length-1 arrays
         resolved_args = [
             cast("ArrayLikeT", self.asarray(arg, dtype=dtype))
-            for arg, dtype in zip(args, resolved_dtypes, strict=False)
+            for arg, dtype in zip(args, resolved_dtypes[:len(args)], strict=True)
         ]
         # Broadcast to ensure all-scalar or all-nd-array
         broadcasted_args = self.broadcast_arrays(*resolved_args)
@@ -308,7 +308,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         # Choose the broadcasted argument if it wasn't a Python scalar
         non_generic_value_promoted_args = [
             y if hasattr(x, "ndim") else x
-            for x, y in zip(args, broadcasted_args, strict=False)
+            for x, y in zip(args, broadcasted_args, strict=True)
         ]
         # Allow other nplikes to replace implementation
         impl = self.prepare_ufunc(ufunc)

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -279,7 +279,7 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
         # Interpret the arguments under these dtypes, converting scalars to length-1 arrays
         resolved_args = [
             cast("ArrayLikeT", self.asarray(arg, dtype=dtype))
-            for arg, dtype in zip(args, resolved_dtypes[:len(args)], strict=True)
+            for arg, dtype in zip(args, resolved_dtypes[: len(args)], strict=True)
         ]
         # Broadcast to ensure all-scalar or all-nd-array
         broadcasted_args = self.broadcast_arrays(*resolved_args)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -670,7 +670,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         # Interpret the arguments under these dtypes
         resolved_args = [
             self.asarray(arg, dtype=dtype)
-            for arg, dtype in zip(args, resolved_dtypes[:len(args)], strict=True)
+            for arg, dtype in zip(args, resolved_dtypes[: len(args)], strict=True)
         ]
         # Broadcast to ensure all-scalar or all-nd-array
         broadcasted_args = self.broadcast_arrays(*resolved_args)

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -670,7 +670,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         # Interpret the arguments under these dtypes
         resolved_args = [
             self.asarray(arg, dtype=dtype)
-            for arg, dtype in zip(args, resolved_dtypes, strict=False)
+            for arg, dtype in zip(args, resolved_dtypes[:len(args)], strict=True)
         ]
         # Broadcast to ensure all-scalar or all-nd-array
         broadcasted_args = self.broadcast_arrays(*resolved_args)
@@ -708,7 +708,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         # Choose the broadcasted argument if it wasn't a Python scalar
         non_generic_value_promoted_args = [
             y if hasattr(x, "ndim") else x
-            for x, y in zip(args, broadcasted_args, strict=False)
+            for x, y in zip(args, broadcasted_args, strict=True)
         ]
         # Build proxy (empty) arrays
         proxy_args = [
@@ -1196,7 +1196,7 @@ class TypeTracer(NumpyLike[TypeTracerArray]):
         if len(new_shape) != len(shape):
             raise ValueError
 
-        for result, intended in zip(new_shape, shape, strict=False):
+        for result, intended in zip(new_shape, shape, strict=True):
             if intended is unknown_length:
                 continue
             if result is unknown_length:
@@ -1785,7 +1785,7 @@ def _attach_report(
 
     elif isinstance(layout, ak.contents.RecordArray):
         assert isinstance(form, ak.forms.RecordForm)
-        for x, y in zip(layout.contents, form.contents, strict=False):
+        for x, y in zip(layout.contents, form.contents, strict=True):
             _attach_report(x, y, report, getkey)
 
     elif isinstance(layout, (ak.contents.RegularArray, ak.contents.UnmaskedArray)):
@@ -1798,7 +1798,7 @@ def _attach_report(
         layout.tags.data.report = report  # type: ignore[attr-defined]
         layout.index.data.form_key = getkey(form, "index")  # type: ignore[attr-defined]
         layout.index.data.report = report  # type: ignore[attr-defined]
-        for x, y in zip(layout.contents, form.contents, strict=False):
+        for x, y in zip(layout.contents, form.contents, strict=True):
             _attach_report(x, y, report, getkey)
 
     else:

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -165,7 +165,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 raise ValueError(
                     f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
                 )
-            for expected_dim, actual_dim in zip(self._shape, shape):
+            for expected_dim, actual_dim in zip(self._shape, shape, strict=False):
                 if expected_dim is not unknown_length and expected_dim != actual_dim:
                     raise ValueError(
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
@@ -184,7 +184,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 raise ValueError(
                     f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {array.shape}"
                 )
-            for expected_dim, actual_dim in zip(self._shape, array.shape):
+            for expected_dim, actual_dim in zip(self._shape, array.shape, strict=False):
                 if expected_dim is not unknown_length and expected_dim != actual_dim:
                     raise ValueError(
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {array.shape}"

--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -165,7 +165,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 raise ValueError(
                     f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
                 )
-            for expected_dim, actual_dim in zip(self._shape, shape, strict=False):
+            for expected_dim, actual_dim in zip(self._shape, shape, strict=True):
                 if expected_dim is not unknown_length and expected_dim != actual_dim:
                     raise ValueError(
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {shape}"
@@ -184,7 +184,7 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
                 raise ValueError(
                     f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {array.shape}"
                 )
-            for expected_dim, actual_dim in zip(self._shape, array.shape, strict=False):
+            for expected_dim, actual_dim in zip(self._shape, array.shape, strict=True):
                 if expected_dim is not unknown_length and expected_dim != actual_dim:
                     raise ValueError(
                         f"{type(self).__name__} had shape {self._shape} before materialization while the materialized array has shape {array.shape}"

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -119,7 +119,7 @@ def prepare_advanced_indexing(items, backend: Backend):
 
     # And re-assemble the index with the broadcasted items
     prepared = []
-    for i_broadcast, item in zip(broadcastable_index, items, strict=False):
+    for i_broadcast, item in zip(broadcastable_index, items, strict=True):
         # Non-broadcasted item
         if i_broadcast is None:
             prepared.append(item)

--- a/src/awkward/_slicing.py
+++ b/src/awkward/_slicing.py
@@ -119,7 +119,7 @@ def prepare_advanced_indexing(items, backend: Backend):
 
     # And re-assemble the index with the broadcasted items
     prepared = []
-    for i_broadcast, item in zip(broadcastable_index, items):
+    for i_broadcast, item in zip(broadcastable_index, items, strict=False):
         # Non-broadcasted item
         if i_broadcast is None:
             prepared.append(item)

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -35,16 +35,22 @@ __all__ = list(
 AxisMaybeNone = TypeVar("AxisMaybeNone", int, None)  # noqa: F405
 
 if sys.version_info < (3, 11):
-    from typing import ClassVar, Final, SupportsIndex, final, runtime_checkable
+    from typing import (
+        ClassVar,
+        Final,
+        Literal,
+        SupportsIndex,
+        TypeAlias,
+        TypeGuard,
+        final,
+        runtime_checkable,
+    )
 
     from typing_extensions import (
-        Literal,
         ParamSpec,
         Protocol,
         Self,
-        TypeAlias,
         TypedDict,
-        TypeGuard,
         Unpack,
     )
 

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1300,7 +1300,7 @@ class Content(Meta):
                             outimag[i] = f2(f1(f0(x)))
 
                 if outimag is not None:
-                    for i, (real, imag) in enumerate(zip(out, outimag)):
+                    for i, (real, imag) in enumerate(zip(out, outimag, strict=False)):
                         out[i] = {complex_real_string: real, complex_imag_string: imag}
 
             return out

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -1300,7 +1300,7 @@ class Content(Meta):
                             outimag[i] = f2(f1(f0(x)))
 
                 if outimag is not None:
-                    for i, (real, imag) in enumerate(zip(out, outimag, strict=False)):
+                    for i, (real, imag) in enumerate(zip(out, outimag, strict=True)):
                         out[i] = {complex_real_string: real, complex_imag_string: imag}
 
             return out

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1444,7 +1444,7 @@ class NumpyArray(NumpyMeta, Content):
                 # Shapes agree
                 and all(
                     x is unknown_length or y is unknown_length or x == y
-                    for x, y in zip(self.shape, other.shape, strict=False)
+                    for x, y in zip(self.shape, other.shape, strict=True)
                 )
             )
         )

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -1444,7 +1444,7 @@ class NumpyArray(NumpyMeta, Content):
                 # Shapes agree
                 and all(
                     x is unknown_length or y is unknown_length or x == y
-                    for x, y in zip(self.shape, other.shape)
+                    for x, y in zip(self.shape, other.shape, strict=False)
                 )
             )
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -323,7 +323,7 @@ class RecordArray(RecordMeta[Content], Content):
         # also for tuple records
         contents = [
             x._form_with_key_path((*path, k))
-            for k, x in zip(self.fields, self._contents, strict=False)
+            for k, x in zip(self.fields, self._contents, strict=True)
         ]
 
         return self.form_cls(
@@ -672,7 +672,7 @@ class RecordArray(RecordMeta[Content], Content):
             if self.is_tuple and other.is_tuple:
                 if len(self._contents) == len(other._contents):
                     for self_cont, other_cont in zip(
-                        self._contents, other._contents, strict=False
+                        self._contents, other._contents, strict=True
                     ):
                         if not self_cont._mergeable_next(
                             other_cont, mergebool, mergecastable
@@ -1155,7 +1155,7 @@ class RecordArray(RecordMeta[Content], Content):
             c._to_cudf(cudf, mask=None, length=length) for c in self.contents
         )
         dt = cudf.core.dtypes.StructDtype(
-            {field: c.dtype for field, c in zip(self.fields, children, strict=False)}
+            {field: c.dtype for field, c in zip(self.fields, children, strict=True)}
         )
         m = mask._to_cudf(cudf, None, length) if mask else None
         return cudf.core.column.struct.StructColumn(
@@ -1183,11 +1183,11 @@ class RecordArray(RecordMeta[Content], Content):
         out = backend.nplike.empty(
             self.length,
             dtype=[
-                (str(n), x.dtype) for n, x in zip(self.fields, contents, strict=False)
+                (str(n), x.dtype) for n, x in zip(self.fields, contents, strict=True)
             ],
         )
         mask = None
-        for n, x in zip(self.fields, contents, strict=False):
+        for n, x in zip(self.fields, contents, strict=True):
             if allow_missing and isinstance(x, self._backend.nplike.ma.MaskedArray):
                 if mask is None:
                     mask = backend.nplike.ma.zeros(
@@ -1323,7 +1323,7 @@ class RecordArray(RecordMeta[Content], Content):
             contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
-                out[i] = dict(zip(fields, [x[i] for x in contents], strict=False))
+                out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -1365,6 +1365,6 @@ class RecordArray(RecordMeta[Content], Content):
                 content._is_equal_to(
                     other.content(field), index_dtype, numpyarray, all_parameters
                 )
-                for field, content in zip(self.fields, self._contents, strict=False)
+                for field, content in zip(self.fields, self._contents, strict=True)
             )
         )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -323,7 +323,7 @@ class RecordArray(RecordMeta[Content], Content):
         # also for tuple records
         contents = [
             x._form_with_key_path((*path, k))
-            for k, x in zip(self.fields, self._contents)
+            for k, x in zip(self.fields, self._contents, strict=False)
         ]
 
         return self.form_cls(
@@ -671,7 +671,9 @@ class RecordArray(RecordMeta[Content], Content):
         elif isinstance(other, RecordArray):
             if self.is_tuple and other.is_tuple:
                 if len(self._contents) == len(other._contents):
-                    for self_cont, other_cont in zip(self._contents, other._contents):
+                    for self_cont, other_cont in zip(
+                        self._contents, other._contents, strict=False
+                    ):
                         if not self_cont._mergeable_next(
                             other_cont, mergebool, mergecastable
                         ):
@@ -1153,7 +1155,7 @@ class RecordArray(RecordMeta[Content], Content):
             c._to_cudf(cudf, mask=None, length=length) for c in self.contents
         )
         dt = cudf.core.dtypes.StructDtype(
-            {field: c.dtype for field, c in zip(self.fields, children)}
+            {field: c.dtype for field, c in zip(self.fields, children, strict=False)}
         )
         m = mask._to_cudf(cudf, None, length) if mask else None
         return cudf.core.column.struct.StructColumn(
@@ -1180,10 +1182,12 @@ class RecordArray(RecordMeta[Content], Content):
             )
         out = backend.nplike.empty(
             self.length,
-            dtype=[(str(n), x.dtype) for n, x in zip(self.fields, contents)],
+            dtype=[
+                (str(n), x.dtype) for n, x in zip(self.fields, contents, strict=False)
+            ],
         )
         mask = None
-        for n, x in zip(self.fields, contents):
+        for n, x in zip(self.fields, contents, strict=False):
             if allow_missing and isinstance(x, self._backend.nplike.ma.MaskedArray):
                 if mask is None:
                     mask = backend.nplike.ma.zeros(
@@ -1319,7 +1323,7 @@ class RecordArray(RecordMeta[Content], Content):
             contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
-                out[i] = dict(zip(fields, [x[i] for x in contents]))
+                out[i] = dict(zip(fields, [x[i] for x in contents], strict=False))
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -1361,6 +1365,6 @@ class RecordArray(RecordMeta[Content], Content):
                 content._is_equal_to(
                     other.content(field), index_dtype, numpyarray, all_parameters
                 )
-                for field, content in zip(self.fields, self._contents)
+                for field, content in zip(self.fields, self._contents, strict=False)
             )
         )

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -289,7 +289,7 @@ def _expand_braces(text, seen=None):
     else:
         for combo in itertools.product(*alts):
             replaced = list(text)
-            for (start, stop), replacement in zip(spans, combo, strict=False):
+            for (start, stop), replacement in zip(spans, combo, strict=True):
                 replaced[start:stop] = replacement
             yield from _expand_braces("".join(replaced), seen)
 

--- a/src/awkward/forms/form.py
+++ b/src/awkward/forms/form.py
@@ -31,7 +31,6 @@ from awkward._typing import (
     Self,
     Tuple,
     TypeAlias,
-    Union,
 )
 
 __all__ = ("Form", "from_dict", "from_json", "from_type", "reserved_nominal_parameters")
@@ -39,7 +38,7 @@ __all__ = ("Form", "from_dict", "from_json", "from_type", "reserved_nominal_para
 np = NumpyMetadata.instance()
 numpy_backend = NumpyBackend.instance()
 
-FormKeyPathT: TypeAlias = Tuple[Union[str, int, None], ...]
+FormKeyPathT: TypeAlias = Tuple[str | int | None, ...]
 
 reserved_nominal_parameters: Final = frozenset(
     {
@@ -290,7 +289,7 @@ def _expand_braces(text, seen=None):
     else:
         for combo in itertools.product(*alts):
             replaced = list(text)
-            for (start, stop), replacement in zip(spans, combo):
+            for (start, stop), replacement in zip(spans, combo, strict=False):
                 replaced[start:stop] = replacement
             yield from _expand_braces("".join(replaced), seen)
 

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -110,13 +110,13 @@ class RecordForm(RecordMeta[Form], Form):
         )
 
     def _columns(self, path, output, list_indicator):
-        for content, field in zip(self._contents, self.fields):
+        for content, field in zip(self._contents, self.fields, strict=False):
             content._columns((*path, field), output, list_indicator)
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
         contents = []
         fields = []
-        for content, field in zip(self._contents, self.fields):
+        for content, field in zip(self._contents, self.fields, strict=False):
             next_content = content._prune_columns(True)
             if next_content is None:
                 continue
@@ -134,7 +134,7 @@ class RecordForm(RecordMeta[Form], Form):
     def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
         contents = []
         fields = []
-        for content, field in zip(self._contents, self.fields):
+        for content, field in zip(self._contents, self.fields, strict=False):
             # Try and match this field, allowing derived matcher to match any field if empty
             next_match_specifier = match_specifier(field, next_match_if_empty=True)
             if next_match_specifier is None:
@@ -186,6 +186,6 @@ class RecordForm(RecordMeta[Form], Form):
             and all(f in computed_fields_set for f in other.fields)
             and all(
                 content._is_equal_to(other.content(field), all_parameters, form_key)
-                for field, content in zip(self.fields, self._contents)
+                for field, content in zip(self.fields, self._contents, strict=False)
             )
         )

--- a/src/awkward/forms/recordform.py
+++ b/src/awkward/forms/recordform.py
@@ -110,13 +110,13 @@ class RecordForm(RecordMeta[Form], Form):
         )
 
     def _columns(self, path, output, list_indicator):
-        for content, field in zip(self._contents, self.fields, strict=False):
+        for content, field in zip(self._contents, self.fields, strict=True):
             content._columns((*path, field), output, list_indicator)
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Self | None:
         contents = []
         fields = []
-        for content, field in zip(self._contents, self.fields, strict=False):
+        for content, field in zip(self._contents, self.fields, strict=True):
             next_content = content._prune_columns(True)
             if next_content is None:
                 continue
@@ -134,7 +134,7 @@ class RecordForm(RecordMeta[Form], Form):
     def _select_columns(self, match_specifier: _SpecifierMatcher) -> Self:
         contents = []
         fields = []
-        for content, field in zip(self._contents, self.fields, strict=False):
+        for content, field in zip(self._contents, self.fields, strict=True):
             # Try and match this field, allowing derived matcher to match any field if empty
             next_match_specifier = match_specifier(field, next_match_if_empty=True)
             if next_match_specifier is None:
@@ -186,6 +186,6 @@ class RecordForm(RecordMeta[Form], Form):
             and all(f in computed_fields_set for f in other.fields)
             and all(
                 content._is_equal_to(other.content(field), all_parameters, form_key)
-                for field, content in zip(self.fields, self._contents, strict=False)
+                for field, content in zip(self.fields, self._contents, strict=True)
             )
         )

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -135,7 +135,7 @@ class UnionForm(UnionMeta[Form], Form):
         )
 
     def _columns(self, path, output, list_indicator):
-        for content, field in zip(self._contents, self.fields):
+        for content, field in zip(self._contents, self.fields, strict=False):
             content._columns((*path, field), output, list_indicator)
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Form | None:
@@ -202,7 +202,7 @@ class UnionForm(UnionMeta[Form], Form):
             and any(
                 all(
                     x._is_equal_to(y, all_parameters, form_key)
-                    for x, y in zip(self._contents, c)
+                    for x, y in zip(self._contents, c, strict=False)
                 )
                 for c in permutations(other.contents)
             )

--- a/src/awkward/forms/unionform.py
+++ b/src/awkward/forms/unionform.py
@@ -135,7 +135,7 @@ class UnionForm(UnionMeta[Form], Form):
         )
 
     def _columns(self, path, output, list_indicator):
-        for content, field in zip(self._contents, self.fields, strict=False):
+        for content, field in zip(self._contents, self.fields, strict=True):
             content._columns((*path, field), output, list_indicator)
 
     def _prune_columns(self, is_inside_record_or_union: bool) -> Form | None:
@@ -202,7 +202,7 @@ class UnionForm(UnionMeta[Form], Form):
             and any(
                 all(
                     x._is_equal_to(y, all_parameters, form_key)
-                    for x, y in zip(self._contents, c, strict=False)
+                    for x, y in zip(self._contents, c, strict=True)
                 )
                 for c in permutations(other.contents)
             )

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -281,7 +281,7 @@ def _impl(
                 return False
 
             # Now project out the contents, and check for equality
-            for i, j in zip(left_tag_order, right_tag_order):
+            for i, j in zip(left_tag_order, right_tag_order, strict=False):
                 if not visitor(left.project(i), right.project(j)):
                     return False
             return True

--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -281,7 +281,7 @@ def _impl(
                 return False
 
             # Now project out the contents, and check for equality
-            for i, j in zip(left_tag_order, right_tag_order, strict=False):
+            for i, j in zip(left_tag_order, right_tag_order, strict=True):
                 if not visitor(left.project(i), right.project(j)):
                     return False
             return True

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -268,7 +268,7 @@ def _impl(
         _unify_named_axis, lateral_context[NAMED_AXIS_KEY].named_axis
     )
     wrapped_out = []
-    for layout_out, array_in in zip(out, arrays, strict=False):
+    for layout_out, array_in in zip(out, arrays, strict=True):
         _behavior = behavior_of_obj(array_in, behavior=behavior)
         _attrs = attrs_of_obj(array_in, attrs=attrs)
         wrapped = wrap_layout(

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -268,7 +268,7 @@ def _impl(
         _unify_named_axis, lateral_context[NAMED_AXIS_KEY].named_axis
     )
     wrapped_out = []
-    for layout_out, array_in in zip(out, arrays):
+    for layout_out, array_in in zip(out, arrays, strict=False):
         _behavior = behavior_of_obj(array_in, behavior=behavior)
         _attrs = attrs_of_obj(array_in, attrs=attrs)
         wrapped = wrap_layout(

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -96,10 +96,14 @@ def _descend_to_record_or_leaf(layout, pullback=_identity):
 # layout.copy, the pull-back functions can be arbitrarily deep: the closures maintain the structure of the array
 def _recurse(inputs):
     # Descend to records, identities, or leaves
-    pullbacks, next_inputs = zip(*[_descend_to_record_or_leaf(x) for x in inputs])
+    pullbacks, next_inputs = zip(
+        *[_descend_to_record_or_leaf(x) for x in inputs], strict=False
+    )
     # With no records, we can exit here
     if not any(c.is_record for c in next_inputs):
-        return [pull(layout) for pull, layout in zip(pullbacks, next_inputs)]
+        return [
+            pull(layout) for pull, layout in zip(pullbacks, next_inputs, strict=False)
+        ]
     # Otherwise, we can only work with all non-record, or all record/identity
     elif not all(c.is_record or c.is_identity_like for c in next_inputs):
         raise AssertionError(
@@ -142,7 +146,7 @@ def _recurse(inputs):
         )
 
     # Now we transpose the list-of-lists to group layouts by original record, instead of by the field
-    layouts_by_record = zip(*layouts_by_field)
+    layouts_by_record = zip(*layouts_by_field, strict=False)
     # Rebuild the original records with the new fields
     next_records = iter(
         [
@@ -150,7 +154,7 @@ def _recurse(inputs):
                 fields=all_fields,
                 contents=contents,
             )
-            for record, contents in zip(next_records, layouts_by_record)
+            for record, contents in zip(next_records, layouts_by_record, strict=False)
         ]
     )
 
@@ -161,7 +165,9 @@ def _recurse(inputs):
     ]
 
     # Rebuild the outermost layouts using pull-back functions
-    return [pull(layout) for pull, layout in zip(pullbacks, inner_layouts)]
+    return [
+        pull(layout) for pull, layout in zip(pullbacks, inner_layouts, strict=False)
+    ]
 
 
 def _impl(arrays, highlevel, behavior, attrs):
@@ -188,5 +194,5 @@ def _impl(arrays, highlevel, behavior, attrs):
             highlevel=highlevel,
             attrs=attrs_of_obj(array_in, attrs=attrs),
         )
-        for layout_out, array_in in zip(result_layouts, arrays)
+        for layout_out, array_in in zip(result_layouts, arrays, strict=False)
     ]

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -165,9 +165,7 @@ def _recurse(inputs):
     ]
 
     # Rebuild the outermost layouts using pull-back functions
-    return [
-        pull(layout) for pull, layout in zip(pullbacks, inner_layouts, strict=True)
-    ]
+    return [pull(layout) for pull, layout in zip(pullbacks, inner_layouts, strict=True)]
 
 
 def _impl(arrays, highlevel, behavior, attrs):

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -97,12 +97,12 @@ def _descend_to_record_or_leaf(layout, pullback=_identity):
 def _recurse(inputs):
     # Descend to records, identities, or leaves
     pullbacks, next_inputs = zip(
-        *[_descend_to_record_or_leaf(x) for x in inputs], strict=False
+        *[_descend_to_record_or_leaf(x) for x in inputs], strict=True
     )
     # With no records, we can exit here
     if not any(c.is_record for c in next_inputs):
         return [
-            pull(layout) for pull, layout in zip(pullbacks, next_inputs, strict=False)
+            pull(layout) for pull, layout in zip(pullbacks, next_inputs, strict=True)
         ]
     # Otherwise, we can only work with all non-record, or all record/identity
     elif not all(c.is_record or c.is_identity_like for c in next_inputs):
@@ -146,7 +146,7 @@ def _recurse(inputs):
         )
 
     # Now we transpose the list-of-lists to group layouts by original record, instead of by the field
-    layouts_by_record = zip(*layouts_by_field, strict=False)
+    layouts_by_record = zip(*layouts_by_field, strict=True)
     # Rebuild the original records with the new fields
     next_records = iter(
         [
@@ -154,7 +154,7 @@ def _recurse(inputs):
                 fields=all_fields,
                 contents=contents,
             )
-            for record, contents in zip(next_records, layouts_by_record, strict=False)
+            for record, contents in zip(next_records, layouts_by_record, strict=True)
         ]
     )
 
@@ -166,7 +166,7 @@ def _recurse(inputs):
 
     # Rebuild the outermost layouts using pull-back functions
     return [
-        pull(layout) for pull, layout in zip(pullbacks, inner_layouts, strict=False)
+        pull(layout) for pull, layout in zip(pullbacks, inner_layouts, strict=True)
     ]
 
 
@@ -194,5 +194,5 @@ def _impl(arrays, highlevel, behavior, attrs):
             highlevel=highlevel,
             attrs=attrs_of_obj(array_in, attrs=attrs),
         )
-        for layout_out, array_in in zip(result_layouts, arrays, strict=False)
+        for layout_out, array_in in zip(result_layouts, arrays, strict=True)
     ]

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -232,7 +232,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
                 )
             )
             fields = list(arrays.keys())
-            array_layouts = dict(zip(fields, layouts, strict=False))
+            array_layouts = dict(zip(fields, layouts, strict=True))
 
             # propagate named axis from input to output,
             #   use strategy "unify" (see: awkward._namedaxis)
@@ -330,7 +330,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
         ]
         outs = [
             ak.contents.IndexedArray.simplified(x, y)
-            for x, y in zip(indexes, layouts, strict=False)
+            for x, y in zip(indexes, layouts, strict=True)
         ]
 
         result = ak.contents.RecordArray(outs, fields, parameters=parameters)

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -232,7 +232,7 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
                 )
             )
             fields = list(arrays.keys())
-            array_layouts = dict(zip(fields, layouts))
+            array_layouts = dict(zip(fields, layouts, strict=False))
 
             # propagate named axis from input to output,
             #   use strategy "unify" (see: awkward._namedaxis)
@@ -329,7 +329,8 @@ def _impl(arrays, axis, nested, parameters, with_name, highlevel, behavior, attr
             )
         ]
         outs = [
-            ak.contents.IndexedArray.simplified(x, y) for x, y in zip(indexes, layouts)
+            ak.contents.IndexedArray.simplified(x, y)
+            for x, y in zip(indexes, layouts, strict=False)
         ]
 
         result = ak.contents.RecordArray(outs, fields, parameters=parameters)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -434,7 +434,8 @@ def _form_has_type(form, type_):
 
         if form.is_tuple:
             return all(
-                _form_has_type(c, t) for c, t in zip(form.contents, type_.contents)
+                _form_has_type(c, t)
+                for c, t in zip(form.contents, type_.contents, strict=False)
             )
         else:
             return (frozenset(form.fields) == frozenset(type_.fields)) and all(
@@ -447,7 +448,7 @@ def _form_has_type(form, type_):
         for contents in permutations(form.contents):
             if all(
                 _form_has_type(form, type_)
-                for form, type_ in zip(contents, type_.contents)
+                for form, type_ in zip(contents, type_.contents, strict=False)
             ):
                 return True
         return False
@@ -557,7 +558,7 @@ def enforce_concatenated_form(layout, form):
         for form_projection_indices in permutations(form_indices, len(layout.contents)):
             if all(
                 mergeable(c, form_contents[i])
-                for c, i in zip(layout.contents, form_projection_indices)
+                for c, i in zip(layout.contents, form_projection_indices, strict=False)
             ):
                 break
         else:
@@ -567,7 +568,7 @@ def enforce_concatenated_form(layout, form):
 
         next_contents = [
             enforce_concatenated_form(c, form.contents[i])
-            for c, i in zip(layout.contents, form_projection_indices)
+            for c, i in zip(layout.contents, form_projection_indices, strict=False)
         ]
         next_contents.extend(
             [

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -435,7 +435,7 @@ def _form_has_type(form, type_):
         if form.is_tuple:
             return all(
                 _form_has_type(c, t)
-                for c, t in zip(form.contents, type_.contents, strict=False)
+                for c, t in zip(form.contents, type_.contents, strict=True)
             )
         else:
             return (frozenset(form.fields) == frozenset(type_.fields)) and all(
@@ -448,7 +448,7 @@ def _form_has_type(form, type_):
         for contents in permutations(form.contents):
             if all(
                 _form_has_type(form, type_)
-                for form, type_ in zip(contents, type_.contents, strict=False)
+                for form, type_ in zip(contents, type_.contents, strict=True)
             ):
                 return True
         return False
@@ -558,7 +558,7 @@ def enforce_concatenated_form(layout, form):
         for form_projection_indices in permutations(form_indices, len(layout.contents)):
             if all(
                 mergeable(c, form_contents[i])
-                for c, i in zip(layout.contents, form_projection_indices, strict=False)
+                for c, i in zip(layout.contents, form_projection_indices, strict=True)
             ):
                 break
         else:
@@ -568,7 +568,7 @@ def enforce_concatenated_form(layout, form):
 
         next_contents = [
             enforce_concatenated_form(c, form.contents[i])
-            for c, i in zip(layout.contents, form_projection_indices, strict=False)
+            for c, i in zip(layout.contents, form_projection_indices, strict=True)
         ]
         next_contents.extend(
             [

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -283,7 +283,7 @@ def _layout_has_type(layout: ak.contents.Content, type_: ak.types.Type) -> bool:
         if layout.is_tuple:
             return all(
                 _layout_has_type(c, t)
-                for c, t in zip(layout.contents, type_.contents, strict=False)
+                for c, t in zip(layout.contents, type_.contents, strict=True)
             )
         else:
             return (frozenset(layout.fields) == frozenset(type_.fields)) and all(
@@ -297,7 +297,7 @@ def _layout_has_type(layout: ak.contents.Content, type_: ak.types.Type) -> bool:
         for contents in permutations(layout.contents):
             if all(
                 _layout_has_type(layout, type_)
-                for layout, type_ in zip(contents, type_.contents, strict=False)
+                for layout, type_ in zip(contents, type_.contents, strict=True)
             ):
                 return True
         return False
@@ -384,7 +384,7 @@ def _type_is_enforceable(
                     # Require that all layouts match types for layout permutation
                     if all(
                         _layout_has_type(c, t)
-                        for c, t in zip(layout.contents, retained_types, strict=False)
+                        for c, t in zip(layout.contents, retained_types, strict=True)
                     ):
                         return _TypeEnforceableResult(
                             is_enforceable=True, requires_packing=False
@@ -406,7 +406,7 @@ def _type_is_enforceable(
                     # Require that all layouts match types for layout permutation
                     if all(
                         _layout_has_type(c, t)
-                        for c, t in zip(retained_contents, type_.contents, strict=False)
+                        for c, t in zip(retained_contents, type_.contents, strict=True)
                     ):
                         return _TypeEnforceableResult(
                             is_enforceable=True, requires_packing=True
@@ -424,7 +424,7 @@ def _type_is_enforceable(
                     # How many contents match types in this permutation?
                     content_matches_type = [
                         _layout_has_type(c, t)
-                        for c, t in zip(layout.contents, permuted_types, strict=False)
+                        for c, t in zip(layout.contents, permuted_types, strict=True)
                     ]
                     n_matching = sum(content_matches_type, 0)
 
@@ -438,7 +438,7 @@ def _type_is_enforceable(
                             range(len(layout.contents)),
                             permuted_types,
                             content_matches_type,
-                            strict=False,
+                            strict=True,
                         ):
                             if not is_match:
                                 # This content is being converted
@@ -533,7 +533,7 @@ def _type_is_enforceable(
                 type_contents = iter(type_.contents)
                 contents_enforceable = [
                     _type_is_enforceable(c, t)
-                    for c, t in zip(layout.contents, type_contents, strict=False)
+                    for c, t in zip(layout.contents, type_contents, strict=True)
                 ]
                 # Anything left in `type_contents` are the types of new slots
                 for next_type in type_contents:
@@ -760,7 +760,7 @@ def _recurse_union_union(
             # Require that all layouts match types for layout permutation
             if all(
                 _layout_has_type(c, t)
-                for c, t in zip(layout.contents, retained_types, strict=False)
+                for c, t in zip(layout.contents, retained_types, strict=True)
             ):
                 break
 
@@ -780,7 +780,7 @@ def _recurse_union_union(
         # we don't need to project these contents — they won't be operated upon (besides parameters)
         contents = [
             _enforce_type(b, c)
-            for b, c in zip(layout.contents, retained_types, strict=False)
+            for b, c in zip(layout.contents, retained_types, strict=True)
         ]
         contents.extend(
             [
@@ -802,7 +802,7 @@ def _recurse_union_union(
             # Require that all layouts match types for layout permutation
             if all(
                 _layout_has_type(c, t)
-                for c, t in zip(retained_contents, type_.contents, strict=False)
+                for c, t in zip(retained_contents, type_.contents, strict=True)
             ):
                 break
         else:
@@ -817,7 +817,7 @@ def _recurse_union_union(
         # we don't need to project these contents — they won't be operated upon (besides parameters)
         contents = [
             _enforce_type(c, t)
-            for c, t in zip(retained_contents, type_.contents, strict=False)
+            for c, t in zip(retained_contents, type_.contents, strict=True)
         ]
 
         is_trivial_permutation = ix_perm_contents == range(n_type_contents)
@@ -832,7 +832,7 @@ def _recurse_union_union(
         # Ensure that the union references all of the tags of the permutation,
         # and re-order the tags if this is not the trivial permutation
         _total_used_tags = 0
-        for i, j in zip(ix_perm_contents, range(n_type_contents), strict=False):
+        for i, j in zip(ix_perm_contents, range(n_type_contents), strict=True):
             layout_tag_is_i = layout.tags.data == i
 
             # Rewrite the tags if they need to be condensed (i.e., not if this is the trivial permutation)
@@ -865,7 +865,7 @@ def _recurse_union_union(
             # How many contents match types in this permutation?
             content_matches_type = [
                 _layout_has_type(c, t)
-                for c, t in zip(layout.contents, permuted_types, strict=False)
+                for c, t in zip(layout.contents, permuted_types, strict=True)
             ]
             n_matching = sum(content_matches_type, 0)
 
@@ -874,7 +874,7 @@ def _recurse_union_union(
                 # Now build the result
                 contents = [
                     _enforce_type(c, t)
-                    for c, t in zip(layout.contents, permuted_types, strict=False)
+                    for c, t in zip(layout.contents, permuted_types, strict=True)
                 ]
                 return layout.copy(
                     contents=contents,
@@ -888,7 +888,7 @@ def _recurse_union_union(
                     range(len(layout.contents)),
                     permuted_types,
                     content_matches_type,
-                    strict=False,
+                    strict=True,
                 ):
                     # If the types agree between the intended type and content, then include this content
                     # as-is, only recursing to update parameters. Because the types agree, we're safe

--- a/src/awkward/operations/ak_enforce_type.py
+++ b/src/awkward/operations/ak_enforce_type.py
@@ -282,7 +282,8 @@ def _layout_has_type(layout: ak.contents.Content, type_: ak.types.Type) -> bool:
 
         if layout.is_tuple:
             return all(
-                _layout_has_type(c, t) for c, t in zip(layout.contents, type_.contents)
+                _layout_has_type(c, t)
+                for c, t in zip(layout.contents, type_.contents, strict=False)
             )
         else:
             return (frozenset(layout.fields) == frozenset(type_.fields)) and all(
@@ -296,7 +297,7 @@ def _layout_has_type(layout: ak.contents.Content, type_: ak.types.Type) -> bool:
         for contents in permutations(layout.contents):
             if all(
                 _layout_has_type(layout, type_)
-                for layout, type_ in zip(contents, type_.contents)
+                for layout, type_ in zip(contents, type_.contents, strict=False)
             ):
                 return True
         return False
@@ -383,7 +384,7 @@ def _type_is_enforceable(
                     # Require that all layouts match types for layout permutation
                     if all(
                         _layout_has_type(c, t)
-                        for c, t in zip(layout.contents, retained_types)
+                        for c, t in zip(layout.contents, retained_types, strict=False)
                     ):
                         return _TypeEnforceableResult(
                             is_enforceable=True, requires_packing=False
@@ -405,7 +406,7 @@ def _type_is_enforceable(
                     # Require that all layouts match types for layout permutation
                     if all(
                         _layout_has_type(c, t)
-                        for c, t in zip(retained_contents, type_.contents)
+                        for c, t in zip(retained_contents, type_.contents, strict=False)
                     ):
                         return _TypeEnforceableResult(
                             is_enforceable=True, requires_packing=True
@@ -423,7 +424,7 @@ def _type_is_enforceable(
                     # How many contents match types in this permutation?
                     content_matches_type = [
                         _layout_has_type(c, t)
-                        for c, t in zip(layout.contents, permuted_types)
+                        for c, t in zip(layout.contents, permuted_types, strict=False)
                     ]
                     n_matching = sum(content_matches_type, 0)
 
@@ -437,6 +438,7 @@ def _type_is_enforceable(
                             range(len(layout.contents)),
                             permuted_types,
                             content_matches_type,
+                            strict=False,
                         ):
                             if not is_match:
                                 # This content is being converted
@@ -531,7 +533,7 @@ def _type_is_enforceable(
                 type_contents = iter(type_.contents)
                 contents_enforceable = [
                     _type_is_enforceable(c, t)
-                    for c, t in zip(layout.contents, type_contents)
+                    for c, t in zip(layout.contents, type_contents, strict=False)
                 ]
                 # Anything left in `type_contents` are the types of new slots
                 for next_type in type_contents:
@@ -757,7 +759,8 @@ def _recurse_union_union(
             retained_types = [type_.contents[j] for j in ix_perm_contents]
             # Require that all layouts match types for layout permutation
             if all(
-                _layout_has_type(c, t) for c, t in zip(layout.contents, retained_types)
+                _layout_has_type(c, t)
+                for c, t in zip(layout.contents, retained_types, strict=False)
             ):
                 break
 
@@ -776,7 +779,8 @@ def _recurse_union_union(
         # Given that we _know_ all layouts match their types for the permutation,
         # we don't need to project these contents — they won't be operated upon (besides parameters)
         contents = [
-            _enforce_type(b, c) for b, c in zip(layout.contents, retained_types)
+            _enforce_type(b, c)
+            for b, c in zip(layout.contents, retained_types, strict=False)
         ]
         contents.extend(
             [
@@ -798,7 +802,7 @@ def _recurse_union_union(
             # Require that all layouts match types for layout permutation
             if all(
                 _layout_has_type(c, t)
-                for c, t in zip(retained_contents, type_.contents)
+                for c, t in zip(retained_contents, type_.contents, strict=False)
             ):
                 break
         else:
@@ -812,7 +816,8 @@ def _recurse_union_union(
         # Given that we _know_ all layouts match their types for the permutation,
         # we don't need to project these contents — they won't be operated upon (besides parameters)
         contents = [
-            _enforce_type(c, t) for c, t in zip(retained_contents, type_.contents)
+            _enforce_type(c, t)
+            for c, t in zip(retained_contents, type_.contents, strict=False)
         ]
 
         is_trivial_permutation = ix_perm_contents == range(n_type_contents)
@@ -827,7 +832,7 @@ def _recurse_union_union(
         # Ensure that the union references all of the tags of the permutation,
         # and re-order the tags if this is not the trivial permutation
         _total_used_tags = 0
-        for i, j in zip(ix_perm_contents, range(n_type_contents)):
+        for i, j in zip(ix_perm_contents, range(n_type_contents), strict=False):
             layout_tag_is_i = layout.tags.data == i
 
             # Rewrite the tags if they need to be condensed (i.e., not if this is the trivial permutation)
@@ -859,7 +864,8 @@ def _recurse_union_union(
 
             # How many contents match types in this permutation?
             content_matches_type = [
-                _layout_has_type(c, t) for c, t in zip(layout.contents, permuted_types)
+                _layout_has_type(c, t)
+                for c, t in zip(layout.contents, permuted_types, strict=False)
             ]
             n_matching = sum(content_matches_type, 0)
 
@@ -867,7 +873,8 @@ def _recurse_union_union(
             if n_matching == len(type_.contents):
                 # Now build the result
                 contents = [
-                    _enforce_type(c, t) for c, t in zip(layout.contents, permuted_types)
+                    _enforce_type(c, t)
+                    for c, t in zip(layout.contents, permuted_types, strict=False)
                 ]
                 return layout.copy(
                     contents=contents,
@@ -878,7 +885,10 @@ def _recurse_union_union(
                 next_contents = []
                 index: ak.index.Index | None = None
                 for tag, content_type, is_match in zip(
-                    range(len(layout.contents)), permuted_types, content_matches_type
+                    range(len(layout.contents)),
+                    permuted_types,
+                    content_matches_type,
+                    strict=False,
                 ):
                     # If the types agree between the intended type and content, then include this content
                     # as-is, only recursing to update parameters. Because the types agree, we're safe
@@ -1125,7 +1135,8 @@ def _recurse_record_any(
             # Recurse into shared contents
             type_contents = iter(type_.contents)
             next_contents = [
-                _enforce_type(c, t) for c, t in zip(layout.contents, type_contents)
+                _enforce_type(c, t)
+                for c, t in zip(layout.contents, type_contents, strict=False)
             ]
             # Anything left in `type_contents` are the types of new slots
             for next_type in type_contents:

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -696,7 +696,7 @@ def _reconstitute(
                 shape_generator,
                 enable_virtualarray_caching,
             )
-            for content, field in zip(form.contents, form.fields, strict=False)
+            for content, field in zip(form.contents, form.fields, strict=True)
         ]
         return ak.contents.RecordArray(
             contents,

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -696,7 +696,7 @@ def _reconstitute(
                 shape_generator,
                 enable_virtualarray_caching,
             )
-            for content, field in zip(form.contents, form.fields)
+            for content, field in zip(form.contents, form.fields, strict=False)
         ]
         return ak.contents.RecordArray(
             contents,

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -284,7 +284,8 @@ or
             last_row_arrays is not None
             and len(last_row_arrays) == len(row_arrays)
             and all(
-                numpy.array_equal(x, y) for x, y in zip(last_row_arrays, row_arrays)
+                numpy.array_equal(x, y)
+                for x, y in zip(last_row_arrays, row_arrays, strict=False)
             )
         ):
             oldcolumns = tables[-1].columns

--- a/src/awkward/operations/ak_to_dataframe.py
+++ b/src/awkward/operations/ak_to_dataframe.py
@@ -285,7 +285,7 @@ or
             and len(last_row_arrays) == len(row_arrays)
             and all(
                 numpy.array_equal(x, y)
-                for x, y in zip(last_row_arrays, row_arrays, strict=False)
+                for x, y in zip(last_row_arrays, row_arrays, strict=True)
             )
         ):
             oldcolumns = tables[-1].columns

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -334,13 +334,13 @@ def _impl(
             if only == "string":
                 return [
                     x
-                    for x, y in zip(parquet_column_names, column_types)
+                    for x, y in zip(parquet_column_names, column_types, strict=False)
                     if y == "string"
                 ]
             elif only == "floating":
                 return [
                     x
-                    for x, y in zip(parquet_column_names, column_types)
+                    for x, y in zip(parquet_column_names, column_types, strict=False)
                     if isinstance(y, metadata.dtype)
                     and issubclass(y.type, metadata.floating)
                 ]

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -334,13 +334,13 @@ def _impl(
             if only == "string":
                 return [
                     x
-                    for x, y in zip(parquet_column_names, column_types, strict=False)
+                    for x, y in zip(parquet_column_names, column_types, strict=True)
                     if y == "string"
                 ]
             elif only == "floating":
                 return [
                     x
-                    for x, y in zip(parquet_column_names, column_types, strict=False)
+                    for x, y in zip(parquet_column_names, column_types, strict=True)
                     if isinstance(y, metadata.dtype)
                     and issubclass(y.type, metadata.floating)
                 ]

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -99,4 +99,4 @@ def _impl(array, how, highlevel, behavior, attrs):
         items = (
             ctx.wrap(layout[n], highlevel=highlevel, allow_other=True) for n in fields
         )
-    return tuple(items) if how is tuple else dict(zip(fields, items))
+    return tuple(items) if how is tuple else dict(zip(fields, items, strict=False))

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -99,4 +99,4 @@ def _impl(array, how, highlevel, behavior, attrs):
         items = (
             ctx.wrap(layout[n], highlevel=highlevel, allow_other=True) for n in fields
         )
-    return tuple(items) if how is tuple else dict(zip(fields, items, strict=False))
+    return tuple(items) if how is tuple else dict(zip(fields, items, strict=True))

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -229,7 +229,7 @@ class Record:
         if self.is_tuple and json_conversions is None:
             return tuple(contents)
         else:
-            return dict(zip(self._array.fields, contents))
+            return dict(zip(self._array.fields, contents, strict=False))
 
     def to_backend(self, backend: Backend | str | None = None) -> Self:
         if backend is None:

--- a/src/awkward/record.py
+++ b/src/awkward/record.py
@@ -229,7 +229,7 @@ class Record:
         if self.is_tuple and json_conversions is None:
             return tuple(contents)
         else:
-            return dict(zip(self._array.fields, contents, strict=False))
+            return dict(zip(self._array.fields, contents, strict=True))
 
     def to_backend(self, backend: Backend | str | None = None) -> Self:
         if backend is None:

--- a/src/awkward/types/_awkward_datashape_parser.py
+++ b/src/awkward/types/_awkward_datashape_parser.py
@@ -264,8 +264,6 @@ else:
         __metclass__ = ABCMeta
 
 
-Py36 = (sys.version_info[:2] >= (3, 6))
-
 NO_VALUE = object()
 
 
@@ -1038,19 +1036,10 @@ class Pattern(Serialize):
     def max_width(self):
         raise NotImplementedError()
 
-    if Py36:
-        ##
-
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = (f'(?{f}:{value})')
-            return value
-
-    else:
-        def _get_flags(self, value):
-            for f in self.flags:
-                value = ('(?%s)' % f) + value
-            return value
+    def _get_flags(self, value):
+        for f in self.flags:
+            value = (f'(?{f}:{value})')
+        return value
 
 
 

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -142,7 +142,7 @@ class RecordType(Type):
 
             if not self.is_tuple:
                 pairs = []
-                for k, v in zip(self._fields, children):
+                for k, v in zip(self._fields, children, strict=False):
                     if ak.prettyprint.is_identifier.match(k) is None:
                         key_str = json.dumps(k)
                     else:
@@ -198,7 +198,7 @@ class RecordType(Type):
         if self.is_tuple and other.is_tuple:
             return all(
                 this._is_equal_to(that, all_parameters)
-                for this, that in zip(self._contents, other._contents)
+                for this, that in zip(self._contents, other._contents, strict=False)
             )
         # Both records
         elif not (self.is_tuple or other.is_tuple):
@@ -207,7 +207,7 @@ class RecordType(Type):
 
             return all(
                 content._is_equal_to(other.content(field), all_parameters)
-                for field, content in zip(self._fields, self._contents)
+                for field, content in zip(self._fields, self._contents, strict=False)
             )
 
         # Mixed

--- a/src/awkward/types/recordtype.py
+++ b/src/awkward/types/recordtype.py
@@ -142,7 +142,7 @@ class RecordType(Type):
 
             if not self.is_tuple:
                 pairs = []
-                for k, v in zip(self._fields, children, strict=False):
+                for k, v in zip(self._fields, children, strict=True):
                     if ak.prettyprint.is_identifier.match(k) is None:
                         key_str = json.dumps(k)
                     else:
@@ -198,7 +198,7 @@ class RecordType(Type):
         if self.is_tuple and other.is_tuple:
             return all(
                 this._is_equal_to(that, all_parameters)
-                for this, that in zip(self._contents, other._contents, strict=False)
+                for this, that in zip(self._contents, other._contents, strict=True)
             )
         # Both records
         elif not (self.is_tuple or other.is_tuple):
@@ -207,7 +207,7 @@ class RecordType(Type):
 
             return all(
                 content._is_equal_to(other.content(field), all_parameters)
-                for field, content in zip(self._fields, self._contents, strict=False)
+                for field, content in zip(self._fields, self._contents, strict=True)
             )
 
         # Mixed

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -107,7 +107,7 @@ class UnionType(Type):
             and any(
                 all(
                     this._is_equal_to(that, all_parameters)
-                    for this, that in zip(self._contents, contents, strict=False)
+                    for this, that in zip(self._contents, contents, strict=True)
                 )
                 for contents in permutations(other._contents)
             )

--- a/src/awkward/types/uniontype.py
+++ b/src/awkward/types/uniontype.py
@@ -107,7 +107,7 @@ class UnionType(Type):
             and any(
                 all(
                     this._is_equal_to(that, all_parameters)
-                    for this, that in zip(self._contents, contents)
+                    for this, that in zip(self._contents, contents, strict=False)
                 )
                 for contents in permutations(other._contents)
             )

--- a/tests-cuda/test_3749_cuda_backend_sort.py
+++ b/tests-cuda/test_3749_cuda_backend_sort.py
@@ -39,9 +39,9 @@ def test_sort_cuda_float():
 
     # Compare with tolerance for floats
     assert len(result_list) == len(expected)
-    for res_sublist, exp_sublist in zip(result_list, expected, strict=False):
+    for res_sublist, exp_sublist in zip(result_list, expected, strict=True):
         assert len(res_sublist) == len(exp_sublist)
-        for res_val, exp_val in zip(res_sublist, exp_sublist, strict=False):
+        for res_val, exp_val in zip(res_sublist, exp_sublist, strict=True):
             assert abs(res_val - exp_val) < 1e-10
 
 

--- a/tests-cuda/test_3749_cuda_backend_sort.py
+++ b/tests-cuda/test_3749_cuda_backend_sort.py
@@ -39,9 +39,9 @@ def test_sort_cuda_float():
 
     # Compare with tolerance for floats
     assert len(result_list) == len(expected)
-    for res_sublist, exp_sublist in zip(result_list, expected):
+    for res_sublist, exp_sublist in zip(result_list, expected, strict=False):
         assert len(res_sublist) == len(exp_sublist)
-        for res_val, exp_val in zip(res_sublist, exp_sublist):
+        for res_val, exp_val in zip(res_sublist, exp_sublist, strict=False):
             assert abs(res_val - exp_val) < 1e-10
 
 

--- a/tests/samples/__init__.py
+++ b/tests/samples/__init__.py
@@ -1,3 +1,2 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 
-from __future__ import absolute_import

--- a/tests/test_0025_record_array.py
+++ b/tests/test_0025_record_array.py
@@ -117,7 +117,7 @@ def test_basic():
         [1, 2, 3, 4, 5],
     ]
 
-    pairs = list(zip(recordarray.fields, recordarray.contents))
+    pairs = list(zip(recordarray.fields, recordarray.contents, strict=False))
     assert pairs[0][0] == "one"
     assert pairs[1][0] == "two"
     assert pairs[2][0] == "2"

--- a/tests/test_0025_record_array.py
+++ b/tests/test_0025_record_array.py
@@ -117,7 +117,7 @@ def test_basic():
         [1, 2, 3, 4, 5],
     ]
 
-    pairs = list(zip(recordarray.fields, recordarray.contents, strict=False))
+    pairs = list(zip(recordarray.fields, recordarray.contents, strict=True))
     assert pairs[0][0] == "one"
     assert pairs[1][0] == "two"
     assert pairs[2][0] == "2"

--- a/tests/test_0089_numpy_functions.py
+++ b/tests/test_0089_numpy_functions.py
@@ -13,12 +13,12 @@ to_list = ak.operations.to_list
 def test_mixing_lists_and_none():
     def add(a, b):
         outer = []
-        for ai, bi in zip(a, b):
+        for ai, bi in zip(a, b, strict=False):
             if ai is None or bi is None:
                 outer.append(None)
             else:
                 inner = []
-                for aj, bj in zip(ai, bi):
+                for aj, bj in zip(ai, bi, strict=False):
                     if aj is None or bj is None:
                         inner.append(None)
                     else:

--- a/tests/test_0089_numpy_functions.py
+++ b/tests/test_0089_numpy_functions.py
@@ -13,12 +13,12 @@ to_list = ak.operations.to_list
 def test_mixing_lists_and_none():
     def add(a, b):
         outer = []
-        for ai, bi in zip(a, b, strict=False):
+        for ai, bi in zip(a, b, strict=True):
             if ai is None or bi is None:
                 outer.append(None)
             else:
                 inner = []
-                for aj, bj in zip(ai, bi, strict=False):
+                for aj, bj in zip(ai, bi, strict=True):
                     if aj is None or bj is None:
                         inner.append(None)
                     else:

--- a/tests/test_0111_jagged_and_masked_getitem.py
+++ b/tests/test_0111_jagged_and_masked_getitem.py
@@ -487,9 +487,7 @@ def test_bool_missing():
     x1, x2, x3, x4, x5 = True, True, True, False, None
     mask = [x1, x2, x3, x4, x5]
     expected = [
-        m if m is None else x
-        for x, m in zip(data, mask, strict=True)
-        if m is not False
+        m if m is None else x for x, m in zip(data, mask, strict=True) if m is not False
     ]
     array2 = ak.highlevel.Array(mask, check_valid=True).layout
 

--- a/tests/test_0111_jagged_and_masked_getitem.py
+++ b/tests/test_0111_jagged_and_masked_getitem.py
@@ -486,11 +486,19 @@ def test_bool_missing():
 
     x1, x2, x3, x4, x5 = True, True, True, False, None
     mask = [x1, x2, x3, x4, x5]
-    expected = [m if m is None else x for x, m in zip(data, mask) if m is not False]
+    expected = [
+        m if m is None else x
+        for x, m in zip(data, mask, strict=False)
+        if m is not False
+    ]
     array2 = ak.highlevel.Array(mask, check_valid=True).layout
 
     for mask in itertools.repeat([True, False, None], 5):
-        expected = [m if m is None else x for x, m in zip(data, mask) if m is not False]
+        expected = [
+            m if m is None else x
+            for x, m in zip(data, mask, strict=False)
+            if m is not False
+        ]
         array2 = ak.highlevel.Array(mask, check_valid=True).layout
         assert to_list(array[array2]) == expected
         assert array.to_typetracer()[array2].form == array[array2].form

--- a/tests/test_0111_jagged_and_masked_getitem.py
+++ b/tests/test_0111_jagged_and_masked_getitem.py
@@ -488,7 +488,7 @@ def test_bool_missing():
     mask = [x1, x2, x3, x4, x5]
     expected = [
         m if m is None else x
-        for x, m in zip(data, mask, strict=False)
+        for x, m in zip(data, mask, strict=True)
         if m is not False
     ]
     array2 = ak.highlevel.Array(mask, check_valid=True).layout

--- a/tests/test_0395_fix_numba_indexedarray.py
+++ b/tests/test_0395_fix_numba_indexedarray.py
@@ -137,7 +137,8 @@ def test_zip():
     def f1(array1, array2):
         out = np.zeros(len(array1), np.float64)
         i = 0
-        for a1, a2 in zip(array1, array2):
+        # numba doesn't support strict= on zip
+        for a1, a2 in zip(array1, array2):  # noqa: B905
             out[i] = a1 - a2
             i += 1
         return out

--- a/tests/test_1473_from_rdataframe.py
+++ b/tests/test_1473_from_rdataframe.py
@@ -11,8 +11,6 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_1508_awkward_from_rdataframe.py
+++ b/tests/test_1508_awkward_from_rdataframe.py
@@ -13,8 +13,6 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_1613_generator_tolayout_records.py
+++ b/tests/test_1613_generator_tolayout_records.py
@@ -11,10 +11,15 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 cpp17 = hasattr(ROOT.std, "optional")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def manage_imt():
+    ROOT.ROOT.EnableImplicitMT(1)
+    yield
+    ROOT.ROOT.DisableImplicitMT()
 
 
 @pytest.mark.parametrize("flatlist_as_rvec", [False, True])

--- a/tests/test_1620_layout_builders.py
+++ b/tests/test_1620_layout_builders.py
@@ -9,8 +9,6 @@ import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_1625_multiple_columns_from_rdataframe.py
+++ b/tests/test_1625_multiple_columns_from_rdataframe.py
@@ -9,8 +9,6 @@ import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_1829_to_from_rdataframe_bool.py
+++ b/tests/test_1829_to_from_rdataframe_bool.py
@@ -11,8 +11,6 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_1960_awkward_from_rdataframe.py
+++ b/tests/test_1960_awkward_from_rdataframe.py
@@ -11,9 +11,14 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
+
+
+@pytest.fixture(scope="module", autouse=True)
+def manage_imt():
+    ROOT.ROOT.EnableImplicitMT(1)
+    yield
+    ROOT.ROOT.DisableImplicitMT()
 
 
 def test_unknown_column_type():

--- a/tests/test_2023_from_rdataframe.py
+++ b/tests/test_2023_from_rdataframe.py
@@ -11,9 +11,14 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
+
+
+@pytest.fixture(scope="module", autouse=True)
+def manage_imt():
+    ROOT.ROOT.EnableImplicitMT(1)
+    yield
+    ROOT.ROOT.DisableImplicitMT()
 
 
 def test_rdf_column_of_Long64_t_type():

--- a/tests/test_2202_filter_multiple_columns_from_rdataframe.py
+++ b/tests/test_2202_filter_multiple_columns_from_rdataframe.py
@@ -9,8 +9,6 @@ import awkward as ak
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_2234_from_rdataframe_keep_order.py
+++ b/tests/test_2234_from_rdataframe_keep_order.py
@@ -13,8 +13,6 @@ compiler = ROOT.gInterpreter.Declare
 
 
 def test_data_frame_filter():
-    ROOT.ROOT.EnableImplicitMT()
-
     array_x = ak.Array(
         [
             {"x": [1.1, 1.2, 1.3]},

--- a/tests/test_2258_from_rdataframe_with_arguments.py
+++ b/tests/test_2258_from_rdataframe_with_arguments.py
@@ -11,8 +11,6 @@ import awkward._lookup
 
 ROOT = pytest.importorskip("ROOT")
 
-ROOT.ROOT.EnableImplicitMT(1)
-
 compiler = ROOT.gInterpreter.Declare
 
 

--- a/tests/test_3375_add_rdf_column.py
+++ b/tests/test_3375_add_rdf_column.py
@@ -47,8 +47,6 @@ def test_add_column():
 
     rdf = add_column(rdf, arr_val, "values")
 
-    ROOT.ROOT.DisableImplicitMT()
-
     rdf.Display().Print()
 
 
@@ -85,7 +83,5 @@ def test_add_numpy():
     arr_val = np.array([10, 20, 30])
 
     rdf = add_numpy_column(rdf, arr_val, "values")
-
-    ROOT.ROOT.DisableImplicitMT()
 
     rdf.Display().Print()

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -78,7 +78,7 @@ def compare_results(cpu_list, jax_list):
         )
 
         # Compare each element
-        for cpu_item, jax_item in zip(cpu_list, jax_list, strict=False):
+        for cpu_item, jax_item in zip(cpu_list, jax_list, strict=True):
             compare_results(cpu_item, jax_item)
     else:
         # For non-numeric types, use exact equality

--- a/tests/test_3464_jax_reducers.py
+++ b/tests/test_3464_jax_reducers.py
@@ -78,7 +78,7 @@ def compare_results(cpu_list, jax_list):
         )
 
         # Compare each element
-        for cpu_item, jax_item in zip(cpu_list, jax_list):
+        for cpu_item, jax_item in zip(cpu_list, jax_list, strict=False):
             compare_results(cpu_item, jax_item)
     else:
         # For non-numeric types, use exact equality


### PR DESCRIPTION
(builds on #3815, since I needed that to test locally)

Dropping 3.9, and adding `strict=`, trying to use `True` everywhere the tests would let me.

- **chore: fix noxfile on Intel macOS**
- **chore: drop Python 3.9**
- **chore: remove Python < 3.6 compat line**
- **fix: add strict= to zip**
