### PR TITLE
fix: proper comparison in `ak.almost_equal` between record array fields

### DIFF
--- a/src/awkward/operations/ak_almost_equal.py
+++ b/src/awkward/operations/ak_almost_equal.py
@@ -304,7 +304,8 @@ def _impl(
                     or not check_parameters
                 )
                 and left.is_tuple == right.is_tuple
-                and (left.is_tuple or (len(left.fields) == len(right.fields)))
+                and len(left.fields) == len(right.fields)
+                and (left.is_tuple or set(left.fields) == set(right.fields))
                 and all(visitor(left.content(f), right.content(f)) for f in left.fields)
             )
         elif left.is_unknown and right.is_unknown:

--- a/tests/test_3962_array_equal_record_mismatch.py
+++ b/tests/test_3962_array_equal_record_mismatch.py
@@ -1,0 +1,21 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import awkward as ak
+
+
+def test_tuple_different_arity():
+    a1 = ak.Array([(1,), (2,)])
+    a2 = ak.Array([(1, 10), (2, 20)])
+
+    assert ak.array_equal(a1, a2) is False
+    assert ak.array_equal(a2, a1) is False
+
+
+def test_record_different_field_names():
+    a1 = ak.Array([{"x": 1}, {"x": 2}])
+    a2 = ak.Array([{"y": 1}, {"y": 2}])
+
+    assert ak.array_equal(a1, a2) is False
+    assert ak.array_equal(a2, a1) is False

--- a/tests/test_3962_array_equal_record_mismatch.py
+++ b/tests/test_3962_array_equal_record_mismatch.py
@@ -19,3 +19,11 @@ def test_record_different_field_names():
 
     assert ak.array_equal(a1, a2) is False
     assert ak.array_equal(a2, a1) is False
+
+
+def test_record_field_order_insensitive():
+    a1 = ak.Array([{"x": 1, "y": 10}, {"x": 2, "y": 20}])
+    a2 = ak.Array([{"y": 10, "x": 1}, {"y": 20, "x": 2}])
+
+    assert ak.array_equal(a1, a2) is True
+    assert ak.array_equal(a2, a1) is True

--- a/tests/test_3962_array_equal_record_mismatch.py
+++ b/tests/test_3962_array_equal_record_mismatch.py
@@ -21,6 +21,14 @@ def test_record_different_field_names():
     assert ak.array_equal(a2, a1) is False
 
 
+def test_tuple_vs_record_same_arity():
+    a1 = ak.Array([(1,), (2,)])
+    a2 = ak.Array([{"0": 1}, {"0": 2}])
+
+    assert ak.array_equal(a1, a2) is False
+    assert ak.array_equal(a2, a1) is False
+
+
 def test_record_field_order_insensitive():
     a1 = ak.Array([{"x": 1, "y": 10}, {"x": 2, "y": 20}])
     a2 = ak.Array([{"y": 10, "x": 1}, {"y": 20, "x": 2}])


### PR DESCRIPTION
Yet another `ak.almost_equal` problem regarding comparing record arrays this time.
Comparing tuple vs non-tuple record arrays and the number of names of fields within them was not done right.