### PR TITLE
chore: upgrade hypothesis-awkward to >=0.10

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,5 +1,5 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-hypothesis-awkward>=0.6.1
+hypothesis-awkward>=0.10
 jax[cpu]>=0.2.15;sys_platform != "win32"
 numba>=0.50.0;sys_platform != "win32"
 numexpr>=2.7

--- a/tests/properties/operations/test_array_equal.py
+++ b/tests/properties/operations/test_array_equal.py
@@ -9,7 +9,7 @@ import awkward as ak
 
 
 @settings(max_examples=200)
-@given(a=st_ak.constructors.arrays(allow_nan=True))
+@given(a=st_ak.constructors.arrays())
 def test_reflexivity(a: ak.Array) -> None:
     """An array must be equal to itself."""
     assert ak.array_equal(a, a, equal_nan=True)
@@ -17,8 +17,8 @@ def test_reflexivity(a: ak.Array) -> None:
 
 @settings(max_examples=200)
 @given(
-    a1=st_ak.constructors.arrays(allow_nan=True),
-    a2=st_ak.constructors.arrays(allow_nan=True),
+    a1=st_ak.constructors.arrays(),
+    a2=st_ak.constructors.arrays(),
 )
 def test_symmetry(a1: ak.Array, a2: ak.Array) -> None:
     """Argument order must not affect the result."""

--- a/tests/properties/operations/test_to_from_buffers.py
+++ b/tests/properties/operations/test_to_from_buffers.py
@@ -9,7 +9,7 @@ import awkward as ak
 
 
 @settings(max_examples=1000)
-@given(a=st_ak.constructors.arrays(allow_nan=True))
+@given(a=st_ak.constructors.arrays())
 def test_roundtrip(a: ak.Array) -> None:
     """`to_buffers` followed by `from_buffers` reconstructs the array."""
     sent = ak.to_buffers(a)


### PR DESCRIPTION
## Summary
- Upgrade `hypothesis-awkward` from `>=0.6.1` to `>=0.10` in `requirements-test-full.txt`
- Remove explicit `allow_nan=True` from `st_ak.constructors.arrays()` calls, as it is now the default in `hypothesis-awkward>=0.10`

## Test plan
- [x] `python -m pytest tests/properties/ -v` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)