### PR TITLE
feat: add awkward.* aliases to objects.inv for intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -404,6 +404,38 @@ def _skip_member(app, what, name, obj, skip, options):
     return skip
 
 
+def _add_awkward_inventory_aliases(app, exception):
+    """Duplicate ak.* inventory entries as awkward.* so intersphinx works.
+
+    Downstream projects that annotate ``awkward.Array`` (resolved from
+    ``import awkward as ak``) need ``awkward.*`` entries in objects.inv.
+    See https://github.com/scikit-hep/awkward/issues/3950.
+    """
+    if exception:
+        return
+    import zlib
+
+    inv_path = os.path.join(app.outdir, "objects.inv")
+    with open(inv_path, "rb") as f:
+        # Read the 4-line header verbatim
+        header = b"".join(f.readline() for _ in range(4))
+        # Decompress the body
+        body = zlib.decompress(f.read()).decode("utf-8")
+
+    extra_lines = []
+    for line in body.splitlines():
+        name = line.split(" ", 1)[0]
+        if name.startswith("ak."):
+            extra_lines.append("awkward." + line[3:])
+
+    if extra_lines:
+        new_body = body.rstrip("\n") + "\n" + "\n".join(extra_lines) + "\n"
+        with open(inv_path, "wb") as f:
+            f.write(header)
+            f.write(zlib.compress(new_body.encode("utf-8")))
+
+
 def setup(app):
     app.connect("html-page-context", install_jupyterlite_styles)
     app.connect("autoapi-skip-member", _skip_member)
+    app.connect("build-finished", _add_awkward_inventory_aliases)

--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -175,6 +175,7 @@ def flatten(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
          1.1,
          2.2,
          999]
+
     """
     # Dispatch
     yield (array,)


### PR DESCRIPTION
## Summary

- Post-process the Sphinx inventory after build to duplicate `ak.*` entries as `awkward.*`, so downstream projects can resolve intersphinx cross-references like `awkward.Array`
- Closes #3950

## Motivation

Downstream projects that use type annotations like `ak.Array` or `ak.contents.RegularArray` have their documentation tools (mkdocstrings, sphinx-autodoc, etc.) resolve these to the fully qualified `awkward.*` names. Since the inventory only contained `ak.*` entries, cross-reference lookups failed silently — no links were generated.

With this change, a downstream project like hypothesis-awkward can write:

```python
def arrays(draw, *, regulararray: bool) -> ak.Array:
```

and its API reference will automatically link `ak.Array` to the Awkward Array documentation. Similarly, references like `[RegularArray][ak.contents.RegularArray]` will resolve correctly.

## Details

A `build-finished` Sphinx event handler reads the generated `objects.inv`, duplicates each `ak.*` entry with an `awkward.*` prefix pointing to the same URL, and writes it back.

## Test plan

- [x] Built docs locally with `sphinx-build -M html . _build -D nb_execution_mode=off`
- [x] Verified `objects.inv` contains `awkward.Array`, `awkward.Record`, `awkward.flatten` entries
- [x] Confirmed a downstream project's intersphinx resolves `awkward.Array` against the local inventory

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>