### PR TITLE
docs: show private members in autoapi-generated docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ autoapi_ignore = []
 autoapi_options = [
     "members",
     "undoc-members",
+    "private-members",
     "show-module-summary",
     "imported-members",
 ]
@@ -387,10 +388,12 @@ def _skip_member(app, what, name, obj, skip, options):
     # Keep the top-level awkward package
     if name == "awkward":
         return False
-    # Skip private modules (awkward._*)
-    parts = name.split(".")
-    if any(part.startswith("_") for part in parts):
-        return True
+    # Skip private modules (awkward._*) but not private methods/attributes
+    # within public classes (those are controlled by the "private-members" option)
+    if what in ("module", "package"):
+        parts = name.split(".")
+        if any(part.startswith("_") for part in parts):
+            return True
     # Skip internal submodules that would collide with class pages on
     # case-insensitive filesystems (e.g., ak.contents.recordarray vs
     # ak.contents.RecordArray). The class is re-exported at the package


### PR DESCRIPTION
## Summary

In today's awkward-uproot meeting, it was pointed out that private methods
and attributes are no longer shown on class pages after switching to
`sphinx-autoapi` (#3948).

This was because the `_skip_member` hook skipped all names containing
`_`-prefixed parts, overriding the `"private-members"` autoapi option.

This PR:
- Adds `"private-members"` to `autoapi_options`
- Narrows the `_skip_member` hook to only skip private **modules** (like
  `awkward._ext`), not private methods/attributes within public classes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>