### PR TITLE
docs: update ak.flatten docstring to Google style

### DIFF
--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -21,7 +21,7 @@ np = NumpyMetadata.instance()
 
 @high_level_function()
 def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
-    """Removes one level of nesting by merging consecutive lists.
+    """Returns an array with one or all levels of nesting removed.
 
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -133,7 +133,6 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         </NumpyArray>
 
         However, it is important to keep in mind that this is a special case:
-
         #ak.flatten and `content` are not interchangeable!
 
         >>> array = ak.Array(

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -21,7 +21,8 @@ np = NumpyMetadata.instance()
 
 @high_level_function()
 def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
-    """
+    """Removes one level of nesting by merging consecutive lists.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, the operation flattens all levels of
@@ -41,12 +42,14 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns an array with one level of nesting removed by erasing the
-    boundaries between consecutive lists. Since this operates on a level of
-    nesting, `axis=0` is a special case that only removes values at the
-    top level that are equal to None.
+    Returns:
+        An array with one level of nesting removed by erasing the
+        boundaries between consecutive lists. Since this operates on a level of
+        nesting, `axis=0` is a special case that only removes values at the
+        top level that are equal to None.
 
-    Consider the following.
+    Examples:
+        Consider the following.
 
         >>> array = ak.Array([[[1.1, 2.2, 3.3],
         ...                    [],
@@ -57,8 +60,8 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         ...                    [8.8, 9.9]
         ...                   ]])
 
-    At `axis=1`, the outer lists (length 4, length 0, length 2) become a single
-    list (of length 6).
+        At `axis=1`, the outer lists (length 4, length 0, length 2) become a single
+        list (of length 6).
 
         >>> ak.flatten(array, axis=1).show()
         [[1.1, 2.2, 3.3],
@@ -68,17 +71,17 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
          [7.7],
          [8.8, 9.9]]
 
-    At `axis=2`, the inner lists (lengths 3, 0, 2, 1, 1, and 2) become three
-    lists (of lengths 6, 0, and 3).
+        At `axis=2`, the inner lists (lengths 3, 0, 2, 1, 1, and 2) become three
+        lists (of lengths 6, 0, and 3).
 
         >>> ak.flatten(array, axis=2).show()
         [[1.1, 2.2, 3.3, 4.4, 5.5, 6.6],
          [],
          [7.7, 8.8, 9.9]]
 
-    There's also an option to completely flatten the array with `axis=None`.
-    This is useful for passing the data to a function that doesn't care about
-    nested structure, such as a plotting routine.
+        There's also an option to completely flatten the array with `axis=None`.
+        This is useful for passing the data to a function that doesn't care about
+        nested structure, such as a plotting routine.
 
         >>> ak.flatten(array, axis=None).show()
         [1.1,
@@ -91,22 +94,22 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
          8.8,
          9.9]
 
-    Missing values are eliminated by flattening: there is no distinction
-    between an empty list and a value of None at the level of flattening.
+        Missing values are eliminated by flattening: there is no distinction
+        between an empty list and a value of None at the level of flattening.
 
         >>> array = ak.Array([[1.1, 2.2, 3.3], None, [4.4], [], [5.5]])
         >>> ak.flatten(array, axis=1)
         <Array [1.1, 2.2, 3.3, 4.4, 5.5] type='5 * float64'>
 
-    As a consequence, flattening at `axis=0` does only one thing: it removes
-    None values from the top level.
+        As a consequence, flattening at `axis=0` does only one thing: it removes
+        None values from the top level.
 
         >>> ak.flatten(array, axis=0)
         <Array [[1.1, 2.2, 3.3], [4.4], [], [5.5]] type='4 * var * float64'>
 
-    As a technical detail, the flattening operation can be trivial in a common
-    case, #ak.contents.ListOffsetArray in which the first `offset` is `0`.
-    In that case, the flattened data is simply the array node's `content`.
+        As a technical detail, the flattening operation can be trivial in a common
+        case, #ak.contents.ListOffsetArray in which the first `offset` is `0`.
+        In that case, the flattened data is simply the array node's `content`.
 
         >>> array = ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
         >>> array.layout
@@ -129,9 +132,9 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
             [0.  1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9]
         </NumpyArray>
 
-    However, it is important to keep in mind that this is a special case:
+        However, it is important to keep in mind that this is a special case:
 
-    #ak.flatten and `content` are not interchangeable!
+        #ak.flatten and `content` are not interchangeable!
 
         >>> array = ak.Array(
         ...     ak.contents.ListArray(


### PR DESCRIPTION
## Summary

In today's awkward-uproot meeting, updating all docstrings in
`src/awkward/operations/` to conform to Google style was discussed, using
Claude Code for the updates.

This PR is a pilot — it updates only `ak.flatten` to collect feedback on the
approach before proceeding with the rest. The changes are intentionally
minimal: the original text is preserved as much as possible, with only
structural edits to conform to the style:

- Add a one-line summary
- Add `Returns:` and `Examples:` section headers
- Indent narrative text under `Examples:`

If this looks good, more PRs will follow for the remaining operations.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>