### PR TITLE
fix: couple of fixes in tests that arose from running them in parallel threads

### DIFF
--- a/tests/test_2106_pickle_class.py
+++ b/tests/test_2106_pickle_class.py
@@ -15,7 +15,7 @@ import awkward as ak
 
 @contextlib.contextmanager
 def temporary_module():
-    name = str(uuid.uuid1()).replace("-", "_")
+    name = "_" + uuid.uuid4().hex
     module = types.ModuleType(name)
     sys.modules[name] = module
     yield module

--- a/tests/test_3685_to_from_safetensors.py
+++ b/tests/test_3685_to_from_safetensors.py
@@ -2,25 +2,21 @@
 #
 from __future__ import annotations
 
-import os
-
 import pytest
 
 safetensors = pytest.importorskip("safetensors")
 
 
-def test_roundtrip():
+def test_roundtrip(tmp_path):
     import awkward as ak
 
     array = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
 
-    path = "./test.safetensors"
+    path = str(tmp_path / "test.safetensors")
     ak.to_safetensors(array, path)
 
     loaded = ak.from_safetensors(path)
     virtual_loaded = ak.from_safetensors(path, virtual=True)
-
-    os.remove(path)
 
     assert array.layout.is_equal_to(loaded.layout, all_parameters=True)
     assert array.layout.is_equal_to(
@@ -28,21 +24,19 @@ def test_roundtrip():
     )
 
 
-def test_virtual_array_to_safetensors():
+def test_virtual_array_to_safetensors(tmp_path):
     import awkward as ak
 
     array = ak.Array([[1, 2, 3], [], [4, 5], [6], [7, 8, 9, 10]])
 
-    path = "./test_virtual{}.safetensors".format
+    path0 = str(tmp_path / "test_virtual0.safetensors")
+    path1 = str(tmp_path / "test_virtual1.safetensors")
 
-    ak.to_safetensors(array, path(0))
-    virtual_loaded = ak.from_safetensors(path(0), virtual=True)
+    ak.to_safetensors(array, path0)
+    virtual_loaded = ak.from_safetensors(path0, virtual=True)
 
-    ak.to_safetensors(virtual_loaded, path(1))
-    loaded = ak.from_safetensors(path(1), virtual=False)
-
-    os.remove(path(0))
-    os.remove(path(1))
+    ak.to_safetensors(virtual_loaded, path1)
+    loaded = ak.from_safetensors(path1, virtual=False)
 
     assert virtual_loaded.layout.materialize().is_equal_to(
         loaded.layout, all_parameters=True


### PR DESCRIPTION
`uuid1` is not thread safe as it says it "Generate a UUID from a host ID, sequence number, and the current time according" so two threads can happily generate the same UUID. Using `uuid4` is much better and it's practically impossible to have two threads generate the same UUID.

For the safe tensors tests, we just use temporary files so there are no file clashes between threads.