### PR TITLE
ci: add dependabot config for hypothesis-awkward

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
       actions:
         patterns:
           - "*"
+
+  # Bump hypothesis-awkward, which is pinned to an exact version in
+  # requirements-test-full.txt. Newer versions produce more varied test
+  # samples, so existing tests might fail. Pinning + dependabot ensures
+  # those failures surface in a dedicated upgrade PR rather than
+  # randomly in unrelated CI runs.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "hypothesis-awkward"


### PR DESCRIPTION
## Summary

Alternative solution to #3943, as suggested by @ariostas — use dependabot instead of a custom workflow.

This builds on #3942, which pinned `hypothesis-awkward` to an exact version. This PR adds a dependabot config to automatically propose version bumps.

The current dependabot config only watches GitHub Actions, not pip. This PR enables the `pip` ecosystem with `allow: [{dependency-name: "hypothesis-awkward"}]`. Dependabot will scan all requirement files in the repository but will only create PRs for `hypothesis-awkward`. Currently, `hypothesis-awkward` appears only in `requirements-test-full.txt`, so this is sufficient.

If this works, we can close #3943.

We will need to revisit this approach if we need to watch more pinned packages in the future — dependabot scans all requirement files, so packages pinned intentionally to old versions in other files (e.g., `requirements-test-minimal.txt`) would need to be handled carefully.

## Test plan
- [ ] Verify dependabot picks up `hypothesis-awkward` and proposes a PR when a new version is available
- [ ] Verify dependabot does not propose updates for other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)