### PR TITLE
ci: use reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  change-detection:
+    uses: ./.github/workflows/reusable-change-detection.yml
+
+  tests:
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-tests)
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
+
+  header-only-tests:
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-header-only-tests)
+    uses: ./.github/workflows/reusable-header-only-test.yml
+
+  coverage:
+    uses: ./.github/workflows/reusable-coverage.yml
+
+  docs:
+    uses: ./.github/workflows/reusable-docs.yml
+
+  pass:
+    if: always()
+    needs:
+      - change-detection
+      - tests
+      - header-tests
+      - coverage
+      - docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: >-
+            ${{
+              fromJSON(needs.change-detection.outputs.run-tests)
+              && ''
+              || '
+              tests,
+              '
+            }} ${{
+              fromJSON(needs.change-detection.outputs.run-header-only-tests)
+              && ''
+              || '
+              header-only-tests,
+              '
+            }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
 
   tests:
     needs: change-detection
-    #if: fromJSON(needs.change-detection.outputs.run-tests)
+    if: fromJSON(needs.change-detection.outputs.run-tests)
     uses: ./.github/workflows/reusable-test.yml
-    #with:
-    #  run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
+    with:
+     run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
   build-wheels:
     needs: change-detection
-    #if: fromJSON(needs.change-detection.outputs.build-wheels)
+    if: fromJSON(needs.change-detection.outputs.build-wheels)
     uses: ./.github/workflows/reusable-build-wheels.yml
 
   packaging-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ jobs:
   change-detection:
     uses: ./.github/workflows/reusable-change-detection.yml
 
-  print-output:
-    needs: change-detection
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print outputs from change detection
-        run: |
-          echo "run-tests: ${{ needs.change-detection.outputs.run-tests }}"
-          echo "build-wheels: ${{ needs.change-detection.outputs.build-wheels }}"
-          echo "run-header-only-tests: ${{ needs.change-detection.outputs.run-header-only-tests }}"
-          echo "run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}"
-
   tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,6 @@ jobs:
     with:
      run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
-  build-wheels:
-    needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.build-wheels)
-    uses: ./.github/workflows/reusable-build-wheels.yml
-
   packaging-tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.build-wheels)
@@ -70,7 +65,7 @@ jobs:
               fromJSON(needs.change-detection.outputs.build-wheels)
               && ''
               || '
-              build-wheels, packaging-tests,
+              packaging-tests,
               '
             }} ${{
               fromJSON(needs.change-detection.outputs.run-header-only-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
   tests:
     needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.run-tests)
+    #if: fromJSON(needs.change-detection.outputs.run-tests)
     uses: ./.github/workflows/reusable-test.yml
-    with:
-      run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
+    #with:
+    #  run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
   build-wheels:
     needs: change-detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - change-detection
       - tests
       - build-wheels
+      - packaging-tests
       - header-only-tests
       - coverage
       - docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
     needs:
       - change-detection
       - tests
-      - build-wheels
       - packaging-tests
       - header-only-tests
       - coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
     if: fromJSON(needs.change-detection.outputs.build-wheels)
     uses: ./.github/workflows/reusable-build-wheels.yml
 
+  packaging-tests:
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.build-wheels)
+    uses: ./.github/workflows/reusable-packaging-test.yml
+
   header-only-tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-header-only-tests)
@@ -65,6 +70,12 @@ jobs:
               && ''
               || '
               build-wheels,
+              '
+            }} ${{
+              fromJSON(needs.change-detection.outputs.packaging-tests)
+              && ''
+              || '
+              packaging-tests,
               '
             }} ${{
               fromJSON(needs.change-detection.outputs.run-header-only-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
     with:
       run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
+  build-wheels:
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.build-wheels)
+    uses: ./.github/workflows/reusable-build-wheels.yml
+
   header-only-tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-header-only-tests)
@@ -38,7 +43,8 @@ jobs:
     needs:
       - change-detection
       - tests
-      - header-tests
+      - build-wheels
+      - header-only-tests
       - coverage
       - docs
     runs-on: ubuntu-latest
@@ -53,6 +59,12 @@ jobs:
               && ''
               || '
               tests,
+              '
+            }} ${{
+              fromJSON(needs.change-detection.outputs.build-wheels)
+              && ''
+              || '
+              build-wheels,
               '
             }} ${{
               fromJSON(needs.change-detection.outputs.run-header-only-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,17 @@ jobs:
   change-detection:
     uses: ./.github/workflows/reusable-change-detection.yml
 
+  print-output:
+    needs: change-detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print outputs from change detection
+        run: |
+          echo "run-tests: ${{ needs.change-detection.outputs.run-tests }}"
+          echo "build-wheels: ${{ needs.change-detection.outputs.build-wheels }}"
+          echo "run-header-only-tests: ${{ needs.change-detection.outputs.run-header-only-tests }}"
+          echo "run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}"
+
   tests:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     #  run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
   build-wheels:
-    needs: change-detection
+    #needs: change-detection
     if: fromJSON(needs.change-detection.outputs.build-wheels)
     uses: ./.github/workflows/reusable-build-wheels.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,7 @@ jobs:
               fromJSON(needs.change-detection.outputs.build-wheels)
               && ''
               || '
-              build-wheels,
-              '
-            }} ${{
-              fromJSON(needs.change-detection.outputs.packaging-tests)
-              && ''
-              || '
-              packaging-tests,
+              build-wheels, packaging-tests,
               '
             }} ${{
               fromJSON(needs.change-detection.outputs.run-header-only-tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     #  run-gpu-kernel-tests: ${{ needs.change-detection.outputs.run-gpu-kernel-tests }}
 
   build-wheels:
-    #needs: change-detection
-    if: fromJSON(needs.change-detection.outputs.build-wheels)
+    needs: change-detection
+    #if: fromJSON(needs.change-detection.outputs.build-wheels)
     uses: ./.github/workflows/reusable-build-wheels.yml
 
   packaging-tests:

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   build-wheels:
-    uses: ./.github/workflows/build-wheels.yml
+    uses: ./.github/workflows/reusable-build-wheels.yml
 
   upload-awkward-cpp:
     needs: [build-wheels]

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build-wheels-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -8,9 +8,6 @@ on:
   workflow_dispatch:
   # Use from other workflows
   workflow_call:
-  pull_request:
-    paths:
-      - .github/workflows/build-wheels.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
-    if: github.repository_owner == 'scikit-hep'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -1,0 +1,98 @@
+name: Change detection
+
+on:
+  workflow_call:
+    outputs:
+      run-tests:
+        description: Whether or not run the tests
+        value: ${{ jobs.change-detection.outputs.run-tests || false }}
+      run-header-only-tests:
+        description: Whether or not run the header-only tests
+        value: ${{ jobs.change-detection.outputs.run-header-only-tests || false }}
+      run-gpu-kernel-tests:
+        description: Whether or not run the gpu kernel tests
+        value: ${{ jobs.change-detection.outputs.run-gpu-kernel-tests || false }}
+
+jobs:
+  change-detection:
+    name: Identify source changes
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      run-tests: ${{ steps.code-changes.outputs.run-tests || false }}
+      run-header-only-tests: ${{ steps.header-changes.outputs.run-header-only-tests || false }}
+      run-gpu-kernel-tests: ${{ steps.gpu-changes.outputs.run-gpu-kernel-tests || false }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Changed code files
+        if: github.event_name == 'pull_request'
+        id: changed-code-files
+        uses: Ana06/get-changed-files@v2.3.0
+        with:
+          format: "json"
+          filter: |
+            .github/workflows/ci.yml
+            .github/workflows/reusable-test.yml
+            awkward-cpp/include/**
+            awkward-cpp/rapidjson/**
+            awkward-cpp/src/**
+            awkward-cpp/CMakeLists.txt
+            awkward-cpp/pyproject.toml
+            dev/**
+            header-only/**
+            src/awkward/**
+            tests/awkward/**
+            .gitmodules
+            codecov.yml
+            kernel-specification.yml
+            kernel-test-data.json
+            noxfile.py
+            pyproject.toml
+            requirements-*.txt
+      - name: Set a flag for running the tests
+        if: >-
+          github.event_name != 'pull_request' ||
+          steps.changed-code-files.outputs.added_modified_renamed != '[]'
+        id: code-changes
+        run: echo "run-tests=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Changed header files
+        if: github.event_name == 'pull_request'
+        id: changed-header-files
+        uses: Ana06/get-changed-files@v2.3.0
+        with:
+          format: "json"
+          filter: |
+            .github/workflows/ci.yml
+            .github/workflows/reusable-header-only-test.yml
+            header-only/**
+      - name: Set a flag for running the header tests
+        if: >-
+          github.event_name != 'pull_request' ||
+          steps.changed-header-files.outputs.added_modified_renamed != '[]'
+        id: header-changes
+        run: echo "run-header-only-tests=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Changed GPU code files
+        if: github.event_name == 'pull_request'
+        id: changed-gpu-files
+        uses: Ana06/get-changed-files@v2.3.0
+        with:
+          format: "json"
+          filter: |
+            .github/workflows/ci.yml
+            .github/workflows/reusable-test.yml
+            dev/**
+            kernel-specification.yml
+            kernel-test-data.json
+            src/awkward/_backends/cupy.py
+            src/awkward/_connect/cuda/**
+            src/awkward/_kernels.py
+            tests-cuda/**
+      - name: Set a flag for running the header tests
+        if: >-
+          github.event_name != 'pull_request' ||
+          steps.changed-gpu-files.outputs.added_modified_renamed != '[]'
+        id: gpu-changes
+        run: echo "run-gpu-kernel-tests=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Changed code files
-        if: github.event_name == 'pull_request'
         id: changed-code-files
         uses: Ana06/get-changed-files@v2.3.0
         with:
@@ -62,7 +61,6 @@ jobs:
         run: echo "run-tests=true" >> "${GITHUB_OUTPUT}"
 
       - name: Changed C++ files
-        if: github.event_name == 'pull_request'
         id: changed-cpp-files
         uses: Ana06/get-changed-files@v2.3.0
         with:
@@ -83,7 +81,6 @@ jobs:
         run: echo "build-wheels=true" >> "${GITHUB_OUTPUT}"
 
       - name: Changed header files
-        if: github.event_name == 'pull_request'
         id: changed-header-files
         uses: Ana06/get-changed-files@v2.3.0
         with:
@@ -100,7 +97,6 @@ jobs:
         run: echo "run-header-only-tests=true" >> "${GITHUB_OUTPUT}"
 
       - name: Changed GPU code files
-        if: github.event_name == 'pull_request'
         id: changed-gpu-files
         uses: Ana06/get-changed-files@v2.3.0
         with:
@@ -116,8 +112,6 @@ jobs:
             src/awkward/_kernels.py
             tests-cuda/**
       - name: Set a flag for running the GPU tests
-        if: >-
-          github.event_name != 'pull_request' ||
-          steps.changed-gpu-files.outputs.added_modified_renamed != '[]'
+        if: steps.changed-gpu-files.outputs.added_modified_renamed != '[]'
         id: gpu-changes
         run: echo "run-gpu-kernel-tests=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -46,7 +46,7 @@ jobs:
             dev/**
             header-only/**
             src/awkward/**
-            tests/awkward/**
+            tests/**
             .gitmodules
             codecov.yml
             kernel-specification.yml
@@ -115,7 +115,7 @@ jobs:
             src/awkward/_connect/cuda/**
             src/awkward/_kernels.py
             tests-cuda/**
-      - name: Set a flag for running the header tests
+      - name: Set a flag for running the GPU tests
         if: >-
           github.event_name != 'pull_request' ||
           steps.changed-gpu-files.outputs.added_modified_renamed != '[]'

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -6,6 +6,9 @@ on:
       run-tests:
         description: Whether or not run the tests
         value: ${{ jobs.change-detection.outputs.run-tests || false }}
+      build-wheels:
+        description: Whether or not build the wheels
+        value: ${{ jobs.change-detection.outputs.build-wheels || false }}
       run-header-only-tests:
         description: Whether or not run the header-only tests
         value: ${{ jobs.change-detection.outputs.run-header-only-tests || false }}
@@ -20,6 +23,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       run-tests: ${{ steps.code-changes.outputs.run-tests || false }}
+      build-wheels: ${{ steps.cpp-changes.outputs.build-wheels || false }}
       run-header-only-tests: ${{ steps.header-changes.outputs.run-header-only-tests || false }}
       run-gpu-kernel-tests: ${{ steps.gpu-changes.outputs.run-gpu-kernel-tests || false }}
     steps:
@@ -56,6 +60,27 @@ jobs:
           steps.changed-code-files.outputs.added_modified_renamed != '[]'
         id: code-changes
         run: echo "run-tests=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Changed C++ files
+        if: github.event_name == 'pull_request'
+        id: changed-cpp-files
+        uses: Ana06/get-changed-files@v2.3.0
+        with:
+          format: "json"
+          filter: |
+            .github/workflows/ci.yml
+            .github/workflows/reusable-build-wheels.yml
+            awkward-cpp/include/**
+            awkward-cpp/rapidjson/**
+            awkward-cpp/src/**
+            awkward-cpp/CMakeLists.txt
+            awkward-cpp/pyproject.toml
+      - name: Set a flag for building wheels
+        if: >-
+          github.event_name != 'pull_request' ||
+          steps.changed-cpp-files.outputs.added_modified_renamed != '[]'
+        id: cpp-changes
+        run: echo "build-wheels=true" >> "${GITHUB_OUTPUT}"
 
       - name: Changed header files
         if: github.event_name == 'pull_request'

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -1,19 +1,7 @@
 name: Codecov
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
-      - CONTRIBUTING.md
-      - CITATION.cff
-      - LICENSE
-      - .readthedocs.yml
-      - docs-img/**
-      - docs/**
-      - awkward-cpp/docs/**
-      - studies/**
+  workflow_call:
 
   workflow_dispatch:
 
@@ -121,6 +109,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,12 +1,11 @@
 name: Docs
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_call:
+
+  workflow_dispatch:
+
   release:
     types: [released]
-  workflow_dispatch:
 
 concurrency:
   group: 'docs-${{ github.head_ref || github.run_id }}'

--- a/.github/workflows/reusable-header-only-test.yml
+++ b/.github/workflows/reusable-header-only-test.yml
@@ -1,7 +1,8 @@
 name: Header-only Tests
 
 on:
-  pull_request:
+  workflow_call:
+
   workflow_dispatch:
 
 

--- a/.github/workflows/reusable-packaging-test.yml
+++ b/.github/workflows/reusable-packaging-test.yml
@@ -1,7 +1,8 @@
 name: Packaging Tests
 
 on:
-  pull_request:
+  workflow_call:
+
   workflow_dispatch:
 
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -10,7 +10,7 @@ on:
         description: Whether or not to run the gpu kernel tests
         required: false
         default: false
-        type: string
+        type: string # The workflow freezes if this is set to boolean for some reason
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,22 +1,24 @@
 name: Tests
 
 on:
-  pull_request:
-    paths-ignore:
-      - README.md
-      - CONTRIBUTING.md
-      - CITATION.cff
-      - LICENSE
-      - .readthedocs.yml
-      - docs-img/**
-      - docs/**
-      - awkward-cpp/docs/**
-      - studies/**
-
   schedule:
     - cron: 0 12 1 * *
 
+  workflow_call:
+    inputs:
+      run-gpu-kernel-tests:
+        description: Whether or not to run the gpu kernel tests
+        required: false
+        default: false
+        type: boolean
+
   workflow_dispatch:
+    inputs:
+      run-gpu-kernel-tests:
+        description: Whether or not to run the gpu kernel tests
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: 'test-${{ github.head_ref || github.run_id }}'
@@ -208,7 +210,6 @@ jobs:
             cuda-version=${{ matrix.cuda-version }}
             cxx-compiler
             numba-cuda
-            ${{ matrix.cuda-version == 13 && 'root=6.36.06' || '' }}
 
       - name: Generate build files
         run: |
@@ -242,44 +243,26 @@ jobs:
       - name: Install awkward, awkward-cpp, and dependencies
         run: >-
           python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
-          -r requirements-test-gpu.txt ${{ matrix.cuda-version == 13 && '-r requirements-test-full.txt' || '' }}
+          -r requirements-test-gpu.txt
 
       - name: Print versions
         run: python -m pip list
 
       - name: Test CUDA kernels
+        if: ${{ fromJSON(inputs.run-gpu-kernel-tests) }}
         run: python -m pytest -vv -rs tests-cuda-kernels
 
       - name: Test CUDA kernels with explicitly defined values
+        if: ${{ fromJSON(inputs.run-gpu-kernel-tests) }}
         run: python -m pytest -vv -rs tests-cuda-kernels-explicit
-
-      - name: Test non-kernels (Python)
-        if: matrix.cuda-version == 13
-        run: >-
-          python -m pytest -vv -rs tests --cov=awkward --cov-report=term
-          --cov-report=xml:non-cuda-coverage.xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Test CUDA non-kernel (Python)
         run: >-
           python -m pytest -vv -rs tests-cuda --ignore=tests-cuda/test_3459_virtualarray_with_cuda.py
-          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-coverage.xml' || '' }}
 
       - name: Test CUDA virtual arrays
         run: >-
           python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
-          ${{ matrix.cuda-version == 13 && '--cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml' || '' }}
-
-      - name: Upload Codecov results
-        if: matrix.cuda-version == 13
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.cuda-version == 13 }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   Linux-ROOT:
     runs-on: ubuntu-latest
@@ -390,13 +373,3 @@ jobs:
 
       - name: Test
         run: python -m pytest -vv -rs tests -k cppyy
-
-
-  pass-tests:
-    if: always()
-    needs: [ run-tests, Linux-ROOT, Linux-cppyy ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -10,7 +10,7 @@ on:
         description: Whether or not to run the gpu kernel tests
         required: false
         default: false
-        type: boolean
+        type: string
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upload-nightly-wheels.yml
+++ b/.github/workflows/upload-nightly-wheels.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           PROJECT_REPO="scikit-hep/awkward"
           BRANCH="main"
-          WORKFLOW_NAME="build-wheels.yml"
+          WORKFLOW_NAME="reusable-build-wheels.yml"
           ARTIFACT_PATTERN="awkward*wheel*"  # awkward-wheel and awkward-cpp-wheels-*
 
           gh run --repo "${PROJECT_REPO}" \


### PR DESCRIPTION
I'm switching some of the workflows so that they are triggered by `workflow_call` to make conditional runs easier to handle, as suggested by @henryiii. This should solve the issue described here: https://github.com/scikit-hep/awkward/pull/3948#issuecomment-4195510464.

There are another couple of improvements.
- The header-only tests only run if something in that directory was changed. It was unnecessary to run it every time.
- The kernel tests now only run if a GPU-related change was made. This is to avoid the very slow testing of GPU kernels due to #3840.
- The coverage workflow is now centralized instead of being done across two workflows.