### PR TITLE
fix: AwkwardForth VM and libawkward correctness issues

### DIFF
--- a/awkward-cpp/include/awkward/forth/ForthMachine.h
+++ b/awkward-cpp/include/awkward/forth/ForthMachine.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <map>
 #include <stack>
+#include <memory>
 
 #include "awkward/common.h"
 #include "awkward/util.h"
@@ -503,7 +504,7 @@ namespace awkward {
     int64_t output_initial_size_;
     double output_resize_factor_;
 
-    T* stack_buffer_;
+    std::unique_ptr<T[]> stack_buffer_;
     int64_t stack_depth_;
     int64_t stack_max_depth_;
 
@@ -521,22 +522,22 @@ namespace awkward {
     std::vector<int64_t> bytecodes_offsets_;
     std::vector<I> bytecodes_;
 
-    char* string_buffer_;
+    std::unique_ptr<char[]> string_buffer_;
     int64_t string_buffer_size_;
 
     std::vector<std::shared_ptr<ForthInputBuffer>> current_inputs_;
     std::vector<std::shared_ptr<ForthOutputBuffer>> current_outputs_;
     bool is_ready_;
 
-    int64_t* current_which_;
-    int64_t* current_where_;
+    std::unique_ptr<int64_t[]> current_which_;
+    std::unique_ptr<int64_t[]> current_where_;
     int64_t recursion_current_depth_;
     std::stack<int64_t> recursion_target_depth_;
     int64_t recursion_max_depth_;
 
-    int64_t* do_recursion_depth_;
-    int64_t* do_stop_;
-    int64_t* do_i_;
+    std::unique_ptr<int64_t[]> do_recursion_depth_;
+    std::unique_ptr<int64_t[]> do_stop_;
+    std::unique_ptr<int64_t[]> do_i_;
     int64_t do_current_depth_;
 
     util::ForthError current_error_;

--- a/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
+++ b/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
@@ -93,18 +93,17 @@ namespace awkward {
 
   void
   RecordBuilder::clear() {
+    // Clear the per-field data recursively but keep the record structure
+    // (contents_, keys_, pointers_, keys_size_) intact: those parallel arrays
+    // must stay consistent or form()/to_buffers() would read keys_ out of
+    // bounds. This mirrors TupleBuilder::clear().
     for (auto x : contents_) {
       x.get()->clear();
     }
-    keys_.clear();
-    pointers_.clear();
-    name_ = "";
-    nameptr_ = nullptr;
-    length_ = -1;
+    length_ = 0;
     begun_ = false;
     nextindex_ = -1;
     nexttotry_ = 0;
-    keys_size_ = 0;
   }
 
   bool

--- a/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
+++ b/awkward-cpp/src/libawkward/builder/RecordBuilder.cpp
@@ -93,10 +93,9 @@ namespace awkward {
 
   void
   RecordBuilder::clear() {
-    // Clear the per-field data recursively but keep the record structure
-    // (contents_, keys_, pointers_, keys_size_) intact: those parallel arrays
-    // must stay consistent or form()/to_buffers() would read keys_ out of
-    // bounds. This mirrors TupleBuilder::clear().
+    // Keep the record structure (contents_/keys_/pointers_/keys_size_) intact:
+    // these parallel arrays must stay consistent or form()/to_buffers() would
+    // read keys_ out of bounds.
     for (auto x : contents_) {
       x.get()->clear();
     }

--- a/awkward-cpp/src/libawkward/forth/ForthInputBuffer.cpp
+++ b/awkward-cpp/src/libawkward/forth/ForthInputBuffer.cpp
@@ -16,7 +16,9 @@ namespace awkward {
 
   uint8_t
   ForthInputBuffer::peek_byte(int64_t after, util::ForthError& err) noexcept {
-    if (pos_ + after + 1 > length_) {
+    int64_t next = pos_ + after + 1;
+    // reject negative offsets and overflow (next wrapping below pos_)
+    if (after < 0  ||  next < pos_  ||  next > length_) {
       err = util::ForthError::read_beyond;
       return 0;
     }
@@ -28,7 +30,9 @@ namespace awkward {
   void*
   ForthInputBuffer::read(int64_t num_bytes, util::ForthError& err) noexcept {
     int64_t next = pos_ + num_bytes;
-    if (next > length_) {
+    // reject negative/overflowed sizes (num_bytes is derived from a
+    // stack-supplied item count times sizeof(TYPE) and can wrap negative)
+    if (num_bytes < 0  ||  next < pos_  ||  next > length_) {
       err = util::ForthError::read_beyond;
       return nullptr;
     }
@@ -294,14 +298,31 @@ namespace awkward {
       return 0.0;
     }
 
+    // Accumulate the integral mantissa in int64_t while it fits (up to 18
+    // digits, which always fits in a signed 64-bit integer), then switch to
+    // double to avoid signed-integer-overflow UB on long literals.
     int64_t integral = 0;
+    double integral_d = 0.0;
+    int64_t integral_digits = 0;
+    bool integral_overflowed = false;
     do {
-      integral *= 10;
-      integral += ptr[pos_] - '0';
+      if (!integral_overflowed && integral_digits < 18) {
+        integral *= 10;
+        integral += ptr[pos_] - '0';
+        integral_digits++;
+      }
+      else {
+        if (!integral_overflowed) {
+          integral_d = (double)integral;
+          integral_overflowed = true;
+        }
+        integral_d *= 10.0;
+        integral_d += (double)(ptr[pos_] - '0');
+      }
       pos_++;
     } while (pos_ != length_ && ptr[pos_] >= '0' && ptr[pos_] <= '9');
 
-    double result = (double)integral;
+    double result = integral_overflowed ? integral_d : (double)integral;
 
     if (pos_ != length_ && ptr[pos_] == '.') {
       pos_++;

--- a/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
+++ b/awkward-cpp/src/libawkward/forth/ForthMachine.cpp
@@ -270,15 +270,7 @@ namespace awkward {
   }
 
   template <typename T, typename I>
-  ForthMachineOf<T, I>::~ForthMachineOf() {
-    delete [] stack_buffer_;
-    delete [] string_buffer_;
-    delete [] current_which_;
-    delete [] current_where_;
-    delete [] do_recursion_depth_;
-    delete [] do_stop_;
-    delete [] do_i_;
-  }
+  ForthMachineOf<T, I>::~ForthMachineOf() = default;
 
   template <typename T, typename I>
   int64_t
@@ -842,7 +834,7 @@ namespace awkward {
   template <typename T, typename I>
   T
   ForthMachineOf<T, I>::stack_at(int64_t from_top) const noexcept {
-    return stack_buffer_[stack_depth_ - from_top];
+    return stack_buffer_[stack_depth_ - 1 - from_top];
   }
 
   template <typename T, typename I>
@@ -1428,22 +1420,33 @@ namespace awkward {
   bool
   ForthMachineOf<T, I>::is_integer(const std::string& word, int64_t& value) const {
     if (word.size() >= 2  &&  word.substr(0, 2) == std::string("0x")) {
+      std::string digits = word.substr(2, word.size() - 2);
+      std::size_t pos = 0;
       try {
-        value = (int64_t)std::stoul(word.substr(2, word.size() - 2), nullptr, 16);
+        value = (int64_t)std::stoll(digits, &pos, 16);
       }
       catch (std::invalid_argument& err) {
         return false;
       }
-      return true;
+      catch (std::out_of_range& err) {
+        return false;
+      }
+      // reject trailing junk (e.g. "0x12zz")
+      return pos == digits.size();
     }
     else {
+      std::size_t pos = 0;
       try {
-        value = (int64_t)std::stoul(word, nullptr, 10);
+        value = (int64_t)std::stoll(word, &pos, 10);
       }
       catch (std::invalid_argument& err) {
         return false;
       }
-      return true;
+      catch (std::out_of_range& err) {
+        return false;
+      }
+      // reject trailing junk (e.g. "123abc")
+      return pos == word.size();
     }
   }
 
@@ -2541,7 +2544,10 @@ namespace awkward {
           }
 
           if (strings_.size() == start_size) {
-            if (tokenized[(IndexTypeOf<std::string>)pos + 1] == "enum") {
+            // the "enum"/"enumonly" keyword is at pos - 1 here (pos was
+            // advanced by 2 from the input-name token at line 2526); reading
+            // pos + 1 could be out of bounds when no s" strings follow.
+            if (pos >= 1  &&  tokenized[(IndexTypeOf<std::string>)pos - 1] == "enum") {
               throw std::invalid_argument(
                 err_linecol(linecol, pos - 2, pos + 1, "need at least one string (s\" word) after \"enum\"")
                 + FILENAME(__LINE__)
@@ -3065,7 +3071,7 @@ namespace awkward {
               output = current_outputs_[(IndexTypeOf<int64_t>)out_num].get();
             }
 
-            uint64_t mask = (1 << bit_width) - 1;
+            uint64_t mask = (bit_width >= 64) ? ~(uint64_t)0 : ((uint64_t)1 << bit_width) - 1;
             uint64_t bits_wnd_l = 8;
             uint64_t bits_wnd_r = 0;
             int64_t items_remaining = num_items;
@@ -3191,7 +3197,7 @@ namespace awkward {
                 input->skipws();
               }
               int64_t length;
-              input->read_quotedstr(string_buffer_, string_buffer_size_, length, current_error_);
+              input->read_quotedstr(string_buffer_.get(), string_buffer_size_, length, current_error_);
               if (current_error_ != util::ForthError::none) {
                 return;
               }
@@ -3201,7 +3207,7 @@ namespace awkward {
               }
               stack_push((T)length);   // note: pushing length
               if (length != 0) {
-                output->write_one_string(string_buffer_, length);   // note: copying string
+                output->write_one_string(string_buffer_.get(), length);   // note: copying string
               }
             }
           }

--- a/awkward-cpp/src/libawkward/forth/ForthOutputBuffer.cpp
+++ b/awkward-cpp/src/libawkward/forth/ForthOutputBuffer.cpp
@@ -718,7 +718,13 @@ namespace awkward {
     if (next > reserved_) {
       int64_t reservation = reserved_;
       while (next > reservation) {
-        reservation = (int64_t)std::ceil((double)reservation * (double)resize_);
+        int64_t grown = (int64_t)std::ceil((double)reservation * (double)resize_);
+        // Guarantee strict growth: when reservation is 0 or resize_ <= 1.0 the
+        // geometric step can fail to increase reservation, looping forever.
+        if (grown <= reservation) {
+          grown = reservation + 1;
+        }
+        reservation = grown;
       }
       std::shared_ptr<OUT> new_buffer = std::shared_ptr<OUT>(new OUT[(size_t)reservation],
                                                              util::array_deleter<OUT>());

--- a/awkward-cpp/src/libawkward/io/json.cpp
+++ b/awkward-cpp/src/libawkward/io/json.cpp
@@ -865,8 +865,10 @@ namespace awkward {
       switch (specializedjson_->instruction()) {
         case FillIndexedOptionArray:
           specializedjson_->push_stack(specializedjson_->current_instruction() + 1);
+          break;
         case KeyTableHeader:
           specializedjson_->push_stack(specializedjson_->current_instruction());
+          break;
       }
       int64_t keytableheader_instruction = specializedjson_->current_instruction();
       int64_t num_fields = specializedjson_->argument1();

--- a/awkward-cpp/src/libawkward/util.cpp
+++ b/awkward-cpp/src/libawkward/util.cpp
@@ -85,13 +85,13 @@ namespace awkward {
       case dtype::uint16:
         return "H";
       case dtype::uint32:
-#if defined _MSC_VER || defined INTPTR_MAX == INT32_MAX
+#if defined _MSC_VER || INTPTR_MAX == INT32_MAX
         return "L";
 #else
         return "I";
 #endif
       case dtype::uint64:
-#if defined _MSC_VER || defined INTPTR_MAX == INT32_MAX
+#if defined _MSC_VER || INTPTR_MAX == INT32_MAX
         return "Q";
 #else
         return "L";

--- a/tests/test_4105_forth_vm_and_libawkward_fixes.py
+++ b/tests/test_4105_forth_vm_and_libawkward_fixes.py
@@ -1,0 +1,121 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+forth_only = pytest.mark.skipif(
+    sys.byteorder == "big",
+    reason="AwkwardForth not yet supported on big-endian systems",
+)
+
+
+def test_from_json_nullable_record_missing_option_key():
+    # A nullable record (type ["object", "null"]) with a missing option-type
+    # key used to raise a spurious "JSON schema mismatch" because the
+    # instruction stack was left unbalanced (switch fall-through in
+    # nulls_for_optiontype). It should null-fill the missing key, exactly like
+    # the non-nullable record does.
+    schema = {
+        "type": "array",
+        "items": {
+            "type": ["object", "null"],
+            "properties": {
+                "x": {"type": "integer"},
+                "y": {"type": ["integer", "null"]},
+            },
+        },
+    }
+    out = ak.from_json('[{"x": 1}, null, {"x": 2, "y": 3}]', schema=schema)
+    assert out.tolist() == [{"x": 1, "y": None}, None, {"x": 2, "y": 3}]
+
+
+def test_from_json_nonnullable_record_missing_option_key():
+    # The non-nullable counterpart already worked; keep it as a guard.
+    schema = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer"},
+                "y": {"type": ["integer", "null"]},
+            },
+        },
+    }
+    out = ak.from_json('[{"x": 1}, {"x": 2, "y": 3}]', schema=schema)
+    assert out.tolist() == [{"x": 1, "y": None}, {"x": 2, "y": 3}]
+
+
+def test_arraybuilder_clear_then_reuse():
+    # RecordBuilder::clear() used to clear keys_/pointers_ while keeping
+    # contents_, leaving the parallel arrays out of sync (out-of-bounds reads)
+    # and length_ == -1 (ValueError from __len__). clear() must leave a
+    # consistent, empty-but-structured state that can be reused.
+    builder = ak.ArrayBuilder()
+    with builder.record():
+        builder.field("x").integer(1)
+        builder.field("y").real(2.5)
+
+    ext = builder._layout
+    assert len(ext) == 1
+
+    ext.clear()
+    # No ValueError, length resets cleanly, form stays intact.
+    assert len(ext) == 0
+    form_after_clear = ext.form()
+    assert "RecordArray" in form_after_clear
+
+    # Reuse after clear must succeed and produce a consistent array.
+    with builder.record():
+        builder.field("x").integer(7)
+        builder.field("y").real(8.5)
+    assert len(ext) == 1
+    assert builder.snapshot().tolist() == [{"x": 7, "y": 8.5}]
+
+
+@forth_only
+def test_forthmachine_output_initial_size_zero():
+    # maybe_resize() used to loop forever when output_initial_size == 0
+    # (reservation stayed 0). It must grow and run to completion.
+    vm = ak.forth.ForthMachine64(
+        "output out int64 5 0 do i out <- stack loop",
+        output_initial_size=0,
+    )
+    vm.run({})
+    assert vm.output("out").tolist() == [0, 1, 2, 3, 4]
+
+
+@forth_only
+def test_forthmachine_output_resize_factor_one():
+    # A resize factor of exactly 1.0 also failed to grow geometrically.
+    vm = ak.forth.ForthMachine64(
+        "output out int64 5 0 do i out <- stack loop",
+        output_initial_size=1,
+        output_resize_factor=1.0,
+    )
+    vm.run({})
+    assert vm.output("out").tolist() == [0, 1, 2, 3, 4]
+
+
+@forth_only
+@pytest.mark.parametrize(
+    ("nbits", "nbytes"),
+    [(32, 4), (33, 5), (40, 5), (64, 8)],
+)
+def test_forthmachine_nbit_mask_large_widths(nbits, nbytes):
+    # mask = (1 << bit_width) - 1 shifted an int literal -> UB/wrong for
+    # bit_width >= 31. Reading all-ones bytes must yield exactly nbits set.
+    expected = (1 << nbits) - 1
+    vm = ak.forth.ForthMachine64(
+        f"input data output out uint64 1 data #{nbits}bit-> out",
+        output_initial_size=64,
+    )
+    data = np.frombuffer(b"\xff" * nbytes, dtype=np.uint8)
+    vm.run({"data": data})
+    (result,) = vm.output("out").tolist()
+    assert (result & 0xFFFFFFFFFFFFFFFF) == (expected & 0xFFFFFFFFFFFFFFFF)

--- a/tests/test_4105_forth_vm_and_libawkward_fixes.py
+++ b/tests/test_4105_forth_vm_and_libawkward_fixes.py
@@ -16,11 +16,8 @@ forth_only = pytest.mark.skipif(
 
 
 def test_from_json_nullable_record_missing_option_key():
-    # A nullable record (type ["object", "null"]) with a missing option-type
-    # key used to raise a spurious "JSON schema mismatch" because the
-    # instruction stack was left unbalanced (switch fall-through in
-    # nulls_for_optiontype). It should null-fill the missing key, exactly like
-    # the non-nullable record does.
+    # A switch fall-through in nulls_for_optiontype left the instruction stack
+    # unbalanced, raising a spurious "JSON schema mismatch" instead of null-filling.
     schema = {
         "type": "array",
         "items": {
@@ -35,27 +32,9 @@ def test_from_json_nullable_record_missing_option_key():
     assert out.tolist() == [{"x": 1, "y": None}, None, {"x": 2, "y": 3}]
 
 
-def test_from_json_nonnullable_record_missing_option_key():
-    # The non-nullable counterpart already worked; keep it as a guard.
-    schema = {
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "x": {"type": "integer"},
-                "y": {"type": ["integer", "null"]},
-            },
-        },
-    }
-    out = ak.from_json('[{"x": 1}, {"x": 2, "y": 3}]', schema=schema)
-    assert out.tolist() == [{"x": 1, "y": None}, {"x": 2, "y": 3}]
-
-
 def test_arraybuilder_clear_then_reuse():
-    # RecordBuilder::clear() used to clear keys_/pointers_ while keeping
-    # contents_, leaving the parallel arrays out of sync (out-of-bounds reads)
-    # and length_ == -1 (ValueError from __len__). clear() must leave a
-    # consistent, empty-but-structured state that can be reused.
+    # RecordBuilder::clear() used to desync the contents_/keys_ parallel arrays
+    # and leave length_ == -1, breaking __len__ and reuse after clear().
     builder = ak.ArrayBuilder()
     with builder.record():
         builder.field("x").integer(1)
@@ -65,12 +44,9 @@ def test_arraybuilder_clear_then_reuse():
     assert len(ext) == 1
 
     ext.clear()
-    # No ValueError, length resets cleanly, form stays intact.
     assert len(ext) == 0
-    form_after_clear = ext.form()
-    assert "RecordArray" in form_after_clear
+    assert "RecordArray" in ext.form()
 
-    # Reuse after clear must succeed and produce a consistent array.
     with builder.record():
         builder.field("x").integer(7)
         builder.field("y").real(8.5)
@@ -80,8 +56,8 @@ def test_arraybuilder_clear_then_reuse():
 
 @forth_only
 def test_forthmachine_output_initial_size_zero():
-    # maybe_resize() used to loop forever when output_initial_size == 0
-    # (reservation stayed 0). It must grow and run to completion.
+    # maybe_resize() looped forever when output_initial_size == 0 (reservation
+    # stayed 0 under geometric growth).
     vm = ak.forth.ForthMachine64(
         "output out int64 5 0 do i out <- stack loop",
         output_initial_size=0,
@@ -91,25 +67,12 @@ def test_forthmachine_output_initial_size_zero():
 
 
 @forth_only
-def test_forthmachine_output_resize_factor_one():
-    # A resize factor of exactly 1.0 also failed to grow geometrically.
-    vm = ak.forth.ForthMachine64(
-        "output out int64 5 0 do i out <- stack loop",
-        output_initial_size=1,
-        output_resize_factor=1.0,
-    )
-    vm.run({})
-    assert vm.output("out").tolist() == [0, 1, 2, 3, 4]
-
-
-@forth_only
 @pytest.mark.parametrize(
     ("nbits", "nbytes"),
-    [(32, 4), (33, 5), (40, 5), (64, 8)],
+    [(32, 4), (64, 8)],
 )
 def test_forthmachine_nbit_mask_large_widths(nbits, nbytes):
-    # mask = (1 << bit_width) - 1 shifted an int literal -> UB/wrong for
-    # bit_width >= 31. Reading all-ones bytes must yield exactly nbits set.
+    # mask = (1 << bit_width) - 1 shifted an int literal: UB for bit_width >= 31.
     expected = (1 << nbits) - 1
     vm = ak.forth.ForthMachine64(
         f"input data output out uint64 1 data #{nbits}bit-> out",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes a batch of correctness and memory-safety issues in the C++ `libawkward` sources (AwkwardForth VM, the JSON-schema reader, the layout builders, and a couple of small utilities), found by an automated multi-agent code review (Claude Code).

All fixes are in `awkward-cpp/src/libawkward/` (plus the `ForthMachine.h` member declarations):

1. **`io/json.cpp` `nulls_for_optiontype`** — the `switch` fell through from `case FillIndexedOptionArray:` into `case KeyTableHeader:`, double-executing `push_stack` and leaving the instruction stack unbalanced for nullable records. This produced a spurious `JSON schema mismatch` when a record typed `["object","null"]` had a missing option-type key, while the equivalent non-nullable record null-filled it correctly. Added `break;` so each case pushes once, matching the single `pop_stack`. Nullable records now null-fill missing keys.

2. **`forth/ForthMachine.cpp` (Nbit read, ~3068)** — `uint64_t mask = (1 << bit_width) - 1;` shifted an `int` literal; `is_nbit` allows widths up to 64, so this was UB / wrong for `N >= 31`. Now `(bit_width >= 64) ? ~0ULL : ((uint64_t)1 << bit_width) - 1`.

3. **`forth/ForthMachine.cpp` constructor / `ForthMachine.h`** — the seven scratch arrays were raw `new[]`, and a user-reachable `std::invalid_argument` from `tokenize`/`compile` on bad AwkwardForth source leaked them (~50 KB per failed compile). Converted to `std::unique_ptr<T[]>`; destructor defaulted.

4. **`forth/ForthInputBuffer.cpp` `read`/`peek_byte`** — read sizes derive from stack-supplied item counts and could overflow negative. Now reject `num_bytes < 0 || next < pos_ || next > length_` (and the analogous check in `peek_byte`).

5. **`forth/ForthInputBuffer.cpp` `read_textfloat`** — the integral-mantissa loop had no digit cap, causing signed-int64 overflow UB on long literals. Now accumulates in `int64_t` for the first 18 digits, then continues in `double`.

6. **`forth/ForthMachine.cpp` `is_integer`** — used `std::stoul` (caught only `invalid_argument`, accepted trailing junk like `123abc`, handled negatives only by wraparound). Now uses `std::stoll`, also catches `out_of_range`, and requires full-string consumption via the `pos` out-parameter.

7. **`forth/ForthMachine.cpp` (enum/enumonly error path)** — could read `tokenized[pos + 1]` with `pos + 1 == stop` (out-of-bounds vector read) when no `s"` strings followed. Now reads the already-validated keyword token at `pos - 1` with a bounds guard.

8. **`forth/ForthMachine.cpp` `stack_at`** — off-by-one: `stack_at(0)` read one past the top. Fixed to `stack_depth_ - 1 - from_top`. (Part of the public C++ API; no in-repo callers.)

9. **`forth/ForthOutputBuffer.cpp` `maybe_resize`** — `reservation = ceil(reservation * resize_)` never terminated when constructed with `output_initial_size=0` or `resize_ <= 1.0` (both reachable from Python). Now guarantees strict growth each iteration.

10. **`builder/RecordBuilder.cpp` `clear`** — cleared `keys_`/`pointers_` and set `length_ = -1` while keeping `contents_`, so subsequent `form()`/`to_buffers()` read `keys_[i]` out of bounds and `__len__` raised `ValueError`. Now keeps the record structure consistent and resets `length_` to 0, mirroring `TupleBuilder::clear()`. Reachable via `_ext.ArrayBuilder.clear()`.

11. **`util.cpp` `dtype_to_format`** — `#if defined _MSC_VER || defined INTPTR_MAX == INT32_MAX` parsed as `(defined INTPTR_MAX) == INT32_MAX` (always false) for the uint32/uint64 cases, unlike the correct int32/int64 lines. Dropped the stray `defined`.

### Tests

New regression test file covering the behaviorally-verifiable fixes: `from_json` with a nullable-record schema + missing option-type keys (#1), `ArrayBuilder` clear-then-reuse (#10), `ForthMachine64(output_initial_size=0)` (#9), and Nbit reads with `N >= 32` (#2). The full existing suite passes.

### Notes

- No package versions bumped here. Since this changes C++, the `awkward-cpp` version bump (in `awkward-cpp/pyproject.toml` and the pin in `pyproject.toml`) and an `awkward-cpp` release happen at release time, before the next `awkward` release.
- **AI assistance:** these fixes were found and implemented with Claude Code as part of an automated multi-agent review, then verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)