### PR TITLE
fix: consistent byteorder settings

### DIFF
--- a/src/awkward/_do.py
+++ b/src/awkward/_do.py
@@ -78,7 +78,7 @@ def to_buffers(
     form_key: str | None = "node{id}",
     id_start: Integral = 0,
     backend: Backend | None = None,
-    byteorder: Literal["<", ">"] = "<",
+    byteorder: Literal["<", ">"] = ak._util.native_byteorder,
 ) -> tuple[form.Form, int, Mapping[str, Any]]:
     if container is None:
         container = {}

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -34,7 +34,7 @@ def from_buffers(
     buffer_key="{form_key}-{attribute}",
     *,
     backend="cpu",
-    byteorder="<",
+    byteorder=ak._util.native_byteorder,
     allow_noncanonical_form=False,
     enable_virtualarray_caching=True,
     highlevel=True,

--- a/tests/test_2067_to_buffers_byteorder.py
+++ b/tests/test_2067_to_buffers_byteorder.py
@@ -20,8 +20,8 @@ def test_byteorder():
 def test_byteorder_default():
     array = ak.Array([[[1, 2, 3], [4, 5], None, "hi"]])
 
-    _, _, container_little = ak.to_buffers(array, byteorder="<")
+    _, _, container_native = ak.to_buffers(array, byteorder=ak._util.native_byteorder)
     _, _, container_default = ak.to_buffers(array)
 
-    for name, buffer in container_little.items():
+    for name, buffer in container_native.items():
         assert buffer.tobytes() == container_default[name].tobytes()

--- a/tests/test_2305_nep_18_lazy_conversion.py
+++ b/tests/test_2305_nep_18_lazy_conversion.py
@@ -9,8 +9,11 @@ import awkward as ak
 
 
 def test_binary():
-    ak_array = ak.Array(np.arange(10, dtype="<u4"))
-    np_array = np.arange(10, dtype=">u4")
+    # awkward expects native byteorder
+    dtype = np.dtype("u4")
+    ak_array = ak.Array(np.arange(10, dtype=dtype))
+    np_array = np.arange(10, dtype=dtype.newbyteorder("S"))
+    breakpoint()
     with pytest.raises(TypeError):
         # ak.array_equal now overrides np.array_equal, and requires
         # both arrays to be valid within awkward.

--- a/tests/test_2305_nep_18_lazy_conversion.py
+++ b/tests/test_2305_nep_18_lazy_conversion.py
@@ -13,7 +13,6 @@ def test_binary():
     dtype = np.dtype("u4")
     ak_array = ak.Array(np.arange(10, dtype=dtype))
     np_array = np.arange(10, dtype=dtype.newbyteorder("S"))
-    breakpoint()
     with pytest.raises(TypeError):
         # ak.array_equal now overrides np.array_equal, and requires
         # both arrays to be valid within awkward.


### PR DESCRIPTION
Making a few changes to have consistent byteorder settings in the codebase.

First of all, `ak.to_buffers` defaults to native byteorder here: https://github.com/scikit-hep/awkward/blob/864018464d3100e660da6e7c30663795abed2d29/src/awkward/operations/ak_to_buffers.py#L24
We do the same for `ak._do.to_buffers` (which is used inside `ak.to_buffers`) for consistency even though it's semi-public API.

Secondly, buffers are generally native (always or almost always) as they are in-memory. Therefore `ak.to_buffers` should have the same defaults as `ak.to_buffers`. `ak.from_buffers(*ak.to_buffers(...))` should just work on all systems. One shouldn't have to specify `ak.from_buffers(*ak.to_buffers(...), byteorder=ak._util.native_byteorder)` in order for this to work on a big-endian system for example.

And finally, awkward expects arrays/dtypes to be in native byteorder when the `NumpyArray` and `Index` classes are constructed as wrappers around the buffers. We modify the naming in the tests to express just that as the default in awkward internally is not "little". It's "native".

All of these changes are no-ops for little endian systems as `ak._util.native_byteorder` is `"<"`. But they make byteorder settings more self-consistent in the codebase and make these ops that depend on byteorder seamless in big endian systems without one having to specify `byteorder=">"` explicitly just because they are on a different system.