### PR TITLE
fix: properly respect requested byteorder in `ak.from_buffers` for ndarray buffers

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -279,6 +279,7 @@ def _from_buffer(
         # Require 1D buffers
         copy = None if isinstance(nplike, Jax) else False  # Jax can not avoid this
         array = nplike.reshape(buffer.view(dtype), shape=(-1,), copy=copy)
+        array = ak._util.native_to_byteorder(array, byteorder)
 
         # we can't compare with count or slice when we're working with tracers
         if not (isinstance(nplike, Jax) and nplike.is_currently_tracing()):

--- a/tests/test_3820_from_buffers_byteorder.py
+++ b/tests/test_3820_from_buffers_byteorder.py
@@ -150,7 +150,7 @@ def test_jagged_bytes():
         "node0-offsets": np.array([0, 2, 2, 3], dtype="<i8").tobytes(),
         "node1-data": np.array([1.0, 2.0, 3.0], dtype="<f8").tobytes(),
     }
-    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+    with pytest.raises((ValueError, OverflowError)):
         array = ak.from_buffers(form, length, container, byteorder=">")
 
     form = ak.forms.ListOffsetForm(
@@ -161,7 +161,7 @@ def test_jagged_bytes():
         "node0-offsets": np.array([0, 2, 2, 3], dtype=">i8").tobytes(),
         "node1-data": np.array([1.0, 2.0, 3.0], dtype=">f8").tobytes(),
     }
-    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+    with pytest.raises((ValueError, OverflowError)):
         array = ak.from_buffers(form, length, container, byteorder="<")
 
     form = ak.forms.ListOffsetForm(

--- a/tests/test_3820_from_buffers_byteorder.py
+++ b/tests/test_3820_from_buffers_byteorder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 import awkward as ak
 
@@ -140,6 +141,28 @@ def test_jagged_bytes():
             )
         ),
     )
+
+    form = ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float64", form_key="node1"), form_key="node0"
+    )
+    length = 3
+    container = {
+        "node0-offsets": np.array([0, 2, 2, 3], dtype="<i8").tobytes(),
+        "node1-data": np.array([1.0, 2.0, 3.0], dtype="<f8").tobytes(),
+    }
+    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+        array = ak.from_buffers(form, length, container, byteorder=">")
+
+    form = ak.forms.ListOffsetForm(
+        "i64", ak.forms.NumpyForm("float64", form_key="node1"), form_key="node0"
+    )
+    length = 3
+    container = {
+        "node0-offsets": np.array([0, 2, 2, 3], dtype=">i8").tobytes(),
+        "node1-data": np.array([1.0, 2.0, 3.0], dtype=">f8").tobytes(),
+    }
+    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+        array = ak.from_buffers(form, length, container, byteorder="<")
 
     form = ak.forms.ListOffsetForm(
         "i64", ak.forms.NumpyForm("float64", form_key="node1"), form_key="node0"


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/3821
Currently the byteorder argument is only respected when the input buffers are bytes and not ndarrays.
This fixes that.