### PR TITLE
fix: define behavior class within the test function in `test_1511_set_attribute.py` to make it thread-local

### DIFF
--- a/tests/test_1511_set_attribute.py
+++ b/tests/test_1511_set_attribute.py
@@ -37,30 +37,26 @@ def test_record():
     assert record._not_an_existing_attribute == 10
 
 
-class BadBehaviorBase:
-    FIELD_STRING = "I am not a list of fields!"
-
-    @property
-    def fields(self):
-        return self.__class__.FIELD_STRING
-
-    @fields.setter
-    def fields(self, value):
-        self.__class__.FIELD_STRING = value
-
-
-class BadBehaviorArray(BadBehaviorBase, ak.Array):
-    pass
-
-
-class BadBehaviorRecord(BadBehaviorBase, ak.Record):
-    pass
-
-
-behavior = {("*", "bad"): BadBehaviorArray, "bad": BadBehaviorRecord}
-
-
 def test_bad_behavior_array():
+    class BadBehaviorBase:
+        FIELD_STRING = "I am not a list of fields!"
+
+        @property
+        def fields(self):
+            return self.__class__.FIELD_STRING
+
+        @fields.setter
+        def fields(self, value):
+            self.__class__.FIELD_STRING = value
+
+    class BadBehaviorArray(BadBehaviorBase, ak.Array):
+        pass
+
+    class BadBehaviorRecord(BadBehaviorBase, ak.Record):
+        pass
+
+    behavior = {("*", "bad"): BadBehaviorArray, "bad": BadBehaviorRecord}
+
     record = ak.contents.RecordArray([ak.contents.NumpyArray(np.arange(10))], ["x"])
     array = ak.Array(record, with_name="bad", behavior=behavior)
     assert isinstance(array, BadBehaviorArray)
@@ -71,6 +67,24 @@ def test_bad_behavior_array():
 
 
 def test_bad_behavior_record():
+    class BadBehaviorBase:
+        FIELD_STRING = "I am not a list of fields!"
+
+        @property
+        def fields(self):
+            return self.__class__.FIELD_STRING
+
+        @fields.setter
+        def fields(self, value):
+            self.__class__.FIELD_STRING = value
+
+    class BadBehaviorArray(BadBehaviorBase, ak.Array):
+        pass
+
+    class BadBehaviorRecord(BadBehaviorBase, ak.Record):
+        pass
+
+    behavior = {("*", "bad"): BadBehaviorArray, "bad": BadBehaviorRecord}
     record = ak.contents.RecordArray([ak.contents.NumpyArray(np.arange(10))], ["x"])
     array = ak.Array(record, with_name="bad", behavior=behavior)
     record = array[0]


### PR DESCRIPTION
I have hit this failure in CI once
```
 ==================================== ERRORS ====================================
___________________ ERROR at call of test_bad_behavior_array ___________________

    def test_bad_behavior_array():
        record = ak.contents.RecordArray([ak.contents.NumpyArray(np.arange(10))], ["x"])
        array = ak.Array(record, with_name="bad", behavior=behavior)
        assert isinstance(array, BadBehaviorArray)
    
>       assert array.fields == BadBehaviorArray.FIELD_STRING
E       AssertionError: assert 'I am not a list of fields!' == 'yo ho ho and a bottle of rum'
E         
E         - yo ho ho and a bottle of rum
E         + I am not a list of fields!

array      = <[FieldNotFoundError("no field 'I' in record with 1 fields") raised in repr()] BadBehaviorArray object at 0x2a2804d1a50>
record     = <RecordArray is_tuple='false' len='10'>
    <content index='0' field='x'>
        <NumpyArray dtype='int64' len='10'>[0 1 2 3 4 5 6 7 8 9]</NumpyArray>
    </content>
</RecordArray>

tests/test_1511_set_attribute.py:68: AssertionError
```
but can't reproduce locally with `while (pytest tests/test_1511_set_attribute.py --parallel-threads 4); do; done`.

The problem here is that this class is defined globally and therefore shared among threads and it has a setter for an attribute. Let's guard against multiple threads changing the attribute in parallel.