### PR TITLE
fix: pass the right input type to `awkward_NumpyArray_subrange_equal*` kernels

### DIFF
--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -654,7 +654,7 @@ class NumpyArray(NumpyMeta, Content):
                 )
             )
 
-        return bool(is_equal[0])
+        return True if is_equal[0] == 1 else False
 
     def _as_unique_strings(self, offsets):
         offsets = ak.index.Index64(offsets.data, nplike=offsets.nplike)

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -611,7 +611,7 @@ class NumpyArray(NumpyMeta, Content):
         return self._backend.nplike.is_c_contiguous(self._data)
 
     def _subranges_equal(self, starts, stops, length, sorted=True):
-        is_equal = ak.index.Index64.zeros(1, nplike=self._backend.nplike)
+        is_equal = self._backend.nplike.zeros(1, dtype=np.bool_)
 
         assert (
             starts.nplike is self._backend.nplike
@@ -632,7 +632,7 @@ class NumpyArray(NumpyMeta, Content):
                     starts.data,
                     stops.data,
                     starts.length,
-                    is_equal.data,
+                    is_equal,
                 )
             )
         else:
@@ -650,11 +650,11 @@ class NumpyArray(NumpyMeta, Content):
                     starts.data,
                     stops.data,
                     starts.length,
-                    is_equal.data,
+                    is_equal,
                 )
             )
 
-        return True if is_equal[0] == 1 else False
+        return bool(is_equal[0])
 
     def _as_unique_strings(self, offsets):
         offsets = ak.index.Index64(offsets.data, nplike=offsets.nplike)


### PR DESCRIPTION
`awkward_NumpyArray_subrange_equal` and `awkward_NumpyArray_subrange_equal_bool` expect a boolean as their last argument (see their signature). However here we pass in an int64 zero which the kernel will cast to bool, the kernel will change the first byte of this (leaving the other 7 bytes untouched) and then numpy will interpret the result as int64 (as the `is_equal` array's dtype does not change). This does not generally work on all systems.
We here pass the correct (expected) dtype to the kernel.