### PR TITLE
docs: add summary lines to 13 structural operation docstrings

### DIFF
--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -25,7 +25,8 @@ def argcartesian(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the Cartesian product of arrays, returning integer indexes.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -57,16 +58,18 @@ def argcartesian(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes a Cartesian product (i.e. cross product) of data from a set of
-    `arrays`, like #ak.cartesian, but returning integer indexes for
-    #ak.Array.__getitem__.
+    Returns:
+        Computes a Cartesian product (i.e. cross product) of data from a set of
+        `arrays`, like #ak.cartesian, but returning integer indexes for
+        #ak.Array.__getitem__.
 
-    For example, the Cartesian product of
+    Examples:
+        For example, the Cartesian product of
 
         >>> one = ak.Array([1.1, 2.2, 3.3])
         >>> two = ak.Array(["a", "b"])
 
-    is
+        is
 
         >>> ak.cartesian([one, two], axis=0).show()
         [(1.1, 'a'),
@@ -76,7 +79,7 @@ def argcartesian(
          (3.3, 'a'),
          (3.3, 'b')]
 
-    But with argcartesian, only the indexes are returned.
+        But with argcartesian, only the indexes are returned.
 
         >>> ak.argcartesian([one, two], axis=0).show()
         [(0, 0),
@@ -86,8 +89,8 @@ def argcartesian(
          (2, 0),
          (2, 1)]
 
-    These are the indexes that can select the items that go into the actual
-    Cartesian product.
+        These are the indexes that can select the items that go into the actual
+        Cartesian product.
 
         >>> one_index, two_index = ak.unzip(ak.argcartesian([one, two], axis=0))
         >>> one[one_index]
@@ -95,8 +98,8 @@ def argcartesian(
         >>> two[two_index]
         <Array ['a', 'b', 'a', 'b', 'a', 'b'] type='6 * string'>
 
-    All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
-    so see the #ak.cartesian documentation for a more complete description.
+        All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
+        so see the #ak.cartesian documentation for a more complete description.
     """
     # Dispatch
     if isinstance(arrays, Mapping):

--- a/src/awkward/operations/ak_argcombinations.py
+++ b/src/awkward/operations/ak_argcombinations.py
@@ -28,7 +28,8 @@ def argcombinations(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes combinations of `n` items from an array, returning integer indexes.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         n (int): The number of items to choose from each list: `2` chooses
@@ -60,14 +61,15 @@ def argcombinations(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes a Cartesian product (i.e. cross product) of `array` with itself
-    that is restricted to combinations sampled without replacement,
-    like #ak.combinations, but returning integer indexes for
-    #ak.Array.__getitem__.
+    Returns:
+        Computes a Cartesian product (i.e. cross product) of `array` with itself
+        that is restricted to combinations sampled without replacement,
+        like #ak.combinations, but returning integer indexes for
+        #ak.Array.__getitem__.
 
-    The motivation and uses of this function are similar to those of
-    #ak.argcartesian. See #ak.combinations and #ak.argcartesian for a more
-    complete description.
+        The motivation and uses of this function are similar to those of
+        #ak.argcartesian. See #ak.combinations and #ak.argcartesian for a more
+        complete description.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -36,7 +36,8 @@ def broadcast_arrays(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Broadcasts arrays together so they can be combined element-by-element.
+
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).
         depth_limit (None or int, default is None): If None, attempt to fully
@@ -59,33 +60,35 @@ def broadcast_arrays(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like NumPy's
-    [broadcast_arrays](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast_arrays.html)
-    function, this function returns the input `arrays` with enough elements
-    duplicated that they can be combined element-by-element.
+    Returns:
+        Like NumPy's
+        [broadcast_arrays](https://docs.scipy.org/doc/numpy/reference/generated/numpy.broadcast_arrays.html)
+        function, this function returns the input `arrays` with enough elements
+        duplicated that they can be combined element-by-element.
 
-    For NumPy arrays, this means that scalars are replaced with arrays with
-    the same scalar value repeated at every element of the array, and regular
-    dimensions are created to increase low-dimensional data into
-    high-dimensional data.
+        For NumPy arrays, this means that scalars are replaced with arrays with
+        the same scalar value repeated at every element of the array, and regular
+        dimensions are created to increase low-dimensional data into
+        high-dimensional data.
 
-    For example,
+    Examples:
+        For example,
 
         >>> ak.broadcast_arrays(5,
         ...                     [1, 2, 3, 4, 5])
         [<Array [5, 5, 5, 5, 5] type='5 * int64'>,
          <Array [1, 2, 3, 4, 5] type='5 * int64'>]
 
-    and
+        and
 
         >>> ak.broadcast_arrays(np.array([1, 2, 3]),
         ...                     np.array([[0.1, 0.2, 0.3], [10, 20, 30]]))
         [<Array [[  1,   2,   3], [ 1,  2,  3]] type='2 * 3 * int64'>,
          <Array [[0.1, 0.2, 0.3], [10, 20, 30]] type='2 * 3 * float64'>]
 
-    Note that in the second example, when the `3 * int64` array is expanded
-    to match the `2 * 3 * float64` array, it is the deepest dimension that
-    is aligned. If we try to match a `2 * int64` with the `2 * 3 * float64`,
+        Note that in the second example, when the `3 * int64` array is expanded
+        to match the `2 * 3 * float64` array, it is the deepest dimension that
+        is aligned. If we try to match a `2 * int64` with the `2 * 3 * float64`,
 
         >>> ak.broadcast_arrays(np.array([1, 2]),
         ...                     np.array([[0.1, 0.2, 0.3], [10, 20, 30]]))
@@ -102,68 +105,68 @@ def broadcast_arrays(
             )
         Error details: cannot broadcast RegularArray of size 2 with RegularArray of size 3
 
-    NumPy has the same behavior: arrays with different numbers of dimensions
-    are aligned to the right before expansion. One can control this by
-    explicitly adding a new axis (reshape to add a dimension of length 1)
-    where the expansion is supposed to take place because a dimension of
-    length 1 can be expanded like a scalar.
+        NumPy has the same behavior: arrays with different numbers of dimensions
+        are aligned to the right before expansion. One can control this by
+        explicitly adding a new axis (reshape to add a dimension of length 1)
+        where the expansion is supposed to take place because a dimension of
+        length 1 can be expanded like a scalar.
 
         >>> ak.broadcast_arrays(np.array([1, 2])[:, np.newaxis],
         ...                     np.array([[0.1, 0.2, 0.3], [10, 20, 30]]))
         [<Array [[  1,   1,   1], [ 2,  2,  2]] type='2 * 3 * int64'>,
          <Array [[0.1, 0.2, 0.3], [10, 20, 30]] type='2 * 3 * float64'>]
 
-    Again, NumPy does the same thing (`np.newaxis` is equal to None, so this
-    trick is often shown with None in the slice-tuple). Where the broadcasting
-    happens can be controlled, but numbers of dimensions that don't match are
-    implicitly aligned to the right (fitting innermost structure, not
-    outermost).
+        Again, NumPy does the same thing (`np.newaxis` is equal to None, so this
+        trick is often shown with None in the slice-tuple). Where the broadcasting
+        happens can be controlled, but numbers of dimensions that don't match are
+        implicitly aligned to the right (fitting innermost structure, not
+        outermost).
 
-    While that might be an arbitrary decision for rectilinear arrays, it is
-    much more natural for implicit broadcasting to align left for tree-like
-    structures. That is, the root of each data structure should agree and
-    leaves may be duplicated to match. For example,
+        While that might be an arbitrary decision for rectilinear arrays, it is
+        much more natural for implicit broadcasting to align left for tree-like
+        structures. That is, the root of each data structure should agree and
+        leaves may be duplicated to match. For example,
 
         >>> ak.broadcast_arrays([            100,   200,        300],
         ...                     [[1.1, 2.2, 3.3],    [], [4.4, 5.5]])
         [<Array [[100, 100, 100], [], [300, 300]] type='3 * var * int64'>,
          <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>]
 
-    One typically wants single-item-per-element data to be duplicated to
-    match multiple-items-per-element data. Operations on the broadcasted
-    arrays like::
+        One typically wants single-item-per-element data to be duplicated to
+        match multiple-items-per-element data. Operations on the broadcasted
+        arrays like::
 
-        one_dimensional + nested_lists
+            one_dimensional + nested_lists
 
-    would then have the same effect as the procedural code::
+        would then have the same effect as the procedural code::
 
-        for x, outer in zip(one_dimensional, nested_lists):
-            output = []
-            for inner in outer:
-                output.append(x + inner)
-            yield output
+            for x, outer in zip(one_dimensional, nested_lists):
+                output = []
+                for inner in outer:
+                    output.append(x + inner)
+                yield output
 
-    where `x` has the same value for each `inner` in the inner loop.
+        where `x` has the same value for each `inner` in the inner loop.
 
-    Awkward Array's broadcasting manages to have it both ways by applying the
-    following rules:
+        Awkward Array's broadcasting manages to have it both ways by applying the
+        following rules:
 
-    * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
-      implicit broadcasting aligns to the right, like NumPy.
-    * If any dimension is variable (i.e. #ak.types.ListType), which can
-      never be true of NumPy, implicit broadcasting aligns to the left.
-    * Explicit broadcasting with a length-1 regular dimension always
-      broadcasts, like NumPy.
+        * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
+          implicit broadcasting aligns to the right, like NumPy.
+        * If any dimension is variable (i.e. #ak.types.ListType), which can
+          never be true of NumPy, implicit broadcasting aligns to the left.
+        * Explicit broadcasting with a length-1 regular dimension always
+          broadcasts, like NumPy.
 
-    Thus, it is important to be aware of the distinction between a dimension
-    that is declared to be regular in the type specification and a dimension
-    that is allowed to be variable (even if it happens to have the same length
-    for all elements). This distinction is can be accessed through the
-    #ak.Array.type, but it is lost when converting an array into JSON or
-    Python objects.
+        Thus, it is important to be aware of the distinction between a dimension
+        that is declared to be regular in the type specification and a dimension
+        that is allowed to be variable (even if it happens to have the same length
+        for all elements). This distinction is can be accessed through the
+        #ak.Array.type, but it is lost when converting an array into JSON or
+        Python objects.
 
-    If arrays have the same depth but different lengths of nested
-    lists, attempting to broadcast them together is a broadcasting error.
+        If arrays have the same depth but different lengths of nested
+        lists, attempting to broadcast them together is a broadcasting error.
 
         >>> one = ak.Array([[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]])
         >>> two = ak.Array([[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]])
@@ -180,8 +183,8 @@ def broadcast_arrays(
             )
         Error details: cannot broadcast nested list
 
-    For this, one can set the `depth_limit` to prevent the operation from
-    attempting to broadcast what can't be broadcasted.
+        For this, one can set the `depth_limit` to prevent the operation from
+        attempting to broadcast what can't be broadcasted.
 
         >>> this, that = ak.broadcast_arrays(one, two, depth_limit=1)
         >>> this.show()

--- a/src/awkward/operations/ak_broadcast_fields.py
+++ b/src/awkward/operations/ak_broadcast_fields.py
@@ -17,7 +17,8 @@ cpu = NumpyBackend.instance()
 
 @high_level_function()
 def broadcast_fields(*arrays, highlevel=True, behavior=None, attrs=None):
-    """
+    """Returns a list of arrays whose record types contain the same fields.
+
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
@@ -27,12 +28,14 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None, attrs=None):
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Return a list of arrays whose types contain the same number of fields. Unlike
-    #ak.broadcast_arrays, this function does not require record types to occur at the
-    same depths. Where fields are missing from one record, they are inserted at the same
-    position with an `option[unknown]` type. This type is easily erased by ufunc and
-    concatenation operations.
+    Returns:
+        Return a list of arrays whose types contain the same number of fields. Unlike
+        #ak.broadcast_arrays, this function does not require record types to occur at the
+        same depths. Where fields are missing from one record, they are inserted at the same
+        position with an `option[unknown]` type. This type is easily erased by ufunc and
+        concatenation operations.
 
+    Examples:
         >>> x, y = ak.broadcast_fields(
         ...     [{"x": {"y": 1, "z": 2, "w": [1]}}],
         ...     [{"x": [{"y": 1}]}],
@@ -53,7 +56,6 @@ def broadcast_fields(*arrays, highlevel=True, behavior=None, attrs=None):
                 w: ?unknown
             }
         }
-
     """
     # Dispatch
     yield arrays

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -39,7 +39,8 @@ def cartesian(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the Cartesian product (cross product) of data from a set of arrays.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -71,17 +72,19 @@ def cartesian(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes a Cartesian product (i.e. cross product) of data from a set of
-    `arrays`. This operation creates records (if `arrays` is a dict) or tuples
-    (if `arrays` is another kind of iterable) that hold the combinations
-    of elements, and it can introduce new levels of nesting.
+    Returns:
+        Computes a Cartesian product (i.e. cross product) of data from a set of
+        `arrays`. This operation creates records (if `arrays` is a dict) or tuples
+        (if `arrays` is another kind of iterable) that hold the combinations
+        of elements, and it can introduce new levels of nesting.
 
-    As a simple example with `axis=0`, the Cartesian product of
+    Examples:
+        As a simple example with `axis=0`, the Cartesian product of
 
         >>> one = ak.Array([1, 2, 3])
         >>> two = ak.Array(["a", "b"])
 
-    is
+        is
 
         >>> ak.cartesian([one, two], axis=0).show()
         [(1, 'a'),
@@ -91,24 +94,24 @@ def cartesian(
          (3, 'a'),
          (3, 'b')]
 
-    With nesting, a new level of nested lists is created to group combinations
-    that share the same element from `one` into the same list.
+        With nesting, a new level of nested lists is created to group combinations
+        that share the same element from `one` into the same list.
 
         >>> ak.cartesian([one, two], axis=0, nested=True).show()
         [[(1, 'a'), (1, 'b')],
          [(2, 'a'), (2, 'b')],
          [(3, 'a'), (3, 'b')]]
 
-    The primary purpose of this function, however, is to compute a different
-    Cartesian product for each element of an array: in other words, `axis=1`.
-    The following arrays each have four elements.
+        The primary purpose of this function, however, is to compute a different
+        Cartesian product for each element of an array: in other words, `axis=1`.
+        The following arrays each have four elements.
 
         >>> one = ak.Array([[1, 2, 3], [], [4, 5], [6]])
         >>> two = ak.Array([["a", "b"], ["c"], ["d"], ["e", "f"]])
 
-    The default `axis=1` produces 6 pairs from the Cartesian product of
-    `[1, 2, 3]` and `["a", "b"]`, 0 pairs from `[]` and `["c"]`, 1 pair from
-    `[4, 5]` and `["d"]`, and 1 pair from `[6]` and `["e", "f"]`.
+        The default `axis=1` produces 6 pairs from the Cartesian product of
+        `[1, 2, 3]` and `["a", "b"]`, 0 pairs from `[]` and `["c"]`, 1 pair from
+        `[4, 5]` and `["d"]`, and 1 pair from `[6]` and `["e", "f"]`.
 
         >>> ak.cartesian([one, two]).show()
         [[(1, 'a'), (1, 'b'), (2, 'a'), (2, 'b'), (3, 'a'), (3, 'b')],
@@ -116,9 +119,9 @@ def cartesian(
          [(4, 'd'), (5, 'd')],
          [(6, 'e'), (6, 'f')]]
 
-    The nesting depth is the same as the original arrays; with `nested=True`,
-    the nesting depth is increased by 1 and tuples are grouped by their
-    first element.
+        The nesting depth is the same as the original arrays; with `nested=True`,
+        the nesting depth is increased by 1 and tuples are grouped by their
+        first element.
 
         >>> ak.cartesian([one, two], nested=True).show()
         [[[(1, 'a'), (1, 'b')], [(2, 'a'), (2, ...)], [(3, 'a'), (3, 'b')]],
@@ -126,8 +129,8 @@ def cartesian(
          [[(4, 'd')], [(5, 'd')]],
          [[(6, 'e'), (6, 'f')]]]
 
-    These tuples are #ak.contents.RecordArray nodes with unnamed fields. To
-    name the fields, we can pass `one` and `two` in a dict, rather than a list.
+        These tuples are #ak.contents.RecordArray nodes with unnamed fields. To
+        name the fields, we can pass `one` and `two` in a dict, rather than a list.
 
         >>> ak.cartesian({"x": one, "y": two}).show()
         [[{x: 1, y: 'a'}, {x: 1, y: 'b'}, {...}, ..., {x: 3, y: 'a'}, {x: 3, y: 'b'}],
@@ -135,14 +138,14 @@ def cartesian(
          [{x: 4, y: 'd'}, {x: 5, y: 'd'}],
          [{x: 6, y: 'e'}, {x: 6, y: 'f'}]]
 
-    With more than two elements in the Cartesian product, `nested` can specify
-    which are grouped and which are not. For example,
+        With more than two elements in the Cartesian product, `nested` can specify
+        which are grouped and which are not. For example,
 
         >>> one = ak.Array([1, 2, 3, 4])
         >>> two = ak.Array([1.1, 2.2, 3.3])
         >>> three = ak.Array(["a", "b"])
 
-    can be left entirely ungrouped:
+        can be left entirely ungrouped:
 
         >>> ak.cartesian([one, two, three], axis=0).show()
         [(1, 1.1, 'a'),
@@ -166,7 +169,7 @@ def cartesian(
          (4, 3.3, 'a'),
          (4, 3.3, 'b')]
 
-    can be grouped by `one` (adding 1 more dimension):
+        can be grouped by `one` (adding 1 more dimension):
 
         >>> ak.cartesian([one, two, three], axis=0, nested=[0]).show()
         [[(1, 1.1, 'a'), (1, 1.1, 'b'), (1, 2.2, 'a')],
@@ -178,7 +181,7 @@ def cartesian(
          [(4, 1.1, 'a'), (4, 1.1, 'b'), (4, 2.2, 'a')],
          [(4, 2.2, 'b'), (4, 3.3, 'a'), (4, 3.3, 'b')]]
 
-    can be grouped by `one` and `two` (adding 2 more dimensions):
+        can be grouped by `one` and `two` (adding 2 more dimensions):
 
         >>> ak.cartesian([one, two, three], axis=0, nested=[0, 1]).show()
         [[[(1, 1.1, 'a'), (1, 1.1, 'b')], [...], [(1, 3.3, 'a'), (1, 3.3, ...)]],
@@ -186,7 +189,7 @@ def cartesian(
          [[(3, 1.1, 'a'), (3, 1.1, 'b')], [...], [(3, 3.3, 'a'), (3, 3.3, ...)]],
          [[(4, 1.1, 'a'), (4, 1.1, 'b')], [...], [(4, 3.3, 'a'), (4, 3.3, ...)]]]
 
-    or grouped by unique `one`-`two` pairs (adding 1 more dimension):
+        or grouped by unique `one`-`two` pairs (adding 1 more dimension):
 
         >>> ak.cartesian([one, two, three], axis=0, nested=[1]).show()
         [[(1, 1.1, 'a'), (1, 1.1, 'b')],
@@ -202,18 +205,18 @@ def cartesian(
          [(4, 2.2, 'a'), (4, 2.2, 'b')],
          [(4, 3.3, 'a'), (4, 3.3, 'b')]]
 
-    The order of the output is fixed: it is always lexicographical in the
-    order that the `arrays` are written.
+        The order of the output is fixed: it is always lexicographical in the
+        order that the `arrays` are written.
 
-    To emulate an SQL or Pandas "group by" operation, put the keys that you
-    wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by
-    unique n-tuples. If necessary, record keys can later be reordered with a
-    list of strings in #ak.Array.__getitem__.
+        To emulate an SQL or Pandas "group by" operation, put the keys that you
+        wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by
+        unique n-tuples. If necessary, record keys can later be reordered with a
+        list of strings in #ak.Array.__getitem__.
 
-    To get list index positions in the tuples/records, rather than data from
-    the original `arrays`, use #ak.argcartesian instead of #ak.cartesian. The
-    #ak.argcartesian form can be particularly useful as nested indexing in
-    #ak.Array.__getitem__.
+        To get list index positions in the tuples/records, rather than data from
+        the original `arrays`, use #ak.argcartesian instead of #ak.cartesian. The
+        #ak.argcartesian form can be particularly useful as nested indexing in
+        #ak.Array.__getitem__.
     """
     # Dispatch
     if isinstance(arrays, Mapping):

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -31,7 +31,8 @@ def combinations(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes combinations of `n` items from an array, without replacement.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         n (int): The number of items to choose in each list: `2` chooses
@@ -63,17 +64,19 @@ def combinations(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes a Cartesian product (i.e. cross product) of `array` with itself
-    that is restricted to combinations sampled without replacement. If the
-    normal Cartesian product is thought of as an `n` dimensional tensor, these
-    represent the "upper triangle" of sets without repetition. If
-    `replacement=True`, the diagonal of this "upper triangle" is included.
+    Returns:
+        Computes a Cartesian product (i.e. cross product) of `array` with itself
+        that is restricted to combinations sampled without replacement. If the
+        normal Cartesian product is thought of as an `n` dimensional tensor, these
+        represent the "upper triangle" of sets without repetition. If
+        `replacement=True`, the diagonal of this "upper triangle" is included.
 
-    As a simple example with `axis=0`, consider the following
+    Examples:
+        As a simple example with `axis=0`, consider the following
 
         >>> array = ak.Array(["a", "b", "c", "d", "e"])
 
-    The combinations choose `2` are:
+        The combinations choose `2` are:
 
         >>> ak.combinations(array, 2, axis=0).show()
         [('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
@@ -81,7 +84,7 @@ def combinations(
                                  ('c', 'd'), ('c', 'e'),
                                              ('d', 'e')]
 
-    Including the diagonal allows pairs like `('a', 'a')`.
+        Including the diagonal allows pairs like `('a', 'a')`.
 
         >>> ak.combinations(array, 2, axis=0, replacement=True).show()
         [('a', 'a'), ('a', 'b'), ('a', 'c'), ('a', 'd'), ('a', 'e'),
@@ -90,8 +93,8 @@ def combinations(
                                              ('d', 'd'), ('d', 'e'),
                                                          ('e', 'e')]
 
-    The combinations choose `3` can't be easily arranged as a triangle
-    in two dimensions.
+        The combinations choose `3` can't be easily arranged as a triangle
+        in two dimensions.
 
         >>> ak.combinations(array, 3, axis=0).show()
         [('a', 'b', 'c'),
@@ -105,10 +108,10 @@ def combinations(
          ('b', 'd', 'e'),
          ('c', 'd', 'e')]
 
-    Including the (three-dimensional) diagonal allows triples like
-    `('a', 'a', 'a')`, but also `('a', 'a', 'b')`, `('a', 'b', 'b')`, etc.,
-    but not `('a', 'b', 'a')`. All combinations are in the same order as
-    the original array.
+        Including the (three-dimensional) diagonal allows triples like
+        `('a', 'a', 'a')`, but also `('a', 'a', 'b')`, `('a', 'b', 'b')`, etc.,
+        but not `('a', 'b', 'a')`. All combinations are in the same order as
+        the original array.
 
         >>> ak.combinations(array, 3, axis=0, replacement=True).show()
         [('a', 'a', 'a'),
@@ -132,15 +135,15 @@ def combinations(
          ('d', 'e', 'e'),
          ('e', 'e', 'e')]
 
-    The primary purpose of this function, however, is to compute a different
-    set of combinations for each element of an array: in other words, `axis=1`.
-    The following has a different number of items in each element.
+        The primary purpose of this function, however, is to compute a different
+        set of combinations for each element of an array: in other words, `axis=1`.
+        The following has a different number of items in each element.
 
         >>> array = ak.Array([[1, 2, 3, 4], [], [5], [6, 7, 8]])
 
-    There are 6 ways to choose pairs from 4 elements, 0 ways to choose pairs
-    from 0 elements, 0 ways to choose pairs from 1 element, and 3 ways to
-    choose pairs from 3 elements.
+        There are 6 ways to choose pairs from 4 elements, 0 ways to choose pairs
+        from 0 elements, 0 ways to choose pairs from 1 element, and 3 ways to
+        choose pairs from 3 elements.
 
         >>> ak.combinations(array, 2).show()
         [[(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)],
@@ -148,10 +151,10 @@ def combinations(
          [],
          [(6, 7), (6, 8), (7, 8)]]
 
-    Note, however, that the combinatorics isn't determined by equality of
-    the data themselves, but by their placement in the array. For example,
-    even if all elements of an array are equal, the output has the same
-    structure.
+        Note, however, that the combinatorics isn't determined by equality of
+        the data themselves, but by their placement in the array. For example,
+        even if all elements of an array are equal, the output has the same
+        structure.
 
         >>> same = ak.Array([[7, 7, 7, 7], [], [7], [7, 7, 7]])
         >>> ak.combinations(same, 2).show()
@@ -160,7 +163,7 @@ def combinations(
          [],
          [(7, 7), (7, 7), (7, 7)]]
 
-    To get records instead of tuples, pass a set of field names to `fields`.
+        To get records instead of tuples, pass a set of field names to `fields`.
 
         >>> ak.combinations(array, 2, fields=["x", "y"]).show()
         [
@@ -172,8 +175,8 @@ def combinations(
          [{'x': 6, 'y': 7}, {'x': 6, 'y': 8},
                             {'x': 7, 'y': 8}]]
 
-    This operation can be constructed from #ak.argcartesian and other
-    primitives:
+        This operation can be constructed from #ak.argcartesian and other
+        primitives:
 
         >>> left, right = ak.unzip(ak.argcartesian([array, array]))
         >>> keep = left < right
@@ -185,13 +188,13 @@ def combinations(
          [],
          [(6, 7), (6, 8), (7, 8)]]
 
-    but it is frequently needed for data analysis, and the logic of which
-    indexes to `keep` (above) gets increasingly complicated for large `n`.
+        but it is frequently needed for data analysis, and the logic of which
+        indexes to `keep` (above) gets increasingly complicated for large `n`.
 
-    To get list index positions in the tuples/records, rather than data from
-    the original `array`, use #ak.argcombinations instead of #ak.combinations.
-    The #ak.argcombinations form can be particularly useful as nested indexing
-    in #ak.Array.__getitem__.
+        To get list index positions in the tuples/records, rather than data from
+        the original `array`, use #ak.argcombinations instead of #ak.combinations.
+        The #ak.argcombinations form can be particularly useful as nested indexing
+        in #ak.Array.__getitem__.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_concatenate.py
+++ b/src/awkward/operations/ak_concatenate.py
@@ -36,7 +36,8 @@ np = NumpyMetadata.instance()
 def concatenate(
     arrays, axis=0, *, mergebool=True, highlevel=True, behavior=None, attrs=None
 ):
-    """
+    """Returns an array with the given arrays concatenated along an axis.
+
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).
         axis (int or str): The dimension at which this operation is applied. The
@@ -59,10 +60,11 @@ def concatenate(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns an array with `arrays` concatenated. For `axis=0`, this means that
-    one whole array follows another. For `axis=1`, it means that the `arrays`
-    must have the same lengths and nested lists are each concatenated,
-    element for element, and similarly for deeper levels.
+    Returns:
+        An array with `arrays` concatenated. For `axis=0`, this means that
+        one whole array follows another. For `axis=1`, it means that the `arrays`
+        must have the same lengths and nested lists are each concatenated,
+        element for element, and similarly for deeper levels.
     """
     # Dispatch
     if (

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -21,7 +21,8 @@ np = NumpyMetadata.instance()
 def pad_none(
     array, target, axis=1, *, clip=False, highlevel=True, behavior=None, attrs=None
 ):
-    """
+    """Increases the lengths of lists to a target length by adding None values.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         target (int): The intended length of the lists. If `clip=True`,
@@ -47,9 +48,11 @@ def pad_none(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Increase the lengths of lists to a target length by adding None values.
+    Returns:
+        Increase the lengths of lists to a target length by adding None values.
 
-    Consider the following
+    Examples:
+        Consider the following
 
         >>> array = ak.Array([[[1.1, 2.2, 3.3],
         ...                    [],
@@ -60,8 +63,8 @@ def pad_none(
         ...                    [8.8, 9.9]
         ...                   ]])
 
-    At `axis=0`, this operation pads the whole array, adding None at the
-    outermost level:
+        At `axis=0`, this operation pads the whole array, adding None at the
+        outermost level:
 
         >>> ak.pad_none(array, 5, axis=0).show()
         [[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]],
@@ -70,44 +73,44 @@ def pad_none(
          None,
          None]
 
-    At `axis=1`, this operation pads the first nested level:
+        At `axis=1`, this operation pads the first nested level:
 
         >>> ak.pad_none(array, 3, axis=1).show()
         [[[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]],
          [None, None, None],
          [[7.7], [8.8, 9.9], None]]
 
-    And so on for higher values of `axis`:
+        And so on for higher values of `axis`:
 
         >>> ak.pad_none(array, 2, axis=2).show()
         [[[1.1, 2.2, 3.3], [None, None], [4.4, 5.5], [6.6, None]],
          [],
          [[7.7, None], [8.8, 9.9]]]
 
-    Note that the `clip` parameter not only determines whether the lengths are
-    at least `target` or exactly `target`, it also determines the type of the
-    output:
+        Note that the `clip` parameter not only determines whether the lengths are
+        at least `target` or exactly `target`, it also determines the type of the
+        output:
 
-    * `clip=True` returns regular lists (#ak.types.RegularType), and
-    * `clip=False` returns in-principle variable lengths
-      (#ak.types.ListType).
+        * `clip=True` returns regular lists (#ak.types.RegularType), and
+        * `clip=False` returns in-principle variable lengths
+          (#ak.types.ListType).
 
-    The in-principle variable-length lists might, in fact, all have the same
-    length, but the type difference is significant, for instance in
-    broadcasting rules (see #ak.broadcast_arrays).
+        The in-principle variable-length lists might, in fact, all have the same
+        length, but the type difference is significant, for instance in
+        broadcasting rules (see #ak.broadcast_arrays).
 
-    The difference between
+        The difference between
 
         >>> ak.pad_none(array, 2, axis=2)
         <Array [[[1.1, 2.2, 3.3], ..., [...]], ...] type='3 * var * var * ?float64'>
 
-    and
+        and
 
         >>> ak.pad_none(array, 2, axis=2, clip=True)
         <Array [[[1.1, 2.2], ..., [6.6, None]], ...] type='3 * var * 2 * ?float64'>
 
-    is not just in the length of `[1.1, 2.2, 3.3]` vs `[1.1, 2.2]`, but also
-    in the distinction between the following types.
+        is not just in the length of `[1.1, 2.2, 3.3]` vs `[1.1, 2.2]`, but also
+        in the distinction between the following types.
 
         >>> ak.pad_none(array, 2, axis=2).type.show()
         3 * var * var * ?float64

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -15,7 +15,8 @@ np = NumpyMetadata.instance()
 
 @high_level_function()
 def ravel(array, *, highlevel=True, behavior=None, attrs=None):
-    """
+    """Returns an array with all levels of nesting removed.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
@@ -25,12 +26,14 @@ def ravel(array, *, highlevel=True, behavior=None, attrs=None):
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns an array with all level of nesting removed by erasing the
-    boundaries between consecutive lists.
+    Returns:
+        An array with all level of nesting removed by erasing the
+        boundaries between consecutive lists.
 
-    This is the equivalent of NumPy's `np.ravel` for Awkward Arrays.
+        This is the equivalent of NumPy's `np.ravel` for Awkward Arrays.
 
-    Consider the following:
+    Examples:
+        Consider the following:
 
         >>> array = ak.Array([[[1.1, 2.2, 3.3],
         ...                    [],
@@ -41,7 +44,7 @@ def ravel(array, *, highlevel=True, behavior=None, attrs=None):
         ...                    [8.8, 9.9]
         ...                   ]])
 
-    Ravelling the array produces a flat array
+        Ravelling the array produces a flat array
 
         >>> ak.ravel(array).show()
         [1.1,
@@ -54,8 +57,8 @@ def ravel(array, *, highlevel=True, behavior=None, attrs=None):
          8.8,
          9.9]
 
-    Missing values are not eliminated by flattening. See #ak.flatten with
-    `axis=None` for an equivalent function that eliminates the option type.
+        Missing values are not eliminated by flattening. See #ak.flatten with
+        `axis=None` for an equivalent function that eliminates the option type.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -24,7 +24,8 @@ numpy_backend = NumpyBackend.instance()
 
 @high_level_function()
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=None):
-    """
+    """Returns an array with an additional level of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         counts (int or array): Number of elements the new level should have.
@@ -46,11 +47,13 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns an array with an additional level of nesting. This is roughly the
-    inverse of #ak.flatten, where `counts` were obtained by #ak.num (both with
-    `axis=1`).
+    Returns:
+        An array with an additional level of nesting. This is roughly the
+        inverse of #ak.flatten, where `counts` were obtained by #ak.num (both
+        with `axis=1`).
 
-    For example,
+    Examples:
+        For example,
 
         >>> original = ak.Array([[0, 1, 2], [], [3, 4], [5], [6, 7, 8, 9]])
         >>> counts = ak.num(original)
@@ -62,10 +65,10 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
         >>> ak.unflatten(array, counts)
         <Array [[0, 1, 2], [], [3, ...], [5], [6, 7, 8, 9]] type='5 * var * int64'>
 
-    An inner dimension can be unflattened by setting the `axis` parameter, but
-    operations like this constrain the `counts` more tightly.
+        An inner dimension can be unflattened by setting the `axis` parameter, but
+        operations like this constrain the `counts` more tightly.
 
-    For example, we can subdivide an already divided list:
+        For example, we can subdivide an already divided list:
 
         >>> original = ak.Array([[1, 2, 3, 4], [], [5, 6, 7], [8, 9]])
         >>> ak.unflatten(original, [2, 2, 1, 2, 1, 1], axis=1).show()
@@ -74,8 +77,8 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
          [[5], [6, 7]],
          [[8], [9]]]
 
-    But the counts have to add up to the lengths of those lists. We can't mix
-    values from the first `[1, 2, 3, 4]` with values from the next `[5, 6, 7]`.
+        But the counts have to add up to the lengths of those lists. We can't mix
+        values from the first `[1, 2, 3, 4]` with values from the next `[5, 6, 7]`.
 
         >>> ak.unflatten(original, [2, 1, 2, 2, 1, 1], axis=1).show()
         ValueError: while calling
@@ -88,10 +91,10 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
             )
         Error details: structure imposed by 'counts' does not fit in the array or partition at axis=1
 
-    Also note that new lists created by this function cannot cross partitions
-    (which is only possible at `axis=0`, anyway).
+        Also note that new lists created by this function cannot cross partitions
+        (which is only possible at `axis=0`, anyway).
 
-    See also #ak.num and #ak.flatten.
+        See also #ak.num and #ak.flatten.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_unzip.py
+++ b/src/awkward/operations/ak_unzip.py
@@ -21,7 +21,8 @@ def unzip(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Splits records or tuples into a tuple or dict of arrays, one per field.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         how (type): The type of the returned output. This can be `tuple` or `dict`.
@@ -32,13 +33,15 @@ def unzip(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    If the `array` contains tuples or records, this operation splits them
-    into a Python tuple (or dict) of arrays, one for each field.
+    Returns:
+        If the `array` contains tuples or records, this operation splits them
+        into a Python tuple (or dict) of arrays, one for each field.
 
-    If the `array` does not contain tuples or records, the single `array`
-    is placed in a length 1 Python tuple (or dict).
+        If the `array` does not contain tuples or records, the single `array`
+        is placed in a length 1 Python tuple (or dict).
 
-    For example,
+    Examples:
+        For example,
 
         >>> array = ak.Array([{"x": 1.1, "y": [1]},
         ...                   {"x": 2.2, "y": [2, 2]},
@@ -49,9 +52,9 @@ def unzip(
         >>> y
         <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>
 
-    The `how` argument determines the structure of the output. Using `how=dict`
-    returns a dictionary of arrays instead of a tuple, and let's you round-trip
-    through `ak.zip`:
+        The `how` argument determines the structure of the output. Using `how=dict`
+        returns a dictionary of arrays instead of a tuple, and let's you round-trip
+        through `ak.zip`:
 
         >>> array = ak.Array([{"x": 1.1, "y": [1]},
         ...                   {"x": 2.2, "y": [2, 2]},
@@ -61,7 +64,6 @@ def unzip(
         {'x': <Array [1.1, 2.2, 3.3] type='3 * float64'>,
          'y': <Array [[1], [2, 2], [3, 3, 3]] type='3 * var * int64'>}
         >>> assert ak.zip(ak.unzip(array, how=dict), depth_limit=1).to_list() == array.to_list()  # True
-
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -29,7 +29,8 @@ def zip(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Combines arrays into records or tuples, broadcasting them together.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -53,23 +54,25 @@ def zip(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Combines `arrays` into a single structure as the fields of a collection
-    of records or the slots of a collection of tuples. If the `arrays` have
-    nested structure, they are broadcasted with one another to form the
-    records or tuples as deeply as possible, though this can be limited by
-    `depth_limit`.
+    Returns:
+        Combines `arrays` into a single structure as the fields of a collection
+        of records or the slots of a collection of tuples. If the `arrays` have
+        nested structure, they are broadcasted with one another to form the
+        records or tuples as deeply as possible, though this can be limited by
+        `depth_limit`.
 
-    This operation may be thought of as the opposite of projection in
-    #ak.Array.__getitem__, which extracts fields one at a time, or
-    #ak.unzip, which extracts them all in one call.
+        This operation may be thought of as the opposite of projection in
+        #ak.Array.__getitem__, which extracts fields one at a time, or
+        #ak.unzip, which extracts them all in one call.
 
-    Consider the following arrays, `one` and `two`.
+    Examples:
+        Consider the following arrays, `one` and `two`.
 
         >>> one = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]])
         >>> two = ak.Array([["a", "b", "c"], [], ["d", "e"], ["f"]])
 
-    Zipping them together using a dict creates a collection of records with
-    the same nesting structure as `one` and `two`.
+        Zipping them together using a dict creates a collection of records with
+        the same nesting structure as `one` and `two`.
 
         >>> ak.zip({"x": one, "y": two}).show()
         [[{x: 1.1, y: 'a'}, {x: 2.2, y: 'b'}, {x: 3.3, y: 'c'}],
@@ -77,7 +80,7 @@ def zip(
          [{x: 4.4, y: 'd'}, {x: 5.5, y: 'e'}],
          [{x: 6.6, y: 'f'}]]
 
-    Doing so with a list creates tuples, whose fields are not named.
+        Doing so with a list creates tuples, whose fields are not named.
 
         >>> ak.zip([one, two]).show()
         [[(1.1, 'a'), (2.2, 'b'), (3.3, 'c')],
@@ -85,9 +88,9 @@ def zip(
          [(4.4, 'd'), (5.5, 'e')],
          [(6.6, 'f')]]
 
-    Adding a third array with the same length as `one` and `two` but less
-    internal structure is okay: it gets broadcasted to match the others.
-    (See #ak.broadcast_arrays for broadcasting rules.)
+        Adding a third array with the same length as `one` and `two` but less
+        internal structure is okay: it gets broadcasted to match the others.
+        (See #ak.broadcast_arrays for broadcasting rules.)
 
         >>> three = ak.Array([100, 200, 300, 400])
         >>> ak.zip([one, two, three]).show()
@@ -96,8 +99,8 @@ def zip(
          [(4.4, 'd', 300), (5.5, 'e', 300)],
          [(6.6, 'f', 400)]]
 
-    However, if arrays have the same depth but different lengths of nested
-    lists, attempting to zip them together is a broadcasting error.
+        However, if arrays have the same depth but different lengths of nested
+        lists, attempting to zip them together is a broadcasting error.
 
         >>> one = ak.Array([[[1, 2, 3], [], [4, 5], [6]], [], [[7, 8]]])
         >>> two = ak.Array([[[1.1, 2.2], [3.3], [4.4], [5.5]], [], [[6.6]]])
@@ -115,30 +118,30 @@ def zip(
             )
         Error details: cannot broadcast nested list
 
-    For this, one can set the `depth_limit` to prevent the operation from
-    attempting to broadcast what can't be broadcasted.
+        For this, one can set the `depth_limit` to prevent the operation from
+        attempting to broadcast what can't be broadcasted.
 
         >>> ak.zip([one, two], depth_limit=1).show()
         [([[1, 2, 3], [], [4, ...], [6]], [[1.1, ...], ...]),
          ([], []),
          ([[7, 8]], [[6.6]])]
 
-    As an extreme, `depth_limit=1` is a handy way to make a record structure
-    at the outermost level, regardless of whether the fields have matching
-    structure or not.
+        As an extreme, `depth_limit=1` is a handy way to make a record structure
+        at the outermost level, regardless of whether the fields have matching
+        structure or not.
 
-    When zipping together arrays with optional values, it can be useful to create
-    the #ak.contents.RecordArray node after the option types. By default, #ak.zip
-    does not do this:
+        When zipping together arrays with optional values, it can be useful to create
+        the #ak.contents.RecordArray node after the option types. By default, #ak.zip
+        does not do this:
 
         >>> one = ak.Array([1, 2, None])
         >>> two = ak.Array([None, 5, 6])
         >>> ak.zip([one, two])
         <Array [(1, None), (2, 5), (None, 6)] type='3 * (?int64, ?int64)'>
 
-    If the `optiontype_outside_record` option is set to `True`, Awkward will continue to
-    broadcast the arrays together at the depth_limit until it reaches non-option
-    types. This effectively takes the union of the option mask:
+        If the `optiontype_outside_record` option is set to `True`, Awkward will continue to
+        broadcast the arrays together at the depth_limit until it reaches non-option
+        types. This effectively takes the union of the option mask:
 
         >>> ak.zip([one, two], optiontype_outside_record=True)
         <Array [None, (2, 5), None] type='3 * ?(int64, int64)'>

--- a/src/awkward/operations/ak_zip_no_broadcast.py
+++ b/src/awkward/operations/ak_zip_no_broadcast.py
@@ -26,7 +26,8 @@ def zip_no_broadcast(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Combines arrays into a collection of records or tuples without broadcasting.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -42,23 +43,25 @@ def zip_no_broadcast(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Combines `arrays` into a single structure as the fields of a collection
-    of records or the slots of a collection of tuples.
+    Returns:
+        Combines `arrays` into a single structure as the fields of a collection
+        of records or the slots of a collection of tuples.
 
-    Caution: unlike #ak.zip this function will _not_ broadcast the arrays together.
-    During typetracing, it assumes that the given arrays have already the same layouts and lengths.
+        Caution: unlike #ak.zip this function will _not_ broadcast the arrays together.
+        During typetracing, it assumes that the given arrays have already the same layouts and lengths.
 
-    This operation may be thought of as the opposite of projection in
-    #ak.Array.__getitem__, which extracts fields one at a time, or
-    #ak.unzip, which extracts them all in one call.
+        This operation may be thought of as the opposite of projection in
+        #ak.Array.__getitem__, which extracts fields one at a time, or
+        #ak.unzip, which extracts them all in one call.
 
-    Consider the following arrays, `one` and `two`.
+    Examples:
+        Consider the following arrays, `one` and `two`.
 
         >>> one = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5], [6.6]])
         >>> two = ak.Array([["a", "b", "c"], [], ["d", "e"], ["f"]])
 
-    Zipping them together using a dict creates a collection of records with
-    the same nesting structure as `one` and `two`.
+        Zipping them together using a dict creates a collection of records with
+        the same nesting structure as `one` and `two`.
 
         >>> ak.zip_no_broadcast({"x": one, "y": two}).show()
         [[{x: 1.1, y: 'a'}, {x: 2.2, y: 'b'}, {x: 3.3, y: 'c'}],
@@ -66,7 +69,7 @@ def zip_no_broadcast(
          [{x: 4.4, y: 'd'}],
          []]
 
-    Doing so with a list creates tuples, whose fields are not named.
+        Doing so with a list creates tuples, whose fields are not named.
 
         >>> ak.zip_no_broadcast([one, two]).show()
         [[(1.1, 'a'), (2.2, 'b'), (3.3, 'c')],
@@ -74,7 +77,7 @@ def zip_no_broadcast(
          [(4.4, 'd')],
          []]
 
-    See also #ak.zip and #ak.unzip.
+        See also #ak.zip and #ak.unzip.
     """
     # Dispatch
     if isinstance(arrays, Mapping):


### PR DESCRIPTION
## Summary

Rolls the pilot from #3946 out to the 13 operations in the **Structural** batch of #3980:

`ravel`, `unflatten`, `zip`, `unzip`, `zip_no_broadcast`, `cartesian`, `argcartesian`, `combinations`, `argcombinations`, `concatenate`, `broadcast_arrays`, `broadcast_fields`, `pad_none`.

Each docstring now has:

- A one-line summary on the opening `"""`.
- `Returns:` and `Examples:` section headers (the latter only where examples exist).

Original body text is preserved; only structural edits are applied. The summary lines were reviewed against the checklist posted at #3980 (comment).

## Summary lines

| Operation | Summary |
|---|---|
| `ak.ravel` | Returns an array with all levels of nesting removed. |
| `ak.unflatten` | Returns an array with an additional level of nesting. |
| `ak.zip` | Combines arrays into records or tuples, broadcasting them together. |
| `ak.unzip` | Splits records or tuples into a tuple or dict of arrays, one per field. |
| `ak.zip_no_broadcast` | Combines arrays into a collection of records or tuples without broadcasting. |
| `ak.cartesian` | Computes the Cartesian product (cross product) of data from a set of arrays. |
| `ak.argcartesian` | Computes the Cartesian product of arrays, returning integer indexes. |
| `ak.combinations` | Computes combinations of \`n\` items from an array, without replacement. |
| `ak.argcombinations` | Computes combinations of \`n\` items from an array, returning integer indexes. |
| `ak.concatenate` | Returns an array with the given arrays concatenated along an axis. |
| `ak.broadcast_arrays` | Broadcasts arrays together so they can be combined element-by-element. |
| `ak.broadcast_fields` | Returns a list of arrays whose record types contain the same fields. |
| `ak.pad_none` | Increases the lengths of lists to a target length by adding None values. |

## Test plan

- [ ] pre-commit passes locally on the 13 modified files (ruff check, ruff format, codespell, mypy).
- [ ] `import awkward; ak.ravel.__doc__` etc. render correctly.
- [ ] Sphinx docs build cleanly on CI.
- [ ] Rendered docstrings look right for at least one with narrative (e.g. `ak.zip`) and one without examples (e.g. `ak.concatenate`, `ak.argcombinations`).

Part of #3980. Draft for initial review; will mark ready once CI passes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>