### PR TITLE
chore: prepare for numpy 2.5 compatibility

### DIFF
--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -37,6 +37,17 @@ def _nplike_concatenate_has_casting(module: Any) -> bool:
         return True
 
 
+@lru_cache
+def _nplike_reshape_has_copy(module: Any) -> bool:
+    x = module.zeros(2)
+    try:
+        module.reshape(x, (2,), copy=False)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
 ArrayLikeT = TypeVar("ArrayLikeT", bound=ArrayLike)
 
 
@@ -371,10 +382,14 @@ class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
             return self._module.reshape(self._module.copy(x, order="C"), shape)
         else:
             result = self._module.asarray(x)
+            if _nplike_reshape_has_copy(self._module):
+                return self._module.reshape(result, shape, copy=False)
             try:
                 result.shape = shape
             except AttributeError:
-                raise ValueError("cannot reshape array without copying") from None
+                raise ValueError(
+                    "Unable to avoid creating a copy while reshaping."
+                ) from None
             return result
 
     def shape_item_as_index(self, x1: ShapeItem) -> int:

--- a/src/awkward/_nplikes/numpy_like.py
+++ b/src/awkward/_nplikes/numpy_like.py
@@ -81,7 +81,6 @@ class NumpyMetadata(PublicSingleton):
     nan = numpy.nan
     inf = numpy.inf
 
-    nat = numpy.datetime64("NaT")
     datetime_data = staticmethod(numpy.datetime_data)
     issubdtype = staticmethod(numpy.issubdtype)
 

--- a/tests/test_2198_almost_equal.py
+++ b/tests/test_2198_almost_equal.py
@@ -23,7 +23,7 @@ def test_dtype():
     assert not ak.almost_equal([1, 2, 3], ["1", "2", "3"], dtype_exact=True)
     assert not ak.almost_equal(
         np.array([1, 2, 3], dtype=np.int64),
-        np.array([1, 2, 3], dtype=np.timedelta64),
+        np.array([1, 2, 3], dtype=np.dtype("timedelta64[s]")),
         dtype_exact=True,
     )
     assert not ak.almost_equal(

--- a/tests/test_2319_from_buffers_array.py
+++ b/tests/test_2319_from_buffers_array.py
@@ -74,7 +74,9 @@ def test_2d_1d_fortran_ordered():
         }
     """
 
-    with pytest.raises(ValueError, match="cannot reshape array without copying"):
+    with pytest.raises(
+        ValueError, match="Unable to avoid creating a copy while reshaping"
+    ):
         ak.from_buffers(form, array.size, container, highlevel=False)
 
 
@@ -91,7 +93,9 @@ def test_2d_2d_fortran_ordered():
         }
     """
 
-    with pytest.raises(ValueError, match="cannot reshape array without copying"):
+    with pytest.raises(
+        ValueError, match="Unable to avoid creating a copy while reshaping"
+    ):
         ak.from_buffers(form, array.size, container, highlevel=False)
 
 


### PR DESCRIPTION
I wanna see if this change breaks anything in numpy<2.5 and numpy 1 using our CI.
Numpy 2.5 deprecates setting the `.shape` attribute and unitless timedelta dtype.
I did this with local testing of course as we have no numpy 2.5 CI.