### PR TITLE
fix: return shallow copy of fields list when `.fields` is being accessed from highlevel array/record

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -588,7 +588,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         See also #ak.fields.
         """
-        return self._layout.fields
+        return self._layout.fields.copy()
 
     @property
     def is_tuple(self):
@@ -2063,7 +2063,7 @@ class Record(NDArrayOperatorsMixin):
 
         See also #ak.fields.
         """
-        return self._layout.array.fields
+        return self._layout.array.fields.copy()
 
     @property
     def is_tuple(self):

--- a/tests/test_3906_fields_access_returns_shallow_copy.py
+++ b/tests/test_3906_fields_access_returns_shallow_copy.py
@@ -1,0 +1,64 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_highlevel_array():
+    array = ak.Array(
+        {
+            "x": [1, 2, 3],
+            "y": [4, 5, 6],
+        }
+    )
+
+    fields = array.fields
+    assert fields == ["x", "y"]
+    fields.remove("x")
+    assert fields == ["y"]
+    assert array.fields == ["x", "y"]
+
+
+def test_lowlevel_layout():
+    layout = ak.contents.RecordArray(
+        [ak.contents.NumpyArray([1, 2, 3]), ak.contents.NumpyArray([4, 5, 6])],
+        ["x", "y"],
+    )
+
+    fields = layout.fields
+    assert fields == ["x", "y"]
+    fields.remove("x")
+    assert fields == ["y"]
+    assert layout.fields == ["y"]
+
+
+def test_highlevel_record():
+    record = ak.Record(
+        {
+            "x": 1,
+            "y": 4,
+        }
+    )
+
+    fields = record.fields
+    assert fields == ["x", "y"]
+    fields.remove("x")
+    assert fields == ["y"]
+    assert record.fields == ["x", "y"]
+
+
+def test_lowlevel_record():
+    record = ak.record.Record(
+        ak.contents.RecordArray(
+            [ak.contents.NumpyArray([1, 2, 3]), ak.contents.NumpyArray([4, 5, 6])],
+            ["x", "y"],
+        ),
+        0,
+    )
+
+    fields = record.fields
+    assert fields == ["x", "y"]
+    fields.remove("x")
+    assert fields == ["y"]
+    assert record.fields == ["y"]


### PR DESCRIPTION
prevents this which ruins the array:
```py
In [1]: import awkward as ak

In [2]: arr = ak.Array(
   ...:     {
   ...:         "x": [1, 2, 3],
   ...:         "y": [4, 5, 6],
   ...:     }
   ...: )
   ...:
   ...: print(arr.fields) # ['x', 'y']
['x', 'y']

In [3]: arr.fields.remove("x")
```
Which will mutate the layout of the array in-place.
Also matches the behavior of `ak.fields` which returns a shallow copy already:
https://github.com/scikit-hep/awkward/blob/6a8e21af4e1d2c2c42c4420888a3fd1404c59583/src/awkward/operations/ak_fields.py#L38-L40