### PR TITLE
docs: remove colour in intro cards

### DIFF
--- a/docs/_static/css/awkward.css
+++ b/docs/_static/css/awkward.css
@@ -27,7 +27,6 @@ html[data-theme="dark"] .sd-card {
 
 .intro-grid .sd-card-header {
   border: none;
-  color: #150458 !important;
   font-size: var(--pst-font-size-h5);
   font-weight: bold;
   padding: 2.5rem 0rem 0.5rem 0rem;


### PR DESCRIPTION
In dark mode, the docs intro cards look thus:

<img width="469" height="369" alt="image" src="https://github.com/user-attachments/assets/cdb17871-d680-45b4-94c0-8a6a840cd12c" />

We set this rule after inheriting it from SciPy, but I think that's no longer a good idea.