### PR TITLE
fix: `ak.array_equal` with datetimes and timedeltas with NaTs

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -221,7 +221,11 @@ def _impl(
             ):
                 return (
                     (left.dtype == right.dtype)
-                    and backend.nplike.all(left.data == right.data)
+                    and backend.nplike.array_equal(
+                        left.data,
+                        right.data,
+                        equal_nan=equal_nan,
+                    )
                     and left.shape == right.shape
                 )
             elif exact_eq:

--- a/tests/properties/operations/test_to_from_buffers.py
+++ b/tests/properties/operations/test_to_from_buffers.py
@@ -9,9 +9,9 @@ import awkward as ak
 
 
 @settings(max_examples=1000)
-@given(a=st_ak.constructors.arrays())
+@given(a=st_ak.constructors.arrays(allow_nan=True))
 def test_roundtrip(a: ak.Array) -> None:
     """`to_buffers` followed by `from_buffers` reconstructs the array."""
     sent = ak.to_buffers(a)
     returned = ak.from_buffers(*sent)
-    assert ak.array_equal(a, returned)
+    assert ak.array_equal(a, returned, equal_nan=True)

--- a/tests/test_3921_array_equal_datetime_and_timedelta.py
+++ b/tests/test_3921_array_equal_datetime_and_timedelta.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+
+
+def test():
+    array = ak.Array(np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[D]"))
+    assert ak.array_equal(array, array)
+
+    array1 = ak.Array(np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[D]"))
+    array2 = ak.Array(np.array(["2020-01-03", "2020-01-04"], dtype="datetime64[D]"))
+    assert not ak.array_equal(array1, array2)
+
+    array1 = ak.Array(np.array(["2020-01-01", "NaT"], dtype="datetime64[D]"))
+    array2 = ak.Array(np.array(["2020-01-01", "NaT"], dtype="datetime64[D]"))
+    assert not ak.array_equal(array1, array2, equal_nan=False)
+    assert ak.array_equal(array1, array2, equal_nan=True)


### PR DESCRIPTION
`backend.nplike.all(left.data == right.data)` does not respect `equal_nan=True`. We should use something that does like `backend.nplike.array_equal`