### PR TITLE
chore: do not skip `test_recordarray_argmax_y_field` and make the xfail reason consistent for `test_listarray_sort` in  `tests-cuda/test_3459_virtualarray_with_cuda.py`

### DIFF
--- a/tests-cuda/test_3459_virtualarray_with_cuda.py
+++ b/tests-cuda/test_3459_virtualarray_with_cuda.py
@@ -2258,7 +2258,7 @@ def test_listarray_nanargmax(numpy_like):
 
 
 @pytest.mark.xfail(
-    reason="ListArray.to_ListOffsetArray64 fails with virtual arrays on CUDA"
+    reason="Fails due to CuPy issue: https://github.com/cupy/cupy/issues/9089. Will be available in CuPy 14.0.0."
 )
 def test_listarray_sort(listarray, virtual_listarray):
     assert not virtual_listarray.is_any_materialized

--- a/tests-cuda/test_3459_virtualarray_with_cuda.py
+++ b/tests-cuda/test_3459_virtualarray_with_cuda.py
@@ -3348,7 +3348,6 @@ def test_recordarray_argmax_x_field(recordarray, virtual_recordarray):
     assert virtual_recordarray.is_any_materialized
 
 
-@pytest.mark.skip(reason="ignore virtual arrays with cccl argmax for the moment")
 def test_recordarray_argmax_y_field(recordarray, virtual_recordarray):
     # Test argmax on the y field (NumpyArray)
     assert not virtual_recordarray.is_any_materialized


### PR DESCRIPTION
As far as I know, on the x-field tests should be skipped there. The y-field tests are fine and do not error. The exact same test for argmin is not skipped.

Also the reason `test_listarray_sort` fails is the same as many other tests in the same file so they should have the same xfail reason.