### PR TITLE
Docs: explain axis semantics and axis-related types

### DIFF
--- a/docs/user-guide/axis.md
+++ b/docs/user-guide/axis.md
@@ -1,0 +1,65 @@
+# Axes in Awkward Array
+
+## What is an axis?
+
+An axis describes how operations in Awkward Array traverse, reduce, or
+combine elements of a nested array structure.
+
+Like NumPy, axes can be specified positionally using integers. Awkward
+extends this concept by allowing axes to be named, which helps preserve
+meaning and correctness when working with complex or deeply nested data.
+
+## Positional axes
+
+A positional axis is specified using an integer.
+
+- Positive integers count from the outermost level inward
+- Negative integers count from the innermost level outward
+- `axis=None` indicates that the operation should be applied across all
+  axes of the array
+
+This behavior is consistent with NumPy-style axis semantics, extended to
+Awkward’s nested array model.
+
+## Named axes
+
+In addition to positional axes, Awkward supports named axes. A named axis
+identifies a dimension by meaning rather than by position.
+
+Named axes are useful when arrays carry metadata describing the role of
+different dimensions, allowing operations to remain correct even if the
+underlying structure changes.
+
+In the documentation and type annotations, a named axis is represented by
+the `AxisName` type.
+
+## Multiple axes
+
+Some operations accept more than one axis at a time. In these cases, axes
+may be provided as a tuple.
+
+Each element of the tuple may be a positional or named axis. The order of
+axes in the tuple determines the order in which the operation is applied.
+
+In the documentation, this usage is represented by the `AxisTuple` type.
+
+## Axis mappings
+
+Certain operations transform or rename axis metadata rather than operating
+on array values directly.
+
+An axis mapping describes how existing axes are renamed or reassigned. This
+is primarily used in functions that manipulate named axis metadata, such as
+`ak.with_named_axis`.
+
+In the documentation, this behavior is represented by the `AxisMapping`
+type.
+
+## Axis types in the API
+
+Types such as `AxisName`, `AxisTuple`, and `AxisMapping` appear in function
+signatures and documentation to describe the functional role of the axis
+parameter.
+
+They are intended to clarify how an axis is interpreted by an operation,
+not to expose internal implementation details.

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -49,6 +49,9 @@ def moment(
             outermost, `1` is the first level of nested lists, etc., and
             negative `axis` counts from the innermost: `-1` is the innermost,
             `-2` is the next level up, etc.
+            See the :doc:`Axis documentation </user-guide/axis>` for an explanation
+            of positional and named axes.
+
         keepdims (bool): If False, this function decreases the number of
             dimensions by 1; if True, the output values are wrapped in a new
             length-1 dimension so that the result of this operation may be

--- a/src/awkward/operations/ak_with_named_axis.py
+++ b/src/awkward/operations/ak_with_named_axis.py
@@ -29,8 +29,12 @@ def with_named_axis(
     """
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
-        named_axis: AxisTuple | AxisMapping: Names to give to the array axis; this assigns
-            the `"__named_axis__"` attr. If None, any existing name is unset.
+        named_axis: AxisTuple | AxisMapping
+            Names to give to the array axis; this assigns the `"__named_axis__"` attr.
+            If None, any existing name is unset.
+            See the :doc:`Axis documentation </user-guide/axis>` for an explanation
+            of positional and named axes.
+
         highlevel (bool): If True, return an #ak.Array; otherwise, return
             a low-level #ak.contents.Content subclass.
         behavior (None or dict): Custom #ak.behavior for the output array, if


### PR DESCRIPTION
This PR introduces a foundational documentation page describing axis
semantics in Awkward Array. It explains how axes are interpreted in
high-level operations, covering positional axes, named axes, multiple-axis
specification, and axis remapping.

The page provides conceptual context for the AxisName, AxisTuple, and
AxisMapping types that appear in the public API, focusing on their
functional roles rather than implementation details.

Relevant API docstrings (e.g. ak.moment and ak.with_named_axis) are updated
to link to this documentation, improving discoverability and ensuring
consistent interpretation of axis-related parameters across the reference
manual.
@ianna
@ikrommyd