### PR TITLE
chore: pin hypothesis-awkward to exact version

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,5 +1,5 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-hypothesis-awkward>=0.10
+hypothesis-awkward==0.10.0
 jax[cpu]>=0.2.15;sys_platform != "win32"
 numba>=0.50.0;sys_platform != "win32"
 numexpr>=2.7


### PR DESCRIPTION
## Summary
- Pin `hypothesis-awkward` to an exact version (`==0.10.0`) in `requirements-test-full.txt` so that test failures from new versions surface in a dedicated upgrade PR rather than randomly in CI.

Newer versions of `hypothesis-awkward` produce more varied test samples, which means existing tests might fail with the new samples. Pinning ensures these failures appear in a deliberate upgrade PR rather than unexpectedly in unrelated CI runs.

Split from #3941. A separate workflow to auto-bump this pin will follow in a subsequent PR.

It would be great to merge this soon so that CI doesn't pick up a newer version of `hypothesis-awkward` before the pin is in place.

## Test plan
- [ ] Verify CI passes with the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)