### PR TITLE
chore: xfail `tests-cuda/test_3051_to_cuda.py` only in the latest cudf

### DIFF
--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from packaging.version import parse as parse_version
 
 import awkward as ak
 
@@ -8,7 +9,10 @@ cudf = pytest.importorskip("cudf", exc_type=ImportError)
 cupy = pytest.importorskip("cupy")
 
 
-@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
 def test_jagged():
     arr = ak.Array([[[1, 2, 3], [], [3, 4]], []])
     out = ak.to_cudf(arr)
@@ -16,7 +20,10 @@ def test_jagged():
     assert out.to_arrow().tolist() == [[[1, 2, 3], [], [3, 4]], []]
 
 
-@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
 def test_nested():
     arr = ak.Array(
         [{"a": 0, "b": 1.0, "c": {"d": 0}}, {"a": 1, "b": 0.0, "c": {"d": 1}}]
@@ -49,7 +56,10 @@ def test_null():
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
-@pytest.mark.xfail(reason="cudf internals changed since v25.12.00")
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
 def test_strings():
     arr = ak.Array(["hey", "hi", "hum"])
     out = ak.to_cudf(arr)


### PR DESCRIPTION
if a developer intentionally installs cudf < 25.12, this test will fail. I just did this locally and it is annoying to get a failure.
It's correct to xfail only if cudf >= 25.12