### PR TITLE
build: drop support for PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,6 @@ jobs:
             python-architecture: x64
             runs-on: ubuntu-latest
             dependencies-kind: minimal
-          - python-version: 'pypy3.10'
-            python-architecture: x64
-            runs-on: ubuntu-latest
-            dependencies-kind: pypy
           - python-version: '3.11'
             python-architecture: arm64
             runs-on: macos-14
@@ -163,11 +159,6 @@ jobs:
           python -m pytest -vv -rs tests --cov=awkward --cov-report=term
           --cov-report=xml
         if: startsWith(matrix.python-version, '3.')
-
-      - name: Test non-kernels (PyPy)
-        run: >-
-          python -m pytest -vv -rs tests
-        if: startsWith(matrix.python-version, 'pypy')
 
       - name: Test non-kernels (Python) in multiple threads
         if: matrix.python-version == '3.14t'

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -81,7 +81,7 @@ cmake.version = ">=3.29"
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-enable = ["pypy", "cpython-freethreading"]
+enable = ["cpython-freethreading"]
 test-requires = ["pytest>=6", "."]
 test-command = ["echo {project}:", "ls {project}", "echo {package}:", "ls {package}",
 """

--- a/requirements-test-pypy.txt
+++ b/requirements-test-pypy.txt
@@ -1,3 +1,0 @@
-pytest>=6
-pytest-cov
-pytest-xdist

--- a/tests/test_3347_weakref_mask_highlevel_array.py
+++ b/tests/test_3347_weakref_mask_highlevel_array.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
-import platform
-
 import pytest
 
 import awkward as ak
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="PyPy has a different GC strategy than CPython and thus weakrefs may stay alive a little bit longer than expected, see: https://doc.pypy.org/en/latest/cpython_differences.html#differences-related-to-garbage-collection-strategies",
-)
 def test_Array_mask_weakref():
     arr = ak.Array([1])
     m = arr.mask


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3827
We follow numpy and drop PyPy support as PyPy is no longer under active development.