### PR TITLE
fix: restore docstring cross-references lost in autoapi migration

### DIFF
--- a/docs/_autoapi_templates/python/data.rst
+++ b/docs/_autoapi_templates/python/data.rst
@@ -1,0 +1,45 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:{% if obj.is_type_alias() %}type{% else %}{{ obj.type }}{% endif %}:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.name }}{% endif %}
+   {% if obj.is_type_alias() %}
+      {% if obj.value %}
+
+   :canonical: {{ obj.value }}
+      {% endif %}
+   {% else %}
+      {% if obj.annotation is not none %}
+
+   :type: {% if obj.annotation %} {{ obj.annotation }}{% endif %}
+      {% endif %}
+      {% if obj.value is not none %}
+
+         {% if obj.value.splitlines()|count > 1 %}
+   :value: Multiline-String
+
+   .. raw:: html
+
+      <details><summary>Show Value</summary>
+
+   .. code-block:: python
+
+      {{ obj.value|indent(width=6,blank=true) }}
+
+   .. raw:: html
+
+      </details>
+
+         {% else %}
+   :value: {{ obj.value|truncate(100) }}
+         {% endif %}
+      {% endif %}
+   {% endif %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|process_docstring(obj)|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/_autoapi_templates/python/method.rst
+++ b/docs/_autoapi_templates/python/method.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:method:: {% if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}{% if obj.type_params %}[{{ obj.type_params }}]{% endif %}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+   {% for (args, return_annotation) in obj.overloads %}
+
+               {%+ if is_own_page %}{{ obj.id }}{% else %}{{ obj.short_name }}{% endif %}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+   {% endfor %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|process_docstring(obj)|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/_autoapi_templates/python/property.rst
+++ b/docs/_autoapi_templates/python/property.rst
@@ -1,0 +1,21 @@
+{% if obj.display %}
+   {% if is_own_page %}
+{{ obj.id }}
+{{ "=" * obj.id | length }}
+
+   {% endif %}
+.. py:property:: {% if is_own_page %}{{ obj.id}}{% else %}{{ obj.short_name }}{% endif %}
+   {% if obj.annotation %}
+
+   :type: {{ obj.annotation }}
+   {% endif %}
+   {% for property in obj.properties %}
+
+   :{{ property }}:
+   {% endfor %}
+
+   {% if obj.docstring %}
+
+   {{ obj.docstring|process_docstring(obj)|indent(3) }}
+   {% endif %}
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ autoapi_options = [
     "members",
     "undoc-members",
     "private-members",
+    "special-members",
     "show-module-summary",
     "imported-members",
 ]
@@ -184,7 +185,10 @@ def _process_docstring_filter(docstring, obj):
 
     lines = docstring.split("\n")
     for i, line in enumerate(lines):
-        line = line.replace("`", "``")
+        # Promote single backticks to double-backtick inline literals, but leave
+        # already-doubled backticks untouched (``write(str)`` must stay a pair).
+        line = re.sub(r"(?<!`)`(?!`)", "``", line)
+        line = re.sub(r"<<<([^>]+)>>>", r"`\1`_", line)
         line = re.sub(
             r"#(ak\.[A-Za-z0-9_\.]*[A-Za-z0-9_])",
             r":py:obj:`\1`",
@@ -237,7 +241,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "_templates", "Thumbs.db", "jupyter_execute", ".*"]
+exclude_patterns = ["_build", "_templates", "_autoapi_templates", "Thumbs.db", "jupyter_execute", ".*"]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -388,6 +392,12 @@ def _skip_member(app, what, name, obj, skip, options):
     # Keep the top-level awkward package
     if name == "awkward":
         return False
+    # Skip module-level dunder functions (e.g., awkward.__dir__); special-members
+    # is enabled for class methods but these should not be documented as top-level.
+    if what == "function":
+        short = name.rsplit(".", 1)[-1]
+        if short.startswith("__") and short.endswith("__"):
+            return True
     # Skip private modules (awkward._*) but not private methods/attributes
     # within public classes (those are controlled by the "private-members" option)
     if what in ("module", "package"):


### PR DESCRIPTION
Fixes the `<<<...>>>`, `#ak.xxx`, markdown links, and backtick handling regressions introduced by #3948, reported on #3966.

`_process_docstring_filter` was only wired into the custom `class.rst`, `function.rst`, and `module.rst` templates. Autoapi's default `method.rst`, `property.rst`, and `data.rst` rendered `obj.docstring` untouched, so members of classes showed literal `<<<filtering>>>`, `#ak.mask`, etc.

### Changes
- `docs/conf.py`: restore `<<<marker>>>` substitution; make backtick-doubling preserve already-paired `` ``...`` ``
- `docs/conf.py`: add `special-members` to `autoapi_options` (restores v2.8's dunder method listings — `__getitem__`, `__len__`, etc.)
- `docs/conf.py`: skip module-level dunder functions in `_skip_member` (no more orphan `awkward.__dir__` pages)
- `docs/conf.py`: add `_autoapi_templates` to `exclude_patterns`
- new `docs/_autoapi_templates/python/{method,property,data}.rst` templates that apply the `process_docstring` filter

### Verification
Full HTML diff vs `main`: 80 pages differ, every diff explained by the above transformations. Class dunder lists match v2.8 exactly (23/23 identical on `ak.Array`). No content regressions.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>