### PR TITLE
feat: add `ListOffsetArray_reduce_local` `nextparents_64` and `outoffsets_64` kernels implementations using cupy

### DIFF
--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -112,7 +112,7 @@ cuda_kernels_impl = [
     # "awkward_ListOffsetArray_reduce_local_nextparents_64",
     "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
     "awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64",
-    "awkward_ListOffsetArray_reduce_local_outoffsets_64",
+    # "awkward_ListOffsetArray_reduce_local_outoffsets_64",
     "awkward_UnionArray_flatten_length",
     "awkward_UnionArray_flatten_combine",
     "awkward_UnionArray_nestedfill_tags_index",

--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -109,7 +109,7 @@ cuda_kernels_impl = [
     "awkward_MaskedArray_getitem_next_jagged_project",
     "awkward_UnionArray_project",
     "awkward_ListOffsetArray_drop_none_indexes",
-    "awkward_ListOffsetArray_reduce_local_nextparents_64",
+    # "awkward_ListOffsetArray_reduce_local_nextparents_64",
     "awkward_ListOffsetArray_reduce_nonlocal_maxcount_offsetscopy_64",
     "awkward_ListOffsetArray_reduce_nonlocal_outstartsstops_64",
     "awkward_ListOffsetArray_reduce_local_outoffsets_64",

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -87,6 +87,7 @@ class CupyBackend(Backend):
         - awkward_prod_bool
         - awkward_count_64
         - awkward_countnonzero
+        - awkward_ListOffsetArray_reduce_local_nextparents_64
         """
         return kernel_name in (
             "awkward_sort",
@@ -100,6 +101,7 @@ class CupyBackend(Backend):
             "awkward_reduce_prod_bool",
             "awkward_reduce_count_64",
             "awkward_reduce_countnonzero",
+            "awkward_ListOffsetArray_reduce_local_nextparents_64",
         )
 
     def _get_cuda_compute_impl(self, kernel_name: str):
@@ -146,6 +148,9 @@ class CupyBackend(Backend):
 
         if kernel_name == "awkward_reduce_countnonzero":
             return cuda_compute.awkward_reduce_countnonzero
+
+        if kernel_name == "awkward_ListOffsetArray_reduce_local_nextparents_64":
+            return cuda_compute.awkward_ListOffsetArray_reduce_local_nextparents_64
 
         return None
 

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -88,6 +88,7 @@ class CupyBackend(Backend):
         - awkward_count_64
         - awkward_countnonzero
         - awkward_ListOffsetArray_reduce_local_nextparents_64
+        - awkward_ListOffsetArray_reduce_local_outoffsets_64
         """
         return kernel_name in (
             "awkward_sort",
@@ -102,6 +103,7 @@ class CupyBackend(Backend):
             "awkward_reduce_count_64",
             "awkward_reduce_countnonzero",
             "awkward_ListOffsetArray_reduce_local_nextparents_64",
+            "awkward_ListOffsetArray_reduce_local_outoffsets_64",
         )
 
     def _get_cuda_compute_impl(self, kernel_name: str):
@@ -151,6 +153,9 @@ class CupyBackend(Backend):
 
         if kernel_name == "awkward_ListOffsetArray_reduce_local_nextparents_64":
             return cuda_compute.awkward_ListOffsetArray_reduce_local_nextparents_64
+
+        if kernel_name == "awkward_ListOffsetArray_reduce_local_outoffsets_64":
+            return cuda_compute.awkward_ListOffsetArray_reduce_local_outoffsets_64
 
         return None
 

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -629,3 +629,26 @@ def awkward_reduce_countnonzero(
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
     unary_transform(segment_ids, result, segment_reduce_count_nonzero, outlength)
+
+
+# For each position j in nextparents, finds which list i it belongs to based on the offsets
+# Basically construct parents from offsets
+def awkward_ListOffsetArray_reduce_local_nextparents_64(
+    nextparents, offsets, length, nextparents_length
+):
+    nextparents_dtype = nextparents.dtype.type
+
+    # note: we iterate over j so that fill_nextparents() returns only one value as needed for unary_transform()
+    def fill_nextparents(j):
+        for i in range(length):
+            # offsets[0] is the `initialoffset`
+            start = offsets[i] - offsets[0]
+            # we iterate up until `nextparents_length` using unary_transform(), so we don't need to check j<nextparents_length
+            stop = offsets[i + 1] - offsets[0]
+            if start <= j < stop:
+                return nextparents_dtype(i)
+        # return -1 if there is an error (should never be returned)
+        return nextparents_dtype(-1)
+
+    segment_ids = CountingIterator(nextparents_dtype(0))
+    unary_transform(segment_ids, nextparents, fill_nextparents, nextparents_length)

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -636,19 +636,7 @@ def awkward_reduce_countnonzero(
 def awkward_ListOffsetArray_reduce_local_nextparents_64(
     nextparents, offsets, length, nextparents_length
 ):
-    nextparents_dtype = nextparents.dtype.type
-
-    # note: we iterate over j so that fill_nextparents() returns only one value as needed for unary_transform()
-    def fill_nextparents(j):
-        for i in range(length):
-            # offsets[0] is the `initialoffset`
-            start = offsets[i] - offsets[0]
-            # we iterate up until `nextparents_length` using unary_transform(), so we don't need to check j<nextparents_length
-            stop = offsets[i + 1] - offsets[0]
-            if start <= j < stop:
-                return nextparents_dtype(i)
-        # return -1 if there is an error (should never be returned)
-        return nextparents_dtype(-1)
-
-    segment_ids = CountingIterator(nextparents_dtype(0))
-    unary_transform(segment_ids, nextparents, fill_nextparents, nextparents_length)
+    # create indices [0, 1, ..., nextparents_length-1] shifted by the first offset (to handle non-zero starting offset)
+    indices = cp.arange(nextparents_length) + offsets[0]
+    # subtract one, so that indexing starts from 0
+    nextparents[:] = cp.searchsorted(offsets, indices, side="right") - 1

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -641,9 +641,12 @@ def awkward_ListOffsetArray_reduce_local_nextparents_64(
     # subtract one, so that indexing starts from 0
     nextparents[:] = cp.searchsorted(offsets, indices, side="right") - 1
 
+
 # Basically construct offsets from parents
-def awkward_ListOffsetArray_reduce_local_outoffsets_64(outoffsets, parents, lenparents, outlength):
+def awkward_ListOffsetArray_reduce_local_outoffsets_64(
+    outoffsets, parents, lenparents, outlength
+):
     # for each output index k, find the first position i where parents[i] >= k
-    outoffsets[:outlength] = cp.searchsorted(parents, cp.arange(outlength), side='left')
+    outoffsets[:outlength] = cp.searchsorted(parents, cp.arange(outlength), side="left")
     # the last offset gets lenparents
     outoffsets[outlength] = lenparents

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -640,3 +640,10 @@ def awkward_ListOffsetArray_reduce_local_nextparents_64(
     indices = cp.arange(nextparents_length) + offsets[0]
     # subtract one, so that indexing starts from 0
     nextparents[:] = cp.searchsorted(offsets, indices, side="right") - 1
+
+# Basically construct offsets from parents
+def awkward_ListOffsetArray_reduce_local_outoffsets_64(outoffsets, parents, lenparents, outlength):
+    # for each output index k, find the first position i where parents[i] >= k
+    outoffsets[:outlength] = cp.searchsorted(parents, cp.arange(outlength), side='left')
+    # the last offset gets lenparents
+    outoffsets[outlength] = lenparents


### PR DESCRIPTION
These kernels are deprecated and not needed anymore