### PR TITLE
ci: fix deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,4 +173,6 @@ jobs:
     - name: Upload archive to release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload "${GITHUB_REF_NAME}" header-only/header-only.zip --clobber
+        RELEASE_TAG: ${{ github.ref_name }}
+        REPOSITORY: ${{ github.repository }}
+      run: gh release upload "${RELEASE_TAG}" header-only/header-only.zip --repo "${REPOSITORY}" --clobber


### PR DESCRIPTION
This PR fixes #4081. It was caused by #4075 where the upload step was changed from a third-party action to just usin `gh`, which is safer. Since the repository is not checked out, it needed to be specified with `--repo`.