### PR TITLE
fix: argmax and argmin possibly going out of bounds in some cases

### DIFF
--- a/awkward-cpp/src/cpu-kernels/awkward_reduce_argmax.cpp
+++ b/awkward-cpp/src/cpu-kernels/awkward_reduce_argmax.cpp
@@ -10,6 +10,7 @@ ERROR awkward_reduce_argmax(
   const IN* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   for (int64_t k = 0;  k < outlength;  k++) {
     toptr[k] = -1;
@@ -27,12 +28,14 @@ ERROR awkward_reduce_argmax_int8_64(
   const int8_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, int8_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_uint8_64(
@@ -40,12 +43,14 @@ ERROR awkward_reduce_argmax_uint8_64(
   const uint8_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, uint8_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_int16_64(
@@ -53,12 +58,14 @@ ERROR awkward_reduce_argmax_int16_64(
   const int16_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, int16_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_uint16_64(
@@ -66,12 +73,14 @@ ERROR awkward_reduce_argmax_uint16_64(
   const uint16_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, uint16_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_int32_64(
@@ -79,12 +88,14 @@ ERROR awkward_reduce_argmax_int32_64(
   const int32_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, int32_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_uint32_64(
@@ -92,12 +103,14 @@ ERROR awkward_reduce_argmax_uint32_64(
   const uint32_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, uint32_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_int64_64(
@@ -105,12 +118,14 @@ ERROR awkward_reduce_argmax_int64_64(
   const int64_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, int64_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_uint64_64(
@@ -118,12 +133,14 @@ ERROR awkward_reduce_argmax_uint64_64(
   const uint64_t* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, uint64_t>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_float32_64(
@@ -131,12 +148,14 @@ ERROR awkward_reduce_argmax_float32_64(
   const float* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, float>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }
 ERROR awkward_reduce_argmax_float64_64(
@@ -144,11 +163,13 @@ ERROR awkward_reduce_argmax_float64_64(
   const double* fromptr,
   const int64_t* parents,
   int64_t lenparents,
+  const int64_t* starts,
   int64_t outlength) {
   return awkward_reduce_argmax<int64_t, double>(
     toptr,
     fromptr,
     parents,
     lenparents,
+    starts,
     outlength);
 }

--- a/kernel-specification.yml
+++ b/kernel-specification.yml
@@ -4037,6 +4037,7 @@ kernels:
           - {name: fromptr, type: "Const[List[int8_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_int16_64
         args:
@@ -4044,6 +4045,7 @@ kernels:
           - {name: fromptr, type: "Const[List[int16_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_int32_64
         args:
@@ -4051,6 +4053,7 @@ kernels:
           - {name: fromptr, type: "Const[List[int32_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_int64_64
         args:
@@ -4058,6 +4061,7 @@ kernels:
           - {name: fromptr, type: "Const[List[int64_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_uint8_64
         args:
@@ -4065,6 +4069,7 @@ kernels:
           - {name: fromptr, type: "Const[List[uint8_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_uint16_64
         args:
@@ -4072,6 +4077,7 @@ kernels:
           - {name: fromptr, type: "Const[List[uint16_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_uint32_64
         args:
@@ -4079,6 +4085,7 @@ kernels:
           - {name: fromptr, type: "Const[List[uint32_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_uint64_64
         args:
@@ -4086,6 +4093,7 @@ kernels:
           - {name: fromptr, type: "Const[List[uint64_t]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_float32_64
         args:
@@ -4093,6 +4101,7 @@ kernels:
           - {name: fromptr, type: "Const[List[float]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
       - name: awkward_reduce_argmax_float64_64
         args:
@@ -4100,10 +4109,11 @@ kernels:
           - {name: fromptr, type: "Const[List[double]]", dir: in, role: reducer-fromptr}
           - {name: parents, type: "Const[List[int64_t]]", dir: in, role: reducer-parents}
           - {name: lenparents, type: "int64_t", dir: in, role: reducer-lenparents}
+          - {name: starts, type: "Const[List[int64_t]]", dir: in, role: reducer-starts}
           - {name: outlength, type: "int64_t", dir: in, role: reducer-outlength}
     description: null
     definition: |
-      def awkward_reduce_argmax(toptr, fromptr, parents, lenparents, outlength):
+      def awkward_reduce_argmax(toptr, fromptr, parents, lenparents, starts, outlength):
           for k in range(outlength):
               toptr[k] = -1
           for i in range(lenparents):

--- a/kernel-test-data.json
+++ b/kernel-test-data.json
@@ -23841,7 +23841,8 @@
                         "fromptr": [],
                         "lenparents": 0,
                         "outlength": 0,
-                        "parents": []
+                        "parents": [],
+                        "starts": []
                     },
                     "outputs": {
                         "toptr": []
@@ -23854,7 +23855,8 @@
                         "fromptr": [1, -1, 1, -1, 1, 21],
                         "lenparents": 6,
                         "outlength": 3,
-                        "parents": [0, 1, 1, 2, 2, 2]
+                        "parents": [0, 1, 1, 2, 2, 2],
+                        "starts": [0, 1, 3]
                     },
                     "outputs": {
                         "toptr": [0, 2, 5]
@@ -23867,7 +23869,8 @@
                         "fromptr": [1, 2, 3, 4, 6, 7],
                         "lenparents": 6,
                         "outlength": 3,
-                        "parents": [0, 1, 1, 2, 2, 2]
+                        "parents": [0, 1, 1, 2, 2, 2],
+                        "starts": [0, 1, 3]
                     },
                     "outputs": {
                         "toptr": [0, 2, 5]
@@ -23880,7 +23883,8 @@
                         "fromptr": [6, 1, 10, 33, -1, 21, 2, 45, 4],
                         "lenparents": 9,
                         "outlength": 5,
-                        "parents": [0, 0, 3, 3, 1, 1, 4, 4, 2]
+                        "parents": [0, 0, 3, 3, 1, 1, 4, 4, 2],
+                        "starts": [0, 2, 4, 6, 7]
                     },
                     "outputs": {
                         "toptr": [0, 5, 8, 3, 7]
@@ -23893,7 +23897,8 @@
                         "fromptr": [1, 2, 3, 4, 6],
                         "lenparents": 5,
                         "outlength": 3,
-                        "parents": [0, 0, 1, 2, 2]
+                        "parents": [0, 0, 1, 2, 2],
+                        "starts": [0, 2, 3]
                     },
                     "outputs": {
                         "toptr": [1, 2, 4]
@@ -23906,7 +23911,8 @@
                         "fromptr": [3, 4, 2, 1, 2, 3, 6, 1, -1, 1, 7, 4],
                         "lenparents": 12,
                         "outlength": 5,
-                        "parents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4]
+                        "parents": [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4],
+                        "starts": [0, 3, 6, 9, 11]
                     },
                     "outputs": {
                         "toptr": [1, 5, 6, 10, 11]
@@ -23919,7 +23925,8 @@
                         "fromptr": [1, 2, 3],
                         "lenparents": 3,
                         "outlength": 1,
-                        "parents": [0, 0, 0]
+                        "parents": [0, 0, 0],
+                        "starts": [0]
                     },
                     "outputs": {
                         "toptr": [2]
@@ -23932,7 +23939,8 @@
                         "fromptr": [0, 1, 2, 3, 4, 6],
                         "lenparents": 6,
                         "outlength": 3,
-                        "parents": [0, 0, 0, 1, 1, 2]
+                        "parents": [0, 0, 0, 1, 1, 2],
+                        "starts": [0, 3, 5]
                     },
                     "outputs": {
                         "toptr": [2, 4, 5]
@@ -23945,7 +23953,8 @@
                         "fromptr": [3, 1, 6, 1, 4, 4, 2, 1, 7, 2, 3, -1],
                         "lenparents": 12,
                         "outlength": 3,
-                        "parents": [0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2]
+                        "parents": [0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2],
+                        "starts": [0, 5, 9]
                     },
                     "outputs": {
                         "toptr": [2, 8, 10]
@@ -23958,7 +23967,8 @@
                         "fromptr": [0, 0, 4, 4, 6],
                         "lenparents": 5,
                         "outlength": 1,
-                        "parents": [0, 0, 0, 0, 0]
+                        "parents": [0, 0, 0, 0, 0],
+                        "starts": [0]
                     },
                     "outputs": {
                         "toptr": [4]
@@ -23971,7 +23981,8 @@
                         "fromptr": [1, 2, 3, 4, 6],
                         "lenparents": 5,
                         "outlength": 1,
-                        "parents": [0, 0, 0, 0, 0]
+                        "parents": [0, 0, 0, 0, 0],
+                        "starts": [0]
                     },
                     "outputs": {
                         "toptr": [4]
@@ -23984,7 +23995,8 @@
                         "fromptr": [1, 2, 3, 4, 5, 6],
                         "lenparents": 6,
                         "outlength": 1,
-                        "parents": [0, 0, 0, 0, 0, 0]
+                        "parents": [0, 0, 0, 0, 0, 0],
+                        "starts": [0]
                     },
                     "outputs": {
                         "toptr": [5]

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -199,7 +199,6 @@ def awkward_reduce_argmin(
 
     # Prepare the start and end offsets
     offsets = cp.concatenate((starts, cp.array([parents_length])))
-    print(offsets)
     start_o = offsets[:-1]
     end_o = offsets[1:]
 
@@ -226,4 +225,3 @@ def awkward_reduce_argmin(
     # pass the result outside the function
     result_v = result.view()
     result_v[...] = _result
-    print(result_v)

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -105,6 +105,17 @@ def local_idx_from_parents(parents, parents_length):
     return cp.arange(parents_length) - start_pos
 
 
+def get_min_value(dtype):
+    dt = cp.dtype(dtype)
+
+    if dt.kind in "iu":  # int / uint
+        return cp.iinfo(dt).min
+    elif dt.kind == "f":  # float
+        return cp.finfo(dt).min
+    else:
+        raise TypeError("Unsupported dtype to get minimal value")
+
+
 # the inputs for this function we get from file ~/awkward/src/awkward/_reducers.py:239, in ArgMax.apply(self, array, parents, starts, shifts, outlength)
 def awkward_reduce_argmax(
     result,
@@ -116,6 +127,15 @@ def awkward_reduce_argmax(
 ):
     index_dtype = starts.dtype
     data_dtype = input_data.dtype
+
+    # initialize the minimum value depending on the dtype
+    if data_dtype.kind in "iu":  # int/uint
+        min = cp.iinfo(data_dtype).min
+    elif data_dtype.kind == "f":  # float
+        min = cp.finfo(data_dtype).min
+    else:
+        raise TypeError("Unsupported dtype to get the minimal value")
+
     ak_array = gpu_struct(
         {
             "data": input_data.dtype.type,
@@ -152,8 +172,6 @@ def awkward_reduce_argmax(
     # _result = cp.zeros([outlength], dtype= ak_array.dtype)
 
     # Initial value for the reduction
-    # min value gets transformed to input_data.dtype automatically?
-    min = cp.iinfo(data_dtype).min
     h_init = ak_array(min, -1)
 
     # Perform the segmented reduce
@@ -178,6 +196,15 @@ def awkward_reduce_argmin(
 ):
     index_dtype = parents_data.dtype
     data_dtype = input_data.dtype
+
+    # initialize the maximum value depending on the dtype
+    if data_dtype.kind in "iu":  # int/uint
+        max = cp.iinfo(data_dtype).max
+    elif data_dtype.kind == "f":  # float
+        max = cp.finfo(data_dtype).max
+    else:
+        raise TypeError("Unsupported dtype to get the maximal value")
+
     ak_array = gpu_struct(
         {
             "data": input_data.dtype.type,
@@ -214,8 +241,6 @@ def awkward_reduce_argmin(
     # _result = cp.zeros([outlength], dtype= ak_array.dtype)
 
     # Initial value for the reduction
-    # max value gets transformed to input_data.dtype automatically?
-    max = cp.iinfo(data_dtype).max
     h_init = ak_array(max, -1)
 
     # Perform the segmented reduce

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -109,7 +109,7 @@ def local_idx_from_parents(parents, parents_length):
 def awkward_reduce_argmax(
     result,
     input_data,
-    parents_data,
+    starts,
     parents_length,
     outlength,
 ):
@@ -136,7 +136,7 @@ def awkward_reduce_argmax(
     # input_struct = cp.stack((input_data, global_indices), axis=1).view(ak_array.dtype)
 
     # Prepare the start and end offsets
-    offsets = parents_to_offsets(parents_data, parents_length)
+    offsets = cp.concatenate((starts, cp.array([parents_length])))
     start_o = offsets[:-1]
     end_o = offsets[1:]
 
@@ -151,7 +151,7 @@ def awkward_reduce_argmax(
     # Initial value for the reduction
     # min value gets transformed to input_data.dtype automatically?
     min = cp.iinfo(cp.int64).min
-    h_init = ak_array(min, min)
+    h_init = ak_array(min, -1)
 
     # Perform the segmented reduce
     segmented_reduce(input_struct, _result, start_o, end_o, max_op, h_init, outlength)
@@ -169,7 +169,7 @@ def awkward_reduce_argmax(
 def awkward_reduce_argmin(
     result,
     input_data,
-    parents_data,
+    starts,
     parents_length,
     outlength,
 ):
@@ -197,7 +197,7 @@ def awkward_reduce_argmin(
     # input_struct = cp.stack((input_data, global_indices), axis=1).view(ak_array.dtype)
 
     # Prepare the start and end offsets
-    offsets = parents_to_offsets(parents_data, parents_length)
+    offsets = cp.concatenate((starts, cp.array([parents_length])))
     start_o = offsets[:-1]
     end_o = offsets[1:]
 
@@ -212,7 +212,7 @@ def awkward_reduce_argmin(
     # Initial value for the reduction
     # max value gets transformed to input_data.dtype automatically?
     max = cp.iinfo(index_dtype).max
-    h_init = ak_array(max, max)
+    h_init = ak_array(max, -1)
 
     # Perform the segmented reduce
     segmented_reduce(input_struct, _result, start_o, end_o, min_op, h_init, outlength)

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -171,11 +171,11 @@ def awkward_reduce_argmax(
 def awkward_reduce_argmin(
     result,
     input_data,
-    starts,
+    parents_data,
     parents_length,
     outlength,
 ):
-    index_dtype = starts.dtype
+    index_dtype = parents_data.dtype
     ak_array = gpu_struct(
         {
             "data": input_data.dtype.type,
@@ -199,7 +199,7 @@ def awkward_reduce_argmin(
     # input_struct = cp.stack((input_data, global_indices), axis=1).view(ak_array.dtype)
 
     # Prepare the start and end offsets
-    offsets = cp.concatenate((starts, cp.array([parents_length])))
+    offsets = parents_to_offsets(parents_data, parents_length)
     start_o = offsets[:-1]
     end_o = offsets[1:]
 

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -115,6 +115,7 @@ def awkward_reduce_argmax(
     outlength,
 ):
     index_dtype = starts.dtype
+    data_dtype = input_data.dtype
     ak_array = gpu_struct(
         {
             "data": input_data.dtype.type,
@@ -152,7 +153,7 @@ def awkward_reduce_argmax(
 
     # Initial value for the reduction
     # min value gets transformed to input_data.dtype automatically?
-    min = cp.iinfo(index_dtype).min
+    min = cp.iinfo(data_dtype).min
     h_init = ak_array(min, -1)
 
     # Perform the segmented reduce
@@ -176,6 +177,7 @@ def awkward_reduce_argmin(
     outlength,
 ):
     index_dtype = parents_data.dtype
+    data_dtype = input_data.dtype
     ak_array = gpu_struct(
         {
             "data": input_data.dtype.type,
@@ -213,7 +215,7 @@ def awkward_reduce_argmin(
 
     # Initial value for the reduction
     # max value gets transformed to input_data.dtype automatically?
-    max = cp.iinfo(index_dtype).max
+    max = cp.iinfo(data_dtype).max
     h_init = ak_array(max, -1)
 
     # Perform the segmented reduce

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -109,8 +109,9 @@ def local_idx_from_parents(parents, parents_length):
 def awkward_reduce_argmax(
     result,
     input_data,
-    starts,
+    _,
     parents_length,
+    starts,
     outlength,
 ):
     index_dtype = starts.dtype

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -182,7 +182,7 @@ class ArgMin(KernelReducer):
                 ](
                     result,
                     kernel_array_data,
-                    starts.data,
+                    parents.data,
                     parents.length,
                     outlength,
                 )

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -166,7 +166,7 @@ class ArgMin(KernelReducer):
                 ](
                     result,
                     kernel_array_data,
-                    starts.data,
+                    parents.data,
                     parents.length,
                     outlength,
                 )
@@ -182,7 +182,7 @@ class ArgMin(KernelReducer):
                 ](
                     result,
                     kernel_array_data,
-                    parents.data,
+                    starts.data,
                     parents.length,
                     outlength,
                 )

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -166,7 +166,7 @@ class ArgMin(KernelReducer):
                 ](
                     result,
                     kernel_array_data,
-                    parents.data,
+                    starts.data,
                     parents.length,
                     outlength,
                 )
@@ -244,7 +244,7 @@ class ArgMax(KernelReducer):
                 ](
                     result,
                     kernel_array_data,
-                    parents.data,
+                    starts.data,
                     parents.length,
                     outlength,
                 )

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -241,11 +241,13 @@ class ArgMax(KernelReducer):
                     result.dtype.type,
                     kernel_array_data.dtype.type,
                     parents.dtype.type,
+                    starts.dtype.type,
                 ](
                     result,
                     kernel_array_data,
-                    starts.data,
+                    parents.data,
                     parents.length,
+                    starts.data,
                     outlength,
                 )
             )


### PR DESCRIPTION
This PR is trying to fix two issues found out by @shwina:
1. awkward_reduce_argmax kernel initializes indices as cp.iinfo(index_dtype).max which can sometimes be passed to the next kernels (with empty lists, for example) and cause out of bounds memory access.
2. offsets are not calculated correctly if the last element of an array is empty.