### PR TITLE
chore: use "M8" dtype instead of "<M8" in tests

### DIFF
--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -27,13 +27,13 @@ def test_dtype():
         dtype_exact=True,
     )
     assert not ak.almost_equal(
-        np.array([1, 2, 3], dtype=np.dtype("<M8[D]")),
-        np.array([1, 2, 3], dtype=np.dtype("<m8[D]")),
+        np.array([1, 2, 3], dtype=np.dtype("M8[D]")),
+        np.array([1, 2, 3], dtype=np.dtype("m8[D]")),
         dtype_exact=True,
     )
     assert not ak.almost_equal(
-        np.array([1, 2, 3], dtype=np.dtype("<M8[D]")),
-        np.array([1, 2, 3], dtype=np.dtype("<m8[D]")),
+        np.array([1, 2, 3], dtype=np.dtype("M8[D]")),
+        np.array([1, 2, 3], dtype=np.dtype("m8[D]")),
         dtype_exact=False,
     )
 

--- a/tests/test_2377_empty_index.py
+++ b/tests/test_2377_empty_index.py
@@ -32,7 +32,7 @@ def _add_necessary_unit(dtype_name: str) -> str:
     return dtype_name
 
 
-# (dtype('bool'), dtype('int8'), dtype('<M8[15us]'), ...) Supported dtypes
+# (dtype('bool'), dtype('int8'), dtype('M8[15us]'), ...) Supported dtypes
 DTYPES = tuple(
     primitive_to_dtype(_add_necessary_unit(k)) for k in _primitive_to_dtype_dict.keys()
 )

--- a/tests/test_2424_almost_equal_union_record.py
+++ b/tests/test_2424_almost_equal_union_record.py
@@ -12,14 +12,14 @@ def test_records_almost_equal():
     first = ak.contents.RecordArray(
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("M8[s]"))),
         ],
         ["x", "y"],
     )
 
     second = ak.contents.RecordArray(
         [
-            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
         ],
         ["y", "x"],
@@ -35,7 +35,7 @@ def test_unions_almost_equal():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -45,7 +45,7 @@ def test_unions_almost_equal():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(first, second)

--- a/tests/test_2857_full_like_scalar.py
+++ b/tests/test_2857_full_like_scalar.py
@@ -11,7 +11,7 @@ import awkward as ak
 def test():
     arr = ak.Array([{"x": 1}, {"x": 2}])
     # Fill with
-    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="<M8[s]")
+    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="M8[s]")
     assert result.layout.is_equal_to(
         ak.contents.RecordArray(
             [
@@ -27,7 +27,7 @@ def test():
 def test_typetracer():
     arr = ak.Array([{"x": 1}, {"x": 2}], backend="typetracer")
     # Fill with
-    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="<M8[s]")
+    result = ak.full_like(arr, np.datetime64(20, "s"), dtype="M8[s]")
     assert result.layout.form == (
         ak.forms.RecordForm(
             [ak.forms.NumpyForm("datetime64[s]")],

--- a/tests/test_3773_almost_equal_unionarray.py
+++ b/tests/test_3773_almost_equal_unionarray.py
@@ -100,7 +100,7 @@ def test_empty_union():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -110,7 +110,7 @@ def test_empty_union():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -127,7 +127,7 @@ def test_empty_union():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -137,7 +137,7 @@ def test_empty_union():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -154,7 +154,7 @@ def test_empty_union():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -164,7 +164,7 @@ def test_empty_union():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -181,7 +181,7 @@ def test_empty_union():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -190,7 +190,7 @@ def test_empty_union():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -211,7 +211,7 @@ def test_size_one_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -221,7 +221,7 @@ def test_size_one_tags():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -238,7 +238,7 @@ def test_size_one_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -248,7 +248,7 @@ def test_size_one_tags():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -265,7 +265,7 @@ def test_size_one_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -275,7 +275,7 @@ def test_size_one_tags():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -292,7 +292,7 @@ def test_size_one_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
         ],
     )
@@ -302,7 +302,7 @@ def test_size_one_tags():
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert ak.almost_equal(left, left)
@@ -323,7 +323,7 @@ def test_all_tags_used():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -332,7 +332,7 @@ def test_all_tags_used():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -353,7 +353,7 @@ def test_all_tags_used():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -362,7 +362,7 @@ def test_all_tags_used():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -383,7 +383,7 @@ def test_all_tags_used():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -392,7 +392,7 @@ def test_all_tags_used():
         ak.index.Index64([0, 0, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -415,7 +415,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -424,7 +424,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -445,7 +445,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -454,7 +454,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -475,7 +475,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -484,7 +484,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -505,7 +505,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -514,7 +514,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -535,7 +535,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -544,7 +544,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -565,7 +565,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -574,7 +574,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],
@@ -595,7 +595,7 @@ def test_unused_tags():
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
 
@@ -604,7 +604,7 @@ def test_unused_tags():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
             ak.contents.NumpyArray(np.array([4.0, 5.0, 6.0], dtype=np.float64)),
         ],

--- a/tests/test_3773_unionarray_simplified_mergecastable_and_dropunused.py
+++ b/tests/test_3773_unionarray_simplified_mergecastable_and_dropunused.py
@@ -133,7 +133,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -145,7 +145,7 @@ def test_dropunused():
         [
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert simplified.is_equal_to(expected)
@@ -157,7 +157,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -182,7 +182,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -200,7 +200,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -216,7 +216,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -239,7 +239,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -250,7 +250,7 @@ def test_dropunused():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert simplified.is_equal_to(expected)
@@ -262,7 +262,7 @@ def test_dropunused():
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
             ak.contents.NumpyArray(np.array([0, 1, 0, 1], dtype=np.bool_)),
             ak.contents.NumpyArray(np.array([1, 2, 3], dtype=np.int64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     simplified = array.simplified(
@@ -273,7 +273,7 @@ def test_dropunused():
         ak.index.Index64([0, 1, 0, 0, 1]),
         [
             ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0], dtype=np.float64)),
-            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("<M8[s]"))),
+            ak.contents.NumpyArray(np.array([0, 1], dtype=np.dtype("M8[s]"))),
         ],
     )
     assert simplified.is_equal_to(expected)


### PR DESCRIPTION
Towards https://github.com/scikit-hep/awkward/issues/3630
`M8` is `<M8` on little-endian systems.
```py
In [3]: np.dtype("<M8[D]")
Out[3]: dtype('<M8[D]')

In [4]: np.dtype("M8[D]")
Out[4]: dtype('<M8[D]')
```
Since we want to properly support and test big-endian systems, we get the chore out of the way to not ask explicitly for little-endian dtypes for no reason in the tests.