### PR TITLE
feat: add `IndexedArray_flatten_nextcarry` kernel implementation using cuda.compute

### DIFF
--- a/dev/generate-kernel-signatures.py
+++ b/dev/generate-kernel-signatures.py
@@ -89,7 +89,7 @@ cuda_kernels_impl = [
     "awkward_index_rpad_and_clip_axis1",
     "awkward_NumpyArray_subrange_equal",
     "awkward_NumpyArray_subrange_equal_bool",
-    "awkward_IndexedArray_flatten_nextcarry",
+    # "awkward_IndexedArray_flatten_nextcarry",
     "awkward_IndexedArray_flatten_none2empty",
     "awkward_IndexedArray_getitem_nextcarry",
     "awkward_IndexedArray_getitem_nextcarry_outindex",

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -75,6 +75,7 @@ class CupyBackend(Backend):
         Other kernels that are currently supported:
         - awkward_sort
         - awkward_argsort (future)
+        - awkward_IndexedArray_flatten_nextcarry
 
         These kernels should be moved to awkward/_connect/cuda/reducers.py too in the next PR:
         - awkward_sum
@@ -100,6 +101,7 @@ class CupyBackend(Backend):
             "awkward_reduce_prod_bool",
             "awkward_reduce_count_64",
             "awkward_reduce_countnonzero",
+            "awkward_IndexedArray_flatten_nextcarry",
         )
 
     def _get_cuda_compute_impl(self, kernel_name: str):
@@ -147,7 +149,7 @@ class CupyBackend(Backend):
         if kernel_name == "awkward_reduce_countnonzero":
             return cuda_compute.awkward_reduce_countnonzero
 
-        return None
+        return getattr(cuda_compute, kernel_name, None)
 
     def prepare_reducer(self, reducer: ak._reducers.Reducer) -> ak._reducers.Reducer:
         from awkward._connect.cuda import get_cuda_compute_reducer

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -6,6 +6,7 @@ from cuda.compute import (
     CountingIterator,
     gpu_struct,
     reduce_into,
+    select,
     unary_transform,
 )
 
@@ -629,3 +630,33 @@ def awkward_reduce_countnonzero(
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
     unary_transform(segment_ids, result, segment_reduce_count_nonzero, outlength)
+
+
+# filters an indexed array by collecting all valid (non-negative) indices into a carry array
+def awkward_IndexedArray_flatten_nextcarry(
+    tocarry: cp.ndarray, fromindex: cp.ndarray, lenindex: int, lencontent: int
+) -> None:
+    fromindex = fromindex[:lenindex]
+    index_dtype = fromindex.dtype
+
+    has_error = cp.zeros(1, index_dtype)
+    num_selected = cp.empty(1, index_dtype)
+
+    def cond(j):
+        if j >= lencontent:
+            # set has_error flag to True
+            has_error[0] = np.int64(1)
+            return False
+        # keep index in tocarry if True
+        return j >= 0
+
+    select(fromindex, tocarry, num_selected, cond, lenindex)
+
+    if int(has_error[0]) != 0:
+        out_of_range = fromindex >= lencontent
+        invalid_i = int(cp.argmax(out_of_range))
+        invalid_j = int(fromindex[invalid_i])
+        raise IndexError(
+            f"index out of range: index {invalid_i} has value {invalid_j}, "
+            f"but lencontent is {lencontent}"
+        )


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3967https://github.com/scikit-hep/awkward/issues/3967

New implementation
<img width="1541" height="444" alt="image" src="https://github.com/user-attachments/assets/9d93a8d7-2fc4-42df-a455-52a6fc85b7a2" />

Old implementation
<img width="1544" height="477" alt="image" src="https://github.com/user-attachments/assets/f5afc60c-41fc-4cb7-932a-82af043eb3da" />
