### PR TITLE
ci: drop 3.13t

### DIFF
--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -81,7 +81,6 @@ cmake.version = ">=3.29"
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-enable = ["cpython-freethreading"]
 test-requires = ["pytest>=6", "."]
 test-command = ["echo {project}:", "ls {project}", "echo {package}:", "ls {package}",
 """


### PR DESCRIPTION
Let's drop 3.13t, which was experimental, now that 3.14t has been out for a bit. pybind11 and cibuildwheel are likely dropping this soon too, as it's harder to fix bugs in 3.13t.

Followup to #3835.