### PR TITLE
Fix : reject null bytes in ak.from_iter record keys 

### DIFF
--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -96,6 +96,14 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize, attrs):
     if isinstance(iterable, tuple):
         iterable = list(iterable)
 
+    for element in iterable : 
+        if isinstance(element, dict ) : 
+            for key in element : 
+                if "\x00" in str(key) : 
+                    raise ValueError ( 
+                        "record field names shall not contain null bytes (\\x00)"
+                    )
+
     builder = _ext.ArrayBuilder(initial=initial, resize=resize)
     builder.fromiter(iterable)
 

--- a/src/awkward/operations/ak_from_iter.py
+++ b/src/awkward/operations/ak_from_iter.py
@@ -96,11 +96,11 @@ def _impl(iterable, highlevel, behavior, allow_record, initial, resize, attrs):
     if isinstance(iterable, tuple):
         iterable = list(iterable)
 
-    for element in iterable : 
-        if isinstance(element, dict ) : 
-            for key in element : 
-                if "\x00" in str(key) : 
-                    raise ValueError ( 
+    for element in iterable:
+        if isinstance(element, dict):
+            for key in element:
+                if "\x00" in str(key):
+                    raise ValueError(
                         "record field names shall not contain null bytes (\\x00)"
                     )
 

--- a/tests/test_1162_ak_from_json_schema.py
+++ b/tests/test_1162_ak_from_json_schema.py
@@ -1081,3 +1081,17 @@ def test_complex_nested():
         "2015-01-01T10:01:23Z",
         "2015-01-01T10:01:25Z",
     ]
+
+def test_from_iter_null_byte_as_key() : 
+    import awkward as ak 
+    
+    data = {"\x00any_key" : 0}
+
+    try: 
+        ak.from_iter([data])
+
+    except ValueError : 
+        return  #error was correctly raised 
+    
+    raise AssertionError("ValueError was not raised")
+    # If the given is printed then bug still exists for null byte passing as key 

--- a/tests/test_1162_ak_from_json_schema.py
+++ b/tests/test_1162_ak_from_json_schema.py
@@ -1082,16 +1082,17 @@ def test_complex_nested():
         "2015-01-01T10:01:25Z",
     ]
 
-def test_from_iter_null_byte_as_key() : 
-    import awkward as ak 
-    
-    data = {"\x00any_key" : 0}
 
-    try: 
+def test_from_iter_null_byte_as_key():
+    import awkward as ak
+
+    data = {"\x00any_key": 0}
+
+    try:
         ak.from_iter([data])
 
-    except ValueError : 
-        return  #error was correctly raised 
-    
+    except ValueError:
+        return  # error was correctly raised
+
     raise AssertionError("ValueError was not raised")
-    # If the given is printed then bug still exists for null byte passing as key 
+    # If the given is printed then bug still exists for null byte passing as key


### PR DESCRIPTION
`ak.from_iter` currently allows record field names containing null bytes, which
are silently trimmed and corrupt data on round-trip.

This change rejects such keys early and adds a simple test to enforce it.

Addresses : #3731
