### PR TITLE
chore: pin ROOT to 6.36.06 in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,7 +294,7 @@ jobs:
           create-args: >-
             python=3.10
             numpy
-            root
+            root=6.36.06
 
       - name: Generate build files
         run: pipx run nox -s prepare -- --headers --signatures --tests


### PR DESCRIPTION
see #3885 for details