### PR TITLE
ci: fix build wheels workflow

### DIFF
--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -132,7 +132,7 @@ jobs:
       run: pipx run nox -s prepare
 
     - name: Build distributions
-      run: pipx run build --installer uv
+      run: uvx --from build pyproject-build --installer uv
 
     - name: Check metadata
       run: pipx run twine check dist/*


### PR DESCRIPTION
We started getting an error in the Build Wheels workflow (see e.g. https://github.com/scikit-hep/awkward/actions/runs/26077695272/job/76672036534). I'm not sure what changed to make the previous command stop working, but I switched to the command recommended by the [build readme](https://github.com/pypa/build/blob/main/README.md).