### PR TITLE
fix: array attrs not being validated at creation and being of inconsistent type

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -356,7 +356,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
 
         self._layout = layout
         self._behavior = behavior
-        self._attrs = attrs
+        self._attrs = None if attrs is None else Attrs(attrs)
 
         docstr = layout.purelist_parameter("__doc__")
         if isinstance(docstr, str):
@@ -1904,7 +1904,7 @@ class Record(NDArrayOperatorsMixin):
 
         self._layout = layout
         self._behavior = behavior
-        self._attrs = attrs
+        self._attrs = None if attrs is None else Attrs(attrs)
 
         docstr = layout.purelist_parameter("__doc__")
         if isinstance(docstr, str):
@@ -2718,9 +2718,12 @@ class ArrayBuilder(Sized):
         if behavior is not None and not isinstance(behavior, Mapping):
             raise TypeError("behavior must be None or mapping")
 
+        if attrs is not None and not isinstance(attrs, Mapping):
+            raise TypeError("attrs must be None or a mapping")
+
         self._layout = _ext.ArrayBuilder(initial=initial, resize=resize)
         self._behavior = behavior
-        self._attrs = attrs
+        self._attrs = None if attrs is None else Attrs(attrs)
 
     @classmethod
     def _wrap(cls, layout, behavior=None, attrs=None):
@@ -2741,7 +2744,7 @@ class ArrayBuilder(Sized):
         out = cls.__new__(cls)
         out._layout = layout
         out._behavior = behavior
-        out._attrs = attrs
+        out._attrs = None if attrs is None else Attrs(attrs)
         return out
 
     @property

--- a/tests/test_3996_attrs_validated_at_creation.py
+++ b/tests/test_3996_attrs_validated_at_creation.py
@@ -1,0 +1,77 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+from awkward._attrs import Attrs
+
+
+def test_attrs_wrapped_in_Attrs_at_creation():
+    attrs = {"a": 1, "b": 2}
+
+    array = ak.Array([1, 2, 3], attrs=attrs)
+    assert isinstance(array.attrs, Attrs)
+    assert isinstance(array._attrs, Attrs)
+    assert dict(array.attrs) == attrs
+
+    record = ak.Record({"x": 1}, attrs=attrs)
+    assert isinstance(record.attrs, Attrs)
+    assert isinstance(record._attrs, Attrs)
+    assert dict(record.attrs) == attrs
+
+    builder = ak.ArrayBuilder(attrs=attrs)
+    assert isinstance(builder.attrs, Attrs)
+    assert isinstance(builder._attrs, Attrs)
+    assert dict(builder.attrs) == attrs
+
+
+def test_attrs_isolated_from_original_dict():
+    attrs = {"a": 1}
+    array = ak.Array([1, 2, 3], attrs=attrs)
+    record = ak.Record({"x": 1}, attrs=attrs)
+    builder = ak.ArrayBuilder(attrs=attrs)
+
+    attrs["a"] = 999
+
+    assert array.attrs["a"] == 1
+    assert record.attrs["a"] == 1
+    assert builder.attrs["a"] == 1
+
+
+def test_non_string_keys_rejected_at_creation():
+    bad_attrs = {1: 2}
+
+    with pytest.raises(TypeError, match="'attrs' keys must be strings"):
+        ak.Array([1, 2, 3], attrs=bad_attrs)
+    with pytest.raises(TypeError, match="'attrs' keys must be strings"):
+        ak.Record({"x": 1}, attrs=bad_attrs)
+    with pytest.raises(TypeError, match="'attrs' keys must be strings"):
+        ak.ArrayBuilder(attrs=bad_attrs)
+
+
+def test_non_mapping_attrs_rejected_at_creation():
+    with pytest.raises(TypeError, match="attrs must be None or a mapping"):
+        ak.Array([1, 2, 3], attrs=[("a", 1)])
+    with pytest.raises(TypeError, match="attrs must be None or a mapping"):
+        ak.Record({"x": 1}, attrs=[("a", 1)])
+    with pytest.raises(TypeError, match="attrs must be None or a mapping"):
+        ak.ArrayBuilder(attrs=[("a", 1)])
+
+
+def test_attrs_setter_roundtrip():
+    array = ak.Array([1, 2, 3], attrs={"a": 1})
+    array.attrs = array.attrs
+    assert isinstance(array.attrs, Attrs)
+    assert dict(array.attrs) == {"a": 1}
+
+    record = ak.Record({"x": 1}, attrs={"a": 1})
+    record.attrs = record.attrs
+    assert isinstance(record.attrs, Attrs)
+    assert dict(record.attrs) == {"a": 1}
+
+    builder = ak.ArrayBuilder(attrs={"a": 1})
+    builder.attrs = builder.attrs
+    assert isinstance(builder.attrs, Attrs)
+    assert dict(builder.attrs) == {"a": 1}


### PR DESCRIPTION
We have been allowing this this whole time:
```py
In [1]: import awkward as ak

In [2]: attrs = {1: 2}

In [3]: ak.Array([1,2,3], attrs=attrs)
Out[3]: <Array [1, 2, 3] type='3 * int64'>

In [4]: x = ak.Array([1,2,3], attrs=attrs)

In [5]: x.attrs
Out[5]: {1: 2}

In [6]: x._attrs
Out[6]: {1: 2}
```
which is not correct because A) attrs should normally be of type `Attrs` and not `dict` and B) attrs should have only string keys if you look at the `Attrs` class: https://github.com/scikit-hep/awkward/blob/824329fccb153b9db1e1262f0430666e0f3c586d/src/awkward/_attrs.py#L47-L67

Also setting attrs to itself would raise an error
```py
In [7]: x.attrs = attrs
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[7], line 1
----> 1 x.attrs = attrs

File ~/Dropbox/work/pyhep_dev/awkward/src/awkward/highlevel.py:1327, in Array.__setattr__(self, name, value)
   1303 """
   1304 Args:
   1305     where (str): Attribute name to set
   (...)   1324 to add or modify a field.
   1325 """
   1326 if name.startswith("_") or hasattr(type(self), name):
-> 1327     super().__setattr__(name, value)
   1328 elif name in self._layout.fields:
   1329     raise AttributeError(
   1330         "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
   1331     )

File ~/Dropbox/work/pyhep_dev/awkward/src/awkward/highlevel.py:403, in Array.attrs(self, value)
    400 @attrs.setter
    401 def attrs(self, value: Mapping[str, Any]):
    402     if isinstance(value, Mapping):
--> 403         self._attrs = Attrs(value)
    404     else:
    405         raise TypeError("attrs must be a 'Attrs' mapping")

File ~/Dropbox/work/pyhep_dev/awkward/src/awkward/_attrs.py:49, in Attrs.__init__(self, data)
     48 def __init__(self, data: Mapping[str, Any]):
---> 49     self._data = {_enforce_str_key(k): v for k, v in data.items()}

File ~/Dropbox/work/pyhep_dev/awkward/src/awkward/_attrs.py:72, in _enforce_str_key(key)
     70 def _enforce_str_key(key: Any) -> str:
     71     if not isinstance(key, str):
---> 72         raise TypeError(f"'attrs' keys must be strings, got: {key!r}")
     73     return key

TypeError: 'attrs' keys must be strings, got: 1
```
We make attrs get validated on array/record/builder creation as they should and also make them appear of consistent type `Attrs` to the user. Not sometimes `dict` and sometimes `Attrs`.

This was found through coffea while noticing that when you open up a file in coffea, attrs are a `dict` in virtual/eager mode but of type `Attrs` in dask mode.