### PR TITLE
fix: ensure jax backend uses arrays on cpu only

### DIFF
--- a/docs/user-guide/how-to-specialize-differentiate-jax.md
+++ b/docs/user-guide/how-to-specialize-differentiate-jax.md
@@ -24,11 +24,10 @@ JAX, amongst other things, is a powerful tool for computing derivatives of nativ
 How to differentiate Awkward Arrays?
 ------------------------------------
 
-For this notebook (which is evaluated on a CPU), we need to configure JAX to use only the CPU.
+First, import JAX.
 
 ```{code-cell}
 import jax
-jax.config.update("jax_platform_name", "cpu")
 ```
 
 Next, we must call {func}`ak.jax.register_and_check()` to register Awkward's JAX integration.

--- a/src/awkward/_backends/jax.py
+++ b/src/awkward/_backends/jax.py
@@ -36,6 +36,7 @@ class JaxBackend(Backend):
             DeprecationWarning,
             stacklevel=2,
         )
+        ak.jax.ensure_jax_config()
         self._jax = Jax.instance()
 
     def __getitem__(self, index: KernelKeyType) -> JaxKernel:

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -125,7 +125,10 @@ class JaxKernel(BaseKernel):
                 assert self._jax.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
                     if x.device.platform != "cpu":
-                        raise RuntimeError("The JAX backend requires CPU JAX buffers")
+                        raise RuntimeError(
+                            "The JAX backend requires CPU JAX buffers to be the default. You can make CPU the default backend"
+                            " with jax.config.update('jax_platform_name', 'cpu') or by setting JAX_PLATFORM_NAME=cpu."
+                        )
                     return ctypes.cast(self._jax.memory_ptr(x), t)
                 else:
                     return x

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -124,6 +124,10 @@ class JaxKernel(BaseKernel):
                     raise ValueError(msg)
                 assert self._jax.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
+                    if x.device.platform != "cpu":
+                        raise RuntimeError(
+                            "Awkward's JAX backend requires CPU JAX buffers"
+                        )
                     return ctypes.cast(self._jax.memory_ptr(x), t)
                 else:
                     return x

--- a/src/awkward/_kernels.py
+++ b/src/awkward/_kernels.py
@@ -125,9 +125,7 @@ class JaxKernel(BaseKernel):
                 assert self._jax.is_c_contiguous(x), "kernel expects contiguous array"
                 if x.ndim > 0:
                     if x.device.platform != "cpu":
-                        raise RuntimeError(
-                            "Awkward's JAX backend requires CPU JAX buffers"
-                        )
+                        raise RuntimeError("The JAX backend requires CPU JAX buffers")
                     return ctypes.cast(self._jax.memory_ptr(x), t)
                 else:
                     return x

--- a/src/awkward/_nplikes/jax.py
+++ b/src/awkward/_nplikes/jax.py
@@ -29,6 +29,7 @@ class Jax(ArrayModuleNumpyLike):
             stacklevel=2,
         )
         jax = ak.jax.import_jax()
+        ak.jax.ensure_jax_config()
         self._module = jax.numpy
 
     def prepare_ufunc(self, ufunc: UfuncLike) -> UfuncLike:

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -64,10 +64,10 @@ def ensure_jax_config():
     import jax  # noqa: TID251
 
     if not jax.config.read("jax_enable_x64"):
-        raise RuntimeError("Awkward's JAX backend requires jax_enable_x64=True")
+        raise RuntimeError("The JAX backend requires jax_enable_x64=True")
 
     if jax.default_backend() != "cpu":
-        raise RuntimeError("Awkward's JAX backend requires the JAX CPU backend")
+        raise RuntimeError("The JAX backend requires the JAX CPU backend")
 
 
 HighLevelType = TypeVar(

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -36,7 +36,7 @@ def register_and_check():
     try:
         import jax  # noqa: TID251
 
-        # ak.from_buffers needs this
+        jax.config.update("jax_platform_name", "cpu")
         jax.config.update("jax_enable_x64", True)
 
     except ModuleNotFoundError:
@@ -58,6 +58,16 @@ def register_and_check():
         DeprecationWarning,
         stacklevel=2,
     )
+
+
+def ensure_jax_config():
+    import jax  # noqa: TID251
+
+    if not jax.config.read("jax_enable_x64"):
+        raise RuntimeError("Awkward's JAX backend requires jax_enable_x64=True")
+
+    if jax.default_backend() != "cpu":
+        raise RuntimeError("Awkward's JAX backend requires the JAX CPU backend")
 
 
 HighLevelType = TypeVar(

--- a/src/awkward/jax.py
+++ b/src/awkward/jax.py
@@ -64,10 +64,16 @@ def ensure_jax_config():
     import jax  # noqa: TID251
 
     if not jax.config.read("jax_enable_x64"):
-        raise RuntimeError("The JAX backend requires jax_enable_x64=True")
+        raise RuntimeError(
+            "The JAX backend requires 64-bit dtypes. You can enable them with"
+            " jax.config.update('jax_enable_x64', True) or by setting JAX_ENABLE_X64=1."
+        )
 
     if jax.default_backend() != "cpu":
-        raise RuntimeError("The JAX backend requires the JAX CPU backend")
+        raise RuntimeError(
+            "The JAX backend requires the JAX CPU backend to be the default. You can make it the default"
+            " with jax.config.update('jax_platform_name', 'cpu') or by setting JAX_PLATFORM_NAME=cpu."
+        )
 
 
 HighLevelType = TypeVar(

--- a/src/awkward/operations/ak_from_jax.py
+++ b/src/awkward/operations/ak_from_jax.py
@@ -21,7 +21,7 @@ def from_jax(
 ):
     """
     Args:
-        array (jax.numpy.DeviceArray): The JAX DeviceArray to convert into an Awkward Array.
+        array (jax.Array): The JAX Array to convert into an Awkward Array.
         regulararray (bool): If True and the array is multidimensional,
             the dimensions are represented by nested #ak.contents.RegularArray
             nodes; if False and the array is multidimensional, the dimensions
@@ -34,7 +34,7 @@ def from_jax(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Converts a JAX DeviceArray array into an Awkward Array.
+    Converts a JAX Array into an Awkward Array.
 
     The resulting layout may involve the following #ak.contents.Content types
     (only):

--- a/src/awkward/operations/ak_to_layout.py
+++ b/src/awkward/operations/ak_to_layout.py
@@ -44,7 +44,7 @@ def to_layout(
         array: Array-like data. May be a high level #ak.Array, #ak.Record (if `allow_record`),
             #ak.ArrayBuilder, or low-level #ak.contents.Content, #ak.record.Record (if `allow_record`),
             or a supported backend array (NumPy `ndarray`, CuPy `ndarray`,
-            JAX DeviceArray), data-less TypeTracer, Arrow object, or an arbitrary Python
+            JAX Array), data-less TypeTracer, Arrow object, or an arbitrary Python
             iterable (for #ak.from_iter to convert).
         allow_record (bool): If True, allow #ak.record.Record as an output;
             otherwise, if the output would be a scalar record, raise an error.

--- a/tests/test_1447_jax_autodiff_slices_ufuncs.py
+++ b/tests/test_1447_jax_autodiff_slices_ufuncs.py
@@ -8,7 +8,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_platform_name", "cpu")
 
 ak.jax.register_and_check()
 

--- a/tests/test_1490_jax_reducers_combinations.py
+++ b/tests/test_1490_jax_reducers_combinations.py
@@ -9,7 +9,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_platform_name", "cpu")
 
 ak.jax.register_and_check()
 

--- a/tests/test_1762_jax_behavior_support.py
+++ b/tests/test_1762_jax_behavior_support.py
@@ -8,7 +8,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_platform_name", "cpu")
 
 ak.jax.register_and_check()
 

--- a/tests/test_1764_jax_jacobian.py
+++ b/tests/test_1764_jax_jacobian.py
@@ -7,7 +7,6 @@ import pytest
 import awkward as ak
 
 jax = pytest.importorskip("jax")
-jax.config.update("jax_platform_name", "cpu")
 
 ak.jax.register_and_check()
 


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3458. I did not know it at the time that jax will put all the arrays on the gpu by default if it can.
Jax buffers go through awkward-cpp kernels and if they live on gpu (which is the default for jax if you have a gpu and a gpu enabled jax build) you get a seg fault cause you'd be dereferencing a pointer pointing to a GPU address. We ensure that awkward works with only cpu buffers for jax.