### PR TITLE
fix: add missing .attrs support in parquet serialisation

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -268,7 +268,10 @@ def _load(
     assert len(arrays) != 0
     if len(arrays) == 1:
         return wrap_layout(
-            arrays[0], highlevel=highlevel, attrs=attrs | arrays[0].attrs, behavior=behavior
+            arrays[0],
+            highlevel=highlevel,
+            attrs=attrs | arrays[0].attrs,
+            behavior=behavior,
         )
     else:
         # TODO: if each array is a record?
@@ -334,7 +337,7 @@ def _read_parquet_file(
             arrow_table = parquetfile.read_row_groups(row_groups, parquet_columns)
 
     arrow_table = ak._connect.pyarrow.convert_native_arrow_table_to_awkward(arrow_table)
-    
+
     array_attrs = {}
     if arrow_table.schema.metadata:
         if b"PANDAS_ATTRS" in arrow_table.schema.metadata:
@@ -356,7 +359,7 @@ def _read_parquet_file(
     )
 
     result.attrs = array_attrs
-    
+
     return result
 
 

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -29,7 +29,7 @@ def from_parquet(
     generate_bitmasks=False,
     highlevel=True,
     behavior=None,
-    attrs=None,
+    attrs={},
 ):
     """
     Args:
@@ -268,7 +268,7 @@ def _load(
     assert len(arrays) != 0
     if len(arrays) == 1:
         return wrap_layout(
-            arrays[0], highlevel=highlevel, attrs=attrs, behavior=behavior
+            arrays[0], highlevel=highlevel, attrs=attrs | arrays[0].attrs, behavior=behavior
         )
     else:
         # TODO: if each array is a record?
@@ -334,14 +334,30 @@ def _read_parquet_file(
             arrow_table = parquetfile.read_row_groups(row_groups, parquet_columns)
 
     arrow_table = ak._connect.pyarrow.convert_native_arrow_table_to_awkward(arrow_table)
-    return ak.operations.ak_from_arrow._impl(
+    
+    array_attrs = {}
+    if arrow_table.schema.metadata:
+        if b"PANDAS_ATTRS" in arrow_table.schema.metadata:
+            array_metadata = arrow_table.schema.metadata[b"PANDAS_ATTRS"]
+            array_attrs = json.loads(array_metadata)
+        elif b"AWKWARD_ATTRS" in arrow_table.schema.metadata:
+            array_metadata = arrow_table.schema.metadata[b"AWKWARD_ATTRS"]
+            array_attrs = json.loads(array_metadata)
+    else:
+        array_attrs = {}
+
+    result = ak.operations.ak_from_arrow._impl(
         arrow_table,
         generate_bitmasks,
         # why is high-level False here?
         False,
         None,
-        None,
+        None
     )
+
+    result.attrs = array_attrs
+    
+    return result
 
 
 class _DictOfEmptyBuffers:

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -352,7 +352,7 @@ def _read_parquet_file(
         # why is high-level False here?
         False,
         None,
-        None
+        None,
     )
 
     result.attrs = array_attrs

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -29,7 +29,7 @@ def from_parquet(
     generate_bitmasks=False,
     highlevel=True,
     behavior=None,
-    attrs={},
+    attrs=None,
 ):
     """
     Args:
@@ -270,7 +270,7 @@ def _load(
         return wrap_layout(
             arrays[0],
             highlevel=highlevel,
-            attrs=attrs | arrays[0].attrs,
+            attrs=(attrs if attrs else {}) | arrays[0].attrs,
             behavior=behavior,
         )
     else:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from os import fsdecode
 
+import json
+
 import fsspec
 
 import awkward as ak
@@ -404,6 +406,12 @@ def _impl(
 
     if extensionarray:
         table = convert_awkward_arrow_table_to_native(table)
+
+    if array.attrs:
+        df_metadata = {"AWKWARD_ATTRS": json.dumps(array.attrs.to_dict())}
+        existing_metadata = table.schema.metadata
+        merged_metadata = {**existing_metadata, **df_metadata}
+        table = table.replace_schema_metadata(merged_metadata)
 
     if parquet_extra_options is None:
         parquet_extra_options = {}

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from os import fsdecode
-
-import json
 
 import fsspec
 

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -406,7 +406,7 @@ def _impl(
     if extensionarray:
         table = convert_awkward_arrow_table_to_native(table)
 
-    if array.attrs:
+    if hasattr(array, "attrs") and array.attrs:
         df_metadata = {"AWKWARD_ATTRS": json.dumps(array.attrs.to_dict())}
         existing_metadata = table.schema.metadata
         merged_metadata = {**existing_metadata, **df_metadata}

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -923,9 +923,13 @@ def test_select(with_global_metadata):
         ak.metadata_from_parquet(with_global_metadata, row_groups=[4])
 
 
-def test_attr_serialisation(generate_datafiles):
+def test_awkward_attr_serialisation(generate_datafiles):
     path, _mdlist, _fs = generate_datafiles
     assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property": "value"}
+
+
+def test_pandas_attr_serialisation(generate_datafiles):
+    path, _mdlist, _fs = generate_datafiles
 
     df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     df.attrs = {"property": "value", 1: 2}

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -923,7 +923,7 @@ def test_select(with_global_metadata):
         ak.metadata_from_parquet(with_global_metadata, row_groups=[4])
 
 
-def test_read_awkward_attrs(generate_datafiles):
+def test_attr_serialisation(generate_datafiles):
     path, mdlist, fs = generate_datafiles
     assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property":"value"}
 

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -929,7 +929,7 @@ def test_awkward_attr_serialisation(generate_datafiles):
 
 def test_pandas_attr_serialisation(generate_datafiles):
 
-    pd = pytest.importorskip("pandas")
+    pd = pytest.importorskip("pandas", "2.1.0")
 
     path, _mdlist, _fs = generate_datafiles
 

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -924,7 +924,7 @@ def test_select(with_global_metadata):
 
 
 def test_attr_serialisation(generate_datafiles):
-    path, mdlist, fs = generate_datafiles
+    path, _mdlist, _fs = generate_datafiles
     assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property": "value"}
 
     df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -6,7 +6,6 @@ import os.path
 
 import fsspec
 import numpy as np
-import pandas as pd
 import pytest
 from packaging.version import parse as parse_version
 
@@ -929,6 +928,9 @@ def test_awkward_attr_serialisation(generate_datafiles):
 
 
 def test_pandas_attr_serialisation(generate_datafiles):
+
+    pd = pytest.importorskip("pandas")
+
     path, _mdlist, _fs = generate_datafiles
 
     df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -8,6 +8,7 @@ import fsspec
 import numpy as np
 import pytest
 from packaging.version import parse as parse_version
+import pandas as pd
 
 import awkward as ak
 
@@ -852,7 +853,7 @@ def test_unionarray(tmp_path, through, extensionarray):
 @pytest.fixture()
 def generate_datafiles(tmp_path):
     fs = fsspec.filesystem("file")
-    data1 = ak.from_iter([[1, 2, 3], [4, 5]])
+    data1 = ak.from_iter([[1, 2, 3], [4, 5]], attrs = {"property":"value"})
     data2 = data1 + 1
     md1 = ak.to_parquet(data1, os.path.join(tmp_path, "data1.parq"))
     md2 = ak.to_parquet(data2, os.path.join(tmp_path, "data2.parq"))
@@ -920,3 +921,14 @@ def test_select(with_global_metadata):
 
     with pytest.raises(ValueError):
         ak.metadata_from_parquet(with_global_metadata, row_groups=[4])
+
+
+def test_read_awkward_attrs(generate_datafiles):
+    path, mdlist, fs = generate_datafiles
+    assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property":"value"}
+
+    df = pd.DataFrame({"x" : [1, 2, 3], "y" : [4, 5, 6]})
+    df.attrs = {"property" : "value", 1 : 2}
+    df.to_parquet(f"{path}/data3.parq")
+
+    assert ak.from_parquet(f"{path}/data3.parq").attrs == {"property" : "value", "1" : 2}

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -6,9 +6,9 @@ import os.path
 
 import fsspec
 import numpy as np
+import pandas as pd
 import pytest
 from packaging.version import parse as parse_version
-import pandas as pd
 
 import awkward as ak
 
@@ -853,7 +853,7 @@ def test_unionarray(tmp_path, through, extensionarray):
 @pytest.fixture()
 def generate_datafiles(tmp_path):
     fs = fsspec.filesystem("file")
-    data1 = ak.from_iter([[1, 2, 3], [4, 5]], attrs = {"property":"value"})
+    data1 = ak.from_iter([[1, 2, 3], [4, 5]], attrs={"property": "value"})
     data2 = data1 + 1
     md1 = ak.to_parquet(data1, os.path.join(tmp_path, "data1.parq"))
     md2 = ak.to_parquet(data2, os.path.join(tmp_path, "data2.parq"))
@@ -925,10 +925,10 @@ def test_select(with_global_metadata):
 
 def test_attr_serialisation(generate_datafiles):
     path, mdlist, fs = generate_datafiles
-    assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property":"value"}
+    assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property": "value"}
 
-    df = pd.DataFrame({"x" : [1, 2, 3], "y" : [4, 5, 6]})
-    df.attrs = {"property" : "value", 1 : 2}
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    df.attrs = {"property": "value", 1: 2}
     df.to_parquet(f"{path}/data3.parq")
 
-    assert ak.from_parquet(f"{path}/data3.parq").attrs == {"property" : "value", "1" : 2}
+    assert ak.from_parquet(f"{path}/data3.parq").attrs == {"property": "value", "1": 2}


### PR DESCRIPTION
Makes parquet serialisation support reading and writing the `.attrs` of arrays.  This method should also read `.attrs` written by pandas though has an implicit casting from `dict` to `Attrs` which only allows string keys.  Tests have been written to test both awkward attrs reading and writing and pandas attrs reading.

This is connected to but does not close #3278 as this does not add support to arrow