### PR TITLE
feat: pickle in native byteorder and pass byteorder through pickling and unpickling

### DIFF
--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -99,6 +99,7 @@ def unpickle_array_schema_1(
     form_dict: dict,
     length: ShapeItem,
     container: Mapping[str, Any],
+    byteorder: str,
     behavior: JSONMapping | None,
     attrs: JSONMapping | None,
 ) -> Array:
@@ -113,7 +114,7 @@ def unpickle_array_schema_1(
         attrs=attrs,
         highlevel=True,
         buffer_key="{form_key}-{attribute}",
-        byteorder="<",
+        byteorder=byteorder,
         simplify=False,
         enable_virtualarray_caching=True,
     )
@@ -123,6 +124,7 @@ def unpickle_record_schema_1(
     form_dict: dict,
     length: ShapeItem,
     container: Mapping[str, Any],
+    byteorder: str,
     behavior: JSONMapping | None,
     attrs: JSONMapping | None,
     at: int,
@@ -140,7 +142,7 @@ def unpickle_record_schema_1(
         attrs=attrs,
         highlevel=False,
         buffer_key="{form_key}-{attribute}",
-        byteorder="<",
+        byteorder=byteorder,
         simplify=False,
         enable_virtualarray_caching=True,
     )

--- a/src/awkward/_pickle.py
+++ b/src/awkward/_pickle.py
@@ -99,6 +99,30 @@ def unpickle_array_schema_1(
     form_dict: dict,
     length: ShapeItem,
     container: Mapping[str, Any],
+    behavior: JSONMapping | None,
+    attrs: JSONMapping | None,
+) -> Array:
+    from awkward.operations.ak_from_buffers import _impl
+
+    return _impl(
+        form_dict,
+        length,
+        container,
+        backend="cpu",
+        behavior=behavior,
+        attrs=attrs,
+        highlevel=True,
+        buffer_key="{form_key}-{attribute}",
+        byteorder="<",
+        simplify=False,
+        enable_virtualarray_caching=True,
+    )
+
+
+def unpickle_array_schema_2(
+    form_dict: dict,
+    length: ShapeItem,
+    container: Mapping[str, Any],
     byteorder: str,
     behavior: JSONMapping | None,
     attrs: JSONMapping | None,
@@ -121,6 +145,35 @@ def unpickle_array_schema_1(
 
 
 def unpickle_record_schema_1(
+    form_dict: dict,
+    length: ShapeItem,
+    container: Mapping[str, Any],
+    behavior: JSONMapping | None,
+    attrs: JSONMapping | None,
+    at: int,
+) -> Record:
+    from awkward.highlevel import Record
+    from awkward.operations.ak_from_buffers import _impl
+    from awkward.record import Record as LowLevelRecord
+
+    array_layout = _impl(
+        form_dict,
+        length,
+        container,
+        backend="cpu",
+        behavior=behavior,
+        attrs=attrs,
+        highlevel=False,
+        buffer_key="{form_key}-{attribute}",
+        byteorder="<",
+        simplify=False,
+        enable_virtualarray_caching=True,
+    )
+    layout = LowLevelRecord(array_layout, at)
+    return Record(layout, behavior=behavior, attrs=attrs)
+
+
+def unpickle_record_schema_2(
     form_dict: dict,
     length: ShapeItem,
     container: Mapping[str, Any],

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -1669,6 +1669,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         return numba.typeof(self._numbaview)
 
     def __reduce_ex__(self, protocol: int) -> tuple:
+        # Allow third-party libraries to customise pickling
         result = custom_reduce(self, protocol)
         if result is not NotImplemented:
             return result
@@ -1678,7 +1679,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             packed_layout,
             buffer_key="{form_key}-{attribute}",
             form_key="node{id}",
-            byteorder="<",
+            byteorder=ak._util.native_byteorder,
         )
 
         # For pickle >= 5, we can avoid copying the buffers
@@ -1699,6 +1700,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             form.to_dict(),
             length,
             container,
+            ak._util.native_byteorder,
             behavior,
             attrs,
         )
@@ -2518,7 +2520,7 @@ class Record(NDArrayOperatorsMixin):
             packed_layout.array,
             buffer_key="{form_key}-{attribute}",
             form_key="node{id}",
-            byteorder="<",
+            byteorder=ak._util.native_byteorder,
         )
 
         # For pickle >= 5, we can avoid copying the buffers
@@ -2539,6 +2541,7 @@ class Record(NDArrayOperatorsMixin):
             form.to_dict(),
             length,
             container,
+            ak._util.native_byteorder,
             behavior,
             attrs,
             packed_layout.at,

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -38,8 +38,8 @@ from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._operators import NDArrayOperatorsMixin
 from awkward._pickle import (
     custom_reduce,
-    unpickle_array_schema_1,
-    unpickle_record_schema_1,
+    unpickle_array_schema_2,
+    unpickle_record_schema_2,
 )
 from awkward._regularize import is_non_string_like_iterable
 from awkward._typing import Any, TypeVar
@@ -1696,7 +1696,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         else:
             attrs = without_transient_attrs(self._attrs)
 
-        return unpickle_array_schema_1, (
+        return unpickle_array_schema_2, (
             form.to_dict(),
             length,
             container,
@@ -2537,7 +2537,7 @@ class Record(NDArrayOperatorsMixin):
         else:
             attrs = without_transient_attrs(self._attrs)
 
-        return unpickle_record_schema_1, (
+        return unpickle_record_schema_2, (
             form.to_dict(),
             length,
             container,


### PR DESCRIPTION
If one pickles and unpickles in-memory in a big-endian system, it currently requires two copies. We prevent that by always pickling in the native byteorder. Also in that case, a pickle file created in a system of opposite endianess, will be unpickled incorrectly. We encode the endianess information of the system that the pickle was created inside the pickle so that the system doing the unpickling, knows what byteorder to use when interpreting the bytes.