### PR TITLE
ci: add workflow to auto-bump hypothesis-awkward

### DIFF
--- a/.github/workflows/bump-hypothesis-awkward.yml
+++ b/.github/workflows/bump-hypothesis-awkward.yml
@@ -1,0 +1,93 @@
+name: Bump hypothesis-awkward
+
+on:
+  schedule:
+    - cron: "0 15 * * 3" # Every Wednesday at 15:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          version=$(grep -oP 'hypothesis-awkward==\K[^[:space:]]+' requirements-test-full.txt)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest version from PyPI
+        id: latest
+        run: |
+          pypi_json=$(curl -sSf https://pypi.org/pypi/hypothesis-awkward/json)
+          version=$(echo "$pypi_json" | python3 -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Update requirements file
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        shell: python3 {0}
+        run: |
+          import os, pathlib, sys
+
+          current = os.environ["CURRENT"]
+          latest = os.environ["LATEST"]
+          path = pathlib.Path("requirements-test-full.txt")
+          text = path.read_text()
+
+          old = f"hypothesis-awkward=={current}"
+          new = f"hypothesis-awkward=={latest}"
+
+          if old not in text:
+              print(f"Expected '{old}' not found in requirements-test-full.txt", file=sys.stderr)
+              sys.exit(1)
+
+          path.write_text(text.replace(old, new))
+
+      - name: Open PR
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        run: |
+          branch="chore/bump-hypothesis-awkward-${LATEST}"
+
+          # Check if a PR already exists for this version
+          existing=$(gh pr list --head "$branch" --state open --json number --jq 'length')
+          if [ "$existing" -gt 0 ]; then
+            echo "PR already exists for $LATEST, skipping."
+            exit 0
+          fi
+
+          # Delete stale remote branch if it exists from a previous closed/merged PR
+          if git ls-remote --exit-code --heads origin "$branch" > /dev/null 2>&1; then
+            git push origin --delete "$branch"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+
+          git add requirements-test-full.txt
+          git commit -m "chore: bump hypothesis-awkward from ${CURRENT} to ${LATEST}"
+          git push -u origin "$branch"
+
+          gh pr create \
+            --title "chore: bump hypothesis-awkward from ${CURRENT} to ${LATEST}" \
+            --body "Automated bump of \`hypothesis-awkward\` from \`${CURRENT}\` to \`${LATEST}\`.
+
+          Release: https://pypi.org/project/hypothesis-awkward/${LATEST}/
+
+          This PR was created automatically by the [bump-hypothesis-awkward](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/bump-hypothesis-awkward.yml) workflow."


### PR DESCRIPTION
## Summary
- Add a scheduled GitHub Actions workflow (`bump-hypothesis-awkward.yml`) that checks PyPI once a week and opens a PR when a new version of `hypothesis-awkward` is available.

Split from #3941. Dependabot's `pip` ecosystem cannot watch a single requirements file — it picks up all requirement files in a directory. This workflow is a targeted alternative that only watches `hypothesis-awkward`.

Depends on the pin introduced in #3942.

## Test plan
- [ ] Verify the workflow runs successfully via `workflow_dispatch`
- [ ] Confirm a PR is opened when a newer version of `hypothesis-awkward` is published
- [ ] Confirm no duplicate PR is created if one already exists for the same version

🤖 Generated with [Claude Code](https://claude.com/claude-code)