### PR TITLE
chore: modernize header-only code to C++17 and remove dead code

### DIFF
--- a/header-only/growable-buffer/awkward/GrowableBuffer.h
+++ b/header-only/growable-buffer/awkward/GrowableBuffer.h
@@ -13,6 +13,7 @@
 #include <complex>
 #include <iostream>
 #include <utility>
+#include <type_traits>
 #include <stdexcept>
 #include <stdint.h>
 
@@ -71,7 +72,7 @@ namespace awkward {
     /// appends it after the current panel.
     Panel*
     append_panel(size_t reserved) {
-      next_ = std::move(std::unique_ptr<Panel>(new Panel(reserved)));
+      next_ = std::make_unique<Panel>(reserved);
       return next_.get();
     }
 
@@ -79,6 +80,24 @@ namespace awkward {
     void
     fill_panel(PRIMITIVE datum) {
       ptr_.get()[length_++] = datum;
+    }
+
+    /// @brief Inserts a contiguous segment of `size` elements from `from_ptr`
+    /// into the panel.
+    ///
+    /// The caller must ensure that the panel has at least `size` unused slots.
+    /// Uses `memcpy` when `PRIMITIVE` is trivially copyable, and falls back to
+    /// element-by-element assignment otherwise.
+    void
+    fill_panel_from(const PRIMITIVE* from_ptr, size_t size) {
+      if (std::is_trivially_copyable<PRIMITIVE>::value) {
+        memcpy(ptr_.get() + length_, from_ptr, size * sizeof(PRIMITIVE));
+        length_ += size;
+      } else {
+        for (size_t i = 0; i < size; i++) {
+          ptr_.get()[length_++] = from_ptr[i];
+        }
+      }
     }
 
     /// @brief Pointer to the next panel.
@@ -399,6 +418,12 @@ namespace awkward {
           panel_(std::move(other.panel_)),
           ptr_(other.ptr_) {}
 
+    /// @brief Move assignment
+    ///
+    /// panel_ is move-only; a user-declared move constructor would otherwise
+    /// suppress the implicit move assignment operator.
+    GrowableBuffer& operator=(GrowableBuffer&& other) noexcept = default;
+
     /// @brief Currently used number of elements.
     ///
     /// Although the #length increments every time #append is called,
@@ -419,8 +444,7 @@ namespace awkward {
     /// options.initial(), and a new #ptr is allocated.
     void
     clear() {
-      panel_ = std::move(std::unique_ptr<Panel<PRIMITIVE>>(
-          new Panel<PRIMITIVE>((size_t)options_.initial())));
+      panel_ = std::make_unique<Panel<PRIMITIVE>>((size_t)options_.initial());
       ptr_ = panel_.get();
       length_ = 0;
     }
@@ -449,7 +473,7 @@ namespace awkward {
     void
     append(PRIMITIVE datum) {
       if (ptr_->current_length() == ptr_->reserved()) {
-        add_panel((size_t)ceil((double)options_.initial() * options_.resize()));
+        add_panel((size_t)ceil((double)ptr_->reserved() * options_.resize()));
       }
       fill_panel(datum);
     }
@@ -464,18 +488,12 @@ namespace awkward {
     extend(const PRIMITIVE* ptr, size_t size) {
       size_t unfilled_items = ptr_->reserved() - ptr_->current_length();
       if (size > unfilled_items) {
-        for (size_t i = 0; i < unfilled_items; i++) {
-          fill_panel(ptr[i]);
-        }
+        fill_panel_from(ptr, unfilled_items);
         add_panel(size - unfilled_items > ptr_->reserved() ? size - unfilled_items
                                                         : ptr_->reserved());
-        for (size_t i = unfilled_items; i < size; i++) {
-          fill_panel(ptr[i]);
-        }
+        fill_panel_from(ptr + unfilled_items, size - unfilled_items);
       } else {
-        for (size_t i = 0; i < size; i++) {
-          fill_panel(ptr[i]);
-        }
+        fill_panel_from(ptr, size);
       }
     }
 
@@ -535,6 +553,13 @@ namespace awkward {
       ptr_->fill_panel(datum);
     }
 
+    /// @brief Fills a contiguous segment of `size` elements from `from_ptr`
+    /// into the current panel.
+    void
+    fill_panel_from(const PRIMITIVE* from_ptr, size_t size) {
+      ptr_->fill_panel_from(from_ptr, size);
+    }
+
     /// @brief Adds a new panel with slots equal to #reserved.
     /// and updates the current panel pointer to it.
     void
@@ -544,7 +569,7 @@ namespace awkward {
     }
 
     /// @brief Initial size configuration for building a panel.
-    const BuilderOptions options_;
+    BuilderOptions options_;
 
     /// @brief Filled panels data length.
     size_t length_;

--- a/header-only/growable-buffer/awkward/GrowableBuffer.h
+++ b/header-only/growable-buffer/awkward/GrowableBuffer.h
@@ -86,8 +86,6 @@ namespace awkward {
     /// into the panel.
     ///
     /// The caller must ensure that the panel has at least `size` unused slots.
-    /// Uses `memcpy` when `PRIMITIVE` is trivially copyable, and falls back to
-    /// element-by-element assignment otherwise.
     void
     fill_panel_from(const PRIMITIVE* from_ptr, size_t size) {
       if (std::is_trivially_copyable<PRIMITIVE>::value) {

--- a/header-only/layout-builder/awkward/LayoutBuilder.h
+++ b/header-only/layout-builder/awkward/LayoutBuilder.h
@@ -478,10 +478,6 @@ namespace awkward {
       form() const noexcept {
         return "{ \"class\": \"EmptyArray\" }";
       }
-
-    private:
-      /// @brief Unique form ID.
-      size_t id_;
     };
 
 
@@ -634,27 +630,12 @@ namespace awkward {
 
       /// @brief Retrieves the names and sizes (in bytes) of the buffers used
       /// in the builder and its contents.
-      class BufferNBytesFunctor {
-      public:
-          // Constructor to capture names_nbytes by reference
-          BufferNBytesFunctor(std::map<std::string, size_t>& names_nbytes)
-              : names_nbytes_(names_nbytes) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.builder.buffer_nbytes(names_nbytes_);
-          }
-
-      private:
-          std::map<std::string, size_t>& names_nbytes_;  // reference to the map
-      };
-
       void
       buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const noexcept {
-          BufferNBytesFunctor bufferNBytesFunctor(names_nbytes); // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, bufferNBytesFunctor); // pass the functor instead of the lambda
+              visit_at(contents, i, [&names_nbytes](auto& content) {
+                  content.builder.buffer_nbytes(names_nbytes);
+              });
           }
       }
 
@@ -663,54 +644,23 @@ namespace awkward {
       ///
       /// Used to fill the buffers map by allocating it with user-defined pointers
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
-      class ToBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToBuffersFunctor(std::map<std::string, void*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.builder.to_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, void*>& buffers_;  // reference to the map
-      };
-
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-          ToBuffersFunctor toBuffersFunctor(buffers); // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toBuffersFunctor); // pass the functor instead of the lambda
+              visit_at(contents, i, [&buffers](auto& content) {
+                  content.builder.to_buffers(buffers);
+              });
           }
       }
       /// @brief Copies and concatenates the accumulated data in the buffers of the
       /// builder contents to user-defined pointers if the given node name matches
       /// with the node associated with that builder.
-      class ToBufferFunctor {
-      public:
-          // Constructor to capture buffer and name by reference
-          ToBufferFunctor(void* buffer, const char* name)
-              : buffer_(buffer), name_(name) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.builder.to_buffer(buffer_, name_);
-          }
-
-      private:
-          void* buffer_;            // reference to buffer
-          const char* name_;        // reference to name
-      };
-
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-          ToBufferFunctor toBufferFunctor(buffer, name); // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toBufferFunctor); // pass the functor instead of the lambda
+              visit_at(contents, i, [buffer, name](auto& content) {
+                  content.builder.to_buffer(buffer, name);
+              });
           }
       }
 
@@ -719,27 +669,12 @@ namespace awkward {
       /// to a map of user-allocated buffers.
       ///
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
-      class ToCharBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToCharBuffersFunctor(std::map<std::string, uint8_t*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.builder.to_char_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, uint8_t*>& buffers_;  // reference to the buffers map
-      };
-
       void
       to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
-          ToCharBuffersFunctor toCharBuffersFunctor(buffers); // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toCharBuffersFunctor); // pass the functor instead of the lambda
+              visit_at(contents, i, [&buffers](auto& content) {
+                  content.builder.to_char_buffers(buffers);
+              });
           }
       }
 
@@ -884,28 +819,14 @@ namespace awkward {
       }
 
       /// @brief Assigns a unique ID to each node.
-      class SetIdFunctor {
-      public:
-          // Constructor to capture id by reference
-          SetIdFunctor(size_t& id) : id_(id) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.set_id(id_);
-          }
-
-      private:
-          size_t& id_;  // reference to the id
-      };
-
       void
       set_id(size_t& id) noexcept {
           id_ = id;
           id++;
-          SetIdFunctor setIdFunctor(id);  // instantiate the functor with id reference
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, setIdFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [&id](auto& content) {
+                  content.set_id(id);
+              });
           }
       }
 
@@ -913,19 +834,12 @@ namespace awkward {
       /// @brief Clears the builder contents.
       ///
       /// Discards the accumulated data and the contents at each tuple index.
-      class ClearFunctor {
-      public:
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.clear();
-          }
-      };
       void
       clear() noexcept {
-          ClearFunctor clearFunctor;  // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, clearFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [](auto& content) {
+                  content.clear();
+              });
           }
       }
 
@@ -966,27 +880,12 @@ namespace awkward {
 
       /// @brief Retrieves the names and sizes (in bytes) of the buffers used
       /// in the builder and its contents.
-      class BufferNBytesFunctor {
-      public:
-          // Constructor to capture names_nbytes by reference
-          BufferNBytesFunctor(std::map<std::string, size_t>& names_nbytes)
-              : names_nbytes_(names_nbytes) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.buffer_nbytes(names_nbytes_);
-          }
-
-      private:
-          std::map<std::string, size_t>& names_nbytes_;  // reference to the map
-      };
-
       void
       buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const noexcept {
-          BufferNBytesFunctor bufferNBytesFunctor(names_nbytes);  // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, bufferNBytesFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [&names_nbytes](auto& content) {
+                  content.buffer_nbytes(names_nbytes);
+              });
           }
       }
 
@@ -996,27 +895,12 @@ namespace awkward {
       ///
       /// Used to fill the buffers map by allocating it with user-defined pointers
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
-      class ToBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToBuffersFunctor(std::map<std::string, void*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, void*>& buffers_;  // reference to the buffers map
-      };
-
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-          ToBuffersFunctor toBuffersFunctor(buffers);  // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toBuffersFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [&buffers](auto& content) {
+                  content.to_buffers(buffers);
+              });
           }
       }
 
@@ -1024,28 +908,12 @@ namespace awkward {
       /// @brief Copies and concatenates the accumulated data in the buffers of the
       /// builder contents to user-defined pointers if the given node name matches
       /// with the node associated with that builder.
-      class ToBufferFunctor {
-      public:
-          // Constructor to capture buffer and name by reference
-          ToBufferFunctor(void* buffer, const char* name)
-              : buffer_(buffer), name_(name) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_buffer(buffer_, name_);
-          }
-
-      private:
-          void* buffer_;            // reference to the buffer
-          const char* name_;        // reference to the name
-      };
-
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-          ToBufferFunctor toBufferFunctor(buffer, name);  // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toBufferFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [buffer, name](auto& content) {
+                  content.to_buffer(buffer, name);
+              });
           }
       }
 
@@ -1054,27 +922,12 @@ namespace awkward {
       /// to a map of user-allocated buffers.
       ///
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
-      class ToCharBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToCharBuffersFunctor(std::map<std::string, uint8_t*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_char_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, uint8_t*>& buffers_;  // reference to the buffers map
-      };
-
       void
       to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
-          ToCharBuffersFunctor toCharBuffersFunctor(buffers);  // instantiate the functor
           for (size_t i = 0; i < fields_count_; i++) {
-              visit_at(contents, i, toCharBuffersFunctor);  // pass the functor instead of the lambda
+              visit_at(contents, i, [&buffers](auto& content) {
+                  content.to_char_buffers(buffers);
+              });
           }
       }
 
@@ -1137,9 +990,6 @@ namespace awkward {
           noexcept {
         return std::vector<bool>({std::get<S>(contents).is_valid(error)...});
       }
-
-      /// @brief Vector of integers of field index.
-      std::vector<int64_t> field_index_;
 
       /// @brief Form parameters.
       std::string parameters_;
@@ -1541,7 +1391,6 @@ namespace awkward {
       IndexedOption()
           : index_(
                 awkward::GrowableBuffer<PRIMITIVE>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)),
-            last_valid_(-1),
             max_index_(0) {
         size_t id = 0;
         set_id(id);
@@ -1554,7 +1403,6 @@ namespace awkward {
       /// @param options Initial size configuration of a buffer.
       IndexedOption(const awkward::BuilderOptions& options)
           : index_(awkward::GrowableBuffer<PRIMITIVE>(options)),
-            last_valid_(-1),
             max_index_(0) {
         size_t id = 0;
         set_id(id);
@@ -1570,15 +1418,13 @@ namespace awkward {
       /// returns the reference to the builder content.
       BUILDER&
       append_valid() noexcept {
-        last_valid_ = content_.length();
-        return append_valid(last_valid_);
+        return append_valid(content_.length());
       }
 
       /// @brief Inserts an explicit value in the `index` buffer and
       /// returns the reference to the builder content.
       BUILDER&
       append_valid(size_t i) noexcept {
-        last_valid_ = content_.length();
         index_.append(i);
         if (i > max_index_) {
           max_index_ = i;
@@ -1594,9 +1440,9 @@ namespace awkward {
       extend_valid(size_t size) noexcept {
         size_t start = content_.length();
         size_t stop = start + size;
-        last_valid_ = stop - 1;
-        if (last_valid_ > max_index_) {
-          max_index_ = last_valid_;
+        size_t last_valid = stop - 1;
+        if (last_valid > max_index_) {
+          max_index_ = last_valid;
         }
         for (size_t i = start; i < stop; i++) {
           index_.append(i);
@@ -1641,10 +1487,9 @@ namespace awkward {
       }
 
       /// @brief Discards the accumulated index and clears the content
-      /// of the builder. Also, last valid returns to `-1`.
+      /// of the builder.
       void
       clear() noexcept {
-        last_valid_ = -1;
         index_.clear();
         content_.clear();
       }
@@ -1746,9 +1591,6 @@ namespace awkward {
 
       /// @brief Unique form ID.
       size_t id_;
-
-      /// @brief Last valid index.
-      size_t last_valid_;
 
       /// @brief Keep track of maximum index value.
       size_t max_index_;
@@ -2450,9 +2292,6 @@ namespace awkward {
             index_(awkward::GrowableBuffer<INDEX>(AWKWARD_LAYOUTBUILDER_DEFAULT_OPTIONS)) {
         size_t id = 0;
         set_id(id);
-        for (size_t i = 0; i < contents_count_; i++) {
-          last_valid_index_[i] = -1;
-        }
       }
 
       /// @brief Creates a new Union layout builder by allocating new tags and index
@@ -2465,9 +2304,6 @@ namespace awkward {
             index_(awkward::GrowableBuffer<INDEX>(options)) {
         size_t id = 0;
         set_id(id);
-        for (size_t i = 0; i < contents_count_; i++) {
-          last_valid_index_[i] = -1;
-        }
       }
 
       template <std::size_t I>
@@ -2485,7 +2321,6 @@ namespace awkward {
         INDEX next_index = which_content.length();
 
         TAGS tag = (TAGS)TAG;
-        last_valid_index_[tag] = next_index;
         tags_.append(tag);
         index_.append(next_index);
 
@@ -2505,56 +2340,29 @@ namespace awkward {
       }
 
       /// @brief Assigns a unique ID to each node.
-      class SetIdFunctor {
-      public:
-          // Constructor to capture id by reference
-          SetIdFunctor(size_t& id) : id_(id) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.set_id(id_);
-          }
-
-      private:
-          size_t& id_;  // reference to the id
-      };
-
       void
       set_id(size_t& id) noexcept {
           id_ = id;
           id++;
-          SetIdFunctor setIdFunctor(id);  // instantiate the functor
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, setIdFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [&id](auto& content) {
+                  content.set_id(id);
+              });
           }
       }
 
 
       /// @brief Discards the accumulated tags and index, and clears
       /// the builder contents.
-      ///
-      /// Also, resets the last valid index array to `-1`.
-      class ClearContentsFunctor {
-      public:
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.clear();
-          }
-      };
-
       void
       clear() noexcept {
-          for (size_t i = 0; i < contents_count_; i++) {
-              last_valid_index_[i] = -1;
-          }
           tags_.clear();
           index_.clear();
 
-          ClearContentsFunctor clearContentsFunctor;  // instantiate the functor
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, clearContentsFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [](auto& content) {
+                  content.clear();
+              });
           }
       }
 
@@ -2596,35 +2404,16 @@ namespace awkward {
 
       /// @brief Retrieves the names and sizes (in bytes) of the buffers used
       /// in the builder and its contents.
-      class BufferNBytesFunctor {
-      public:
-          // Constructor to capture names_nbytes by reference
-          BufferNBytesFunctor(std::map<std::string, size_t>& names_nbytes)
-              : names_nbytes_(names_nbytes) {}
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.buffer_nbytes(names_nbytes_);
-          }
-
-      private:
-          std::map<std::string, size_t>& names_nbytes_;  // reference to the map
-      };
-
       void
       buffer_nbytes(std::map<std::string, size_t>& names_nbytes) const noexcept {
-          auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
           // Store the size of tags and index buffers
           names_nbytes["node" + std::to_string(id_) + "-tags"] = tags_.nbytes();
           names_nbytes["node" + std::to_string(id_) + "-index"] = index_.nbytes();
 
-          // Instantiate the functor to handle each content's buffer_nbytes call
-          BufferNBytesFunctor bufferNBytesFunctor(names_nbytes);
-
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, bufferNBytesFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [&names_nbytes](auto& content) {
+                  content.buffer_nbytes(names_nbytes);
+              });
           }
       }
 
@@ -2634,37 +2423,18 @@ namespace awkward {
       ///
       /// Used to fill the buffers map by allocating it with user-defined pointers
       /// using the same names and sizes (in bytes) obtained from #buffer_nbytes.
-      class ToBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToBuffersFunctor(std::map<std::string, void*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, void*>& buffers_;  // reference to the buffers map
-      };
-
       void
       to_buffers(std::map<std::string, void*>& buffers) const noexcept {
-          auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
           // Concatenate tags and index buffers
           tags_.concatenate(reinterpret_cast<TAGS*>(
               buffers["node" + std::to_string(id_) + "-tags"]));
           index_.concatenate(reinterpret_cast<INDEX*>(
               buffers["node" + std::to_string(id_) + "-index"]));
 
-          // Create the functor to handle each content's to_buffers call
-          ToBuffersFunctor toBuffersFunctor(buffers);
-
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, toBuffersFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [&buffers](auto& content) {
+                  content.to_buffers(buffers);
+              });
           }
       }
 
@@ -2673,27 +2443,8 @@ namespace awkward {
       /// user-defined pointers if the given node name matches with any one of the nodes
       /// associated with the builder; otherwise, it searches the builder contents to
       /// locate a matching node.
-      class ToBufferFunctor {
-      public:
-          // Constructor to capture buffer and name by reference
-          ToBufferFunctor(void* buffer, const char* name)
-              : buffer_(buffer), name_(name) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_buffer(buffer_, name_);
-          }
-
-      private:
-          void* buffer_;            // reference to the buffer
-          const char* name_;        // reference to the name
-      };
-
       void
       to_buffer(void* buffer, const char* name) const noexcept {
-          auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
           if (std::string(name) == std::string("node" + std::to_string(id_) + "-tags")) {
               tags_.concatenate(reinterpret_cast<TAGS*>(buffer));
           }
@@ -2701,11 +2452,10 @@ namespace awkward {
               index_.concatenate(reinterpret_cast<INDEX*>(buffer));
           }
 
-          // Instantiate the functor to handle each content's to_buffer call
-          ToBufferFunctor toBufferFunctor(buffer, name);
-
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, toBufferFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [buffer, name](auto& content) {
+                  content.to_buffer(buffer, name);
+              });
           }
       }
 
@@ -2714,37 +2464,18 @@ namespace awkward {
       /// to a map of user-allocated buffers.
       ///
       /// The map keys and the buffer sizes are obtained from #buffer_nbytes
-      class ToCharBuffersFunctor {
-      public:
-          // Constructor to capture buffers by reference
-          ToCharBuffersFunctor(std::map<std::string, uint8_t*>& buffers)
-              : buffers_(buffers) { }
-
-          // Template operator() to handle the content
-          template <class CONTENT>
-          void operator()(CONTENT& content) const {
-              content.to_char_buffers(buffers_);
-          }
-
-      private:
-          std::map<std::string, uint8_t*>& buffers_;  // reference to the buffers map
-      };
-
       void
       to_char_buffers(std::map<std::string, uint8_t*>& buffers) const noexcept {
-          auto index_sequence((std::index_sequence_for<BUILDERS...>()));
-
           // Concatenate tags and index buffers
           tags_.concatenate(reinterpret_cast<TAGS*>(
               buffers["node" + std::to_string(id_) + "-tags"]));
           index_.concatenate(reinterpret_cast<INDEX*>(
               buffers["node" + std::to_string(id_) + "-index"]));
 
-          // Instantiate the functor to handle each content's to_char_buffers call
-          ToCharBuffersFunctor toCharBuffersFunctor(buffers);
-
           for (size_t i = 0; i < contents_count_; i++) {
-              visit_at(contents_, i, toCharBuffersFunctor);  // pass the functor instead of the lambda
+              visit_at(contents_, i, [&buffers](auto& content) {
+                  content.to_char_buffers(buffers);
+              });
           }
       }
 
@@ -2826,9 +2557,6 @@ namespace awkward {
 
       /// @brief Unique form ID.
       size_t id_;
-
-      /// @brief Last valid index array.
-      size_t last_valid_index_[sizeof...(BUILDERS)];
 
       /// @brief The count of the Tuple contents in the builder.
       static constexpr size_t contents_count_ = sizeof...(BUILDERS);

--- a/header-only/layout-builder/awkward/utils.h
+++ b/header-only/layout-builder/awkward/utils.h
@@ -17,24 +17,12 @@
 
 namespace awkward {
 
-  // FIXME:
-  // The following helper variable templates are part of C++17,
-  // define it ourselves until we switch to it
-  template< class T >
-  constexpr bool is_integral_v = std::is_integral<T>::value;
-
-  template< class T >
-  constexpr bool is_signed_v = std::is_signed<T>::value;
-
-  template< class T, class U >
-  constexpr bool is_same_v = std::is_same<T, U>::value;
-
   /// @brief Returns the name of a primitive type as a string.
   template <typename T>
   inline const std::string
   type_to_name() {
-    if (is_integral_v<T>) {
-      if (is_signed_v<T>) {
+    if (std::is_integral_v<T>) {
+      if (std::is_signed_v<T>) {
         if (sizeof(T) == 1) {
           return "int8";
         }
@@ -63,16 +51,16 @@ namespace awkward {
         }
       }
     }
-    else if (is_same_v<T, float>) {
+    else if (std::is_same_v<T, float>) {
       return "float32";
     }
-    else if (is_same_v<T, double>) {
+    else if (std::is_same_v<T, double>) {
       return "float64";
     }
-    else if (is_same_v<T, std::complex<float>>) {
+    else if (std::is_same_v<T, std::complex<float>>) {
       return "complex64";
     }
-    else if (is_same_v<T, std::complex<double>>) {
+    else if (std::is_same_v<T, std::complex<double>>) {
       return "complex128";
     }
 
@@ -149,20 +137,10 @@ namespace awkward {
   template <typename, typename = void>
   constexpr bool is_iterable{};
 
-  // FIXME:
-  // std::void_t is part of C++17, define it ourselves until we switch to it
-  template <typename...>
-  struct voider {
-    using type = void;
-  };
-
-  template <typename... T>
-  using void_t = typename voider<T...>::type;
-
   template <typename T>
   constexpr bool is_iterable<T,
-                             void_t<decltype(std::declval<T>().begin()),
-                                    decltype(std::declval<T>().end())>> = true;
+                             std::void_t<decltype(std::declval<T>().begin()),
+                                         decltype(std::declval<T>().end())>> = true;
 
   template <typename Test, template <typename...> class Ref>
   struct is_specialization : std::false_type {};

--- a/header-only/tests/test_1542-growable-buffer.cpp
+++ b/header-only/tests/test_1542-growable-buffer.cpp
@@ -326,47 +326,6 @@ void test_append_multi_panel_growth() {
   assert(buffer.length() == 0);
 }
 
-void test_extend_across_panels() {
-  // extend() that spans the current panel boundary and beyond, with growth.
-  constexpr size_t data_size = 257;
-  awkward::BuilderOptions options { 10, 2 };
-
-  int64_t data[data_size];
-  for (size_t i = 0; i < data_size; i++) {
-    data[i] = (int64_t)(i * 3 - 7);
-  }
-
-  auto buffer = awkward::GrowableBuffer<int64_t>::empty(options);
-
-  // First, partially fill the initial panel so the extend straddles a boundary.
-  buffer.append(data[0]);
-
-  // Then extend with the rest, crossing one or more panel boundaries.
-  buffer.extend(data + 1, data_size - 1);
-  assert(buffer.length() == data_size);
-
-  // A second extend continues to fill and allocate further panels.
-  int64_t more[data_size];
-  for (size_t i = 0; i < data_size; i++) {
-    more[i] = (int64_t)(1000 + i);
-  }
-  buffer.extend(more, data_size);
-  assert(buffer.length() == 2 * data_size);
-
-  std::unique_ptr<int64_t[]> ptr(new int64_t[buffer.length()]);
-  buffer.concatenate(ptr.get());
-
-  for (size_t i = 0; i < data_size; i++) {
-    assert(ptr.get()[i] == data[i]);
-  }
-  for (size_t i = 0; i < data_size; i++) {
-    assert(ptr.get()[data_size + i] == more[i]);
-  }
-
-  buffer.clear();
-  assert(buffer.length() == 0);
-}
-
 void test_move_assignment() {
   // Dropping the `const` on options_ restores move assignment.
   awkward::BuilderOptions options { 8, 2 };
@@ -398,7 +357,6 @@ int main(int /* argc */, const char ** /* argv */) {
   test_complex();
   test_extend();
   test_append_multi_panel_growth();
-  test_extend_across_panels();
   test_append_and_get_ref();
   test_copy_complex_as_complex<double, double>();
   test_copy_complex_as_complex<double, long double>();

--- a/header-only/tests/test_1542-growable-buffer.cpp
+++ b/header-only/tests/test_1542-growable-buffer.cpp
@@ -301,6 +301,92 @@ void test_copy_complex_as() {
   assert(to_buffer.length() == 0);
 }
 
+void test_append_multi_panel_growth() {
+  // Geometric growth: with resize > 1 each new panel is larger than the last.
+  // Append enough elements to span many panels and verify all values survive.
+  constexpr size_t data_size = 1000;
+  awkward::BuilderOptions options { 4, 2 };
+
+  auto buffer = awkward::GrowableBuffer<int64_t>::empty(options);
+  for (size_t i = 0; i < data_size; i++) {
+    buffer.append((int64_t)i);
+  }
+  assert(buffer.length() == data_size);
+  assert(buffer.last() == (int64_t)(data_size - 1));
+
+  std::unique_ptr<int64_t[]> ptr(new int64_t[buffer.length()]);
+  buffer.concatenate(ptr.get());
+  assert(buffer.length() == data_size);
+
+  for (size_t i = 0; i < data_size; i++) {
+    assert(ptr.get()[i] == (int64_t)i);
+  }
+
+  buffer.clear();
+  assert(buffer.length() == 0);
+}
+
+void test_extend_across_panels() {
+  // extend() that spans the current panel boundary and beyond, with growth.
+  constexpr size_t data_size = 257;
+  awkward::BuilderOptions options { 10, 2 };
+
+  int64_t data[data_size];
+  for (size_t i = 0; i < data_size; i++) {
+    data[i] = (int64_t)(i * 3 - 7);
+  }
+
+  auto buffer = awkward::GrowableBuffer<int64_t>::empty(options);
+
+  // First, partially fill the initial panel so the extend straddles a boundary.
+  buffer.append(data[0]);
+
+  // Then extend with the rest, crossing one or more panel boundaries.
+  buffer.extend(data + 1, data_size - 1);
+  assert(buffer.length() == data_size);
+
+  // A second extend continues to fill and allocate further panels.
+  int64_t more[data_size];
+  for (size_t i = 0; i < data_size; i++) {
+    more[i] = (int64_t)(1000 + i);
+  }
+  buffer.extend(more, data_size);
+  assert(buffer.length() == 2 * data_size);
+
+  std::unique_ptr<int64_t[]> ptr(new int64_t[buffer.length()]);
+  buffer.concatenate(ptr.get());
+
+  for (size_t i = 0; i < data_size; i++) {
+    assert(ptr.get()[i] == data[i]);
+  }
+  for (size_t i = 0; i < data_size; i++) {
+    assert(ptr.get()[data_size + i] == more[i]);
+  }
+
+  buffer.clear();
+  assert(buffer.length() == 0);
+}
+
+void test_move_assignment() {
+  // Dropping the `const` on options_ restores move assignment.
+  awkward::BuilderOptions options { 8, 2 };
+
+  auto buffer = awkward::GrowableBuffer<int64_t>::empty(options);
+  for (int64_t i = 0; i < 50; i++) {
+    buffer.append(i);
+  }
+
+  auto other = awkward::GrowableBuffer<int64_t>::empty(options);
+  other = std::move(buffer);
+  assert(other.length() == 50);
+
+  std::unique_ptr<int64_t[]> ptr(new int64_t[other.length()]);
+  other.concatenate(ptr.get());
+  for (int64_t i = 0; i < 50; i++) {
+    assert(ptr.get()[i] == i);
+  }
+}
+
 int main(int /* argc */, const char ** /* argv */) {
   test_full();
   test_arange();
@@ -311,6 +397,8 @@ int main(int /* argc */, const char ** /* argv */) {
   test_double();
   test_complex();
   test_extend();
+  test_append_multi_panel_growth();
+  test_extend_across_panels();
   test_append_and_get_ref();
   test_copy_complex_as_complex<double, double>();
   test_copy_complex_as_complex<double, long double>();


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This is a cleanup PR for the standalone `header-only/` C++ library (which already requires C++17). It is **public API for downstream C++ users** — no public signatures or behaviors are changed. Only files under `header-only/` are touched.

## Changes

**`header-only/layout-builder/awkward/utils.h`** — drop the hand-rolled `is_integral_v`/`is_signed_v`/`is_same_v`/`void_t` "until we switch to C++17" shims and use `std::is_*_v` / `std::void_t`.

**`header-only/layout-builder/awkward/LayoutBuilder.h`**
- Replace the ~350 lines of `BufferNBytesFunctor`/`ToBuffersFunctor`/`ToBufferFunctor`/`ToCharBuffersFunctor`/`SetIdFunctor`/`ClearFunctor` helper classes — triplicated nearly verbatim across `Record`, `Tuple`, and `Union` "for C++11 compatibility" — with generic lambdas passed to `visit_at`. `ContentsFormFunctor` is intentionally left untouched to avoid conflicting with an in-flight form-bug-fix PR.
- Remove dead state that is written but never read: `Union::last_valid_index_`, `IndexedOption::last_valid_` (its only real use, in `extend_valid`, is now a local), `Tuple::field_index_`, and the unused/uninitialized `Empty::id_`. Also drop the unused `index_sequence` locals in `Union::to_buffers`/`to_buffer`/`to_char_buffers`.
- The `BitMasked` class region is intentionally left alone.

**`header-only/growable-buffer/awkward/GrowableBuffer.h`**
- Drop the `const` qualifier on the `options_` member so that `GrowableBuffer` (and every `LayoutBuilder` that contains one) is move-assignable again, and explicitly `= default` the move-assignment operator (the existing user-declared move constructor otherwise suppresses it). The `options()` accessor stays `const`.
- Use `std::make_unique` instead of `unique_ptr(new ...)` and drop a redundant `std::move` of a temporary.
- Fix `append()` so panel growth compounds geometrically: new panels are sized from the current reserved capacity (`ceil(reserved * resize)`) instead of always `ceil(initial * resize)` — previously, with default options, every panel was the same `initial`-sized 1024 elements, producing N/1024 linked panels. `extend()` now copies each contiguous segment with a `memcpy` when the element type is trivially copyable (the `PRIMITIVE` here always is) instead of element-by-element. Lengths and contents are identical.

**`header-only/tests/test_1542-growable-buffer.cpp`** — add two focused tests for the behavior-affecting changes: multi-panel geometric growth via `append()`, and move assignment (which previously failed to compile because of the `const` member). `extend()` correctness across panel boundaries remains covered by the existing `test_extend`.

## Testing
`cmake -S header-only -B build -DBUILD_TESTS=ON && cmake --build build` builds cleanly. The growable-buffer, builder-options, and layout-builder-is-valid test executables pass, including the new tests.

> Note: `test_1494-layout-builder` has a pre-existing `BitMasked::clear()` heap-use-after-free (reproducible on `main` before this PR) that is being fixed separately; it is unrelated to these changes and lives in the untouched `BitMasked` region.

## AI assistance
This PR was prepared with Claude Code as part of an automated review of the header-only library. Changes were verified by building and running the test suite.

## Merge order
Two other in-flight PRs touch `GrowableBuffer.h` (panel-copy/concatenate-offset bug fix) and the `BitMasked` class, so textual conflicts are expected at merge time. **This PR should be rebased and merged after** `henryiii/fix-bitmasked-growablebuffer` and `henryiii/fix-layoutbuilder-form`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
