### PR TITLE
feat(ak.str): add uniques and distinct_counts for string arrays

### DIFF
--- a/src/awkward/contents/content.py
+++ b/src/awkward/contents/content.py
@@ -133,6 +133,19 @@ class ToArrowOptions(TypedDict):
     record_is_scalar: bool
 
 
+def _is_cudf_column_constructor_error(err: BaseException) -> bool:
+    if not isinstance(err, (TypeError, ValueError)):
+        return False
+    message = str(err)
+    return (
+        "from_pylibcudf" in message
+        or "unexpected keyword" in message
+        or "unexpected positional argument" in message
+        or "missing required positional argument" in message
+        or "takes no arguments" in message
+    )
+
+
 class Content(Meta):
     def _init(self, parameters: dict[str, Any] | None, backend: Backend):
         if parameters is None:

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,8 +222,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(
-            form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -256,10 +255,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(
-            indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(
-            indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -272,8 +269,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0]
-                    :], parameters=self._parameters
+                offsets, self._content[self._offsets[0] :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -284,8 +280,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(
-                    self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -330,8 +325,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(
-                self.length)
+            length_index = self._backend.nplike.shape_item_as_index(self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -353,7 +347,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start: stop + 1]
+        offsets = self._offsets[start : stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -525,8 +519,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(
-                    lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -616,8 +609,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(
-                        nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -674,12 +666,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(
-                    nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get(
-                            "shape", (head.length,), self.length)
+                        out, head.metadata.get("shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -775,8 +765,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
             else:
@@ -805,8 +794,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -851,8 +839,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(
-                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -924,8 +911,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, outoffsets = self._content._as_unique_strings(self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -972,14 +958,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -989,8 +973,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1057,7 +1040,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1090,8 +1073,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1137,8 +1119,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1244,7 +1225,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1269,8 +1250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1312,8 +1292,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1357,8 +1336,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1375,7 +1353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1626,14 +1604,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1651,7 +1627,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
+            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1699,8 +1675,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(
-            self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1940,7 +1915,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0]: npoffsets[length]]
+        akcontent = self._content[npoffsets[0] : npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -2002,8 +1977,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(
-                        *maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2052,7 +2026,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
         else:
             ind_buf = cudf.core.column.numerical.NumericalColumn(
-                buf, index.dtype, None, size=len(index))
+                buf, index.dtype, None, size=len(index)
+            )
 
         cont = self._content._to_cudf(cudf, None, len(self._content))
         if mask is not None:
@@ -2107,8 +2082,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(
-                _max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2144,8 +2118,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(
-                max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2172,7 +2145,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0]: self._offsets[-1]]
+            content = self._content[self._offsets[0] : self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2192,8 +2165,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(
-                                            c.length),
+                                        backend.nplike.shape_item_as_index(c.length),
                                     ]
                                 )
                             ),
@@ -2251,7 +2223,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin: self._offsets[-1]]
+            content = self._content[offsetsmin : self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2336,12 +2308,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(
-                        data[starts_data[i]: stops_data[i]])
+                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
                     )
             return out
 
@@ -2349,7 +2320,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2363,7 +2334,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i]: stops_data[i]]
+                out[i] = content[starts_data[i] : stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2405,11 +2376,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(
-                        content._data, union_tags._data)
+                    content.backend.nplike.isnan(content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(
-                            content.length, dtype=np.int64),
+                        self._backend.nplike.arange(content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,7 +222,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(
+            form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -255,8 +256,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(
+            indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(
+            indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -269,7 +272,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0] :], parameters=self._parameters
+
+                offsets, self._content[self._offsets[0]:], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -280,7 +284,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(
+                    self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -325,7 +330,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(self.length)
+            length_index = self._backend.nplike.shape_item_as_index(
+                self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -347,7 +353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start : stop + 1]
+        offsets = self._offsets[start: stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -519,7 +525,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(
+                    lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -609,7 +616,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(
+                        nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -666,10 +674,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(
+                    nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get("shape", (head.length,), self.length)
+                        out, head.metadata.get(
+                            "shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -765,7 +775,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
             else:
@@ -794,7 +805,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -839,7 +851,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(
+                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -911,7 +924,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -958,12 +972,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -973,7 +989,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1057,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1073,7 +1090,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1119,7 +1137,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1244,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1250,7 +1269,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1292,7 +1312,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1336,7 +1357,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1353,7 +1375,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1604,12 +1626,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1627,7 +1651,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
+            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1675,7 +1699,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(
+            self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1915,7 +1940,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0] : npoffsets[length]]
+        akcontent = self._content[npoffsets[0]: npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -1977,7 +2002,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(
+                        *maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2021,12 +2047,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         index = maybe_materialize(self._offsets.raw(cupy))[0].astype("int32")
         buf = cudf.core.buffer.as_buffer(index)
 
-        try:
+        if parse_version(cudf.__version__) >= parse_version("24.10.00"):
             ind_buf = cudf.core.column.as_column(buf, dtype=index.dtype)
-        except Exception:
+
+        else:
             ind_buf = cudf.core.column.numerical.NumericalColumn(
                 buf, index.dtype, None, size=len(index)
             )
+
         cont = self._content._to_cudf(cudf, None, len(self._content))
         if mask is not None:
             m = np._module.packbits(mask, bitorder="little")
@@ -2040,23 +2068,29 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             from cudf.utils.dtypes import CUDF_STRING_DTYPE
 
             data = cudf.core.buffer.as_buffer(cupy.asarray(self._content.data))
-            return StringColumn(
-                data=data,
-                size=len(ind_buf) - 1,
-                dtype=CUDF_STRING_DTYPE,
-                mask=m,
-                children=(ind_buf,),
-            )
+            if parse_version(cudf.__version__) >= parse_version("24.10.00"):
+                return StringColumn.from_offsets_and_chars(
+                    offsets=ind_buf,
+                    chars=data,
+                    mask=m,
+                )
+            else:
+                return StringColumn(
+                    data=data,
+                    size=len(ind_buf) - 1,
+                    dtype=CUDF_STRING_DTYPE,
+                    mask=m,
+                    children=(ind_buf,),
+                )
 
-        if parse_version(cudf.__version__) >= parse_version("24.10.00"):
+        try:
             return cudf.core.column.lists.ListColumn(
                 size=length,
-                data=None,
                 mask=m,
                 children=(ind_buf, cont),
                 dtype=cudf.core.dtypes.ListDtype(cont.dtype),
             )
-        else:
+        except TypeError:
             return cudf.core.column.lists.ListColumn(
                 length,
                 mask=m,
@@ -2080,7 +2114,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(
+                _max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2116,7 +2151,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(
+                max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2143,7 +2179,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0] : self._offsets[-1]]
+            content = self._content[self._offsets[0]: self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2163,7 +2199,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(c.length),
+                                        backend.nplike.shape_item_as_index(
+                                            c.length),
                                     ]
                                 )
                             ),
@@ -2221,7 +2258,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin : self._offsets[-1]]
+            content = self._content[offsetsmin: self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2306,11 +2343,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                    out[i] = ak._util.tobytes(
+                        data[starts_data[i]: stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
                     )
             return out
 
@@ -2318,7 +2356,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2332,7 +2370,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i] : stops_data[i]]
+                out[i] = content[starts_data[i]: stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2374,9 +2412,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(content._data, union_tags._data)
+                    content.backend.nplike.isnan(
+                        content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(content.length, dtype=np.int64),
+                        self._backend.nplike.arange(
+                            content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,7 +222,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(
+            form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -255,8 +256,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(
+            indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(
+            indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -269,7 +272,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0] :], parameters=self._parameters
+                offsets, self._content[self._offsets[0]
+                    :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -280,7 +284,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(
+                    self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -325,7 +330,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(self.length)
+            length_index = self._backend.nplike.shape_item_as_index(
+                self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -347,7 +353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start : stop + 1]
+        offsets = self._offsets[start: stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -519,7 +525,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(
+                    lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -609,7 +616,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(
+                        nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -666,10 +674,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(
+                    nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get("shape", (head.length,), self.length)
+                        out, head.metadata.get(
+                            "shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -765,7 +775,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
             else:
@@ -794,7 +805,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -839,7 +851,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(
+                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -911,7 +924,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -958,12 +972,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -973,7 +989,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1057,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1073,7 +1090,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1119,7 +1137,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1244,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1250,7 +1269,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1292,7 +1312,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1336,7 +1357,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1353,7 +1375,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1604,12 +1626,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1627,7 +1651,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
+            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1675,7 +1699,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(
+            self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1915,7 +1940,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0] : npoffsets[length]]
+        akcontent = self._content[npoffsets[0]: npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -1977,7 +2002,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(
+                        *maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2022,13 +2048,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         buf = cudf.core.buffer.as_buffer(index)
 
         if parse_version(cudf.__version__) >= parse_version("24.10.00"):
-            ind_buf = cudf.core.column.numerical.NumericalColumn(
-                data=buf, dtype=index.dtype, mask=None, size=len(index)
-            )
+            ind_buf = cudf.core.column.as_column(buf, dtype=index.dtype)
+
         else:
             ind_buf = cudf.core.column.numerical.NumericalColumn(
-                buf, index.dtype, None, size=len(index)
-            )
+                buf, index.dtype, None, size=len(index))
+
         cont = self._content._to_cudf(cudf, None, len(self._content))
         if mask is not None:
             m = np._module.packbits(mask, bitorder="little")
@@ -2082,7 +2107,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(
+                _max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2118,7 +2144,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(
+                max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2145,7 +2172,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0] : self._offsets[-1]]
+            content = self._content[self._offsets[0]: self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2165,7 +2192,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(c.length),
+                                        backend.nplike.shape_item_as_index(
+                                            c.length),
                                     ]
                                 )
                             ),
@@ -2223,7 +2251,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin : self._offsets[-1]]
+            content = self._content[offsetsmin: self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2308,11 +2336,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                    out[i] = ak._util.tobytes(
+                        data[starts_data[i]: stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
                     )
             return out
 
@@ -2320,7 +2349,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2334,7 +2363,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i] : stops_data[i]]
+                out[i] = content[starts_data[i]: stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2376,9 +2405,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(content._data, union_tags._data)
+                    content.backend.nplike.isnan(
+                        content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(content.length, dtype=np.int64),
+                        self._backend.nplike.arange(
+                            content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,8 +222,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(
-            form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -256,10 +255,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(
-            indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(
-            indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -272,8 +269,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-
-                offsets, self._content[self._offsets[0]:], parameters=self._parameters
+                offsets, self._content[self._offsets[0] :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -284,8 +280,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(
-                    self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -330,8 +325,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(
-                self.length)
+            length_index = self._backend.nplike.shape_item_as_index(self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -353,7 +347,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start: stop + 1]
+        offsets = self._offsets[start : stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -525,8 +519,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(
-                    lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -616,8 +609,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(
-                        nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -674,12 +666,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(
-                    nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get(
-                            "shape", (head.length,), self.length)
+                        out, head.metadata.get("shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -775,8 +765,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
             else:
@@ -805,8 +794,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -851,8 +839,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(
-                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -924,8 +911,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, outoffsets = self._content._as_unique_strings(self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -972,14 +958,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -989,8 +973,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1057,7 +1040,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1090,8 +1073,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1137,8 +1119,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1244,7 +1225,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1269,8 +1250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1312,8 +1292,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1357,8 +1336,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1375,7 +1353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1626,14 +1604,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1651,7 +1627,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
+            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1699,8 +1675,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(
-            self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1940,7 +1915,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0]: npoffsets[length]]
+        akcontent = self._content[npoffsets[0] : npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -2002,8 +1977,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(
-                        *maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2114,8 +2088,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(
-                _max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2151,8 +2124,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(
-                max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2179,7 +2151,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0]: self._offsets[-1]]
+            content = self._content[self._offsets[0] : self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2199,8 +2171,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(
-                                            c.length),
+                                        backend.nplike.shape_item_as_index(c.length),
                                     ]
                                 )
                             ),
@@ -2258,7 +2229,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin: self._offsets[-1]]
+            content = self._content[offsetsmin : self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2343,12 +2314,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(
-                        data[starts_data[i]: stops_data[i]])
+                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
                     )
             return out
 
@@ -2356,7 +2326,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2370,7 +2340,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i]: stops_data[i]]
+                out[i] = content[starts_data[i] : stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2412,11 +2382,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(
-                        content._data, union_tags._data)
+                    content.backend.nplike.isnan(content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(
-                            content.length, dtype=np.int64),
+                        self._backend.nplike.arange(content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,7 +222,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(
+            form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -255,8 +256,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(
+            indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(
+            indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -269,7 +272,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0] :], parameters=self._parameters
+                offsets, self._content[self._offsets[0]:], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -280,7 +283,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(
+                    self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -325,7 +329,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(self.length)
+            length_index = self._backend.nplike.shape_item_as_index(
+                self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -347,7 +352,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start : stop + 1]
+        offsets = self._offsets[start: stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -519,7 +524,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(
+                    lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -609,7 +615,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(
+                        nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -666,10 +673,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(
+                    nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get("shape", (head.length,), self.length)
+                        out, head.metadata.get(
+                            "shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -765,7 +774,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
             else:
@@ -794,7 +804,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -839,7 +850,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(
+                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -911,7 +923,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -958,12 +971,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -973,7 +988,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1056,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1073,7 +1089,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1119,7 +1136,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1243,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1250,7 +1268,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1292,7 +1311,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1336,7 +1356,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1353,7 +1374,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1604,12 +1625,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1627,7 +1650,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
+            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1675,7 +1698,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(
+            self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1915,7 +1939,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0] : npoffsets[length]]
+        akcontent = self._content[npoffsets[0]: npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -1977,7 +2001,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(
+                        *maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2049,31 +2074,19 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     chars=data,
                     mask=m,
                 )
-            else:
-                col = StrCol(
-                    children=(ind_buf, data),
-                    size=len(ind_buf) - 1,
-                    dtype=CUDF_STRING_DTYPE,
-                )
-                if m is not None and hasattr(col, "set_mask"):
-                    out = col.set_mask(m)
-                    if out is not None:
-                        col = out
-                return col
+            return StrCol(
+                ind_buf,
+                data,
+                len(ind_buf) - 1,
+            )
 
         ListCol = cudf.core.column.lists.ListColumn
 
-        col = ListCol(
+        return ListCol(
+            ind_buf,
+            cont,
             length,
-            children=(ind_buf, cont),
-            dtype=cudf.core.dtypes.ListDtype(cont.dtype),
         )
-        if m is not None and hasattr(col, "set_mask"):
-            out = col.set_mask(m)
-            if out is not None:
-                col = out
-
-        return col
 
     def _to_backend_array(self, allow_missing, backend):
         array_param = self.parameter("__array__")
@@ -2091,7 +2104,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(
+                _max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2127,7 +2141,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(
+                max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2154,7 +2169,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0] : self._offsets[-1]]
+            content = self._content[self._offsets[0]: self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2174,7 +2189,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(c.length),
+                                        backend.nplike.shape_item_as_index(
+                                            c.length),
                                     ]
                                 )
                             ),
@@ -2232,7 +2248,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin : self._offsets[-1]]
+            content = self._content[offsetsmin: self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2317,11 +2333,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                    out[i] = ak._util.tobytes(
+                        data[starts_data[i]: stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
                     )
             return out
 
@@ -2329,7 +2346,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2343,7 +2360,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i] : stops_data[i]]
+                out[i] = content[starts_data[i]: stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2385,9 +2402,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(content._data, union_tags._data)
+                    content.backend.nplike.isnan(
+                        content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(content.length, dtype=np.int64),
+                        self._backend.nplike.arange(
+                            content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,8 +222,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(
-            form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -256,10 +255,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(
-            indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(
-            indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -272,8 +269,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0]
-                    :], parameters=self._parameters
+                offsets, self._content[self._offsets[0] :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -284,8 +280,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(
-                    self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -330,8 +325,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(
-                self.length)
+            length_index = self._backend.nplike.shape_item_as_index(self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -353,7 +347,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start: stop + 1]
+        offsets = self._offsets[start : stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -525,8 +519,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(
-                    lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -616,8 +609,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(
-                        nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -674,12 +666,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(
-                    nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get(
-                            "shape", (head.length,), self.length)
+                        out, head.metadata.get("shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -775,8 +765,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
             else:
@@ -805,8 +794,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -851,8 +839,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(
-                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -924,8 +911,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, outoffsets = self._content._as_unique_strings(self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -972,14 +958,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -989,8 +973,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1057,7 +1040,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1090,8 +1073,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1137,8 +1119,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1244,7 +1225,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1269,8 +1250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1312,8 +1292,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1357,8 +1336,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1375,7 +1353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1626,14 +1604,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1651,7 +1627,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
+            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1699,8 +1675,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(
-            self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1940,7 +1915,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0]: npoffsets[length]]
+        akcontent = self._content[npoffsets[0] : npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -2002,8 +1977,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(
-                        *maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2106,8 +2080,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(
-                _max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2143,8 +2116,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(
-                max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2171,7 +2143,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0]: self._offsets[-1]]
+            content = self._content[self._offsets[0] : self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2191,8 +2163,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(
-                                            c.length),
+                                        backend.nplike.shape_item_as_index(c.length),
                                     ]
                                 )
                             ),
@@ -2250,7 +2221,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin: self._offsets[-1]]
+            content = self._content[offsetsmin : self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2335,12 +2306,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(
-                        data[starts_data[i]: stops_data[i]])
+                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
                     )
             return out
 
@@ -2348,7 +2318,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2362,7 +2332,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i]: stops_data[i]]
+                out[i] = content[starts_data[i] : stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2404,11 +2374,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(
-                        content._data, union_tags._data)
+                    content.backend.nplike.isnan(content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(
-                            content.length, dtype=np.int64),
+                        self._backend.nplike.arange(content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,8 +222,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(
-            form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -256,10 +255,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(
-            indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(
-            indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -272,7 +269,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0]:], parameters=self._parameters
+                offsets, self._content[self._offsets[0] :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -283,8 +280,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(
-                    self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -329,8 +325,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(
-                self.length)
+            length_index = self._backend.nplike.shape_item_as_index(self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -352,7 +347,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start: stop + 1]
+        offsets = self._offsets[start : stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -524,8 +519,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(
-                    lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -615,8 +609,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(
-                        nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -673,12 +666,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(
-                    nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get(
-                            "shape", (head.length,), self.length)
+                        out, head.metadata.get("shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -774,8 +765,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
             else:
@@ -804,8 +794,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened,
-                                    parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -850,8 +839,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(
-                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -923,8 +911,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, outoffsets = self._content._as_unique_strings(self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -971,14 +958,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(
-                    self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -988,8 +973,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1056,7 +1040,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1089,8 +1073,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1136,8 +1119,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1243,7 +1225,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1268,8 +1250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1311,8 +1292,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError(
-                    "array with strings can only be sorted with axis=-1")
+                raise AxisError("array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1356,8 +1336,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1374,7 +1353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
+            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1625,14 +1604,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(
-                self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1650,7 +1627,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
+            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1698,8 +1675,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(
-            self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1939,7 +1915,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0]: npoffsets[length]]
+        akcontent = self._content[npoffsets[0] : npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -2001,8 +1977,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(
-                        *maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2064,7 +2039,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             m = None
         if self.parameters.get("__array__") == "string":
             from cudf.core.column.string import StringColumn
-            from cudf.utils.dtypes import CUDF_STRING_DTYPE
 
             data = cudf.core.buffer.as_buffer(cupy.asarray(self._content.data))
             StrCol = StringColumn
@@ -2104,8 +2078,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(
-                _max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2141,8 +2114,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(
-                max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2169,7 +2141,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0]: self._offsets[-1]]
+            content = self._content[self._offsets[0] : self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2189,8 +2161,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(
-                                            c.length),
+                                        backend.nplike.shape_item_as_index(c.length),
                                     ]
                                 )
                             ),
@@ -2248,7 +2219,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin: self._offsets[-1]]
+            content = self._content[offsetsmin : self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2333,12 +2304,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(
-                        data[starts_data[i]: stops_data[i]])
+                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
                     )
             return out
 
@@ -2346,7 +2316,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2360,7 +2330,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i]: stops_data[i]]
+                out[i] = content[starts_data[i] : stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2402,11 +2372,9 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(
-                        content._data, union_tags._data)
+                    content.backend.nplike.isnan(content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(
-                            content.length, dtype=np.int64),
+                        self._backend.nplike.arange(content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,7 +222,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(
+            form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -255,8 +256,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(
+            indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(
+            indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -269,7 +272,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0] :], parameters=self._parameters
+                offsets, self._content[self._offsets[0]
+                    :], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -280,7 +284,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(
+                    self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -325,7 +330,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(self.length)
+            length_index = self._backend.nplike.shape_item_as_index(
+                self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -347,7 +353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start : stop + 1]
+        offsets = self._offsets[start: stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -519,7 +525,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(
+                    lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -609,7 +616,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(
+                        nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -666,10 +674,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(
+                    nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get("shape", (head.length,), self.length)
+                        out, head.metadata.get(
+                            "shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -765,7 +775,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
             else:
@@ -794,7 +805,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -839,7 +851,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(
+                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -911,7 +924,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -958,12 +972,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -973,7 +989,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1057,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1073,7 +1090,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1119,7 +1137,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1244,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1250,7 +1269,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1292,7 +1312,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1336,7 +1357,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1353,7 +1375,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1604,12 +1626,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1627,7 +1651,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
+            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1675,7 +1699,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(
+            self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1915,7 +1940,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0] : npoffsets[length]]
+        akcontent = self._content[npoffsets[0]: npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -1977,7 +2002,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(
+                        *maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2021,14 +2047,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         index = maybe_materialize(self._offsets.raw(cupy))[0].astype("int32")
         buf = cudf.core.buffer.as_buffer(index)
 
-        if parse_version(cudf.__version__) >= parse_version("24.10.00"):
+        try:
             ind_buf = cudf.core.column.as_column(buf, dtype=index.dtype)
-
-        else:
+        except Exception:
             ind_buf = cudf.core.column.numerical.NumericalColumn(
                 buf, index.dtype, None, size=len(index)
             )
-
         cont = self._content._to_cudf(cudf, None, len(self._content))
         if mask is not None:
             m = np._module.packbits(mask, bitorder="little")
@@ -2082,7 +2106,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(
+                _max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2118,7 +2143,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(
+                max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2145,7 +2171,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0] : self._offsets[-1]]
+            content = self._content[self._offsets[0]: self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2165,7 +2191,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(c.length),
+                                        backend.nplike.shape_item_as_index(
+                                            c.length),
                                     ]
                                 )
                             ),
@@ -2223,7 +2250,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin : self._offsets[-1]]
+            content = self._content[offsetsmin: self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2308,11 +2335,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                    out[i] = ak._util.tobytes(
+                        data[starts_data[i]: stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
                     )
             return out
 
@@ -2320,7 +2348,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2334,7 +2362,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i] : stops_data[i]]
+                out[i] = content[starts_data[i]: stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2376,9 +2404,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(content._data, union_tags._data)
+                    content.backend.nplike.isnan(
+                        content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(content.length, dtype=np.int64),
+                        self._backend.nplike.arange(
+                            content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -2063,7 +2063,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
         ListCol = cudf.core.column.lists.ListColumn
 
-       
         col = ListCol(
             length,
             children=(ind_buf, cont),
@@ -2073,7 +2072,6 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = col.set_mask(m)
             if out is not None:
                 col = out
-
 
         return col
 

--- a/src/awkward/contents/listoffsetarray.py
+++ b/src/awkward/contents/listoffsetarray.py
@@ -222,7 +222,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         container[key] = ak._util.native_to_byteorder(
             self._offsets.raw(backend.nplike), byteorder
         )
-        self._content._to_buffers(form.content, getkey, container, backend, byteorder)
+        self._content._to_buffers(
+            form.content, getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         offsets = self._offsets.to_nplike(TypeTracer.instance())
@@ -255,8 +256,10 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out.append(">")
         out.extend(self._repr_extra(indent + "    "))
         out.append("\n")
-        out.append(self._offsets._repr(indent + "    ", "<offsets>", "</offsets>\n"))
-        out.append(self._content._repr(indent + "    ", "<content>", "</content>\n"))
+        out.append(self._offsets._repr(
+            indent + "    ", "<offsets>", "</offsets>\n"))
+        out.append(self._content._repr(
+            indent + "    ", "<content>", "</content>\n"))
         out.append(indent + "</ListOffsetArray>")
         out.append(post)
         return "".join(out)
@@ -269,7 +272,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 nplike=self._backend.nplike,
             )
             return ListOffsetArray(
-                offsets, self._content[self._offsets[0] :], parameters=self._parameters
+
+                offsets, self._content[self._offsets[0]:], parameters=self._parameters
             )
         else:
             return ListOffsetArray(
@@ -280,7 +284,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         start, stop = (
             self._offsets[0],
             self._offsets[
-                self._backend.nplike.shape_item_as_index(self._offsets.length - 1)
+                self._backend.nplike.shape_item_as_index(
+                    self._offsets.length - 1)
             ],
         )
         content = self._content._getitem_range(start, stop)
@@ -325,7 +330,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
     def _getitem_at(self, where: IndexType):
         # Wrap `where` by length
         if not is_unknown_scalar(where) and where < 0:
-            length_index = self._backend.nplike.shape_item_as_index(self.length)
+            length_index = self._backend.nplike.shape_item_as_index(
+                self.length)
             where += length_index
         # Validate `where`
         if not (
@@ -347,7 +353,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         if self._backend.nplike.known_data and (start == 0 and stop == self.length):
             return self
 
-        offsets = self._offsets[start : stop + 1]
+        offsets = self._offsets[start: stop + 1]
         if offsets.length is not unknown_length and offsets.length == 0:
             offsets = Index(
                 self._backend.nplike.zeros(1, dtype=self._offsets.dtype),
@@ -519,7 +525,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if self._starts.dtype == "int64":
-                nextoffsets = Index64.empty(lenstarts + 1, nplike=self._backend.nplike)
+                nextoffsets = Index64.empty(
+                    lenstarts + 1, nplike=self._backend.nplike)
             elif self._starts.dtype == "int32":
                 nextoffsets = ak.index.Index32.empty(
                     lenstarts + 1, nplike=self._backend.nplike
@@ -609,7 +616,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
                 return ak.contents.ListOffsetArray(
                     nextoffsets,
-                    nextcontent._getitem_next(nexthead, nexttail, nextadvanced),
+                    nextcontent._getitem_next(
+                        nexthead, nexttail, nextadvanced),
                     parameters=self._parameters,
                 )
 
@@ -666,10 +674,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 nextcontent = self._content._carry(nextcarry, True)
 
-                out = nextcontent._getitem_next(nexthead, nexttail, nextadvanced)
+                out = nextcontent._getitem_next(
+                    nexthead, nexttail, nextadvanced)
                 if advanced is None:
                     return ak._slicing.getitem_next_array_wrap(
-                        out, head.metadata.get("shape", (head.length,), self.length)
+                        out, head.metadata.get(
+                            "shape", (head.length,), self.length)
                     )
                 else:
                     return out
@@ -765,7 +775,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 tooffsets = Index64([inneroffsets[0]])
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
             else:
@@ -794,7 +805,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
                 return (
                     offsets,
-                    ListOffsetArray(tooffsets, flattened, parameters=self._parameters),
+                    ListOffsetArray(tooffsets, flattened,
+                                    parameters=self._parameters),
                 )
 
     def _mergeable_next(
@@ -839,7 +851,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         out = listarray._mergemany(others)
 
         if all(
-            isinstance(x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
+            isinstance(
+                x, ListOffsetArray) and x._offsets.dtype == self._offsets.dtype
             for x in others
         ):
             return out.to_ListOffsetArray64(False)
@@ -911,7 +924,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, outoffsets = self._content._as_unique_strings(self._offsets)
+                out, outoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 out2 = ak.contents.ListOffsetArray(
                     outoffsets, out, parameters=self._parameters
                 )
@@ -958,12 +972,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
             if isinstance(self._content, ak.contents.NumpyArray):
-                out, nextoffsets = self._content._as_unique_strings(self._offsets)
+                out, nextoffsets = self._content._as_unique_strings(
+                    self._offsets)
                 return ak.contents.ListOffsetArray(
                     nextoffsets, out, parameters=self._parameters
                 )
@@ -973,7 +989,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1040,7 +1057,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._unique(
                 negaxis,
                 self._offsets[:-1],
@@ -1073,7 +1090,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1119,7 +1137,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1225,7 +1244,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._argsort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1250,7 +1269,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             or self.parameter("__array__") == "bytestring"
         ):
             if branch or (negaxis != depth):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             # FIXME: check validity error
 
@@ -1292,7 +1312,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self.parameter("__array__") == "string"
                 or self.parameter("__array__") == "bytestring"
             ):
-                raise AxisError("array with strings can only be sorted with axis=-1")
+                raise AxisError(
+                    "array with strings can only be sorted with axis=-1")
 
             if self._backend.nplike.known_data and parents.nplike.known_data:
                 assert self._offsets.length - 1 == parents.length
@@ -1336,7 +1357,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 parameters=self._parameters,
             )
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
             lenstarts = self._offsets.length - 1
 
@@ -1353,7 +1375,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self._offsets[0] : self._offsets[-1]]
+            trimmed = self._content[self._offsets[0]: self._offsets[-1]]
             outcontent = trimmed._sort_next(
                 negaxis,
                 self._offsets[:-1],
@@ -1604,12 +1626,14 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
         else:
-            nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+            nextlen = nplike.index_as_shape_item(
+                self._offsets[-1] - self._offsets[0])
             nextparents = Index64.empty(nextlen, nplike)
 
             # n.b. awkward_ListOffsetArray_reduce_local_nextparents_64 always returns parents that are
@@ -1627,7 +1651,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 )
             )
 
-            trimmed = self._content[self.offsets[0] : self.offsets[-1]]
+            trimmed = self._content[self.offsets[0]: self.offsets[-1]]
             nextstarts = self.offsets[:-1]
 
             outcontent = trimmed._reduce_next(
@@ -1675,7 +1699,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
 
     def _rearrange_prepare_next(self, outlength, parents):
         nplike = self._backend.nplike
-        nextlen = nplike.index_as_shape_item(self._offsets[-1] - self._offsets[0])
+        nextlen = nplike.index_as_shape_item(
+            self._offsets[-1] - self._offsets[0])
         lenstarts = self._offsets.length - 1
         _maxcount = Index64.empty(1, nplike)
         offsetscopy = Index64.empty(self.offsets.length, nplike)
@@ -1915,7 +1940,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         else:
             downsize = options["list_to32"]
         (npoffsets,) = maybe_materialize(self._offsets.raw(numpy))
-        akcontent = self._content[npoffsets[0] : npoffsets[length]]
+        akcontent = self._content[npoffsets[0]: npoffsets[length]]
         if len(npoffsets) > length + 1:
             npoffsets = npoffsets[: length + 1]
         if npoffsets[0] != 0:
@@ -1977,7 +2002,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 [
                     ak._connect.pyarrow.to_validbits(validbytes),
                     pyarrow.py_buffer(npoffsets),
-                    pyarrow.py_buffer(*maybe_materialize(akcontent._raw(numpy))),
+                    pyarrow.py_buffer(
+                        *maybe_materialize(akcontent._raw(numpy))),
                 ],
             )
 
@@ -2088,7 +2114,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                 self._offsets.length,
                 _max_code_points,
             )
-            max_code_points = backend.nplike.index_as_shape_item(_max_code_points[0])
+            max_code_points = backend.nplike.index_as_shape_item(
+                _max_code_points[0])
             # Ensure that we have at-least length-1 bytestrings
             if max_code_points is not unknown_length:
                 max_code_points = max(1, max_code_points)
@@ -2124,7 +2151,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             if max_count is not unknown_length:
                 max_count = max(1, max_count)
 
-            buffer = backend.nplike.empty(max_count * self.length, dtype=np.uint8)
+            buffer = backend.nplike.empty(
+                max_count * self.length, dtype=np.uint8)
 
             self.backend[
                 "awkward_NumpyArray_pad_zero_to_length",
@@ -2151,7 +2179,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
         ):
             return [self]
         else:
-            content = self._content[self._offsets[0] : self._offsets[-1]]
+            content = self._content[self._offsets[0]: self._offsets[-1]]
             contents = content._remove_structure(backend, options)
             if options["keepdims"]:
                 if options["list_to_regular"]:
@@ -2171,7 +2199,8 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                                 backend.nplike.asarray(
                                     [
                                         0,
-                                        backend.nplike.shape_item_as_index(c.length),
+                                        backend.nplike.shape_item_as_index(
+                                            c.length),
                                     ]
                                 )
                             ),
@@ -2229,7 +2258,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             offsets = ak.index.Index(
                 self._offsets.data - offsetsmin, nplike=self._backend.nplike
             )
-            content = self._content[offsetsmin : self._offsets[-1]]
+            content = self._content[offsetsmin: self._offsets[-1]]
         else:
             self._touch_data(recursive=False)
             offsets, content = self._offsets, self._content
@@ -2314,11 +2343,12 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
             if convert_bytes is None:
                 for i in range(starts.length):
-                    out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                    out[i] = ak._util.tobytes(
+                        data[starts_data[i]: stops_data[i]])
             else:
                 for i in range(starts.length):
                     out[i] = convert_bytes(
-                        ak._util.tobytes(data[starts_data[i] : stops_data[i]])
+                        ak._util.tobytes(data[starts_data[i]: stops_data[i]])
                     )
             return out
 
@@ -2326,7 +2356,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             data = nextcontent.data
             out = [None] * starts.length
             for i in range(starts.length):
-                out[i] = ak._util.tobytes(data[starts_data[i] : stops_data[i]]).decode(
+                out[i] = ak._util.tobytes(data[starts_data[i]: stops_data[i]]).decode(
                     errors="surrogateescape"
                 )
             return out
@@ -2340,7 +2370,7 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
             out = [None] * starts.length
 
             for i in range(starts.length):
-                out[i] = content[starts_data[i] : stops_data[i]]
+                out[i] = content[starts_data[i]: stops_data[i]]
             return out
 
     def _to_backend(self, backend: Backend) -> Self:
@@ -2382,9 +2412,11 @@ class ListOffsetArray(ListOffsetMeta[Content], Content):
                     union_tags = ak.index.Index8.zeros(
                         content.length, nplike=self._backend.nplike
                     )
-                    content.backend.nplike.isnan(content._data, union_tags._data)
+                    content.backend.nplike.isnan(
+                        content._data, union_tags._data)
                     union_index = Index64(
-                        self._backend.nplike.arange(content.length, dtype=np.int64),
+                        self._backend.nplike.arange(
+                            content.length, dtype=np.int64),
                         nplike=self._backend.nplike,
                     )
 

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -6,7 +6,11 @@ import copy
 import json
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
-from cudf.core.column.struct import StructColumn
+try:
+    from cudf.core.column.struct import StructColumn
+except ImportError:
+    StructColumn = None
+
 from packaging.version import parse as parse_version
 
 import awkward as ak
@@ -19,7 +23,6 @@ from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
-from cudf.core.column.struct import StructColumn
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import (
     parameters_intersect,
@@ -1166,6 +1169,9 @@ class RecordArray(RecordMeta[Content], Content):
         )
 
     def _to_cudf(self, cudf: Any, mask: Content | None, length: int):
+        if StructColumn is None:
+            raise RuntimeError("ak.to_cudf requires cuDF to be installed")
+
         children = tuple(
             c._to_cudf(cudf, mask=None, length=length) for c in self.contents
         )
@@ -1184,7 +1190,7 @@ class RecordArray(RecordMeta[Content], Content):
         else:
             return StructColumn(
                 data=None,
-                chilren=children,
+                children=children,
                 dtype=dt,
                 mask=m,
                 size=length,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -349,7 +349,8 @@ class RecordArray(RecordMeta[Content], Content):
     ):
         assert isinstance(form, self.form_cls)
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey, container, backend, byteorder)
+            content._to_buffers(form.content(i), getkey,
+                                container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         backend = TypeTracerBackend.instance()
@@ -599,7 +600,8 @@ class RecordArray(RecordMeta[Content], Content):
 
             contents = []
             for i in range(len(self._contents)):
-                contents.append(self.content(i)._getitem_next(head, (), advanced))
+                contents.append(self.content(
+                    i)._getitem_next(head, (), advanced))
 
             parameters = None
             if (
@@ -637,7 +639,8 @@ class RecordArray(RecordMeta[Content], Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(0, self.length)
-                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(
+                    axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -715,7 +718,7 @@ class RecordArray(RecordMeta[Content], Content):
 
         for_each_field = []
         for field in self.contents:
-            trimmed = field[0 : self.length]
+            trimmed = field[0: self.length]
             for_each_field.append([trimmed])
 
         if self.is_tuple:
@@ -723,20 +726,23 @@ class RecordArray(RecordMeta[Content], Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = parameters_intersect(parameters, array._parameters)
+                parameters = parameters_intersect(
+                    parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
-                                for_each_field[i].append(field[0 : array.length])
+                                for_each_field[i].append(
+                                    field[0: array.length])
                         else:
                             raise ValueError(
                                 "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ValueError("cannot merge tuple with non-tuple record")
+                        raise ValueError(
+                            "cannot merge tuple with non-tuple record")
                 else:
                     raise AssertionError(
                         "cannot merge "
@@ -750,7 +756,8 @@ class RecordArray(RecordMeta[Content], Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = parameters_intersect(parameters, array._parameters)
+                parameters = parameters_intersect(
+                    parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
@@ -761,14 +768,15 @@ class RecordArray(RecordMeta[Content], Content):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
 
-                                trimmed = field[0 : array.length]
+                                trimmed = field[0: array.length]
                                 for_each_field[i].append(trimmed)
                         else:
                             raise AssertionError(
                                 "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise AssertionError("cannot merge non-tuple record with tuple")
+                        raise AssertionError(
+                            "cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
@@ -940,7 +948,8 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
+            offsets = ak.index.Index64.empty(
+                outlength + 1, self._backend.nplike)
             assert (
                 offsets.nplike is self._backend.nplike
                 and parents.nplike is self._backend.nplike
@@ -1032,7 +1041,8 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
+                outmask = ak.index.Index8.empty(
+                    outlength, self._backend.nplike)
                 assert (
                     outmask.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1055,7 +1065,8 @@ class RecordArray(RecordMeta[Content], Content):
                 )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
@@ -1169,27 +1180,16 @@ class RecordArray(RecordMeta[Content], Content):
         m = mask._to_cudf(cudf, None, length) if mask else None
         StructCol = cudf.core.column.StructColumn
 
-        if hasattr(StructCol, "from_children"):
-            return StructCol.from_children(
-                children=children,
-                dtype=dt,
-                size=length,
-                mask=m,
-            )
-        else:
-            return StructCol(
-                data=None,
-                children=children,
-                dtype=dt,
-                mask=m,
-                size=length,
-                offset=0,
-            )
+        return StructCol(
+            children,
+            length,
+        )
 
     def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
+        contents = [x._to_backend_array(allow_missing, backend)
+                    for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
 
@@ -1227,7 +1227,8 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self.length]._remove_structure(backend, options))
+                out.extend(content[: self.length]._remove_structure(
+                    backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1311,7 +1312,8 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self.length].to_packed(True) if recursive else x[: self.length]
+                x[: self.length].to_packed(
+                    True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
@@ -1329,7 +1331,8 @@ class RecordArray(RecordMeta[Content], Content):
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions)
+                        for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
@@ -1339,7 +1342,8 @@ class RecordArray(RecordMeta[Content], Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions)
+                        for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
@@ -1382,7 +1386,8 @@ class RecordArray(RecordMeta[Content], Content):
             and set(self.fields) == set(other.fields)
             and all(
                 content._is_equal_to(
-                    other.content(field), index_dtype, numpyarray, all_parameters
+                    other.content(
+                        field), index_dtype, numpyarray, all_parameters
                 )
                 for field, content in zip(self.fields, self._contents, strict=True)
             )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -6,6 +6,8 @@ import copy
 import json
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
+from packaging.version import parse as parse_version
+
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
@@ -46,7 +48,6 @@ from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.recordform import RecordForm
 from awkward.index import Index
 from awkward.record import Record
-from packaging.version import parse as parse_version
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem
@@ -344,8 +345,7 @@ class RecordArray(RecordMeta[Content], Content):
     ):
         assert isinstance(form, self.form_cls)
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey,
-                                container, backend, byteorder)
+            content._to_buffers(form.content(i), getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         backend = TypeTracerBackend.instance()
@@ -595,8 +595,7 @@ class RecordArray(RecordMeta[Content], Content):
 
             contents = []
             for i in range(len(self._contents)):
-                contents.append(self.content(
-                    i)._getitem_next(head, (), advanced))
+                contents.append(self.content(i)._getitem_next(head, (), advanced))
 
             parameters = None
             if (
@@ -634,8 +633,7 @@ class RecordArray(RecordMeta[Content], Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(0, self.length)
-                offsets, flattened = trimmed._offsets_and_flattened(
-                    axis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -713,7 +711,7 @@ class RecordArray(RecordMeta[Content], Content):
 
         for_each_field = []
         for field in self.contents:
-            trimmed = field[0: self.length]
+            trimmed = field[0 : self.length]
             for_each_field.append([trimmed])
 
         if self.is_tuple:
@@ -721,23 +719,20 @@ class RecordArray(RecordMeta[Content], Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
-                                for_each_field[i].append(
-                                    field[0: array.length])
+                                for_each_field[i].append(field[0 : array.length])
                         else:
                             raise ValueError(
                                 "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ValueError(
-                            "cannot merge tuple with non-tuple record")
+                        raise ValueError("cannot merge tuple with non-tuple record")
                 else:
                     raise AssertionError(
                         "cannot merge "
@@ -751,8 +746,7 @@ class RecordArray(RecordMeta[Content], Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
@@ -763,15 +757,14 @@ class RecordArray(RecordMeta[Content], Content):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
 
-                                trimmed = field[0: array.length]
+                                trimmed = field[0 : array.length]
                                 for_each_field[i].append(trimmed)
                         else:
                             raise AssertionError(
                                 "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise AssertionError(
-                            "cannot merge non-tuple record with tuple")
+                        raise AssertionError("cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
@@ -943,8 +936,7 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(
-                outlength + 1, self._backend.nplike)
+            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
             assert (
                 offsets.nplike is self._backend.nplike
                 and parents.nplike is self._backend.nplike
@@ -1036,8 +1028,7 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(
-                    outlength, self._backend.nplike)
+                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
                 assert (
                     outmask.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1060,8 +1051,7 @@ class RecordArray(RecordMeta[Content], Content):
                 )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
@@ -1191,8 +1181,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend)
-                    for x in self._contents]
+        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
 
@@ -1230,8 +1219,7 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self.length]._remove_structure(
-                    backend, options))
+                out.extend(content[: self.length]._remove_structure(backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1315,8 +1303,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self.length].to_packed(
-                    True) if recursive else x[: self.length]
+                x[: self.length].to_packed(True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
@@ -1334,8 +1321,7 @@ class RecordArray(RecordMeta[Content], Content):
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
@@ -1345,8 +1331,7 @@ class RecordArray(RecordMeta[Content], Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
@@ -1389,8 +1374,7 @@ class RecordArray(RecordMeta[Content], Content):
             and set(self.fields) == set(other.fields)
             and all(
                 content._is_equal_to(
-                    other.content(
-                        field), index_dtype, numpyarray, all_parameters
+                    other.content(field), index_dtype, numpyarray, all_parameters
                 )
                 for field, content in zip(self.fields, self._contents, strict=True)
             )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -350,8 +350,7 @@ class RecordArray(RecordMeta[Content], Content):
     ):
         assert isinstance(form, self.form_cls)
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey,
-                                container, backend, byteorder)
+            content._to_buffers(form.content(i), getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         backend = TypeTracerBackend.instance()
@@ -601,8 +600,7 @@ class RecordArray(RecordMeta[Content], Content):
 
             contents = []
             for i in range(len(self._contents)):
-                contents.append(self.content(
-                    i)._getitem_next(head, (), advanced))
+                contents.append(self.content(i)._getitem_next(head, (), advanced))
 
             parameters = None
             if (
@@ -640,8 +638,7 @@ class RecordArray(RecordMeta[Content], Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(0, self.length)
-                offsets, flattened = trimmed._offsets_and_flattened(
-                    axis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -719,7 +716,7 @@ class RecordArray(RecordMeta[Content], Content):
 
         for_each_field = []
         for field in self.contents:
-            trimmed = field[0: self.length]
+            trimmed = field[0 : self.length]
             for_each_field.append([trimmed])
 
         if self.is_tuple:
@@ -727,23 +724,20 @@ class RecordArray(RecordMeta[Content], Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
-                                for_each_field[i].append(
-                                    field[0: array.length])
+                                for_each_field[i].append(field[0 : array.length])
                         else:
                             raise ValueError(
                                 "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ValueError(
-                            "cannot merge tuple with non-tuple record")
+                        raise ValueError("cannot merge tuple with non-tuple record")
                 else:
                     raise AssertionError(
                         "cannot merge "
@@ -757,8 +751,7 @@ class RecordArray(RecordMeta[Content], Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
@@ -769,15 +762,14 @@ class RecordArray(RecordMeta[Content], Content):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
 
-                                trimmed = field[0: array.length]
+                                trimmed = field[0 : array.length]
                                 for_each_field[i].append(trimmed)
                         else:
                             raise AssertionError(
                                 "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise AssertionError(
-                            "cannot merge non-tuple record with tuple")
+                        raise AssertionError("cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
@@ -949,8 +941,7 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(
-                outlength + 1, self._backend.nplike)
+            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
             assert (
                 offsets.nplike is self._backend.nplike
                 and parents.nplike is self._backend.nplike
@@ -1042,8 +1033,7 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(
-                    outlength, self._backend.nplike)
+                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
                 assert (
                     outmask.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1066,8 +1056,7 @@ class RecordArray(RecordMeta[Content], Content):
                 )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
@@ -1200,8 +1189,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend)
-                    for x in self._contents]
+        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
 
@@ -1239,8 +1227,7 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self.length]._remove_structure(
-                    backend, options))
+                out.extend(content[: self.length]._remove_structure(backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1324,8 +1311,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self.length].to_packed(
-                    True) if recursive else x[: self.length]
+                x[: self.length].to_packed(True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
@@ -1343,8 +1329,7 @@ class RecordArray(RecordMeta[Content], Content):
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
@@ -1354,8 +1339,7 @@ class RecordArray(RecordMeta[Content], Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
@@ -1398,8 +1382,7 @@ class RecordArray(RecordMeta[Content], Content):
             and set(self.fields) == set(other.fields)
             and all(
                 content._is_equal_to(
-                    other.content(
-                        field), index_dtype, numpyarray, all_parameters
+                    other.content(field), index_dtype, numpyarray, all_parameters
                 )
                 for field, content in zip(self.fields, self._contents, strict=True)
             )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -1168,16 +1168,17 @@ class RecordArray(RecordMeta[Content], Content):
             {field: c.dtype for field, c in zip(self.fields, children, strict=True)}
         )
         m = mask._to_cudf(cudf, None, length) if mask else None
+        StructCol = cudf.core.column.StructColumn
 
-        if parse_version(cudf.__version__) >= parse_version("24.10.00"):
-            return cudf.core.column.StructColumn.from_children(
+        if hasattr(StructCol, "from_children"):
+            return StructCol.from_children(
                 children=children,
                 dtype=dt,
                 size=length,
                 mask=m,
             )
         else:
-            return StructColumn(
+            return StructCol(
                 data=None,
                 children=children,
                 dtype=dt,

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -11,7 +11,6 @@ try:
 except ImportError:
     StructColumn = None
 
-from packaging.version import parse as parse_version
 
 import awkward as ak
 from awkward._backends.backend import Backend

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -6,12 +6,6 @@ import copy
 import json
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
-try:
-    from cudf.core.column.struct import StructColumn
-except ImportError:
-    StructColumn = None
-
-
 import awkward as ak
 from awkward._backends.backend import Backend
 from awkward._backends.numpy import NumpyBackend
@@ -1158,9 +1152,6 @@ class RecordArray(RecordMeta[Content], Content):
 
     def _to_cudf(self, cudf: Any, mask: Content | None, length: int):
         import inspect
-
-        if StructColumn is None:
-            raise RuntimeError("ak.to_cudf requires cuDF to be installed")
 
         children = tuple(
             c._to_cudf(cudf, mask=None, length=length) for c in self.contents

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -18,6 +18,7 @@ from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
+from cudf.core.column.struct import StructColumn
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import (
     parameters_intersect,
@@ -345,7 +346,8 @@ class RecordArray(RecordMeta[Content], Content):
     ):
         assert isinstance(form, self.form_cls)
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey, container, backend, byteorder)
+            content._to_buffers(form.content(i), getkey,
+                                container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         backend = TypeTracerBackend.instance()
@@ -595,7 +597,8 @@ class RecordArray(RecordMeta[Content], Content):
 
             contents = []
             for i in range(len(self._contents)):
-                contents.append(self.content(i)._getitem_next(head, (), advanced))
+                contents.append(self.content(
+                    i)._getitem_next(head, (), advanced))
 
             parameters = None
             if (
@@ -633,7 +636,8 @@ class RecordArray(RecordMeta[Content], Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(0, self.length)
-                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(
+                    axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -711,7 +715,7 @@ class RecordArray(RecordMeta[Content], Content):
 
         for_each_field = []
         for field in self.contents:
-            trimmed = field[0 : self.length]
+            trimmed = field[0: self.length]
             for_each_field.append([trimmed])
 
         if self.is_tuple:
@@ -719,20 +723,23 @@ class RecordArray(RecordMeta[Content], Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = parameters_intersect(parameters, array._parameters)
+                parameters = parameters_intersect(
+                    parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
-                                for_each_field[i].append(field[0 : array.length])
+                                for_each_field[i].append(
+                                    field[0: array.length])
                         else:
                             raise ValueError(
                                 "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ValueError("cannot merge tuple with non-tuple record")
+                        raise ValueError(
+                            "cannot merge tuple with non-tuple record")
                 else:
                     raise AssertionError(
                         "cannot merge "
@@ -746,7 +753,8 @@ class RecordArray(RecordMeta[Content], Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = parameters_intersect(parameters, array._parameters)
+                parameters = parameters_intersect(
+                    parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
@@ -757,14 +765,15 @@ class RecordArray(RecordMeta[Content], Content):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
 
-                                trimmed = field[0 : array.length]
+                                trimmed = field[0: array.length]
                                 for_each_field[i].append(trimmed)
                         else:
                             raise AssertionError(
                                 "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise AssertionError("cannot merge non-tuple record with tuple")
+                        raise AssertionError(
+                            "cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
@@ -936,7 +945,8 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
+            offsets = ak.index.Index64.empty(
+                outlength + 1, self._backend.nplike)
             assert (
                 offsets.nplike is self._backend.nplike
                 and parents.nplike is self._backend.nplike
@@ -1028,7 +1038,8 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
+                outmask = ak.index.Index8.empty(
+                    outlength, self._backend.nplike)
                 assert (
                     outmask.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1051,7 +1062,8 @@ class RecordArray(RecordMeta[Content], Content):
                 )
 
             if keepdims:
-                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(
+                    out, 1, self.length, parameters=None)
 
             return out
 
@@ -1169,19 +1181,20 @@ class RecordArray(RecordMeta[Content], Content):
                 mask=m,
             )
         else:
-            return cudf.core.column.struct.StructColumn(
-                None,
-                children,
-                dt,
-                m,
-                length,
-                0,
+            return StructColumn(
+                data=None,
+                chilren=children,
+                dtype=dt,
+                mask=m,
+                size=length,
+                offset=0,
             )
 
     def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
+        contents = [x._to_backend_array(allow_missing, backend)
+                    for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
 
@@ -1219,7 +1232,8 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self.length]._remove_structure(backend, options))
+                out.extend(content[: self.length]._remove_structure(
+                    backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1303,7 +1317,8 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self.length].to_packed(True) if recursive else x[: self.length]
+                x[: self.length].to_packed(
+                    True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
@@ -1321,7 +1336,8 @@ class RecordArray(RecordMeta[Content], Content):
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions)
+                        for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
@@ -1331,7 +1347,8 @@ class RecordArray(RecordMeta[Content], Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions)
+                        for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
@@ -1374,7 +1391,8 @@ class RecordArray(RecordMeta[Content], Content):
             and set(self.fields) == set(other.fields)
             and all(
                 content._is_equal_to(
-                    other.content(field), index_dtype, numpyarray, all_parameters
+                    other.content(
+                        field), index_dtype, numpyarray, all_parameters
                 )
                 for field, content in zip(self.fields, self._contents, strict=True)
             )

--- a/src/awkward/contents/recordarray.py
+++ b/src/awkward/contents/recordarray.py
@@ -6,6 +6,7 @@ import copy
 import json
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
+from cudf.core.column.struct import StructColumn
 from packaging.version import parse as parse_version
 
 import awkward as ak
@@ -18,7 +19,6 @@ from awkward._meta.recordmeta import RecordMeta
 from awkward._nplikes.array_like import ArrayLike
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import IndexType, NumpyMetadata
-from cudf.core.column.struct import StructColumn
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._parameters import (
     parameters_intersect,
@@ -346,8 +346,7 @@ class RecordArray(RecordMeta[Content], Content):
     ):
         assert isinstance(form, self.form_cls)
         for i, content in enumerate(self._contents):
-            content._to_buffers(form.content(i), getkey,
-                                container, backend, byteorder)
+            content._to_buffers(form.content(i), getkey, container, backend, byteorder)
 
     def _to_typetracer(self, forget_length: bool) -> Self:
         backend = TypeTracerBackend.instance()
@@ -597,8 +596,7 @@ class RecordArray(RecordMeta[Content], Content):
 
             contents = []
             for i in range(len(self._contents)):
-                contents.append(self.content(
-                    i)._getitem_next(head, (), advanced))
+                contents.append(self.content(i)._getitem_next(head, (), advanced))
 
             parameters = None
             if (
@@ -636,8 +634,7 @@ class RecordArray(RecordMeta[Content], Content):
             contents = []
             for content in self._contents:
                 trimmed = content._getitem_range(0, self.length)
-                offsets, flattened = trimmed._offsets_and_flattened(
-                    axis, depth)
+                offsets, flattened = trimmed._offsets_and_flattened(axis, depth)
                 if self._backend.nplike.known_data and offsets.length != 0:
                     raise AssertionError(
                         "RecordArray content with axis > depth + 1 returned a non-empty offsets from offsets_and_flattened"
@@ -715,7 +712,7 @@ class RecordArray(RecordMeta[Content], Content):
 
         for_each_field = []
         for field in self.contents:
-            trimmed = field[0: self.length]
+            trimmed = field[0 : self.length]
             for_each_field.append([trimmed])
 
         if self.is_tuple:
@@ -723,23 +720,20 @@ class RecordArray(RecordMeta[Content], Content):
                 if isinstance(array, ak.contents.EmptyArray):
                     continue
 
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if self.is_tuple:
                         if len(self.contents) == len(array.contents):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
-                                for_each_field[i].append(
-                                    field[0: array.length])
+                                for_each_field[i].append(field[0 : array.length])
                         else:
                             raise ValueError(
                                 "cannot merge tuples with different numbers of fields"
                             )
                     else:
-                        raise ValueError(
-                            "cannot merge tuple with non-tuple record")
+                        raise ValueError("cannot merge tuple with non-tuple record")
                 else:
                     raise AssertionError(
                         "cannot merge "
@@ -753,8 +747,7 @@ class RecordArray(RecordMeta[Content], Content):
             these_fields.sort()
 
             for array in headless:
-                parameters = parameters_intersect(
-                    parameters, array._parameters)
+                parameters = parameters_intersect(parameters, array._parameters)
 
                 if isinstance(array, ak.contents.RecordArray):
                     if not array.is_tuple:
@@ -765,15 +758,14 @@ class RecordArray(RecordMeta[Content], Content):
                             for i in range(len(self.contents)):
                                 field = array[self.index_to_field(i)]
 
-                                trimmed = field[0: array.length]
+                                trimmed = field[0 : array.length]
                                 for_each_field[i].append(trimmed)
                         else:
                             raise AssertionError(
                                 "cannot merge records with different sets of field names"
                             )
                     else:
-                        raise AssertionError(
-                            "cannot merge non-tuple record with tuple")
+                        raise AssertionError("cannot merge non-tuple record with tuple")
 
                 elif isinstance(array, ak.contents.EmptyArray):
                     pass
@@ -945,8 +937,7 @@ class RecordArray(RecordMeta[Content], Content):
             reducer_should_mask = mask and not reducer.needs_position
 
             # Convert parents into offsets to build a list for axis=1 reduction
-            offsets = ak.index.Index64.empty(
-                outlength + 1, self._backend.nplike)
+            offsets = ak.index.Index64.empty(outlength + 1, self._backend.nplike)
             assert (
                 offsets.nplike is self._backend.nplike
                 and parents.nplike is self._backend.nplike
@@ -1038,8 +1029,7 @@ class RecordArray(RecordMeta[Content], Content):
                     )
 
             if mask:
-                outmask = ak.index.Index8.empty(
-                    outlength, self._backend.nplike)
+                outmask = ak.index.Index8.empty(outlength, self._backend.nplike)
                 assert (
                     outmask.nplike is self._backend.nplike
                     and parents.nplike is self._backend.nplike
@@ -1062,8 +1052,7 @@ class RecordArray(RecordMeta[Content], Content):
                 )
 
             if keepdims:
-                out = ak.contents.RegularArray(
-                    out, 1, self.length, parameters=None)
+                out = ak.contents.RegularArray(out, 1, self.length, parameters=None)
 
             return out
 
@@ -1193,8 +1182,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_backend_array(self, allow_missing, backend):
         if self.fields is None:
             return backend.nplike.empty(self.length, dtype=[])
-        contents = [x._to_backend_array(allow_missing, backend)
-                    for x in self._contents]
+        contents = [x._to_backend_array(allow_missing, backend) for x in self._contents]
         if any(len(x.shape) != 1 for x in contents):
             raise ValueError(f"cannot convert {self} into np.ndarray")
 
@@ -1232,8 +1220,7 @@ class RecordArray(RecordMeta[Content], Content):
         if options["flatten_records"]:
             out = []
             for content in self._contents:
-                out.extend(content[: self.length]._remove_structure(
-                    backend, options))
+                out.extend(content[: self.length]._remove_structure(backend, options))
             return out
         elif options["allow_records"]:
             return [self]
@@ -1317,8 +1304,7 @@ class RecordArray(RecordMeta[Content], Content):
     def _to_packed(self, recursive: bool = True) -> Self:
         return RecordArray(
             [
-                x[: self.length].to_packed(
-                    True) if recursive else x[: self.length]
+                x[: self.length].to_packed(True) if recursive else x[: self.length]
                 for x in self._contents
             ],
             self._fields,
@@ -1336,8 +1322,7 @@ class RecordArray(RecordMeta[Content], Content):
             return out
 
         if self.is_tuple and json_conversions is None:
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = tuple(x[i] for x in contents)
@@ -1347,8 +1332,7 @@ class RecordArray(RecordMeta[Content], Content):
             fields = self._fields
             if fields is None:
                 fields = [str(i) for i in range(len(self._contents))]
-            contents = [x._to_list(behavior, json_conversions)
-                        for x in self._contents]
+            contents = [x._to_list(behavior, json_conversions) for x in self._contents]
             out = [None] * self.length
             for i in range(self.length):
                 out[i] = dict(zip(fields, [x[i] for x in contents], strict=True))
@@ -1391,8 +1375,7 @@ class RecordArray(RecordMeta[Content], Content):
             and set(self.fields) == set(other.fields)
             and all(
                 content._is_equal_to(
-                    other.content(
-                        field), index_dtype, numpyarray, all_parameters
+                    other.content(field), index_dtype, numpyarray, all_parameters
                 )
                 for field, content in zip(self.fields, self._contents, strict=True)
             )

--- a/src/awkward/operations/ak_to_cudf.py
+++ b/src/awkward/operations/ak_to_cudf.py
@@ -18,9 +18,7 @@ def to_cudf(array):
     Buffers that are not already in GPU memory will be transferred, and some
     structural reformatting may happen to account for differences in architecture.
 
-    This function requires the `cudf` library (< 25.12.00) and a compatible GPU.
-    cuDF versions 25.12.00 and later are not currently supported due to
-    incompatible changes in cuDF internals.
+    This function requires the `cudf` library and a compatible GPU.
 
     See also #ak.to_cupy, #ak.from_cupy, #ak.to_dataframe.
     """
@@ -42,14 +40,6 @@ def _impl(array):
 or
     conda install -c rapidsai cudf cuda-version=13"""
         ) from err
-
-    from packaging.version import parse as parse_version
-
-    if parse_version(cudf.__version__) >= parse_version("25.12.00"):
-        raise NotImplementedError(
-            f"ak.to_cudf is not supported for cudf >= 25.12.00 (you have {cudf.__version__}). "
-            "cudf internals changed in ways that are incompatible with the current implementation"
-        )
 
     layout = ak.to_layout(array, allow_record=False)
 

--- a/src/awkward/operations/str/__init__.py
+++ b/src/awkward/operations/str/__init__.py
@@ -15,6 +15,7 @@ from awkward.operations.str.akstr_center import *
 # https://arrow.apache.org/docs/python/api/compute.html#containment-tests
 from awkward.operations.str.akstr_count_substring import *
 from awkward.operations.str.akstr_count_substring_regex import *
+from awkward.operations.str.akstr_distinct_counts import *
 from awkward.operations.str.akstr_ends_with import *
 
 # string component extraction
@@ -81,6 +82,7 @@ from awkward.operations.str.akstr_title import *
 from awkward.operations.str.akstr_to_categorical import *
 from awkward.operations.str.akstr_trim import *
 from awkward.operations.str.akstr_trim_whitespace import *
+from awkward.operations.str.akstr_uniques import *
 from awkward.operations.str.akstr_upper import *
 
 __all__ = [k for k in locals() if not k.startswith("akstr_")]

--- a/src/awkward/operations/str/akstr_distinct_counts.py
+++ b/src/awkward/operations/str/akstr_distinct_counts.py
@@ -1,0 +1,63 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._dispatch import high_level_function
+from awkward._layout import HighLevelContext
+
+__all__ = ("distinct_counts",)
+
+
+def _is_maybe_optional_list_of_string(layout):
+    if layout.is_list and layout.parameter("__array__") in {"string", "bytestring"}:
+        return True
+    elif layout.is_option or layout.is_indexed:
+        return _is_maybe_optional_list_of_string(layout.content)
+    else:
+        return False
+
+
+@high_level_function(module="ak.str")
+def distinct_counts(array, *, highlevel=True, behavior=None, attrs=None):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+        attrs (None or dict): Custom attributes for the output array, if
+            high-level.
+
+    Returns one record per distinct value in a one-dimensional array of
+    strings or bytestrings. Each record contains the distinct value (`"values"`)
+    and its frequency (`"counts"`).
+
+    If `array` contains no string or bytestring data, this function returns it
+    unchanged.
+
+    Requires the pyarrow library and calls
+    [pyarrow.compute.value_counts](https://arrow.apache.org/docs/python/generated/pyarrow.compute.value_counts.html).
+    """
+    # Dispatch
+    yield (array,)
+
+    # Implementation
+    return _impl(array, highlevel, behavior, attrs)
+
+
+def _impl(array, highlevel, behavior, attrs):
+    from awkward._connect.pyarrow import import_pyarrow_compute
+    from awkward.operations.str import _apply_through_arrow
+
+    pc = import_pyarrow_compute("ak.str.distinct_counts")
+
+    with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
+        layout = ctx.unwrap(array)
+
+    if _is_maybe_optional_list_of_string(layout):
+        out = _apply_through_arrow(pc.value_counts, layout, expect_option_type=True)
+    else:
+        out = layout
+
+    return ctx.wrap(out, highlevel=highlevel)

--- a/src/awkward/operations/str/akstr_uniques.py
+++ b/src/awkward/operations/str/akstr_uniques.py
@@ -1,0 +1,62 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+from awkward._dispatch import high_level_function
+from awkward._layout import HighLevelContext
+
+__all__ = ("uniques",)
+
+
+def _is_maybe_optional_list_of_string(layout):
+    if layout.is_list and layout.parameter("__array__") in {"string", "bytestring"}:
+        return True
+    elif layout.is_option or layout.is_indexed:
+        return _is_maybe_optional_list_of_string(layout.content)
+    else:
+        return False
+
+
+@high_level_function(module="ak.str")
+def uniques(array, *, highlevel=True, behavior=None, attrs=None):
+    """
+    Args:
+        array: Array-like data (anything #ak.to_layout recognizes).
+        highlevel (bool): If True, return an #ak.Array; otherwise, return
+            a low-level #ak.contents.Content subclass.
+        behavior (None or dict): Custom #ak.behavior for the output array, if
+            high-level.
+        attrs (None or dict): Custom attributes for the output array, if
+            high-level.
+
+    Returns one copy of each distinct value in a one-dimensional array of
+    strings or bytestrings.
+
+    If `array` contains no string or bytestring data, this function returns it
+    unchanged.
+
+    Requires the pyarrow library and calls
+    [pyarrow.compute.unique](https://arrow.apache.org/docs/python/generated/pyarrow.compute.unique.html).
+    """
+    # Dispatch
+    yield (array,)
+
+    # Implementation
+    return _impl(array, highlevel, behavior, attrs)
+
+
+def _impl(array, highlevel, behavior, attrs):
+    from awkward._connect.pyarrow import import_pyarrow_compute
+    from awkward.operations.str import _apply_through_arrow
+
+    pc = import_pyarrow_compute("ak.str.uniques")
+
+    with HighLevelContext(behavior=behavior, attrs=attrs) as ctx:
+        layout = ctx.unwrap(array)
+
+    if _is_maybe_optional_list_of_string(layout):
+        out = _apply_through_arrow(pc.unique, layout, expect_option_type=True)
+    else:
+        out = layout
+
+    return ctx.wrap(out, highlevel=highlevel)

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -47,18 +47,15 @@ def test_nested():
 )
 def test_null():
     arr = ak.Array([12, None, 21, 12])
-    # calls ByteMaskedArray._to_cudf not NumpyArray
     out = ak.to_cudf(arr)
     assert isinstance(out, cudf.Series)
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
-    # True is valid, LSB order
     arr2 = ak.Array(arr.layout.to_BitMaskedArray(True, True))
     out = ak.to_cudf(arr2)
     assert isinstance(out, cudf.Series)
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
-    # reversed LSB (should be rare, involves extra work!)
     arr3 = ak.Array(arr.layout.to_BitMaskedArray(True, False))
     out = ak.to_cudf(arr3)
     assert isinstance(out, cudf.Series)

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -9,7 +9,6 @@ cudf = pytest.importorskip("cudf", exc_type=ImportError)
 cupy = pytest.importorskip("cupy")
 
 
-@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -22,7 +21,6 @@ def test_jagged():
     assert out.to_arrow().tolist() == [[[1, 2, 3], [], [3, 4]], []]
 
 
-@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -40,7 +38,6 @@ def test_nested():
     ]
 
 
-@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -62,7 +59,6 @@ def test_null():
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
-@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import awkward as ak
 
@@ -55,3 +57,64 @@ def test_strings():
     arr = ak.Array(["hey", "hi", None, "hum"])
     out = ak.to_cudf(arr)
     assert out.to_arrow().tolist() == ["hey", "hi", None, "hum"]
+
+
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
+def test_indexed():
+    layout = ak.contents.IndexedArray(
+        ak.index.Index64(np.array([2, 0, 2, 1], dtype=np.int64)),
+        ak.contents.NumpyArray(np.array([10, 20, 30], dtype=np.int64)),
+    )
+    out = ak.to_cudf(ak.Array(layout))
+    assert out.to_arrow().tolist() == [30, 10, 30, 20]
+
+
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
+def test_unmasked():
+    layout = ak.contents.UnmaskedArray(
+        ak.contents.NumpyArray(np.array([1.5, 2.5, 3.5], dtype=np.float64))
+    )
+    out = ak.to_cudf(ak.Array(layout))
+    assert out.to_arrow().tolist() == [1.5, 2.5, 3.5]
+
+
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
+def test_emptyarray():
+    out = ak.to_cudf(ak.Array(ak.contents.EmptyArray()))
+    assert out.to_arrow().tolist() == []
+
+
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
+def test_indexedoption():
+    layout = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.array([0, -1, 2, 1], dtype=np.int64)),
+        ak.contents.NumpyArray(np.array([10, 20, 30], dtype=np.int64)),
+    )
+    out = ak.to_cudf(ak.Array(layout))
+    assert out.to_arrow().tolist() == [10, None, 30, 20]
+
+
+@pytest.mark.xfail(
+    parse_version(cudf.__version__) >= parse_version("25.12.00"),
+    reason="cudf internals changed since v25.12.00",
+)
+def test_listarray():
+    layout = ak.contents.ListArray(
+        ak.index.Index64(np.array([0, 3, 3], dtype=np.int64)),
+        ak.index.Index64(np.array([3, 3, 5], dtype=np.int64)),
+        ak.contents.NumpyArray(np.array([1, 2, 3, 4, 5], dtype=np.int64)),
+    )
+    out = ak.to_cudf(ak.Array(layout))
+    assert out.to_arrow().tolist() == [[1, 2, 3], [], [4, 5]]

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from packaging.version import parse as parse_version
 
 import awkward as ak
 
@@ -9,11 +8,6 @@ cudf = pytest.importorskip("cudf", exc_type=ImportError)
 cupy = pytest.importorskip("cupy")
 
 
-@pytest.mark.xfail(
-    parse_version(cudf.__version__) >= parse_version("25.12.00"),
-    reason="cudf internals changed since v25.12.00",
-    strict=False,
-)
 def test_jagged():
     arr = ak.Array([[[1, 2, 3], [], [3, 4]], []])
     out = ak.to_cudf(arr)
@@ -21,11 +15,6 @@ def test_jagged():
     assert out.to_arrow().tolist() == [[[1, 2, 3], [], [3, 4]], []]
 
 
-@pytest.mark.xfail(
-    parse_version(cudf.__version__) >= parse_version("25.12.00"),
-    reason="cudf internals changed since v25.12.00",
-    strict=False,
-)
 def test_nested():
     arr = ak.Array(
         [{"a": 0, "b": 1.0, "c": {"d": 0}}, {"a": 1, "b": 0.0, "c": {"d": 1}}]
@@ -38,31 +27,26 @@ def test_nested():
     ]
 
 
-@pytest.mark.xfail(
-    parse_version(cudf.__version__) >= parse_version("25.12.00"),
-    reason="cudf internals changed since v25.12.00",
-)
 def test_null():
     arr = ak.Array([12, None, 21, 12])
+    # calls ByteMaskedArray._to_cudf not NumpyArray
     out = ak.to_cudf(arr)
     assert isinstance(out, cudf.Series)
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
+    # True is valid, LSB order
     arr2 = ak.Array(arr.layout.to_BitMaskedArray(True, True))
     out = ak.to_cudf(arr2)
     assert isinstance(out, cudf.Series)
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
+    # reversed LSB (should be rare, involves extra work!)
     arr3 = ak.Array(arr.layout.to_BitMaskedArray(True, False))
     out = ak.to_cudf(arr3)
     assert isinstance(out, cudf.Series)
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
-@pytest.mark.xfail(
-    parse_version(cudf.__version__) >= parse_version("25.12.00"),
-    reason="cudf internals changed since v25.12.00",
-)
 def test_strings():
     arr = ak.Array(["hey", "hi", "hum"])
     out = ak.to_cudf(arr)

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -13,6 +13,7 @@ cupy = pytest.importorskip("cupy")
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
+    strict=False,
 )
 def test_jagged():
     arr = ak.Array([[[1, 2, 3], [], [3, 4]], []])
@@ -25,6 +26,7 @@ def test_jagged():
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
+    strict=False,
 )
 def test_nested():
     arr = ak.Array(

--- a/tests-cuda/test_3051_to_cuda.py
+++ b/tests-cuda/test_3051_to_cuda.py
@@ -9,6 +9,7 @@ cudf = pytest.importorskip("cudf", exc_type=ImportError)
 cupy = pytest.importorskip("cupy")
 
 
+@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -20,6 +21,7 @@ def test_jagged():
     assert out.to_arrow().tolist() == [[[1, 2, 3], [], [3, 4]], []]
 
 
+@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -36,6 +38,7 @@ def test_nested():
     ]
 
 
+@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",
@@ -60,6 +63,7 @@ def test_null():
     assert out.to_arrow().tolist() == [12, None, 21, 12]
 
 
+@pytest.mark.cuda
 @pytest.mark.xfail(
     parse_version(cudf.__version__) >= parse_version("25.12.00"),
     reason="cudf internals changed since v25.12.00",

--- a/tests/test_2616_use_pyarrow_for_strings.py
+++ b/tests/test_2616_use_pyarrow_for_strings.py
@@ -2187,3 +2187,65 @@ def test_to_categorical():
             ak.to_backend(["foo", "bar", "bar", "fee"], "typetracer")
         ).layout.form
     )
+
+
+def test_uniques():
+    assert ak.str.uniques(["foo", "bar", "bar", "fee", None, "foo"]).tolist() == [
+        "foo",
+        "bar",
+        "fee",
+        None,
+    ]
+    assert ak.str.uniques([b"foo", b"bar", b"bar", b"fee", None, b"foo"]).tolist() == [
+        b"foo",
+        b"bar",
+        b"fee",
+        None,
+    ]
+
+    assert (
+        ak.str.uniques(["foo", "bar", "bar", "fee", None, "foo"]).layout.form
+        == ak.str.uniques(
+            ak.to_backend(["foo", "bar", "bar", "fee", None, "foo"], "typetracer")
+        ).layout.form
+    )
+    assert (
+        ak.str.uniques([b"foo", b"bar", b"bar", b"fee", None, b"foo"]).layout.form
+        == ak.str.uniques(
+            ak.to_backend([b"foo", b"bar", b"bar", b"fee", None, b"foo"], "typetracer")
+        ).layout.form
+    )
+
+
+def test_distinct_counts():
+    assert ak.str.distinct_counts(
+        ["foo", "bar", "bar", "fee", None, "foo"]
+    ).tolist() == [
+        {"values": "foo", "counts": 2},
+        {"values": "bar", "counts": 2},
+        {"values": "fee", "counts": 1},
+        {"values": None, "counts": 1},
+    ]
+    assert ak.str.distinct_counts(
+        [b"foo", b"bar", b"bar", b"fee", None, b"foo"]
+    ).tolist() == [
+        {"values": b"foo", "counts": 2},
+        {"values": b"bar", "counts": 2},
+        {"values": b"fee", "counts": 1},
+        {"values": None, "counts": 1},
+    ]
+
+    assert (
+        ak.str.distinct_counts(["foo", "bar", "bar", "fee", None, "foo"]).layout.form
+        == ak.str.distinct_counts(
+            ak.to_backend(["foo", "bar", "bar", "fee", None, "foo"], "typetracer")
+        ).layout.form
+    )
+    assert (
+        ak.str.distinct_counts(
+            [b"foo", b"bar", b"bar", b"fee", None, b"foo"]
+        ).layout.form
+        == ak.str.distinct_counts(
+            ak.to_backend([b"foo", b"bar", b"bar", b"fee", None, b"foo"], "typetracer")
+        ).layout.form
+    )

--- a/tests/test_2757_attrs_metadata.py
+++ b/tests/test_2757_attrs_metadata.py
@@ -115,6 +115,8 @@ def test_single_arg_ops(func):
         ak.str.rtrim_whitespace,
         ak.str.trim_whitespace,
         ak.str.split_whitespace,
+        ak.str.uniques,
+        ak.str.distinct_counts,
     ],
 )
 def test_string_operations_unary(func):


### PR DESCRIPTION
Closes #2703.
This adds ak.str.uniques and ak.str.distinct_counts, backed by pyarrow.compute.unique and pyarrow.compute.value_counts.
As discussed in the issue, these are restricted to the ak.str.* namespace so that we don’t introduce a surprising PyArrow dependency at the top-level ak.* namespace. For non-string types, uniqueness can already be implemented via sorting + ak.run_lengths, so this mainly targets the especially useful string case.
distinct_counts returns a record array with "values" and "counts" fields, mirroring the structure returned by Arrow.
Missing values follow Arrow’s default null handling (they are excluded from the results). Output order follows Arrow behavior.
Tests include string and bytestring arrays, typetracer form checks, and attrs propagation coverage.