### PR TITLE
chore: switch dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
@@ -18,6 +18,6 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-name: "hypothesis-awkward"


### PR DESCRIPTION
We're getting too much spam from dependabot updates and we have pre-commit autoupdate to monthly anyways. Let's switch dependabot to monthly too.