### PR TITLE
chore: Use kw-only arguments in all cuda.compute invocations

### DIFF
--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -66,16 +66,16 @@ def segmented_sort(
     order = SortOrder.ASCENDING if ascending else SortOrder.DESCENDING
 
     segmented_sort(
-        fromptr,  # d_in_keys
-        toptr,  # d_out_keys
-        None,  # d_in_values (not sorting values, just keys)
-        None,  # d_out_values
-        num_items,  # num_items
-        num_segments,  # num_segments
-        start_offsets,  # start_offsets_in
-        end_offsets,  # end_offsets_in
-        order,  # order (ASCENDING or DESCENDING)
-        None,  # stream (use default stream)
+        d_in_keys=fromptr,
+        d_out_keys=toptr,
+        d_in_values=None,
+        d_out_values=None,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=start_offsets,
+        end_offsets_in=end_offsets,
+        order=order,
+        stream=None,
     )
 
 
@@ -162,7 +162,9 @@ def awkward_reduce_argmax(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_argmax, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_argmax, num_items=outlength
+    )
 
 
 # this function is called from ~/awkward/src/awkward/_reducers.py:161 (ArgMin.apply())
@@ -196,7 +198,9 @@ def awkward_reduce_argmin(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_argmin, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_argmin, num_items=outlength
+    )
 
 
 def awkward_axis_none_reduce_max(array):
@@ -215,7 +219,13 @@ def awkward_axis_none_reduce_max(array):
 
     result_scalar = cp.empty(1, dtype=index_dtype)
     h_init = np.array([min], dtype=index_dtype)
-    reduce_into(array, result_scalar, reduce_op, len(array), h_init)
+    reduce_into(
+        d_in=array,
+        d_out=result_scalar,
+        op=reduce_op,
+        num_items=len(array),
+        h_init=h_init,
+    )
 
     return result_scalar
 
@@ -252,7 +262,9 @@ def awkward_reduce_sum(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_sum, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_sum, num_items=outlength
+    )
 
 
 # original implementation - currently bools don't work because of a bug on numba side
@@ -290,7 +302,9 @@ def awkward_reduce_sum_bool(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_sum, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_sum, num_items=outlength
+    )
 
 
 # this is the same as awkward_reduce_sum (we can possibly use it after the bug on numba side is fixed)
@@ -330,7 +344,9 @@ def awkward_reduce_sum_int32_bool_64(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_sum, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_sum, num_items=outlength
+    )
 
 
 def awkward_reduce_prod(
@@ -366,7 +382,9 @@ def awkward_reduce_prod(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_prod, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_prod, num_items=outlength
+    )
 
 
 def awkward_reduce_prod_bool(
@@ -403,7 +421,9 @@ def awkward_reduce_prod_bool(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_prod, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_prod, num_items=outlength
+    )
 
 
 def awkward_reduce_max(
@@ -443,7 +463,9 @@ def awkward_reduce_max(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_max, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_max, num_items=outlength
+    )
 
 
 # original implementation of `awkward_reduce_max_complex` (doesn't work - keep for archive)
@@ -509,7 +531,9 @@ def awkward_reduce_max_complex(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_max, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_max, num_items=outlength
+    )
 
     # print("this is the result:", result)
 
@@ -551,7 +575,9 @@ def awkward_reduce_min(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_min, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_min, num_items=outlength
+    )
 
 
 def awkward_reduce_count_64(
@@ -588,7 +614,9 @@ def awkward_reduce_count_64(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_count, outlength)
+    unary_transform(
+        d_in=segment_ids, d_out=result, op=segment_reduce_count, num_items=outlength
+    )
 
 
 def awkward_reduce_countnonzero(
@@ -628,4 +656,9 @@ def awkward_reduce_countnonzero(
     type_wrapper = cp.dtype(index_dtype).type
     segment_ids = CountingIterator(type_wrapper(0))
     # TODO: try using segmented_reduce instead when https://github.com/NVIDIA/cccl/issues/6171 is fixed
-    unary_transform(segment_ids, result, segment_reduce_count_nonzero, outlength)
+    unary_transform(
+        d_in=segment_ids,
+        d_out=result,
+        op=segment_reduce_count_nonzero,
+        num_items=outlength,
+    )

--- a/src/awkward/_connect/cuda/reducers.py
+++ b/src/awkward/_connect/cuda/reducers.py
@@ -240,7 +240,13 @@ def awkward_axis_none_reduce_argmin(array):
 
     result_scalar = cp.empty(1, dtype=ak_array)
     h_init = ak_array(max, -1)
-    reduce_into(input_struct, result_scalar, reduce_op, len(array), h_init)
+    reduce_into(
+        d_in=input_struct,
+        d_out=result_scalar,
+        op=reduce_op,
+        num_items=len(array),
+        h_init=h_init,
+    )
 
     # return the index of the maximum value
     return result_scalar.item()[1]
@@ -418,7 +424,13 @@ def awkward_axis_none_reduce_argmax(array):
 
     result_scalar = cp.empty(1, dtype=ak_array)
     h_init = ak_array(min, -1)
-    reduce_into(input_struct, result_scalar, reduce_op, len(array), h_init)
+    reduce_into(
+        d_in=input_struct,
+        d_out=result_scalar,
+        op=reduce_op,
+        num_items=len(array),
+        h_init=h_init,
+    )
 
     # return the index of the maximum value
     return result_scalar.item()[1]


### PR DESCRIPTION
The latest release of `cuda.compute` switches to exclusively keyword-only arguments for all APIs: https://github.com/NVIDIA/cccl/releases/tag/python-0.7.0.