### PR TITLE
feat: extend Python reducers with `offset` support (precursor to `parent` removal)

### DIFF
--- a/src/awkward/_connect/jax/reducers.py
+++ b/src/awkward/_connect/jax/reducers.py
@@ -71,6 +71,7 @@ def awkward_JAXNumpyArray_reduce_adjust_starts_shifts_64(
 def apply_positional_corrections(
     reduced: ak.contents.NumpyArray,
     parents: ak.index.Index,
+    offsets: ak.index.Index | ak.index.EmptyIndex,
     starts: ak.index.Index,
     shifts: ak.index.Index | None,
 ) -> ak._nplikes.ArrayLike:
@@ -144,6 +145,7 @@ class ArgMin(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -153,7 +155,7 @@ class ArgMin(JAXReducer):
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
         corrected_data = apply_positional_corrections(
-            result_array, parents, starts, shifts
+            result_array, parents, offsets, starts, shifts
         )
         return ak.contents.NumpyArray(corrected_data, backend=array.backend)
 
@@ -204,6 +206,7 @@ class ArgMax(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -213,7 +216,7 @@ class ArgMax(JAXReducer):
         result = jax.numpy.asarray(result, dtype=self.preferred_dtype)
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
         corrected_data = apply_positional_corrections(
-            result_array, parents, starts, shifts
+            result_array, parents, offsets, starts, shifts
         )
         return ak.contents.NumpyArray(corrected_data, backend=array.backend)
 
@@ -237,6 +240,7 @@ class Count(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -296,6 +300,7 @@ class CountNonzero(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -324,6 +329,7 @@ class Sum(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -415,6 +421,7 @@ class Prod(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -471,6 +478,7 @@ class Any(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -506,6 +514,7 @@ class All(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -560,6 +569,7 @@ class Min(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -623,6 +633,7 @@ class Max(JAXReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,

--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -146,7 +146,8 @@ def is_unique(layout, axis: Integral | None = None) -> bool:
     negaxis = axis if axis is None else -axis
     starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
     parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
-    return layout._is_unique(negaxis, starts, parents, 1)
+    offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
+    return layout._is_unique(negaxis, starts, parents, offsets, 1)
 
 
 def unique(layout: Content, axis=None):
@@ -176,8 +177,9 @@ def unique(layout: Content, axis=None):
 
         starts = ak.index.Index64.zeros(1, nplike=layout._backend.nplike)
         parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
+        offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
 
-        return layout._unique(negaxis, starts, parents, 1)
+        return layout._unique(negaxis, starts, parents, offsets, 1)
 
     raise AxisError(
         f"unique expects axis 'None' or '-1', got axis={axis} that is not supported yet"
@@ -268,6 +270,7 @@ def reduce(
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
         parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
+        offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -275,6 +278,7 @@ def reduce(
             starts,
             shifts,
             parents,
+            offsets,
             1,
             mask,
             keepdims,
@@ -322,6 +326,7 @@ def reduce(
 
         starts = ak.index.Index64.zeros(1, layout.backend.nplike)
         parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
+        offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
         shifts = None
         next = layout._reduce_next(
             reducer,
@@ -329,6 +334,7 @@ def reduce(
             starts,
             shifts,
             parents,
+            offsets,
             1,
             mask,
             keepdims,
@@ -373,11 +379,13 @@ def argsort(
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
     parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
+    offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
     return layout._argsort_next(
         negaxis,
         starts,
         None,
         parents,
+        offsets,
         1,
         ascending,
         stable,
@@ -412,7 +420,8 @@ def sort(
 
     starts = ak.index.Index64.zeros(1, nplike=layout.backend.nplike)
     parents = ak.index.ZeroIndex(layout.length, layout.backend.nplike)
-    return layout._sort_next(negaxis, starts, parents, 1, ascending, stable)
+    offsets = ak.index.EmptyIndex(2, layout.backend.nplike)
+    return layout._sort_next(negaxis, starts, parents, offsets, 1, ascending, stable)
 
 
 def touch_data(layout: Content, recursive: bool = True):

--- a/src/awkward/_reducers.py
+++ b/src/awkward/_reducers.py
@@ -43,6 +43,7 @@ class Reducer(Protocol):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -86,6 +87,7 @@ class KernelReducer(Reducer):
 def apply_positional_corrections(
     reduced: ak.contents.NumpyArray,
     parents: ak.index.Index | ak.index.ZeroIndex,
+    offsets: ak.index.Index | ak.index.EmptyIndex,
     starts: ak.index.Index,
     shifts: ak.index.Index | None,
 ):
@@ -147,6 +149,7 @@ class ArgMin(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -188,7 +191,7 @@ class ArgMin(KernelReducer):
                 )
             )
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
-        apply_positional_corrections(result_array, parents, starts, shifts)
+        apply_positional_corrections(result_array, parents, offsets, starts, shifts)
         return result_array
 
 
@@ -209,6 +212,7 @@ class ArgMax(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -250,7 +254,7 @@ class ArgMax(KernelReducer):
                 )
             )
         result_array = ak.contents.NumpyArray(result, backend=array.backend)
-        apply_positional_corrections(result_array, parents, starts, shifts)
+        apply_positional_corrections(result_array, parents, offsets, starts, shifts)
         return result_array
 
 
@@ -263,6 +267,7 @@ class Count(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -292,6 +297,7 @@ class CountNonzero(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -349,6 +355,7 @@ class Sum(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -449,6 +456,7 @@ class AxisNoneSum(Sum):
         self,
         array: ak.contents.NumpyArray,
         _parents: ak.index.Index | ak.index.ZeroIndex,
+        _offsets: ak.index.Index | ak.index.EmptyIndex,
         _starts: ak.index.Index,
         _shifts: ak.index.Index | None,
         _outlength: ShapeItem,
@@ -474,6 +482,7 @@ class Prod(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -565,6 +574,7 @@ class Any(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -618,6 +628,7 @@ class All(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -701,6 +712,7 @@ class Min(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,
@@ -809,6 +821,7 @@ class Max(KernelReducer):
         self,
         array: ak.contents.NumpyArray,
         parents: ak.index.Index | ak.index.ZeroIndex,
+        offsets: ak.index.Index | ak.index.EmptyIndex,
         starts: ak.index.Index,
         shifts: ak.index.Index | None,
         outlength: ShapeItem,

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -168,3 +168,13 @@ def maybe_length_of(
         return 0
     else:
         raise TypeError(f"Invalid type {type(obj)} for length calculation")
+
+
+def resolve_index(index, backend):
+    if isinstance(index, tuple) and len(index) == 1:
+        index = index[0]
+
+    if isinstance(index, tuple) and len(index) == 2 and index[0] is None:
+        return ak.index.Index64.zeros(index[1], backend.nplike)
+
+    return index

--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -168,13 +168,3 @@ def maybe_length_of(
         return 0
     else:
         raise TypeError(f"Invalid type {type(obj)} for length calculation")
-
-
-def resolve_index(index, backend):
-    if isinstance(index, tuple) and len(index) == 1:
-        index = index[0]
-
-    if isinstance(index, tuple) and len(index) == 2 and index[0] is None:
-        return ak.index.Index64.zeros(index[1], backend.nplike)
-
-    return index

--- a/src/awkward/contents/bitmaskedarray.py
+++ b/src/awkward/contents/bitmaskedarray.py
@@ -623,18 +623,18 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
     def _numbers_to_type(self, name, including_unknown):
         return self.to_ByteMaskedArray()._numbers_to_type(name, including_unknown)
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._mask.length is not unknown_length and self._mask.length == 0:
             return True
         return self.to_IndexedOptionArray64()._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._mask.length is not unknown_length and self._mask.length == 0:
             return self
         out = self.to_IndexedOptionArray64()._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
         if negaxis is None:
             return out
@@ -642,15 +642,17 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             return out._content
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         return self.to_IndexedOptionArray64()._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         return self.to_IndexedOptionArray64()._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
@@ -665,6 +667,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -676,6 +679,7 @@ class BitMaskedArray(BitMaskedMeta[Content], Content):
             starts,
             shifts,
             parents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -34,7 +34,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -802,30 +802,32 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._mask.length is not unknown_length and self._mask.length == 0:
             return True
         return self.to_IndexedOptionArray64()._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._mask.length is not unknown_length and self._mask.length == 0:
             return self
         return self.to_IndexedOptionArray64()._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         return self.to_IndexedOptionArray64()._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         return self.to_IndexedOptionArray64()._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
@@ -852,6 +854,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -964,6 +967,7 @@ class ByteMaskedArray(ByteMaskedMeta[Content], Content):
             starts,
             nextshifts,
             nextparents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/bytemaskedarray.py
+++ b/src/awkward/contents/bytemaskedarray.py
@@ -34,7 +34,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -57,7 +57,7 @@ from awkward._typing import (
 )
 from awkward._util import UNSET
 from awkward.forms.form import Form, FormKeyPathT
-from awkward.index import Index, Index64, ZeroIndex
+from awkward.index import EmptyIndex, Index, Index64, ZeroIndex
 
 if TYPE_CHECKING:
     from awkward._nplikes.numpy import NumpyLike
@@ -894,6 +894,7 @@ class Content(Meta):
         starts: Index,
         shifts: Index | None,
         parents: Index | ZeroIndex,
+        offsets: Index | EmptyIndex,
         outlength: int,
         mask: bool,
         keepdims: bool,
@@ -907,6 +908,7 @@ class Content(Meta):
         starts: Index,
         shifts: Index | None,
         parents: Index | ZeroIndex,
+        offsets: Index | EmptyIndex,
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -918,6 +920,7 @@ class Content(Meta):
         negaxis: int,
         starts: Index,
         parents: Index | ZeroIndex,
+        offsets: Index | EmptyIndex,
         outlength: int,
         ascending: bool,
         stable: bool,
@@ -1040,6 +1043,7 @@ class Content(Meta):
         negaxis: AxisMaybeNone,
         starts: Index,
         parents: Index | ZeroIndex,
+        offsets: Index | EmptyIndex,
         outlength: int,
     ) -> bool:
         raise NotImplementedError
@@ -1049,6 +1053,7 @@ class Content(Meta):
         negaxis: AxisMaybeNone,
         starts: Index,
         parents: Index | ZeroIndex,
+        offsets: Index | EmptyIndex,
         outlength: int,
     ):
         raise NotImplementedError

--- a/src/awkward/contents/emptyarray.py
+++ b/src/awkward/contents/emptyarray.py
@@ -308,21 +308,23 @@ class EmptyArray(EmptyMeta, Content):
         else:
             return self
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         return self
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         as_numpy = self.to_NumpyArray(np.float64)
         return as_numpy._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         return self
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
@@ -335,6 +337,7 @@ class EmptyArray(EmptyMeta, Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -347,6 +350,7 @@ class EmptyArray(EmptyMeta, Content):
             starts,
             shifts,
             parents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/indexedarray.py
+++ b/src/awkward/contents/indexedarray.py
@@ -795,7 +795,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._index.length is not unknown_length and self._index.length == 0:
             return True
 
@@ -805,9 +805,9 @@ class IndexedArray(IndexedMeta[Content], Content):
             return False
 
         next = self._content._carry(nextindex, False)
-        return next._is_unique(negaxis, starts, parents, outlength)
+        return next._is_unique(negaxis, starts, parents, offsets, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._index.length is not unknown_length and self._index.length == 0:
             return self
 
@@ -851,6 +851,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             negaxis,
             starts,
             nextparents,
+            offsets,
             outlength,
         )
 
@@ -935,16 +936,20 @@ class IndexedArray(IndexedMeta[Content], Content):
         raise NotImplementedError
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         next = self._content._carry(self._index, False)
         return next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         next = self._content._carry(self._index, False)
-        return next._sort_next(negaxis, starts, parents, outlength, ascending, stable)
+        return next._sort_next(
+            negaxis, starts, parents, offsets, outlength, ascending, stable
+        )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
         posaxis = maybe_posaxis(self, axis, depth)
@@ -962,6 +967,7 @@ class IndexedArray(IndexedMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -974,6 +980,7 @@ class IndexedArray(IndexedMeta[Content], Content):
             starts,
             shifts,
             parents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -975,14 +975,14 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._index.length is not unknown_length and self._index.length == 0:
             return True
 
         projected = self.project()
-        return projected._is_unique(negaxis, starts, parents, outlength)
+        return projected._is_unique(negaxis, starts, parents, offsets, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         branch, depth = self.branch_depth
 
         inject_nones = (
@@ -997,6 +997,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             negaxis,
             starts,
             nextparents,
+            offsets,
             outlength,
         )
 
@@ -1218,7 +1219,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         return next, nextparents, numnull, outindex
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         parents = resolve_index(parents, self._backend)
 
@@ -1238,7 +1239,14 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             nextshifts = None
 
         out = next._argsort_next(
-            negaxis, starts, nextshifts, nextparents, outlength, ascending, stable
+            negaxis,
+            starts,
+            nextshifts,
+            nextparents,
+            offsets,
+            outlength,
+            ascending,
+            stable,
         )
 
         # `next._argsort_next` is given the non-None values. We choose to
@@ -1347,7 +1355,9 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         else:
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         parents = resolve_index(parents, self._backend)
 
         assert (
@@ -1359,7 +1369,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         next, nextparents, _numnull, outindex = self._rearrange_prepare_next(parents)
 
         out = next._sort_next(
-            negaxis, starts, nextparents, outlength, ascending, stable
+            negaxis, starts, nextparents, offsets, outlength, ascending, stable
         )
 
         nextoutindex = ak.index.Index64.empty(parents.length, self._backend.nplike)
@@ -1408,6 +1418,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -1430,6 +1441,7 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             starts,
             nextshifts,
             nextparents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -33,7 +33,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -33,7 +33,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/listarray.py
+++ b/src/awkward/contents/listarray.py
@@ -1320,34 +1320,36 @@ class ListArray(ListMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._starts.length is not unknown_length and self._starts.length == 0:
             return True
 
         return self.to_ListOffsetArray64(True)._is_unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._starts.length is not unknown_length and self._starts.length == 0:
             return self
 
         return self.to_ListOffsetArray64(True)._unique(
-            negaxis, starts, parents, outlength
+            negaxis, starts, parents, offsets, outlength
         )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         next = self.to_ListOffsetArray64(True)
         out = next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
         return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         return self.to_ListOffsetArray64(True)._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
     def _combinations(self, n, replacement, recordlookup, parameters, axis, depth):
@@ -1362,6 +1364,7 @@ class ListArray(ListMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -1373,6 +1376,7 @@ class ListArray(ListMeta[Content], Content):
             starts,
             shifts,
             parents,
+            offsets,
             outlength,
             mask,
             keepdims,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -32,7 +32,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -893,7 +893,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._offsets.length is not unknown_length and self._offsets.length - 1 == 0:
             return True
 
@@ -918,10 +918,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 return out2.length == self.length
 
         if negaxis is None:
-            return self._content._is_unique(negaxis, starts, parents, outlength)
+            return self._content._is_unique(
+                negaxis, starts, parents, self._offsets, outlength
+            )
 
         if not branch and (negaxis == depth):
-            return self._content._is_unique(negaxis - 1, starts, parents, outlength)
+            return self._content._is_unique(
+                negaxis - 1, starts, parents, self._offsets, outlength
+            )
         else:
             nextlen = self._backend.nplike.index_as_shape_item(
                 self._offsets[-1] - self._offsets[0]
@@ -946,9 +950,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
             starts = self._offsets[:-1]
 
-            return self._content._is_unique(negaxis, starts, nextparents, outlength)
+            return self._content._is_unique(
+                negaxis, starts, nextparents, self._offsets, outlength
+            )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._offsets.length - 1 == 0:
             return self
 
@@ -1047,6 +1053,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 negaxis,
                 self._offsets[:-1],
                 nextparents,
+                offsets,
                 self._offsets.length - 1,
             )
 
@@ -1064,6 +1071,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         ascending,
         stable,
@@ -1183,6 +1191,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nextstarts,
                 nextshifts,
                 nextparents,
+                offsets,
                 nextstarts.length,
                 ascending,
                 stable,
@@ -1239,6 +1248,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets[:-1],
                 shifts,
                 nextparents,
+                offsets,
                 self._offsets.length - 1,
                 ascending,
                 stable,
@@ -1248,7 +1258,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 outoffsets, outcontent, parameters=self._parameters
             )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         branch, depth = self.branch_depth
 
         nplike = self._backend.nplike
@@ -1324,6 +1336,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 negaxis - 1,
                 nextstarts,
                 nextparents,
+                offsets,
                 maxnextparents + 1,
                 ascending,
                 stable,
@@ -1379,6 +1392,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 negaxis,
                 self._offsets[:-1],
                 nextparents,
+                offsets,
                 lenstarts,
                 ascending,
                 stable,
@@ -1506,6 +1520,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -1523,6 +1538,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 starts,
                 shifts,
                 parents,
+                offsets,
                 outlength,
                 mask,
                 keepdims,
@@ -1616,6 +1632,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nextstarts,
                 nextshifts,
                 nextparents,
+                offsets,
                 maxnextparents + 1,
                 mask,
                 False,
@@ -1666,6 +1683,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nextstarts,
                 shifts,
                 nextparents,
+                offsets,
                 globalstarts_length,
                 mask,
                 keepdims,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,7 +38,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -38,7 +38,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -723,7 +723,7 @@ class NumpyArray(NumpyMeta, Content):
                 backend=self._backend,
             )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self.length is not unknown_length and self.length == 0:
             return True
         elif len(self.shape) != 1:
@@ -731,6 +731,7 @@ class NumpyArray(NumpyMeta, Content):
                 negaxis,
                 starts,
                 parents,
+                offsets,
                 outlength,
             )
         elif not self.is_contiguous:
@@ -738,10 +739,11 @@ class NumpyArray(NumpyMeta, Content):
                 negaxis,
                 starts,
                 parents,
+                offsets,
                 outlength,
             )
         else:
-            out = self._unique(negaxis, starts, parents, outlength)
+            out = self._unique(negaxis, starts, parents, offsets, outlength)
             if isinstance(out, ak.contents.ListOffsetArray):
                 return (
                     out.content.length is not unknown_length
@@ -750,7 +752,7 @@ class NumpyArray(NumpyMeta, Content):
             else:
                 return out.length is not unknown_length and out.length == self.length
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self.shape[0] is not unknown_length and self.shape[0] == 0:
             return self
 
@@ -803,6 +805,7 @@ class NumpyArray(NumpyMeta, Content):
                 negaxis,
                 starts,
                 parents,
+                offsets,
                 outlength,
             )
         else:
@@ -923,15 +926,15 @@ class NumpyArray(NumpyMeta, Content):
             )
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         if len(self.shape) != 1:
             return self.to_RegularArray()._argsort_next(
-                negaxis, starts, shifts, parents, outlength, ascending, stable
+                negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
             )
         elif not self.is_contiguous:
             return self.to_contiguous()._argsort_next(
-                negaxis, starts, shifts, parents, outlength, ascending, stable
+                negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
             )
         else:
             parents = resolve_index(parents, self._backend)
@@ -1031,14 +1034,16 @@ class NumpyArray(NumpyMeta, Content):
             out = NumpyArray(nextcarry.data, parameters=None, backend=self._backend)
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         if len(self.shape) != 1:
             return self.to_RegularArray()._sort_next(
-                negaxis, starts, parents, outlength, ascending, stable
+                negaxis, starts, parents, offsets, outlength, ascending, stable
             )
         elif not self.is_contiguous:
             return self.to_contiguous()._sort_next(
-                negaxis, starts, parents, outlength, ascending, stable
+                negaxis, starts, parents, offsets, outlength, ascending, stable
             )
 
         else:
@@ -1132,6 +1137,7 @@ class NumpyArray(NumpyMeta, Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -1144,6 +1150,7 @@ class NumpyArray(NumpyMeta, Content):
                 starts,
                 shifts,
                 parents,
+                offsets,
                 outlength,
                 mask,
                 keepdims,
@@ -1156,6 +1163,7 @@ class NumpyArray(NumpyMeta, Content):
                 starts,
                 shifts,
                 parents,
+                offsets,
                 outlength,
                 mask,
                 keepdims,
@@ -1167,8 +1175,9 @@ class NumpyArray(NumpyMeta, Content):
         assert self._data.ndim == 1
 
         parents = resolve_index(parents, self._backend)
+        offsets = resolve_index(offsets, self._backend)
 
-        out = reducer.apply(self, parents, starts, shifts, outlength)
+        out = reducer.apply(self, parents, offsets, starts, shifts, outlength)
 
         if mask:
             outmask = ak.index.Index8.empty(outlength, self._backend.nplike)

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -852,21 +852,23 @@ class RecordArray(RecordMeta[Content], Content):
             backend=self._backend,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         for content in self._contents:
-            if not content._is_unique(negaxis, starts, parents, outlength):
+            if not content._is_unique(negaxis, starts, parents, offsets, outlength):
                 return False
         return True
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         raise NotImplementedError
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         raise NotImplementedError
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         if len(self.fields) == 0:
             return ak.contents.NumpyArray(
                 self._backend.nplike.instance().empty(0, dtype=np.int64),
@@ -878,7 +880,7 @@ class RecordArray(RecordMeta[Content], Content):
         for content in self._contents:
             contents.append(
                 content._sort_next(
-                    negaxis, starts, parents, outlength, ascending, stable
+                    negaxis, starts, parents, offsets, outlength, ascending, stable
                 )
             )
         return RecordArray(
@@ -916,6 +918,7 @@ class RecordArray(RecordMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -30,7 +30,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET
+from awkward._util import UNSET, resolve_index
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -30,7 +30,7 @@ from awkward._typing import (
     SupportsIndex,
     final,
 )
-from awkward._util import UNSET, resolve_index
+from awkward._util import UNSET
 from awkward.contents.content import (
     ApplyActionOptions,
     Content,

--- a/src/awkward/contents/regulararray.py
+++ b/src/awkward/contents/regulararray.py
@@ -841,7 +841,7 @@ class RegularArray(RegularMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self.length == 0:
             return True
 
@@ -849,16 +849,18 @@ class RegularArray(RegularMeta[Content], Content):
             negaxis,
             starts,
             parents,
+            offsets,
             outlength,
         )
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self.length == 0:
             return self
         out = self.to_ListOffsetArray64(True)._unique(
             negaxis,
             starts,
             parents,
+            offsets,
             outlength,
         )
 
@@ -874,11 +876,11 @@ class RegularArray(RegularMeta[Content], Content):
         return out
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         next = self.to_ListOffsetArray64(True)
         out = next._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
         if isinstance(out, ak.contents.RegularArray):
@@ -892,9 +894,11 @@ class RegularArray(RegularMeta[Content], Content):
 
         return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         out = self.to_ListOffsetArray64(True)._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
         # FIXME
@@ -1009,6 +1013,7 @@ class RegularArray(RegularMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,
@@ -1076,6 +1081,7 @@ class RegularArray(RegularMeta[Content], Content):
                 nextstarts,
                 nextshifts,
                 nextparents,
+                offsets,
                 # We want a result of length
                 nextoutlength,
                 mask,
@@ -1123,6 +1129,7 @@ class RegularArray(RegularMeta[Content], Content):
                 nextstarts,
                 shifts,
                 nextparents,
+                offsets,
                 self.length,
                 mask,
                 keepdims,

--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -1381,7 +1381,7 @@ class UnionArray(UnionMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1392,9 +1392,9 @@ class UnionArray(UnionMeta[Content], Content):
         if isinstance(simplified, ak.contents.UnionArray):
             raise ValueError("cannot check if an irreducible UnionArray is unique")
 
-        return simplified._is_unique(negaxis, starts, parents, outlength)
+        return simplified._is_unique(negaxis, starts, parents, offsets, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         simplified = type(self).simplified(
             self._tags,
             self._index,
@@ -1405,10 +1405,10 @@ class UnionArray(UnionMeta[Content], Content):
         if isinstance(simplified, ak.contents.UnionArray):
             raise ValueError("cannot make a unique irreducible UnionArray")
 
-        return simplified._unique(negaxis, starts, parents, outlength)
+        return simplified._unique(negaxis, starts, parents, offsets, outlength)
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         simplified = type(self).simplified(
             self._tags,
@@ -1428,10 +1428,12 @@ class UnionArray(UnionMeta[Content], Content):
             raise ValueError("cannot argsort an irreducible UnionArray")
 
         return simplified._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         if self.length is not unknown_length and self.length == 0:
             return self
 
@@ -1449,7 +1451,7 @@ class UnionArray(UnionMeta[Content], Content):
             raise ValueError("cannot sort an irreducible UnionArray")
 
         return simplified._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
     def _reduce_next(
@@ -1459,6 +1461,7 @@ class UnionArray(UnionMeta[Content], Content):
         starts,
         shifts,
         parents,
+        offsets,
         outlength,
         mask,
         keepdims,

--- a/src/awkward/contents/unmaskedarray.py
+++ b/src/awkward/contents/unmaskedarray.py
@@ -416,21 +416,21 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
             parameters=self._parameters,
         )
 
-    def _is_unique(self, negaxis, starts, parents, outlength):
+    def _is_unique(self, negaxis, starts, parents, offsets, outlength):
         if self._content.length is not unknown_length and self._content.length == 0:
             return True
-        return self._content._is_unique(negaxis, starts, parents, outlength)
+        return self._content._is_unique(negaxis, starts, parents, offsets, outlength)
 
-    def _unique(self, negaxis, starts, parents, outlength):
+    def _unique(self, negaxis, starts, parents, offsets, outlength):
         if self._content.length is not unknown_length and self._content.length == 0:
             return self
-        return self._content._unique(negaxis, starts, parents, outlength)
+        return self._content._unique(negaxis, starts, parents, offsets, outlength)
 
     def _argsort_next(
-        self, negaxis, starts, shifts, parents, outlength, ascending, stable
+        self, negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
     ):
         out = self._content._argsort_next(
-            negaxis, starts, shifts, parents, outlength, ascending, stable
+            negaxis, starts, shifts, parents, offsets, outlength, ascending, stable
         )
 
         if isinstance(out, ak.contents.RegularArray):
@@ -440,9 +440,11 @@ class UnmaskedArray(UnmaskedMeta[Content], Content):
         else:
             return out
 
-    def _sort_next(self, negaxis, starts, parents, outlength, ascending, stable):
+    def _sort_next(
+        self, negaxis, starts, parents, offsets, outlength, ascending, stable
+    ):
         out = self._content._sort_next(
-            negaxis, starts, parents, outlength, ascending, stable
+            negaxis, starts, parents, offsets, outlength, ascending, stable
         )
 
         if isinstance(out, ak.contents.RegularArray):


### PR DESCRIPTION
This PR adds an `offset` parameter to the Python-layer reducer dispatch logic. This is the first step in moving toward offset-based kernels and away from the current `parent` tracking mechanism.

- Added `offset` parameter to all Python reducer functions.
- The `offset` is now propagated through the call stack alongside the existing `parent` parameter.
- This is currently restricted to the Python dispatch logic; C++/CUDA kernels are not yet offset-aware.
- Once kernels are updated, the `parent` parameter will be formally deprecated.

@maxymnaumchyk 