### PR TITLE
fix: Numba-CUDA refactoring -- `CUDATargetContext` is spinned off to `FunctionDescriptor`

### DIFF
--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -124,9 +124,12 @@ def call(context, builder, fcn, args):
         builder.icmp_unsigned("!=", err, context.get_constant(numba.uint8, 0)),
         likely=False,
     ):
-        context.fndesc.call_conv.return_user_exc(
-            builder, ValueError, (fcn.name + " failed",)
+        call_conv = (
+            context.fndesc.call_conv
+            if context.__class__.__name__ == "CUDATargetContext"
+            else context.call_conv
         )
+        call_conv.return_user_exc(builder, ValueError, (fcn.name + " failed",))
 
 
 @numba.core.typing.templates.infer_global(len)

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -124,7 +124,9 @@ def call(context, builder, fcn, args):
         builder.icmp_unsigned("!=", err, context.get_constant(numba.uint8, 0)),
         likely=False,
     ):
-        context.call_conv.return_user_exc(builder, ValueError, (fcn.name + " failed",))
+        context.fndesc.call_conv.return_user_exc(
+            builder, ValueError, (fcn.name + " failed",)
+        )
 
 
 @numba.core.typing.templates.infer_global(len)

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -399,7 +399,12 @@ def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkb
                     builder.icmp_signed(">=", atval, length),
                 )
             ):
-                context.fndesc.call_conv.return_user_exc(
+                call_conv = (
+                    context.fndesc.call_conv
+                    if context.__class__.__name__ == "CUDATargetContext"
+                    else context.call_conv
+                )
+                call_conv.return_user_exc(
                     builder, ValueError, ("slice index out of bounds",)
                 )
 

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -399,7 +399,7 @@ def regularize_atval(context, builder, viewproxy, attype, atval, wrapneg, checkb
                     builder.icmp_signed(">=", atval, length),
                 )
             ):
-                context.call_conv.return_user_exc(
+                context.fndesc.call_conv.return_user_exc(
                     builder, ValueError, ("slice index out of bounds",)
                 )
 


### PR DESCRIPTION
Fixes #3842

@maxymnaumchyk - FYI