### PR TITLE
ci: fix some issues with reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
 
   coverage:
     uses: ./.github/workflows/reusable-coverage.yml
+    secrets: inherit
 
   docs:
     uses: ./.github/workflows/reusable-docs.yml
+    secrets: inherit
 
   pass:
     if: always()

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,7 +1,7 @@
 name: Docs Preview
 on:
   workflow_run:
-    workflows: [Docs]
+    workflows: [CI]
     types:
       - completed
 


### PR DESCRIPTION
In #3769 there were a couple of issues that I'm fixing here.

- When a workflow is triggered with `workflow_call` it doesn't have access to any secrets unless they are explicitly passed in or inherited. I decided to just inherit them for simplicity, but I can switch to passing only the needed ones if you prefer.
- The docs preview was triggered by a run of the `Docs` workflow. Since it is now kind of a subworkflow, it was not triggering. So I switched to trigger it after the main CI workflow. (Note that it will not work for this PR, as it uses the workflow file that is in main) 