### PR TITLE
chore: delete nvidia channel from GPU ci as it is outdated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,6 @@ jobs:
           # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
           create-args: >-
             -c rapidsai
-            -c nvidia
             python=3.13
             pandas>=0.24.0
             cccl-python


### PR DESCRIPTION
CI error is a deprecation warning. Not an installation problem.