### PR TITLE
ci: drop cp/pp build selectors

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -65,7 +65,7 @@ jobs:
 
   build_wheels:
     needs: [determine-source-date-epoch]
-    name: "Wheel awkward-cpp: ${{ matrix.arch }} on ${{ matrix.os }} with ${{ matrix.build }}"
+    name: "Wheel awkward-cpp: ${{ matrix.arch }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
@@ -73,20 +73,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-15, macos-15-intel]
         arch: [auto64]
-        build: ["cp", "pp"]
 
         include:
         - os: windows-latest
           arch: auto64
-          build: "cp"
 
         - os: windows-latest
           arch: auto32
-          build: "cp"
 
         - os: ubuntu-24.04-arm
           arch: auto64
-          build: "cp"
 
     steps:
     - uses: actions/checkout@v6
@@ -106,7 +102,6 @@ jobs:
 
     - uses: pypa/cibuildwheel@v3.3
       env:
-        CIBW_BUILD: "${{ matrix.build }}*"
         CIBW_ARCHS: ${{ matrix.arch }}
       with:
         package-dir: awkward-cpp
@@ -117,7 +112,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v6
       with:
-        name: awkward-cpp-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build }}
+        name: awkward-cpp-wheels-${{ matrix.os }}-${{ matrix.arch }}
         path: wheelhouse/*.whl
 
   build_awkward_wheel:


### PR DESCRIPTION
Alternative to #3853, we can just get rid of this build selector entirely.
