### PR TITLE
chore: bump hypothesis-awkward from 0.16.0 to 0.18.0

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,5 +1,5 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-hypothesis-awkward==0.16.0
+hypothesis-awkward==0.18.0
 jax[cpu]>=0.2.15;sys_platform != "win32"
 numba>=0.50.0;sys_platform != "win32"
 numexpr>=2.7


### PR DESCRIPTION
## Summary
- `hypothesis-awkward==0.18.0` requires `hypothesis>=6.152.4` (verified via PyPI `requires_dist`).
- Hypothesis `6.152.4` ([release notes](https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.152.4)) fixes [HypothesisWorks/hypothesis#4708](https://github.com/HypothesisWorks/hypothesis/issues/4708).
- Once this is merged, **#3985 is no longer needed and can be closed.**

## Change
- `requirements-test-full.txt`: `hypothesis-awkward==0.16.0` → `==0.18.0` (skips `0.16.1` and `0.17.0` to arrive at the current latest).
- Per the strategy in #3942 / #3944, pinning + Dependabot is intentional so any sample-distribution change in a new `hypothesis-awkward` release shows up in a dedicated PR rather than in unrelated CI runs.

## Why a manual bump
- Dependabot's PR #3989 (`0.16.0 → 0.17.0`) was closed without merging and its branch was deleted, leaving `hypothesis-awkward` under a `0.x.x` ignore rule that also suppresses `0.18.0`. See the closing comment from `dependabot[bot]` in #3989.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>