### PR TITLE
fix: indent Google-style summary lines in prepare_docstrings.py

### DIFF
--- a/docs/prepare_docstrings.py
+++ b/docs/prepare_docstrings.py
@@ -177,6 +177,15 @@ def dodoc(docstring, qualname, names):
     out = re.sub(r"(\n:type|^:type)", "\n    :type", out)
     out = re.sub(r"(\n:returns|^:returns)", "\n    :returns", out)
     out = re.sub(r"(\n:raises|^:raises)", "\n    :raises", out)
+    # Indent summary lines (text before the first :param directive) so they
+    # sit inside the .. py:function:: / .. py:class:: RST directive.
+    # Only matches when there is non-whitespace text before the first :param.
+    out = re.sub(
+        r"^(\S[^\n]*(?:\n(?! *:param| *:type)\S[^\n]*)*)(\n\n? *:param)",
+        lambda m: re.sub(r"(?m)^(?=\S)", "    ", m.group(1)) + m.group(2),
+        out,
+        count=1,
+    )
     return out
 
 
@@ -383,6 +392,50 @@ test_signature_pos_or_kw()
 test_signature_kwarg()
 test_signature_vararg()
 test_signature_kwonly()
+
+
+def test_dodoc_no_summary():
+    """Existing format (no summary line) should be unchanged."""
+    docstring = (
+        "Args:\n"
+        "    array: Array-like data.\n"
+        "    axis (int): The axis to flatten.\n"
+        "\n"
+        "Returns an array with one level removed."
+    )
+    result = dodoc(docstring, "ak.test", [])
+    # :param lines should be indented
+    assert "\n    :param array:" in result
+    assert "\n    :param axis:" in result
+    # Free-text return description should NOT be indented (existing behavior)
+    assert "\nReturns an array with one level removed." in result
+    assert "\n    Returns an array" not in result
+
+
+def test_dodoc_with_summary():
+    """Google-style summary line should be indented."""
+    docstring = (
+        "Removes one level of nesting.\n"
+        "\n"
+        "Args:\n"
+        "    array: Array-like data.\n"
+        "    axis (int): The axis to flatten.\n"
+        "\n"
+        "Returns:\n"
+        "    An array with one level removed."
+    )
+    result = dodoc(docstring, "ak.test", [])
+    lines = result.split("\n")
+    # Summary should be indented with 4 spaces
+    assert lines[0] == "    Removes one level of nesting."
+    # :param lines should be indented
+    assert "\n    :param array:" in result
+    # :returns should be indented
+    assert "\n    :returns:" in result
+
+
+test_dodoc_no_summary()
+test_dodoc_with_summary()
 
 
 toctree_path = reference_path / "toctree.txt"

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -21,7 +21,8 @@ np = NumpyMetadata.instance()
 
 @high_level_function()
 def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
-    """
+    """Removes one level of nesting by merging consecutive lists.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, the operation flattens all levels of
@@ -41,12 +42,14 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns an array with one level of nesting removed by erasing the
-    boundaries between consecutive lists. Since this operates on a level of
-    nesting, `axis=0` is a special case that only removes values at the
-    top level that are equal to None.
+    Returns:
+        An array with one level of nesting removed by erasing the
+        boundaries between consecutive lists. Since this operates on a level of
+        nesting, `axis=0` is a special case that only removes values at the
+        top level that are equal to None.
 
-    Consider the following.
+    Examples:
+        Consider the following.
 
         >>> array = ak.Array([[[1.1, 2.2, 3.3],
         ...                    [],
@@ -57,8 +60,8 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         ...                    [8.8, 9.9]
         ...                   ]])
 
-    At `axis=1`, the outer lists (length 4, length 0, length 2) become a single
-    list (of length 6).
+        At `axis=1`, the outer lists (length 4, length 0, length 2) become a single
+        list (of length 6).
 
         >>> ak.flatten(array, axis=1).show()
         [[1.1, 2.2, 3.3],
@@ -68,17 +71,17 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
          [7.7],
          [8.8, 9.9]]
 
-    At `axis=2`, the inner lists (lengths 3, 0, 2, 1, 1, and 2) become three
-    lists (of lengths 6, 0, and 3).
+        At `axis=2`, the inner lists (lengths 3, 0, 2, 1, 1, and 2) become three
+        lists (of lengths 6, 0, and 3).
 
         >>> ak.flatten(array, axis=2).show()
         [[1.1, 2.2, 3.3, 4.4, 5.5, 6.6],
          [],
          [7.7, 8.8, 9.9]]
 
-    There's also an option to completely flatten the array with `axis=None`.
-    This is useful for passing the data to a function that doesn't care about
-    nested structure, such as a plotting routine.
+        There's also an option to completely flatten the array with `axis=None`.
+        This is useful for passing the data to a function that doesn't care about
+        nested structure, such as a plotting routine.
 
         >>> ak.flatten(array, axis=None).show()
         [1.1,
@@ -91,22 +94,22 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
          8.8,
          9.9]
 
-    Missing values are eliminated by flattening: there is no distinction
-    between an empty list and a value of None at the level of flattening.
+        Missing values are eliminated by flattening: there is no distinction
+        between an empty list and a value of None at the level of flattening.
 
         >>> array = ak.Array([[1.1, 2.2, 3.3], None, [4.4], [], [5.5]])
         >>> ak.flatten(array, axis=1)
         <Array [1.1, 2.2, 3.3, 4.4, 5.5] type='5 * float64'>
 
-    As a consequence, flattening at `axis=0` does only one thing: it removes
-    None values from the top level.
+        As a consequence, flattening at `axis=0` does only one thing: it removes
+        None values from the top level.
 
         >>> ak.flatten(array, axis=0)
         <Array [[1.1, 2.2, 3.3], [4.4], [], [5.5]] type='4 * var * float64'>
 
-    As a technical detail, the flattening operation can be trivial in a common
-    case, #ak.contents.ListOffsetArray in which the first `offset` is `0`.
-    In that case, the flattened data is simply the array node's `content`.
+        As a technical detail, the flattening operation can be trivial in a common
+        case, #ak.contents.ListOffsetArray in which the first `offset` is `0`.
+        In that case, the flattened data is simply the array node's `content`.
 
         >>> array = ak.Array([[0.0, 1.1, 2.2], [], [3.3, 4.4], [5.5], [6.6, 7.7, 8.8, 9.9]])
         >>> array.layout
@@ -129,8 +132,8 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
             [0.  1.1 2.2 3.3 4.4 5.5 6.6 7.7 8.8 9.9]
         </NumpyArray>
 
-    However, it is important to keep in mind that this is a special case:
-    #ak.flatten and `content` are not interchangeable!
+        However, it is important to keep in mind that this is a special case:
+        #ak.flatten and `content` are not interchangeable!
 
         >>> array = ak.Array(
         ...     ak.contents.ListArray(


### PR DESCRIPTION
## Summary

Sphinx supports Google-style docstrings via `sphinx.ext.napoleon`. However,
Awkward doesn't use it in the standard way. Because Awkward has compiled C++
extensions (`awkward-cpp`), the docs can't import the package at build time
as `sphinx.ext.autodoc` requires. Instead, `docs/prepare_docstrings.py`
parses source files with `ast` and calls `sphinx.ext.napoleon.GoogleDocstring`
directly, then applies regex-based transforms for cross-references, code
blocks, and directive indentation (see #187, #158).

This custom processor indents `:param`, `:type`, `:returns`, and `:raises`
directives to sit inside the RST `.. py:function::` block, but it did not
handle Google-style summary lines. Napoleon outputs summary text at column 0,
causing it to render outside the function directive in the built docs. This
is likely why summary lines have been absent from Awkward docstrings.

This PR adds a targeted regex to `dodoc()` that indents only the summary
paragraph (non-whitespace text before the first `:param` directive) by 4
spaces. The regex is scoped narrowly to avoid affecting docstrings without
a summary line.

### Tests

Two `dodoc()` unit tests are added, following the existing `test_signature_*`
pattern:
- `test_dodoc_no_summary` — verifies existing format is unchanged (no
  regression)
- `test_dodoc_with_summary` — verifies the summary line is indented

### Full document comparison

All RST files were regenerated with and without the fix and diffed. The only
difference across the entire generated documentation was the intended change:
the summary line in `ak.flatten.rst` gaining 4-space indentation.

This branch includes the commit from #3946 (`ak.flatten` docstring update).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>