### PR TITLE
chore: ignore jax deprecation warning in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ filterwarnings = [
     "ignore:.*np\\.MachAr.*:DeprecationWarning",
     "ignore:module 'sre_.*' is deprecated:DeprecationWarning",
     "ignore:Jitify is performing a one-time only warm-up",
+    "ignore:The JAX backend is deprecated:DeprecationWarning",
 ]
 log_level = "INFO"
 testpaths = ["tests", "tests-cuda", "tests-cuda-kernels", "tests-cuda-kernels-explicit"]


### PR DESCRIPTION
it's super annoying when you try to run individual jax tests and get hit with a mllion `DeprecationWarning: The JAX backend is deprecated and will be removed in a future release of Awkward Array. Please plan to migrate your code accordingly.` erors because we treat warnings as errors in pytest.