### PR TITLE
fix: use `set_mask` instead of `set_base_mask` in `to_cudf`

### DIFF
--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -722,7 +722,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             m = cp.resize(m, ((m.nbytes // 64) + 1) * 64)
         m = cudf.core.buffer.as_buffer(m)
         inner = self._content._to_cudf(cudf, mask=None, length=length)
-        inner.set_base_mask(m)
+        inner = inner.set_mask(m)
         return inner
 
     def _to_backend_array(self, allow_missing, backend):

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -1077,7 +1077,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             m = cp.resize(m, ((m.nbytes // 64) + 1) * 64)
         m = cudf.core.buffer.as_buffer(m)
         inner = self._content._to_cudf(cudf, mask=None, length=length)
-        inner.set_base_mask(m)
+        inner = inner.set_mask(m)
         return inner
 
     def _to_backend_array(self, allow_missing, backend):


### PR DESCRIPTION
 `set_base_mask` has been deleted in cudf  v26.02.00 but we can use `set_mask` instead which is not inplace. It's not a new method and is backwards compatible with cudf before 25.12.00 which is when the column constructors have changed.