### PR TITLE
ci: use self-hosted CI for codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
             cuda-version=13
             cuda-toolkit
             cxx-compiler
-            numba-cuda>=0.25,<=0.26
+            numba-cuda
             root=6.36.06
 
       - name: Generate build files

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,7 +59,7 @@ jobs:
           # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
           create-args: >-
             -c rapidsai
-            python='${{ env.PYTHON_VERSION }}'
+            python=${{ env.PYTHON_VERSION }}
             pandas>=0.24.0
             cccl-python
             cupy>=14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,22 +29,46 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Run Codecov
 
     env:
       PIP_ONLY_BINARY: cmake
       PYTHON_VERSION: "3.10"
 
+    # Required for miniconda to activate conda
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
+      - name: Clean the workspace and mamba
+        run: |
+          rm -rf * .[!.]* || echo "Nothing to clean"
+          rm -rf ~/micromamba* || echo "Nothing to clean"
+
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: 'Python ${{ env.PYTHON_VERSION }}'
-        uses: actions/setup-python@v6
+      - name: Get micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: '${{ env.PYTHON_VERSION }}'
+          environment-name: test-env
+          init-shell: bash
+          # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
+          create-args: >-
+            -c rapidsai
+            -c nvidia
+            python='${{ env.PYTHON_VERSION }}'
+            pandas>=0.24.0
+            cccl-python
+            cupy>=14
+            cuda-version=13
+            cuda-toolkit
+            cxx-compiler
+            numba-cuda>=0.25,<=0.26
+            root=6.36.06
 
       - name: Generate build files
         run: pipx run nox -s prepare -- --headers --signatures --tests
@@ -73,14 +97,30 @@ jobs:
         run: python -m pip list
 
       - name: Install test requirements
-        run: python -m pip install -v -r requirements-test-full.txt
+        run: python -m pip install -v -r requirements-test-full.txt -r requirements-test-gpu.txt
 
       - name: Test
         run: >-
           python -m pytest -vv -rs tests --cov=awkward --cov-report=term
-          --cov-report=xml
+          --cov-report=xml:non-cuda-coverage.xml --junitxml=junit.xml -o junit_family=legacy
+
+      - name: Test CUDA
+        run: >-
+          python -m pytest -vv -rs tests-cuda --ignore=tests-cuda/test_3459_virtualarray_with_cuda.py
+          --cov=awkward --cov-report=term --cov-report=xml:cuda-coverage.xml
+
+      - name: Test CUDA virtual arrays
+        run: >-
+          python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
+          --cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,6 +68,7 @@ jobs:
             cxx-compiler
             numba-cuda
             root=6.36.06
+            pipx
 
       - name: Generate build files
         run: pipx run nox -s prepare -- --headers --signatures --tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,7 +59,6 @@ jobs:
           # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
           create-args: >-
             -c rapidsai
-            -c nvidia
             python='${{ env.PYTHON_VERSION }}'
             pandas>=0.24.0
             cccl-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
-            numba-cuda>=0.25
+            numba-cuda>=0.25<=0.26
             ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Test CUDA virtual arrays
         run: >-
           python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
-          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml || '' }}
+          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml' || '' }}
 
       - name: Upload Codecov results
         if: matrix.cuda-version == 13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,6 +210,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
+            numba-cuda>=0.25
             ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }} && matrix.cuda-version == 13
+        if: ${{ !cancelled() && matrix.cuda-version == 13 }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Install awkward, awkward-cpp, and dependencies
         run: >-
           python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
-          -r "requirements-test-gpu.txt" ${{ matrix.cuda-version == 13 && '-r requirements-test-full.txt' || '' }}
+          -r requirements-test-gpu.txt ${{ matrix.cuda-version == 13 && '-r requirements-test-full.txt' || '' }}
 
       - name: Print versions
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,21 +156,13 @@ jobs:
 
       - name: Test non-kernels (Python)
         run: >-
-          python -m pytest -vv -rs tests --cov=awkward --cov-report=term
-          --cov-report=xml
-        if: startsWith(matrix.python-version, '3.')
+          python -m pytest -vv -rs tests
 
       - name: Test non-kernels (Python) in multiple threads
         if: matrix.python-version == '3.14t'
         run: |
           python -m pip install 'pytest-run-parallel>=0.8.2'
           python -m pytest -vv -rs tests --parallel-threads 4 --ignore=tests/test_3364_virtualarray.py --ignore=tests/test_3451_virtualarray_with_jax.py --ignore=tests/test_3475_virtualarray_unknown_length.py
-
-      - name: Upload Codecov results
-        if: (matrix.python-version == '3.10') && (matrix.runs-on == 'ubuntu-latest')
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   run-gpu-tests:
     name: Run GPU Tests
@@ -218,6 +210,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
+            ${{ matrix.cuda-version == 13 && 'root' || '' }}
 
       - name: Generate build files
         run: |
@@ -251,7 +244,7 @@ jobs:
       - name: Install awkward, awkward-cpp, and dependencies
         run: >-
           python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
-          -r "requirements-test-gpu.txt"
+          -r "requirements-test-gpu.txt" ${{ matrix.cuda-version == 13 && '-r requirements-test-full.txt' || '' }}
 
       - name: Print versions
         run: python -m pip list
@@ -262,13 +255,32 @@ jobs:
       - name: Test CUDA kernels with explicitly defined values
         run: python -m pytest -vv -rs tests-cuda-kernels-explicit
 
+      - name: Test non-kernels (Python)
+        if: matrix.cuda-version == 13
+        run: >-
+          python -m pytest -vv -rs tests --cov=awkward --cov-report=term
+          --cov-report=xml:non-cuda-coverage.xml --junitxml=junit.xml -o junit_family=legacy
+
       - name: Test CUDA non-kernel (Python)
         run: >-
           python -m pytest -vv -rs tests-cuda --ignore=tests-cuda/test_3459_virtualarray_with_cuda.py
+          --cov=awkward --cov-report=term --cov-report=xml:cuda-coverage.xml
 
       - name: Test CUDA virtual arrays
         run: >-
-          python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
+          python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py --cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml
+
+      - name: Upload Codecov results
+        if: matrix.cuda-version == 13
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   Linux-ROOT:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,11 +265,12 @@ jobs:
       - name: Test CUDA non-kernel (Python)
         run: >-
           python -m pytest -vv -rs tests-cuda --ignore=tests-cuda/test_3459_virtualarray_with_cuda.py
-          --cov=awkward --cov-report=term --cov-report=xml:cuda-coverage.xml
+          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-coverage.xml' || '' }}
 
       - name: Test CUDA virtual arrays
         run: >-
-          python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py --cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml
+          python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
+          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml || '' }}
 
       - name: Upload Codecov results
         if: matrix.cuda-version == 13
@@ -278,7 +279,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }} && matrix.cuda-version == 13
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
-            numba-cuda>=0.25<=0.26
+            numba-cuda>=0.25,<=0.26
             ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
-            ${{ matrix.cuda-version == 13 && 'root' || '' }}
+            ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cuda-toolkit
             cxx-compiler
-            numba-cuda>=0.25,<=0.26
+            numba-cuda
             ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,6 @@
 codecov:
   require_ci_to_pass: true
 
-ignore:
-  # Requires specialized hardware/env (GPU/CuPy)
-  - "awkward/src/awkward/_connect/cuda/**/*"
-  - "awkward/src/awkward/_nplikes/cupy.py"
-  # Requires ROOT installation
-  - "awkward/src/awkward/_connect/rdataframe/**/*"
-
 comment:
   layout: "files"
 


### PR DESCRIPTION
I changed the test workflow so that it runs the coverage on the self-hosted CI. This has two benefits. Now we can also see the coverage for the GPU part, and I also expect this to speed up the CI quite a bit.