### PR TITLE
feat: lazy parents allocation

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -145,7 +145,7 @@ def combinations(
 def is_unique(layout, axis: Integral | None = None) -> bool:
     negaxis = axis if axis is None else -axis
     starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.nplike)
+    parents = ((None, layout.length),)
     return layout._is_unique(negaxis, starts, parents, 1)
 
 
@@ -175,7 +175,7 @@ def unique(layout: Content, axis=None):
                     )
 
         starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
-        parents = ak.index.Index64.zeros(layout.length, nplike=layout._backend.nplike)
+        parents = ((None, layout.length),)
 
         return layout._unique(negaxis, starts, parents, 1)
 
@@ -267,7 +267,7 @@ def reduce(
             reducer = specialization
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
-        parents = ak.index.Index64.zeros(layout.length, layout.backend.nplike)
+        parents = ((None, layout.length),)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -321,7 +321,7 @@ def reduce(
             del original_reducer  # not used below this point
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
-        parents = ak.index.Index64.zeros(layout.length, layout.backend.nplike)
+        parents = ((None, layout.length),)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -372,7 +372,7 @@ def argsort(
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.nplike)
+    parents = ((None, layout.length),)
     return layout._argsort_next(
         negaxis,
         starts,
@@ -411,7 +411,7 @@ def sort(
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
-    parents = ak.index.Index64.zeros(layout.length, nplike=layout.backend.nplike)
+    parents = ((None, layout.length),)
     return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
 
 

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -145,7 +145,7 @@ def combinations(
 def is_unique(layout, axis: Integral | None = None) -> bool:
     negaxis = axis if axis is None else -axis
     starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
-    parents = ((None, layout.length),)
+    parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
     return layout._is_unique(negaxis, starts, parents, 1)
 
 
@@ -175,7 +175,7 @@ def unique(layout: Content, axis=None):
                     )
 
         starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
-        parents = ((None, layout.length),)
+        parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
 
         return layout._unique(negaxis, starts, parents, 1)
 
@@ -267,7 +267,7 @@ def reduce(
             reducer = specialization
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
-        parents = ((None, layout.length),)
+        parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -321,7 +321,7 @@ def reduce(
             del original_reducer  # not used below this point
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
-        parents = ((None, layout.length),)
+        parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -372,7 +372,7 @@ def argsort(
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
-    parents = ((None, layout.length),)
+    parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
     return layout._argsort_next(
         negaxis,
         starts,
@@ -411,7 +411,7 @@ def sort(
             )
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
-    parents = ((None, layout.length),)
+    parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
     return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
 
 

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -42,7 +42,7 @@ class Reducer(Protocol):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -85,7 +85,7 @@ class KernelReducer(Reducer):
 
 def apply_positional_corrections(
     reduced: ak.contents.NumpyArray,
-    parents: ak.index.Index | tuple[None, int],
+    parents: ak.index.Index | ak.index.ZeroIndex,
     starts: ak.index.Index,
     shifts: ak.index.Index | None,
 ):
@@ -146,7 +146,7 @@ class ArgMin(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -208,7 +208,7 @@ class ArgMax(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -262,7 +262,7 @@ class Count(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -291,7 +291,7 @@ class CountNonzero(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -348,7 +348,7 @@ class Sum(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -448,7 +448,7 @@ class AxisNoneSum(Sum):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        _parents: ak.index.Index | tuple[None, int],
+        _parents: ak.index.Index | ak.index.ZeroIndex,
         _starts: ak.index.Index,
         _shifts: ak.index.Index | None,
         _outlength: ShapeItem,
@@ -473,7 +473,7 @@ class Prod(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -564,7 +564,7 @@ class Any(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -617,7 +617,7 @@ class All(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -700,7 +700,7 @@ class Min(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -808,7 +808,7 @@ class Max(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index | tuple[None, int],
+        parents: ak.index.Index | ak.index.ZeroIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -42,7 +42,7 @@ class Reducer(Protocol):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -85,7 +85,7 @@ class KernelReducer(Reducer):
 
 def apply_positional_corrections(
     reduced: ak.contents.NumpyArray,
-    parents: ak.index.Index,
+    parents: ak.index.Index | tuple[None, int],
     starts: ak.index.Index,
     shifts: ak.index.Index | None,
 ):
@@ -146,7 +146,7 @@ class ArgMin(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -208,7 +208,7 @@ class ArgMax(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -262,7 +262,7 @@ class Count(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -291,7 +291,7 @@ class CountNonzero(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -348,7 +348,7 @@ class Sum(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -448,19 +448,21 @@ class AxisNoneSum(Sum):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
-        starts: ak.index.Index,
-        shifts: ak.index.Index | None,
-        outlength: ShapeItem,
+        _parents: ak.index.Index | tuple[None, int],
+        _starts: ak.index.Index,
+        _shifts: ak.index.Index | None,
+        _outlength: ShapeItem,
     ) -> ak.contents.NumpyArray:
-        del parents, starts, shifts, outlength  # Unused
         assert isinstance(array, ak.contents.NumpyArray)
         if array.dtype.kind == "M":
             raise ValueError(f"cannot compute the sum (ak.sum) of {array.dtype!r}")
-        reduce_fn = getattr(array.backend.nplike, self.name)
-        return ak.contents.NumpyArray(
-            [reduce_fn(array.data, axis=None)], backend=array.backend
-        )
+
+        nplike = array.backend.nplike
+        reduce_fn = getattr(nplike, self.name)
+        result_scalar = reduce_fn(array.data, axis=None)
+        result_array = nplike.asarray(result_scalar).reshape((1,))
+
+        return ak.contents.NumpyArray(result_array, backend=array.backend)
 
 
 class Prod(KernelReducer):
@@ -471,7 +473,7 @@ class Prod(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -562,7 +564,7 @@ class Any(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -615,7 +617,7 @@ class All(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -698,7 +700,7 @@ class Min(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -806,7 +808,7 @@ class Max(KernelReducer):
     def apply(
         self,
         array: ak.contents.NumpyArray,
-        parents: ak.index.Index,
+        parents: ak.index.Index | tuple[None, int],
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -168,3 +168,13 @@ def maybe_length_of(
         return 0
     else:
         raise TypeError(f"Invalid type {type(obj)} for length calculation")
+
+
+def resolve_index(index, backend):
+    if isinstance(index, tuple) and len(index) == 1:
+        index = index[0]
+
+    if isinstance(index, tuple) and len(index) == 2 and index[0] is None:
+        return ak.index.Index64.zeros(index[1], backend.nplike)
+
+    return index

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -168,13 +168,3 @@ def maybe_length_of(
         return 0
     else:
         raise TypeError(f"Invalid type {type(obj)} for length calculation")
-
-
-def resolve_index(index, backend):
-    if isinstance(index, tuple) and len(index) == 1:
-        index = index[0]
-
-    if isinstance(index, tuple) and len(index) == 2 and index[0] is None:
-        return ak.index.Index64.zeros(index[1], backend.nplike)
-
-    return index

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -34,7 +34,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -45,7 +45,7 @@ from awkward.contents.content import (
 from awkward.errors import AxisError
 from awkward.forms.bytemaskedform import ByteMaskedForm
 from awkward.forms.form import Form, FormKeyPathT
-from awkward.index import Index
+from awkward.index import Index, resolve_index
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -34,7 +34,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -882,6 +882,9 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         nextcarry = ak.index.Index64.empty(next_length, nplike=self._backend.nplike)
         nextparents = ak.index.Index64.empty(next_length, nplike=self._backend.nplike)
         outindex = ak.index.Index64.empty(mask_length, nplike=self._backend.nplike)
+
+        parents = resolve_index(parents, self._backend)
+
         assert (
             nextcarry.nplike is self._backend.nplike
             and nextparents.nplike is self._backend.nplike

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -893,7 +893,7 @@ class Content(Meta):
         negaxis: int,
         starts: Index,
         shifts: Index | None,
-        parents: Index,
+        parents: Index | tuple[None, int],
         outlength: int,
         mask: bool,
         keepdims: bool,
@@ -906,7 +906,7 @@ class Content(Meta):
         negaxis: int,
         starts: Index,
         shifts: Index | None,
-        parents: Index,
+        parents: Index | tuple[None, int],
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -917,7 +917,7 @@ class Content(Meta):
         self,
         negaxis: int,
         starts: Index,
-        parents: Index,
+        parents: Index | tuple[None, int],
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -1039,7 +1039,7 @@ class Content(Meta):
         self,
         negaxis: AxisMaybeNone,
         starts: Index,
-        parents: Index,
+        parents: Index | tuple[None, int],
         outlength: int,
     ) -> bool:
         raise NotImplementedError
@@ -1048,7 +1048,7 @@ class Content(Meta):
         self,
         negaxis: AxisMaybeNone,
         starts: Index,
-        parents: Index,
+        parents: Index | tuple[None, int],
         outlength: int,
     ):
         raise NotImplementedError

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -57,7 +57,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.forms.form import Form, FormKeyPathT
-from awkward.index import Index, Index64
+from awkward.index import Index, Index64, ZeroIndex
 
 if TYPE_CHECKING:
     from awkward._nplikes.numpy import NumpyLike
@@ -893,7 +893,7 @@ class Content(Meta):
         negaxis: int,
         starts: Index,
         shifts: Index | None,
-        parents: Index | tuple[None, int],
+        parents: Index | ZeroIndex,
         outlength: int,
         mask: bool,
         keepdims: bool,
@@ -906,7 +906,7 @@ class Content(Meta):
         negaxis: int,
         starts: Index,
         shifts: Index | None,
-        parents: Index | tuple[None, int],
+        parents: Index | ZeroIndex,
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -917,7 +917,7 @@ class Content(Meta):
         self,
         negaxis: int,
         starts: Index,
-        parents: Index | tuple[None, int],
+        parents: Index | ZeroIndex,
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -1039,7 +1039,7 @@ class Content(Meta):
         self,
         negaxis: AxisMaybeNone,
         starts: Index,
-        parents: Index | tuple[None, int],
+        parents: Index | ZeroIndex,
         outlength: int,
     ) -> bool:
         raise NotImplementedError
@@ -1048,7 +1048,7 @@ class Content(Meta):
         self,
         negaxis: AxisMaybeNone,
         starts: Index,
-        parents: Index | tuple[None, int],
+        parents: Index | ZeroIndex,
         outlength: int,
     ):
         raise NotImplementedError

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -43,7 +43,7 @@ from awkward.contents.content import (
 from awkward.errors import AxisError
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.indexedform import IndexedForm
-from awkward.index import Index
+from awkward.index import Index, resolve_index
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -812,6 +812,8 @@ class IndexedArray(IndexedMeta[Content], Content):
             return self
 
         branch, depth = self.branch_depth
+
+        parents = resolve_index(parents, self._backend)
 
         index_length = self._index.length
         parents_length = parents.length

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -33,7 +33,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -44,7 +44,7 @@ from awkward.contents.content import (
 from awkward.errors import AxisError
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.indexedoptionform import IndexedOptionForm
-from awkward.index import Index
+from awkward.index import Index, resolve_index
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -33,7 +33,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -1001,6 +1001,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         )
 
         if branch or (negaxis is not None and negaxis != depth):
+            parents = resolve_index(parents, self._backend)
+
             nextoutindex = ak.index.Index64.empty(parents.length, self._backend.nplike)
             assert (
                 nextoutindex.nplike is self._backend.nplike
@@ -1163,6 +1165,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return nextshifts
 
     def _rearrange_prepare_next(self, parents):
+        parents = resolve_index(parents, self._backend)
+
         assert (
             self._index.nplike is self._backend.nplike
             and parents.nplike is self._backend.nplike
@@ -1216,6 +1220,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
     def _argsort_next(
         self, negaxis, starts, shifts, parents, outlength, ascending, stable
     ):
+        parents = resolve_index(parents, self._backend)
+
         assert (
             starts.nplike is self._backend.nplike
             and parents.nplike is self._backend.nplike
@@ -1342,6 +1348,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             return out
 
     def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+        parents = resolve_index(parents, self._backend)
+
         assert (
             starts.nplike is self._backend.nplike
             and parents.nplike is self._backend.nplike
@@ -1406,6 +1414,8 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         behavior,
     ):
         branch, depth = self.branch_depth
+
+        parents = resolve_index(parents, self._backend)
 
         next, nextparents, _numnull, outindex = self._rearrange_prepare_next(parents)
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -43,7 +43,7 @@ from awkward.contents.content import (
 from awkward.errors import AxisError
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.listoffsetform import ListOffsetForm
-from awkward.index import Index, Index64
+from awkward.index import Index, Index64, resolve_index
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -1085,6 +1085,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
 
                 self_starts, self_stops = self._offsets[:-1], self._offsets[1:]
+
+                parents = resolve_index(parents, self._backend)
+
                 assert (
                     nextcarry.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1122,6 +1125,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 or self.parameter("__array__") == "bytestring"
             ):
                 raise AxisError("array with strings can only be sorted with axis=-1")
+
+            parents = resolve_index(parents, self._backend)
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1261,6 +1266,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nextcarry = Index64.empty(self._offsets.length - 1, nplike)
 
                 starts, stops = self._offsets[:-1], self._offsets[1:]
+
+                parents = resolve_index(parents, self._backend)
+
                 assert (
                     nextcarry.nplike is nplike
                     and parents.nplike is nplike
@@ -1296,6 +1304,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 or self.parameter("__array__") == "bytestring"
             ):
                 raise AxisError("array with strings can only be sorted with axis=-1")
+
+            parents = resolve_index(parents, self._backend)
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1523,6 +1533,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         globalstarts_length = self._offsets.length - 1
 
         if not branch and negaxis == depth:
+            parents = resolve_index(parents, self._backend)
+
             (
                 distincts,
                 maxcount,
@@ -1661,6 +1673,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             outoffsets = Index64.empty(outlength + 1, nplike)
+
+            parents = resolve_index(parents, self._backend)
+
             assert outoffsets.nplike is nplike and parents.nplike is nplike
             self._backend.maybe_kernel_error(
                 self._backend[

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,7 +38,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -49,7 +49,7 @@ from awkward.contents.content import (
 from awkward.errors import AxisError
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.numpyform import NumpyForm
-from awkward.index import Index
+from awkward.index import Index, resolve_index
 from awkward.types.numpytype import primitive_to_dtype
 
 if TYPE_CHECKING:

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,7 +38,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -934,6 +934,8 @@ class NumpyArray(NumpyMeta, Content):
                 negaxis, starts, shifts, parents, outlength, ascending, stable
             )
         else:
+            parents = resolve_index(parents, self._backend)
+
             parents_length = parents.length
             _offsets_length = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
@@ -1040,6 +1042,8 @@ class NumpyArray(NumpyMeta, Content):
             )
 
         else:
+            parents = resolve_index(parents, self._backend)
+
             parents_length = parents.length
             _offsets_length = ak.index.Index64.empty(1, self._backend.nplike)
             assert (
@@ -1161,6 +1165,8 @@ class NumpyArray(NumpyMeta, Content):
         # Yes, we've just tested these, but we need to be explicit that they are invariants
         assert self.is_contiguous
         assert self._data.ndim == 1
+
+        parents = resolve_index(parents, self._backend)
 
         out = reducer.apply(self, parents, starts, shifts, outlength)
 

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -30,7 +30,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -40,7 +40,7 @@ from awkward.contents.content import (
 )
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.regularform import RegularForm
-from awkward.index import Index
+from awkward.index import Index, resolve_index
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -30,7 +30,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,
@@ -1020,6 +1020,8 @@ class RegularArray(RegularMeta[Content], Content):
         if not branch and negaxis == depth:
             nextcarry = ak.index.Index64.empty(nextlen, nplike=nplike)
             nextparents = ak.index.Index64.empty(nextlen, nplike=nplike)
+            parents = resolve_index(parents, self._backend)
+
             assert (
                 parents.nplike is nplike
                 and nextcarry.nplike is nplike
@@ -1184,6 +1186,9 @@ class RegularArray(RegularMeta[Content], Content):
                     assert outcontent.is_regular
 
             outoffsets = ak.index.Index64.empty(outlength + 1, nplike)
+
+            parents = resolve_index(parents, self._backend)
+
             assert outoffsets.nplike is nplike and parents.nplike is nplike
             self._backend.maybe_kernel_error(
                 self._backend[

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -324,3 +324,43 @@ class IndexU32(Index):
 
 class Index64(Index):
     _expected_dtype = np.dtype(np.int64)
+
+
+class LazyIndex:
+    __slots__ = ("_dtype", "_factory", "_index", "_length", "_nplike")
+
+    def __init__(
+        self, factory, length: ShapeItem, nplike: NumpyLike, dtype: DType | None = None
+    ):
+        self._factory = factory
+        self._length = length
+        self._nplike = nplike
+        self._dtype = dtype
+        self._index = None
+
+    def _materialize(self) -> Index:
+        if self._index is None:
+            self._index = self._factory(self._length, self._nplike, dtype=self._dtype)
+        assert self._index is not None
+        return self._index
+
+
+def zero_factory(length, nplike, dtype=None):
+    return ak.index.Index64.zeros(length, nplike)
+
+
+class ZeroIndex(LazyIndex):
+    def __init__(self, length, nplike):
+        def zeros_factory(length, nplike, dtype=None):
+            return ak.index.Index64.zeros(length, nplike)
+
+        super().__init__(
+            factory=zeros_factory, length=length, nplike=nplike, dtype=None
+        )
+
+
+def resolve_index(index: Index | LazyIndex, backend) -> Index:
+    if isinstance(index, LazyIndex):
+        return index._materialize()
+
+    return index

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -345,13 +345,23 @@ class LazyIndex:
         return self._index
 
 
-class ZeroIndex(LazyIndex):
-    def __init__(self, length, nplike):
-        def zeros_factory(length, nplike, dtype=None):
-            return ak.index.Index64.zeros(length, nplike)
-
+class EmptyIndex(LazyIndex):
+    def __init__(self, length, nplike, dtype=None):
         super().__init__(
-            factory=zeros_factory, length=length, nplike=nplike, dtype=None
+            factory=Index.empty,
+            length=length,
+            nplike=nplike,
+            dtype=dtype if dtype is not None else np.dtype(np.int64),
+        )
+
+
+class ZeroIndex(LazyIndex):
+    def __init__(self, length, nplike, dtype=None):
+        super().__init__(
+            factory=Index.zeros,
+            length=length,
+            nplike=nplike,
+            dtype=dtype if dtype is not None else np.dtype(np.int64),
         )
 
 

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -345,10 +345,6 @@ class LazyIndex:
         return self._index
 
 
-def zero_factory(length, nplike, dtype=None):
-    return ak.index.Index64.zeros(length, nplike)
-
-
 class ZeroIndex(LazyIndex):
     def __init__(self, length, nplike):
         def zeros_factory(length, nplike, dtype=None):


### PR DESCRIPTION
**1. Removed `parents` allocations before calling the kernels.**

Avoids allocating `ak.index.Index64.zeros(layout.length)` during the initial stages of reduce. For large arrays, this significantly reduces memory pressure and avoids $O(N)$ initialization costs.
 * Added `resolve_index` to handle the transition between the virtualized `(None, length)` representation and the materialized `Index64 array`.
 * Updated `reduce` to initialize parents using the optimized tuple.
 
**2. Internal Refactoring.**
 * Updated `sum` kernel for `axis==None` to get $475\times$ performance improvement on GPU.
