### PR TITLE
fix: handle union array simplification returning back indexed arrays in `ak.almost_equal`

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -144,6 +144,9 @@ def _impl(
                 mergecastable="equiv" if dtype_exact else "family",
                 dropunused=True,
             )
+            # UnionArray simplifications can produce IndexedArrays
+            if left.is_indexed and not left.is_option:
+                left = left.project()
         if right.is_union:
             right = right.simplified(
                 right.tags,
@@ -154,6 +157,9 @@ def _impl(
                 mergecastable="equiv" if dtype_exact else "family",
                 dropunused=True,
             )
+            # UnionArray simplifications can produce IndexedArrays
+            if right.is_indexed and not right.is_option:
+                right = right.project()
 
         # Simplify regular NumPy types
         if left.is_numpy and left.purelist_depth > 1:

--- a/tests/properties/operations/test_to_from_buffers.py
+++ b/tests/properties/operations/test_to_from_buffers.py
@@ -8,33 +8,10 @@ from hypothesis import given, settings
 import awkward as ak
 
 
-@settings(max_examples=500)
-@given(a=st_ak.constructors.arrays(allow_union=False))
+@settings(max_examples=1000)
+@given(a=st_ak.constructors.arrays())
 def test_roundtrip(a: ak.Array) -> None:
-    """`to_buffers` followed by `from_buffers` reconstructs the array.
-
-    Union arrays are excluded because of known issues:
-
-    - Union arrays: `ak.array_equal` returns `False` for some empty union
-      arrays that are identical, e.g., `0 * union[unknown, (bool, bool)]`.
-
-    See `test_roundtrip_no_equality_check` for a separate test that includes
-    union arrays but only asserts that the roundtrip runs.
-    """
+    """`to_buffers` followed by `from_buffers` reconstructs the array."""
     sent = ak.to_buffers(a)
     returned = ak.from_buffers(*sent)
     assert ak.array_equal(a, returned)
-
-
-@settings(max_examples=500)
-@given(a=st_ak.constructors.arrays())
-def test_roundtrip_no_equality_check(a: ak.Array) -> None:
-    """`to_buffers` followed by `from_buffers` does not error.
-
-    This test includes all array types (including union arrays)
-    but does not assert equality because `ak.array_equal`
-    returns incorrect results for some union arrays.
-    See `test_roundtrip` for equality assertions on the supported subset.
-    """
-    sent = ak.to_buffers(a)
-    ak.from_buffers(*sent)


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3888,
Following https://github.com/scikit-hep/awkward/pull/3889, this tackles bug 2 of https://github.com/scikit-hep/awkward/issues/3888 
Equality can now properly be asserted in the property based testing so we remove the second test that didn't check for equality.