### PR TITLE
chore(ci): harden ci config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   # Bump hypothesis-awkward, which is pinned to an exact version in
   # requirements-test-full.txt. Newer versions produce more varied test
@@ -21,3 +23,5 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "hypothesis-awkward"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -34,13 +37,17 @@ jobs:
 
   coverage:
     uses: ./.github/workflows/reusable-coverage.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     uses: ./.github/workflows/reusable-docs.yml
-    secrets: inherit
+    secrets:
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AWS_DEPLOY_ROLE: ${{ secrets.AWS_DEPLOY_ROLE }}
 
   pass:
+    name: Check CI result
     if: always()
     needs:
       - change-detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
 
   docs:
     uses: ./.github/workflows/reusable-docs.yml
+    permissions:
+      id-token: write # Required by the reusable docs deploy job for AWS OIDC.
+      contents: read
     secrets:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       AWS_DEPLOY_ROLE: ${{ secrets.AWS_DEPLOY_ROLE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           allowed-skips: >-
             ${{

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -7,18 +7,25 @@ on:
             type: boolean
             description: Publish to PyPI
 
-jobs:
+permissions:
+  contents: read
 
+concurrency:
+  group: deploy-cpp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
   build-wheels:
     uses: ./.github/workflows/reusable-build-wheels.yml
 
   upload-awkward-cpp:
+    name: Upload awkward-cpp
     needs: [build-wheels]
     runs-on: ubuntu-latest
     if: inputs.publish-pypi
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write # Required for trusted publishing to PyPI.
+      attestations: write # Required to sign release artifacts before publishing.
       contents: read
     environment:
       name: "pypi"

--- a/.github/workflows/deploy-cpp.yml
+++ b/.github/workflows/deploy-cpp.yml
@@ -25,7 +25,7 @@ jobs:
       url: "https://pypi.org/project/awkward-cpp/"
     steps:
 
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: "awkward-cpp*"
         path: dist
@@ -39,4 +39,4 @@ jobs:
       with:
         subject-path: "dist/awkward*cpp-*"
 
-    - uses: pypa/gh-action-pypi-publish@v1.14.0
+    - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,13 @@ on:
     types:
     - published
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   determine-source-date-epoch:
     name: "Determine SOURCE_DATE_EPOCH"
@@ -71,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-source-date-epoch]
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write # Required to sign release artifacts before publishing.
+      attestations: write # Required to upload artifact attestations.
       contents: read
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
@@ -114,11 +121,13 @@ jobs:
         path: header-only
 
   upload:
+    name: Upload distributions
     needs: [build, check-requirements, check-cpp-on-pypi]
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && github.event.action == 'published') || inputs.publish-pypi
     permissions:
-      id-token: write
+      id-token: write # Required for trusted publishing to PyPI.
+      contents: read
     environment:
       name: "pypi"
       url: "https://pypi.org/project/awkward/"
@@ -134,12 +143,14 @@ jobs:
     - name: Verify sdist artifact attestation
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh attestation verify dist/awkward-*.tar.gz --repo ${{ github.repository }}
+        REPOSITORY: ${{ github.repository }}
+      run: gh attestation verify dist/awkward-*.tar.gz --repo "${REPOSITORY}"
 
     - name: Verify wheel artifact attestation
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh attestation verify dist/awkward-*.whl --repo ${{ github.repository }}
+        REPOSITORY: ${{ github.repository }}
+      run: gh attestation verify dist/awkward-*.whl --repo "${REPOSITORY}"
 
     - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
@@ -148,6 +159,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [bundle-headers]
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      contents: write # Required to upload header-only archives to releases.
     steps:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -157,6 +170,7 @@ jobs:
       run: |
         # Don't include `header-only` parent directory
         env -C header-only/ zip -r header-only.zip .
-    - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-      with:
-        files: header-only/header-only.zip
+    - name: Upload archive to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "${GITHUB_REF_NAME}" header-only/header-only.zip --clobber

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,11 @@ jobs:
       source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           fetch-depth: 0
+          persist-credentials: false
 
       - id: log
         name: Compute SOURCE_DATE_EPOCH
@@ -35,9 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Check awkward-cpp version matches requirement
         run: pipx run nox -s check_cpp_constraint
@@ -50,9 +52,10 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Prepare build files
         run: pipx run nox -s prepare
@@ -74,9 +77,10 @@ jobs:
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -92,7 +96,7 @@ jobs:
       with:
         subject-path: "dist/awkward-*"
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: distributions
         path: dist/*
@@ -101,8 +105,10 @@ jobs:
     name: "Bundle header-only libraries"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/upload-artifact@v7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: header-only
         path: header-only
@@ -117,7 +123,7 @@ jobs:
       name: "pypi"
       url: "https://pypi.org/project/awkward/"
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: distributions
         path: dist
@@ -135,7 +141,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh attestation verify dist/awkward-*.whl --repo ${{ github.repository }}
 
-    - uses: pypa/gh-action-pypi-publish@v1.14.0
+    - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publish-headers:
     name: "Publish header-only libraries alongside release"
@@ -143,7 +149,7 @@ jobs:
     needs: [bundle-headers]
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: header-only
         path: header-only
@@ -151,6 +157,6 @@ jobs:
       run: |
         # Don't include `header-only` parent directory
         env -C header-only/ zip -r header-only.zip .
-    - uses: softprops/action-gh-release@v3
+    - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         files: header-only/header-only.zip

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,9 +1,16 @@
 name: Docs Preview
-on:
+on: # zizmor: ignore[dangerous-triggers] This privileged workflow only deploys artifacts from a completed CI run.
   workflow_run:
     workflows: [CI]
     types:
       - completed
+
+concurrency:
+  group: docs-preview-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   branch-preview:
@@ -11,9 +18,9 @@ jobs:
     name: Deploy Branch Preview
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:
-      id-token: write
+      id-token: write # Required to assume the AWS deployment role through OIDC.
       contents: read
-      pull-requests: write
+      pull-requests: write # Required to comment with the preview URL.
     env:
       S3_BUCKET: "preview.awkward-array.org"
       DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
@@ -55,7 +62,7 @@ jobs:
           });
           const fs = require('fs');
           const path = require('path');
-          const temp = '${{ runner.temp }}/artifacts';
+          const temp = path.join(process.env.RUNNER_TEMP, 'artifacts');
           if (!fs.existsSync(temp)){
             fs.mkdirSync(temp);
           }
@@ -63,18 +70,18 @@ jobs:
           fs.writeFileSync(path.join(temp, 'pr_number.zip'), Buffer.from(downloadPRNumber.data));
     - name: Unzip artifacts
       run: |
-        unzip "${{ runner.temp }}/artifacts/docs.zip" -d "${{ runner.temp }}/artifacts"
-        unzip "${{ runner.temp }}/artifacts/pr_number.zip" -d "${{ runner.temp }}/artifacts"
+        unzip "${RUNNER_TEMP}/artifacts/docs.zip" -d "${RUNNER_TEMP}/artifacts"
+        unzip "${RUNNER_TEMP}/artifacts/pr_number.zip" -d "${RUNNER_TEMP}/artifacts"
     - name: Read PR number
       id: pr_number
       run: |
-        echo "pr_number=$(cat ${{ runner.temp }}/artifacts/pr_number.txt)" >> $GITHUB_OUTPUT
-        rm "${{ runner.temp }}/artifacts/pr_number.txt"
-        rm "${{ runner.temp }}/artifacts/docs.zip"
-        rm "${{ runner.temp }}/artifacts/pr_number.zip"
+        echo "pr_number=$(cat "${RUNNER_TEMP}/artifacts/pr_number.txt")" >> "${GITHUB_OUTPUT}"
+        rm "${RUNNER_TEMP}/artifacts/pr_number.txt"
+        rm "${RUNNER_TEMP}/artifacts/docs.zip"
+        rm "${RUNNER_TEMP}/artifacts/pr_number.zip"
     - name: Sync artifacts
       run: |
-        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER}"
+        aws s3 sync "${RUNNER_TEMP}/artifacts/" "s3://${S3_BUCKET}/PR${STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER}"
       env:
         STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
     - name: Try to find previous bot comment
@@ -86,8 +93,8 @@ jobs:
         body-includes: The documentation preview is ready to be viewed
     - name: Create comment with preview link
       if: steps.fc.outputs.comment-id == ''
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-      with:
-        issue-number: ${{ steps.pr_number.outputs.pr_number }}
-        body: |
-          The documentation preview is ready to be viewed at <${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}>
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
+        PREVIEW_URL: ${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}
+      run: gh pr comment "${PR_NUMBER}" --body "The documentation preview is ready to be viewed at <${PREVIEW_URL}>"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -22,12 +22,12 @@ jobs:
       url: "${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}"
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
       with:
         aws-region: eu-west-2
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
     - name: Download rendered docs
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -74,9 +74,11 @@ jobs:
         rm "${{ runner.temp }}/artifacts/pr_number.zip"
     - name: Sync artifacts
       run: |
-        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${{ steps.pr_number.outputs.pr_number }}"
+        aws s3 sync ${{ runner.temp }}/artifacts/ "s3://${S3_BUCKET}/PR${STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER}"
+      env:
+        STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
     - name: Try to find previous bot comment
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ steps.pr_number.outputs.pr_number }}
@@ -84,7 +86,7 @@ jobs:
         body-includes: The documentation preview is ready to be viewed
     - name: Create comment with preview link
       if: steps.fc.outputs.comment-id == ''
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ steps.pr_number.outputs.pr_number }}
         body: |

--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -25,9 +25,11 @@ jobs:
     environment:
       name: docs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}

--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -8,6 +8,9 @@ on:
       - docs/switcher.json
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: 'docs-version-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
@@ -17,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Push version switcher
     permissions:
-      id-token: write
+      id-token: write # Required to assume the AWS deployment role through OIDC.
       contents: read
     env:
       S3_BUCKET: "awkward-array.org"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Run PyLint
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 concurrency:
   group: lint-${{ github.head_ref }}

--- a/.github/workflows/needs-cpp-release.yml
+++ b/.github/workflows/needs-cpp-release.yml
@@ -14,10 +14,11 @@ jobs:
       source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           fetch-depth: 0
+          persist-credentials: false
 
       - id: log
         name: Compute SOURCE_DATE_EPOCH
@@ -35,9 +36,10 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Prepare build files
         run: pipx run nox -s prepare

--- a/.github/workflows/needs-cpp-release.yml
+++ b/.github/workflows/needs-cpp-release.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: needs-cpp-release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   determine-source-date-epoch:
     name: "Determine SOURCE_DATE_EPOCH"

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -21,10 +21,11 @@ jobs:
       source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
           fetch-depth: 0
+          persist-credentials: false
 
       - id: log
         name: Compute SOURCE_DATE_EPOCH
@@ -41,9 +42,10 @@ jobs:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -54,7 +56,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check awkward-cpp/dist/*
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-sdist
         path: awkward-cpp/dist/*.tar.gz
@@ -84,22 +86,23 @@ jobs:
           arch: auto64
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - name: Prepare build files
       run: pipx run nox -s prepare
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
       with:
@@ -109,7 +112,7 @@ jobs:
       run: pipx run twine check wheelhouse/*.whl
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-wheels-${{ matrix.os }}-${{ matrix.arch }}
         path: wheelhouse/*.whl
@@ -121,12 +124,13 @@ jobs:
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -137,7 +141,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-wheel
         path: dist/*

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -9,6 +9,9 @@ on:
   # Use from other workflows
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-wheels-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   determine-source-date-epoch:
     name: "Determine SOURCE_DATE_EPOCH"
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     runs-on: ubuntu-latest
     outputs:
       source-date-epoch: ${{ steps.log.outputs.source-date-epoch }}
@@ -39,6 +40,7 @@ jobs:
 
   make_sdist:
     name: "Build awkward-cpp sdist"
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     runs-on: ubuntu-latest
     needs: [determine-source-date-epoch]
     env:
@@ -67,6 +69,7 @@ jobs:
   build_wheels:
     needs: [determine-source-date-epoch]
     name: "Wheel awkward-cpp: ${{ matrix.arch }} on ${{ matrix.os }}"
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     runs-on: ${{ matrix.os }}
     env:
       SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
@@ -122,6 +125,7 @@ jobs:
 
   build_awkward_wheel:
     name: "Build awkward sdist and wheel"
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     runs-on: ubuntu-latest
     needs: [determine-source-date-epoch]
     env:

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -27,11 +27,13 @@ jobs:
       run-header-only-tests: ${{ steps.header-changes.outputs.run-header-only-tests || false }}
       run-gpu-kernel-tests: ${{ steps.gpu-changes.outputs.run-gpu-kernel-tests || false }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Changed code files
         id: changed-code-files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: "json"
           filter: |
@@ -62,7 +64,7 @@ jobs:
 
       - name: Changed C++ files
         id: changed-cpp-files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: "json"
           filter: |
@@ -82,7 +84,7 @@ jobs:
 
       - name: Changed header files
         id: changed-header-files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: "json"
           filter: |
@@ -98,7 +100,7 @@ jobs:
 
       - name: Changed GPU code files
         id: changed-gpu-files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: "json"
           filter: |

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -16,6 +16,9 @@ on:
         description: Whether or not run the gpu kernel tests
         value: ${{ jobs.change-detection.outputs.run-gpu-kernel-tests || false }}
 
+permissions:
+  contents: read
+
 jobs:
   change-detection:
     name: Identify source changes

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -2,8 +2,14 @@ name: Codecov
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: 'coverage-${{ github.head_ref || github.run_id }}'
@@ -104,13 +110,13 @@ jobs:
           --cov=awkward --cov-report=term --cov-report=xml:cuda-virtual-coverage.xml
 
       - name: Upload Codecov results
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -35,12 +35,13 @@ jobs:
           rm -rf * .[!.]* || echo "Nothing to clean"
           rm -rf ~/micromamba* || echo "Nothing to clean"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Get micromamba
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-name: test-env
           init-shell: bash
@@ -63,7 +64,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./awkward-cpp/dist
           key: ${{ github.job }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('awkward-cpp/**') }}

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -93,11 +93,10 @@ jobs:
 
     - name: Cache wheel
       id: cache-awkward-cpp-x86-64-wheel
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # zizmor: ignore[cache-poisoning] Reuses a docs-only wheel cache to avoid rebuilding unchanged awkward-cpp docs dependencies.
       with:
         path: ./awkward-cpp/dist
         key: ${{ runner.os }}-${{ env.X86_64_PYTHON_VERSION }}-awkward-x86-64-wasm-${{ hashFiles('awkward-cpp/**') }}
-        lookup-only: true
 
     - name: Build wheel
       if: steps.cache-awkward-cpp-x86-64-wheel.outputs.cache-hit != 'true'
@@ -108,6 +107,7 @@ jobs:
       with:
         name: awkward-cpp-x86-64
         path: awkward-cpp/dist/awkward*.whl
+        if-no-files-found: error
 
   awkward:
     runs-on: ubuntu-24.04

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,11 +1,19 @@
 name: Docs
 on:
   workflow_call:
+    secrets:
+      AWS_ACCOUNT_ID:
+        required: false
+      AWS_DEPLOY_ROLE:
+        required: false
 
   workflow_dispatch:
 
   release:
     types: [released]
+
+permissions:
+  contents: read
 
 concurrency:
   group: 'docs-${{ github.head_ref || github.run_id }}'
@@ -295,7 +303,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'release'
     name: Deploy
     permissions:
-      id-token: write
+      id-token: write # Required to assume the AWS deployment role through OIDC.
       contents: read
     env:
       S3_BUCKET: "awkward-array.org"

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -20,14 +20,15 @@ jobs:
     name: Build C++ WASM
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Generate build files
       run: pipx run nox -s prepare -- --headers --signatures --tests
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
       with:
         package-dir: awkward-cpp
       env:
@@ -37,7 +38,7 @@ jobs:
         CIBW_ENABLE: "pyodide-prerelease"
 
     - name: Upload wheel
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-wasm
         path: awkward-cpp/dist/awkward*wasm32.whl
@@ -51,9 +52,10 @@ jobs:
         # Ensure conda env is activated
         shell: "bash -l {0}"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
       # TODO: remove this once mamba-org/mamba#1726 is fixed
       #       and replace with `-r requirements.txt` in a
@@ -67,7 +69,7 @@ jobs:
       # solve with different external library versions. By default,
       # ROOT uses cxx-compiler too, so hopefully this won't be an issue
     - name: Setup Python via Conda
-      uses: mamba-org/setup-micromamba@v3
+      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
       with:
         # Cache invalidates daily by default
         cache-environment: true
@@ -83,17 +85,18 @@ jobs:
 
     - name: Cache wheel
       id: cache-awkward-cpp-x86-64-wheel
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ./awkward-cpp/dist
         key: ${{ runner.os }}-${{ env.X86_64_PYTHON_VERSION }}-awkward-x86-64-wasm-${{ hashFiles('awkward-cpp/**') }}
+        lookup-only: true
 
     - name: Build wheel
       if: steps.cache-awkward-cpp-x86-64-wheel.outputs.cache-hit != 'true'
       run: python -m build -w ./awkward-cpp
 
     - name: Upload wheel
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-x86-64
         path: awkward-cpp/dist/awkward*.whl
@@ -102,9 +105,10 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build Python
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Generate build files
       run: pipx run nox -s prepare -- --headers --signatures
@@ -113,7 +117,7 @@ jobs:
       run: pipx run build -w
 
     - name: Upload wheel
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward
         path: dist/awkward*.whl
@@ -123,30 +127,31 @@ jobs:
     runs-on: ubuntu-24.04
     name: Execute cppyy notebook
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ env.X86_64_PYTHON_VERSION }}"
 
     - name: Extract pre-built manylinux cppyy wheels
-      uses: shrink/actions-docker-extract@v4
+      uses: shrink/actions-docker-extract@f1ef61065b78731fe3310b4e84e511f6a927a77e # v4.0.0
       with:
         image: "docker.io/agoose77/cppyy-wheels:cp311"
         path: "/wheels/."
         destination: "/tmp/wheels/"
 
     - name: Download awkward wheel
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: awkward
         path: /tmp/wheels/
 
     - name: Download awkward-cpp x86_64 wheel
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: awkward-cpp-x86-64
         path: /tmp/wheels/
@@ -160,7 +165,7 @@ jobs:
       run: jupyter nbconvert --to notebook --execute --inplace user-guide/how-to-use-in-cpp-cppyy.ipynb
 
     - name: Save executed notebook
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: how-to-use-in-cpp-cppyy
         path: docs/user-guide/how-to-use-in-cpp-cppyy.ipynb
@@ -176,7 +181,9 @@ jobs:
     env:
         DOCS_CANONICAL_VERSION: main
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
       # TODO: remove this once mamba-org/mamba#1726 is fixed
       #       and replace with `-r requirements.txt` in a
@@ -190,7 +197,7 @@ jobs:
       # solve with different external library versions. By default,
       # ROOT uses cxx-compiler too, so hopefully this won't be an issue
     - name: Setup Python via Conda
-      uses: mamba-org/setup-micromamba@v3
+      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
       with:
         # Cache invalidates daily by default
         cache-environment: true
@@ -201,7 +208,7 @@ jobs:
            doxygen
 
     - name: Download awkward wheel
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: awkward
         path: dist
@@ -212,7 +219,7 @@ jobs:
         cp dist/awkward*.whl docs/lite/pypi/
 
     - name: Download awkward-cpp x86_64 wheel
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: awkward-cpp-x86-64
         path: dist
@@ -242,7 +249,7 @@ jobs:
         echo "DOCS_VERSION=main" >> $GITHUB_ENV
 
     - name: Download cppyy notebook
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: how-to-use-in-cpp-cppyy
         path: docs/user-guide
@@ -252,19 +259,19 @@ jobs:
       working-directory: docs
 
     - name: Upload docs artefact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: docs
         path: docs/_build/html
 
     - name: Upload Jupyter Book cache
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: doctrees
         path: docs/_build/doctrees
 
     - name: Upload Jupyter Book cache
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jupyter-cache
         path: docs/_build/.jupyter_cache
@@ -276,7 +283,7 @@ jobs:
         mkdir -p ./pr
         echo $PR_NUMBER > ./pr/pr_number.txt
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: pr_number
         path: pr/
@@ -298,19 +305,21 @@ jobs:
       name: docs
       url: ${{ env.PRODUCTION_URL }}${{ steps.sync-main.outputs.path || steps.sync-stable.outputs.path }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
       - name: Download rendered docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs
           path: built-docs
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       # Pushes to main trigger latest

--- a/.github/workflows/reusable-header-only-test.yml
+++ b/.github/workflows/reusable-header-only-test.yml
@@ -19,9 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Run CMake
       run: |

--- a/.github/workflows/reusable-header-only-test.yml
+++ b/.github/workflows/reusable-header-only-test.yml
@@ -5,6 +5,8 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 concurrency:
   group: header-only-test-${{ github.head_ref }}

--- a/.github/workflows/reusable-packaging-test.yml
+++ b/.github/workflows/reusable-packaging-test.yml
@@ -5,6 +5,8 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 concurrency:
   group: packaging-test-${{ github.head_ref }}

--- a/.github/workflows/reusable-packaging-test.yml
+++ b/.github/workflows/reusable-packaging-test.yml
@@ -18,9 +18,10 @@ jobs:
     name: "Build awkward"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Prepare build files
       run: pipx run nox -s prepare
@@ -34,17 +35,17 @@ jobs:
     - name: Build awkward-cpp SDist
       run: pipx run build --sdist awkward-cpp
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-sdist
         path: dist/*.tar.gz
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-wheel
         path: dist/*.whl
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-sdist
         path: awkward-cpp/dist/*.tar.gz
@@ -59,17 +60,18 @@ jobs:
         os: [windows-11-arm, windows-latest, macos-latest, ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
     - name: Prepare build files
       run: pipx run nox -s prepare
 
-    - uses: pypa/cibuildwheel@v3.4
+    - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
       env:
         CIBW_ARCHS_MACOS: universal2
         CIBW_ARCHS_WINDOWS: auto64
@@ -78,7 +80,7 @@ jobs:
         package-dir: awkward-cpp
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: awkward-cpp-wheels-${{ matrix.os }}
         path: wheelhouse/*.whl

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -20,6 +20,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 concurrency:
   group: 'test-${{ github.head_ref || github.run_id }}'
   cancel-in-progress: true
@@ -134,8 +137,11 @@ jobs:
 
       - name: Install awkward, awkward-cpp, and dependencies
         run: >-
-          python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
-          -r "requirements-test-${{ matrix.dependencies-kind }}.txt"
+          python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
+          -r "requirements-test-${MATRIX_DEPENDENCIES_KIND}.txt"
+        env:
+          STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
+          MATRIX_DEPENDENCIES_KIND: ${{ matrix.dependencies-kind }}
 
       - name: Print versions
         run: python -m pip list
@@ -269,6 +275,7 @@ jobs:
           python -m pytest -vv -rs tests-cuda/test_3459_virtualarray_with_cuda.py
 
   Linux-ROOT:
+    name: Linux ROOT
     runs-on: ubuntu-latest
 
     env:
@@ -328,6 +335,7 @@ jobs:
         run: python -m pytest -vv -rs tests
 
   Linux-cppyy:
+    name: Linux cppyy
     # TODO: remove this part of the workflow
     # cppyy is not yet released. Let's load some pre-built wheels via docker (as a binary store)
     runs-on: ubuntu-22.04

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -475,6 +475,7 @@ jobs:
       - name: Install awkward, awkward-cpp, and dependencies
         run: |
           docker run --platform=linux/${ARCH} -e "TERM=${TERM}" \
+            -e STEPS_FIND_WHEEL_OUTPUTS_PATHS \
             --name build_container \
             -v $(pwd):/awkward the_container \
             /bin/bash -c '

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -139,6 +139,7 @@ jobs:
         run: >-
           python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
           -r "requirements-test-${MATRIX_DEPENDENCIES_KIND}.txt"
+        shell: bash
         env:
           STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
           MATRIX_DEPENDENCIES_KIND: ${{ matrix.dependencies-kind }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -92,12 +92,13 @@ jobs:
       PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: 'Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '${{ matrix.python-version }}'
           architecture: '${{ matrix.python-architecture }}'
@@ -108,7 +109,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: awkward-cpp/dist
           key: ${{ github.job }}-${{ matrix.runs-on }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ hashFiles('awkward-cpp/**') }}
@@ -120,7 +121,7 @@ jobs:
           python -m build -w awkward-cpp
 
       - name: Find built wheel
-        uses: tj-actions/glob@v22
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
         id: find-wheel
         with:
           files: |
@@ -192,12 +193,13 @@ jobs:
           rm -rf * .[!.]* || echo "Nothing to clean"
           rm -rf ~/micromamba* || echo "Nothing to clean"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Get micromamba
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-name: test-env
           init-shell: bash
@@ -218,7 +220,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: awkward-cpp/dist
           key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
@@ -230,7 +232,7 @@ jobs:
           python -m build -w awkward-cpp
 
       - name: Find built wheel
-        uses: tj-actions/glob@v22
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
         id: find-wheel
         with:
           files: |
@@ -242,8 +244,10 @@ jobs:
 
       - name: Install awkward, awkward-cpp, and dependencies
         run: >-
-          python -m pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
+          python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
           -r requirements-test-gpu.txt
+        env:
+          STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
 
       - name: Print versions
         run: python -m pip list
@@ -278,12 +282,13 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Setup Python via Conda
-        uses: mamba-org/setup-micromamba@v3
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           # Cache invalidates daily by default
           cache-environment: true
@@ -298,7 +303,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./awkward-cpp/dist
           key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}-py3.14
@@ -331,12 +336,13 @@ jobs:
       PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: 'Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -345,7 +351,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./awkward-cpp/dist
           key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
@@ -357,7 +363,7 @@ jobs:
           python -m build -w ./awkward-cpp
 
       - name: Extract pre-built manylinux cppyy wheels
-        uses: shrink/actions-docker-extract@v4
+        uses: shrink/actions-docker-extract@f1ef61065b78731fe3310b4e84e511f6a927a77e # v4.0.0
         with:
           image: "docker.io/agoose77/cppyy-wheels:cp311"
           path: "/wheels/."
@@ -388,16 +394,17 @@ jobs:
 
     name: "Run s390x Tests"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Initialize binfmt_misc for qemu-user-static
         run: |
           docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install s390x
 
       - name: Cache docker container
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: container-cache
         with:
           path: ~/docker_s390x
@@ -431,7 +438,7 @@ jobs:
 
       - name: Cache awkward-cpp wheel
         id: cache-awkward-cpp-wheel
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: awkward-cpp/dist
           key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
@@ -450,7 +457,7 @@ jobs:
             '
 
       - name: Find built wheel
-        uses: tj-actions/glob@v22
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
         id: find-wheel
         with:
           files: |
@@ -465,10 +472,12 @@ jobs:
               export PATH="/root/.local/bin:$PATH" &&
               source .venv/bin/activate &&
               cd /awkward &&
-              uv pip install -v . ${{ steps.find-wheel.outputs.paths }} pytest-github-actions-annotate-failures
+              uv pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
             '
           docker commit build_container the_container
           docker rm build_container
+        env:
+          STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
 
       - name: Print versions
         run: |

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       run-gpu-kernel-tests:
-        description: Whether or not to run the gpu kernel tests
+        description: Run the gpu kernel tests
         required: false
         default: false
         type: string # The workflow freezes if this is set to boolean for some reason
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       run-gpu-kernel-tests:
-        description: Whether or not to run the gpu kernel tests
+        description: Run the gpu kernel tests
         required: false
         default: false
         type: boolean

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   run-tests:
     name: Run Tests
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +177,7 @@ jobs:
 
   run-gpu-tests:
     name: Run GPU Tests
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
 
     runs-on: self-hosted
 
@@ -277,6 +279,7 @@ jobs:
 
   Linux-ROOT:
     name: Linux ROOT
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     runs-on: ubuntu-latest
 
     env:
@@ -337,6 +340,7 @@ jobs:
 
   Linux-cppyy:
     name: Linux cppyy
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
     # TODO: remove this part of the workflow
     # cppyy is not yet released. Let's load some pre-built wheels via docker (as a binary store)
     runs-on: ubuntu-22.04
@@ -392,7 +396,7 @@ jobs:
 
   run-s390x-tests:
     # Only workflow_dispatch is enabled on forks.
-    if: github.repository == 'scikit-hep/awkward' || github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'scikit-hep' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
 

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,6 +17,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read # Required to read PR metadata for title validation.
+
 concurrency:
   group: semantic-pr-title-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/upload-nightly-wheels.yml
+++ b/.github/workflows/upload-nightly-wheels.yml
@@ -8,7 +8,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: read # Required to inspect and download artifacts from prior workflow runs.
+
+concurrency:
+  group: upload-nightly-wheels-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   upload_nightly_wheels:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 exclude: ^(docs|studies|tests/samples|src/awkward/_typeparser/generated_parser.py)
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -22,20 +22,20 @@ repos:
     args: ["--pytest-test-first"]
 
 - repo: https://github.com/cheshirekow/cmake-format-precommit
-  rev: v0.6.13
+  rev: e2c2116d86a80e72e7146a06e68b7c228afc6319  # frozen: v0.6.13
   hooks:
   - id: cmake-format
     additional_dependencies: [pyyaml]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.12
+  rev: 5e2fb545eba1ea9dc051f6f962d52fe8f76a9794  # frozen: v0.15.13
   hooks:
   - id: ruff-check
     args: ["--fix", "--show-fixes"]
   - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.2
+  rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
   hooks:
   - id: codespell
     args: ["-L", "ue,subjet,parms,fo,numer,thre,nin,nout"]
@@ -49,7 +49,7 @@ repos:
     exclude: .pre-commit-config.yaml
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: "v0.11.0.1"
+  rev: "745eface02aef23e168a8afb6b5737818efbea95"  # frozen: v0.11.0.1
   hooks:
   - id: shellcheck
 
@@ -63,13 +63,13 @@ repos:
     files: ^tests/
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.2
+  rev: f805888065fdb6162e1f800e50bb9460cbd223d6  # frozen: 0.37.2
   hooks:
     - id: check-github-workflows
       args: ["--verbose"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.20.2
+  rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # frozen: v2.1.0
   hooks:
     - id: mypy
       files: src
@@ -77,6 +77,13 @@ repos:
         - numpy>=1.24
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: v0.25
+  rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7  # frozen: v0.25
   hooks:
     - id: validate-pyproject
+
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
+  hooks:
+    - id: zizmor
+      files: "^\\.github"
+      args: [--persona=pedantic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,3 +322,6 @@ isort.required-imports = ["from __future__ import annotations"]
 "numpy".msg = "Use `numpy = ak._nplikes.Numpy.instance()` instead"
 "jax".msg = "Use `jax = ak._nplikes.Jax.instance()` instead"
 "cupy".msg = "Use `cupy = ak._nplikes.Cupy.instance()` instead"
+
+[tool.uv]
+exclude-newer = "7 days"


### PR DESCRIPTION
Since we're hearing about a new security issue practically every day, it's good if we harden out CI setup a bit. I used the [secure-ci](https://github.com/henryiii/skills/blob/main/secure-ci/SKILL.md) skill by Henry, although I did some of the steps manually.