### PR TITLE
fix: named-axis context sharing and ak.where broadcasting crash

### DIFF
--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -13,6 +13,7 @@ from awkward._backends.backend import Backend
 from awkward._backends.dispatch import backend_of
 from awkward._namedaxis import (
     NAMED_AXIS_KEY,
+    NamedAxesWithDims,
     _add_named_axis,
     _unify_named_axis,
 )
@@ -325,20 +326,6 @@ BROADCAST_RULE_TO_FACTORY_IMPL = {
 }
 
 
-def _export_named_axis_from_depth_to_lateral(
-    idx: int,
-    depth_context: dict[str, Any],
-    lateral_context: dict[str, Any],
-) -> None:
-    # set adjusted named axes to lateral (inplace)
-    named_axis, ndim = depth_context[NAMED_AXIS_KEY][idx]
-    seen_named_axis, _ = lateral_context[NAMED_AXIS_KEY][idx]
-    lateral_context[NAMED_AXIS_KEY][idx] = (
-        _unify_named_axis(named_axis, seen_named_axis),
-        ndim,
-    )
-
-
 def broadcast_regular_dim_size(contents: Sequence[ak.contents.Content]) -> ShapeItem:
     # Find known size out of our contents
     dim_size: ShapeItem
@@ -464,10 +451,13 @@ def apply_step(
                             _unify_named_axis(named_axis, seen_named_axis),
                             ndim + 1 if ndim is not None else ndim,
                         )
-                        if o.is_leaf:
-                            _export_named_axis_from_depth_to_lateral(
-                                i, depth_context, lateral_context
-                            )
+                        # Mirror the updated depth named axis into the lateral
+                        # ("seen") context. The two contexts have independent
+                        # storage, so this must be done explicitly (it used to
+                        # rely on the contexts sharing storage).
+                        lateral_context[NAMED_AXIS_KEY][i] = depth_context[
+                            NAMED_AXIS_KEY
+                        ][i]
                     nextinputs.append(o)
                 else:
                     nextinputs.append(o)
@@ -553,6 +543,12 @@ def apply_step(
                 numoutputs = len(outcontents[-1])
             else:
                 assert numoutputs == len(outcontents[-1])
+
+        # When all records have zero fields, the loop above never runs and
+        # numoutputs is left as None. There is no recursion to tell us how many
+        # outputs the action produces, so default to a single output RecordArray.
+        if numoutputs is None:
+            numoutputs = 1
 
         parameters = parameters_factory(nextparameters, numoutputs)
 
@@ -646,10 +642,11 @@ def apply_step(
                             _add_named_axis(named_axis, depth, ndim),
                             ndim + 1 if ndim is not None else ndim,
                         )
-                        if x.is_leaf:
-                            _export_named_axis_from_depth_to_lateral(
-                                i, depth_context, lateral_context
-                            )
+                        # Mirror into the lateral ("seen") context. The two
+                        # contexts have independent storage, so do this explicitly.
+                        lateral_context[NAMED_AXIS_KEY][i] = depth_context[
+                            NAMED_AXIS_KEY
+                        ][i]
                     # Any unknown values or sizes are assumed to be correct as-is
                     elif (
                         dim_size is unknown_length
@@ -715,7 +712,7 @@ def apply_step(
             nextinputs = []
             nextparameters = []
             for i, ((named_axis, ndim), x, x_is_string) in enumerate(
-                zip(named_axes_with_ndims, inputs, input_is_string, strict=False)
+                zip(named_axes_with_ndims, inputs, input_is_string, strict=True)
             ):
                 if isinstance(x, listtypes) and not x_is_string:
                     next_content = broadcast_to_offsets_avoiding_carry(x, offsets)
@@ -735,10 +732,11 @@ def apply_step(
                         _add_named_axis(named_axis, depth + 1, ndim),
                         ndim + 1 if ndim is not None else ndim,
                     )
-                    if x.is_leaf:
-                        _export_named_axis_from_depth_to_lateral(
-                            i, depth_context, lateral_context
-                        )
+                    # Mirror into the lateral ("seen") context. The two contexts
+                    # have independent storage, so do this explicitly.
+                    lateral_context[NAMED_AXIS_KEY][i] = depth_context[NAMED_AXIS_KEY][
+                        i
+                    ]
                 else:
                     nextinputs.append(x)
                     nextparameters.append(NO_PARAMETERS)
@@ -956,13 +954,20 @@ def apply_step(
                 return (out,)
 
         cond_mask = masks[2]
+        # The outer depth/lateral contexts hold one named-axis entry per
+        # original input (x, y, cond), but this internal apply_step only
+        # receives two inputs. Build fresh, correctly-sized contexts so the
+        # named-axis bookkeeping (which zips contexts against inputs) matches.
+        or_depth_context, or_lateral_context = NamedAxesWithDims.prepare_contexts(
+            [xy_mask, cond_mask]
+        )
         mask = apply_step(
             backend,
             (xy_mask, cond_mask),
             action_logical_or,
             0,
-            depth_context,
-            lateral_context,
+            or_depth_context,
+            or_lateral_context,
             simple_options,
         )[0]
 
@@ -984,13 +989,18 @@ def apply_step(
                 )
                 return (out,)
 
+        # As above: build fresh contexts sized to the two inputs of this
+        # internal apply_step rather than reusing the outer 3-input contexts.
+        mask_depth_context, mask_lateral_context = NamedAxesWithDims.prepare_contexts(
+            [xy_unmasked, mask]
+        )
         masked = apply_step(
             backend,
             (xy_unmasked, mask),
             apply_mask_action,
             0,
-            depth_context,
-            lateral_context,
+            mask_depth_context,
+            mask_lateral_context,
             simple_options,
         )
         return masked

--- a/src/awkward/_broadcasting.py
+++ b/src/awkward/_broadcasting.py
@@ -451,10 +451,8 @@ def apply_step(
                             _unify_named_axis(named_axis, seen_named_axis),
                             ndim + 1 if ndim is not None else ndim,
                         )
-                        # Mirror the updated depth named axis into the lateral
-                        # ("seen") context. The two contexts have independent
-                        # storage, so this must be done explicitly (it used to
-                        # rely on the contexts sharing storage).
+                        # mirror into the lateral context (independent storage
+                        # now; this used to rely on the two contexts sharing it)
                         lateral_context[NAMED_AXIS_KEY][i] = depth_context[
                             NAMED_AXIS_KEY
                         ][i]
@@ -544,9 +542,8 @@ def apply_step(
             else:
                 assert numoutputs == len(outcontents[-1])
 
-        # When all records have zero fields, the loop above never runs and
-        # numoutputs is left as None. There is no recursion to tell us how many
-        # outputs the action produces, so default to a single output RecordArray.
+        # With zero fields the loop above never runs, so no recursion tells us
+        # the output count; default to a single RecordArray.
         if numoutputs is None:
             numoutputs = 1
 
@@ -642,8 +639,7 @@ def apply_step(
                             _add_named_axis(named_axis, depth, ndim),
                             ndim + 1 if ndim is not None else ndim,
                         )
-                        # Mirror into the lateral ("seen") context. The two
-                        # contexts have independent storage, so do this explicitly.
+                        # mirror into the lateral context (independent storage)
                         lateral_context[NAMED_AXIS_KEY][i] = depth_context[
                             NAMED_AXIS_KEY
                         ][i]
@@ -732,8 +728,7 @@ def apply_step(
                         _add_named_axis(named_axis, depth + 1, ndim),
                         ndim + 1 if ndim is not None else ndim,
                     )
-                    # Mirror into the lateral ("seen") context. The two contexts
-                    # have independent storage, so do this explicitly.
+                    # mirror into the lateral context (independent storage)
                     lateral_context[NAMED_AXIS_KEY][i] = depth_context[NAMED_AXIS_KEY][
                         i
                     ]
@@ -954,10 +949,9 @@ def apply_step(
                 return (out,)
 
         cond_mask = masks[2]
-        # The outer depth/lateral contexts hold one named-axis entry per
-        # original input (x, y, cond), but this internal apply_step only
-        # receives two inputs. Build fresh, correctly-sized contexts so the
-        # named-axis bookkeeping (which zips contexts against inputs) matches.
+        # Build fresh contexts sized to these two inputs: the outer contexts have
+        # one entry per original input (x, y, cond), but the named-axis bookkeeping
+        # zips contexts against inputs, so a 3-entry context here would mismatch.
         or_depth_context, or_lateral_context = NamedAxesWithDims.prepare_contexts(
             [xy_mask, cond_mask]
         )
@@ -989,8 +983,7 @@ def apply_step(
                 )
                 return (out,)
 
-        # As above: build fresh contexts sized to the two inputs of this
-        # internal apply_step rather than reusing the outer 3-input contexts.
+        # fresh contexts sized to these two inputs (as above)
         mask_depth_context, mask_lateral_context = NamedAxesWithDims.prepare_contexts(
             [xy_unmasked, mask]
         )

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 import threading
 from dataclasses import dataclass
 
@@ -65,7 +64,7 @@ def _prettify_named_axes(
 
     def _prettify(ax: AxisName) -> str:
         repr_ax = str(ax)
-        if re.match("[A-Za-z_][A-Za-z_0-9]*", repr_ax):
+        if repr_ax.isidentifier():
             return repr_ax
         return json.dumps(repr_ax)
 
@@ -691,8 +690,11 @@ class NamedAxesWithDims:
             _named_axes.append(_get_named_axis(array))
             _ndims.append(getattr(layout, "minmax_depth", (None, None))[1])
 
-        depth_context = {NAMED_AXIS_KEY: cls(_named_axes, _ndims)}
-        lateral_context = {NAMED_AXIS_KEY: cls(_named_axes, _ndims)}
+        # The depth and lateral contexts must not share storage: apply_step
+        # mutates each independently (and copies the depth context per branch),
+        # so they need their own copies of the lists.
+        depth_context = {NAMED_AXIS_KEY: cls(list(_named_axes), list(_ndims))}
+        lateral_context = {NAMED_AXIS_KEY: cls(list(_named_axes), list(_ndims))}
         return depth_context, lateral_context
 
     def __setitem__(

--- a/src/awkward/_namedaxis.py
+++ b/src/awkward/_namedaxis.py
@@ -690,9 +690,8 @@ class NamedAxesWithDims:
             _named_axes.append(_get_named_axis(array))
             _ndims.append(getattr(layout, "minmax_depth", (None, None))[1])
 
-        # The depth and lateral contexts must not share storage: apply_step
-        # mutates each independently (and copies the depth context per branch),
-        # so they need their own copies of the lists.
+        # depth and lateral contexts must not share storage: apply_step mutates
+        # each independently, so each needs its own copies of the lists
         depth_context = {NAMED_AXIS_KEY: cls(list(_named_axes), list(_ndims))}
         lateral_context = {NAMED_AXIS_KEY: cls(list(_named_axes), list(_ndims))}
         return depth_context, lateral_context

--- a/tests/test_4108_namedaxis_broadcast_where.py
+++ b/tests/test_4108_namedaxis_broadcast_where.py
@@ -1,0 +1,109 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+
+import awkward as ak
+from awkward._broadcasting import broadcast_and_apply
+from awkward._namedaxis import NAMED_AXIS_KEY, NamedAxesWithDims, _prettify_named_axes
+from awkward.contents import ByteMaskedArray
+from awkward.index import Index8
+
+
+def _option_of_regular(values):
+    """Build an ``option[N * ...]`` layout: an option node wrapping a regular array."""
+    regular = ak.to_regular(ak.Array(values)).layout
+    mask = Index8(np.ones(regular.length, dtype=np.int8))
+    return ak.Array(ByteMaskedArray(mask, regular, valid_when=True))
+
+
+def test_where_regular_2d_option_of_regular():
+    # Verified crash: ValueError: zip() argument 2 is shorter than argument 1
+    cond = ak.to_regular(ak.Array([[True, False], [False, True]]))
+    x = _option_of_regular([[1, 2], [3, 4]])
+    assert str(x.type) == "2 * option[2 * int64]"
+    y = ak.to_regular(ak.Array([[10, 20], [30, 40]]))
+
+    result = ak.where(cond, x, y)
+    assert result.to_list() == [[1, 20], [30, 4]]
+
+
+def test_where_irregular_option_still_works():
+    # The var-length (irregular) branch must keep working too.
+    cond = ak.Array([[True, False], [False, True, True]])
+    x = ak.mask(
+        ak.Array([[1, 2], [3, 4, 5]]),
+        ak.Array([[True, True], [True, True, True]]),
+    )
+    y = ak.Array([[10, 20], [30, 40, 50]])
+    result = ak.where(cond, x, y)
+    assert result.to_list() == [[1, 20], [30, 4, 5]]
+
+
+def test_where_named_axis_survives_regular():
+    # Named axes survive a regular (non-option) where.
+    cond = ak.to_regular(
+        ak.Array([[True, False], [False, True]], named_axis=("x", "y"))
+    )
+    x = ak.to_regular(ak.Array([[1, 2], [3, 4]], named_axis=("x", "y")))
+    y = ak.to_regular(ak.Array([[10, 20], [30, 40]], named_axis=("x", "y")))
+    result = ak.where(cond, x, y)
+    assert result.named_axis == {"x": 0, "y": 1}
+    assert result.to_list() == [[1, 20], [30, 4]]
+
+
+def test_where_named_axis_survives_var_option():
+    # Named axes survive a var-length option where (the option branch).
+    cond = ak.Array([[True, False], [False, True, True]], named_axis=("x", "y"))
+    x = ak.mask(
+        ak.Array([[1, 2], [3, 4, 5]], named_axis=("x", "y")),
+        ak.Array([[True, True], [True, True, True]]),
+    )
+    y = ak.Array([[10, 20], [30, 40, 50]], named_axis=("x", "y"))
+    result = ak.where(cond, x, y)
+    assert result.named_axis == {"x": 0, "y": 1}
+    assert result.to_list() == [[1, 20], [30, 4, 5]]
+
+
+def test_prepare_contexts_independent():
+    depth_context, lateral_context = NamedAxesWithDims.prepare_contexts(
+        [ak.Array([1, 2, 3]), ak.Array([4, 5, 6])]
+    )
+    depth = depth_context[NAMED_AXIS_KEY]
+    lateral = lateral_context[NAMED_AXIS_KEY]
+    # mutate depth; lateral must be unaffected
+    depth[0] = ({"mutated": 0}, 1)
+    assert lateral[0] == ({}, 1)
+    assert depth[0] == ({"mutated": 0}, 1)
+    # lists themselves must be distinct objects
+    assert depth.named_axis is not lateral.named_axis
+    assert depth.ndims is not lateral.ndims
+
+
+def test_broadcast_empty_records():
+    a = ak.to_layout(ak.Array([{}, {}]))
+    b = ak.to_layout(ak.Array([{}, {}]))
+
+    def action(inputs, **kwargs):
+        # generic action: only act on leaves, recurse through records
+        if all(x.is_numpy for x in inputs):
+            return (inputs[0],)
+        return None
+
+    depth_context, lateral_context = NamedAxesWithDims.prepare_contexts([a, b])
+    out = broadcast_and_apply(
+        (a, b),
+        action,
+        depth_context=depth_context,
+        lateral_context=lateral_context,
+    )
+    assert len(out) == 1
+    assert out[0].to_list() == [{}, {}]
+
+
+def test_prettify_non_identifier():
+    # Names that are not valid identifiers must be JSON-quoted.
+    assert _prettify_named_axes({"x y": 0}) == '"x y":0'
+    assert _prettify_named_axes({"x": 0, "y": 1}) == "x:0, y:1"
+    assert _prettify_named_axes({"$": 0}) == '"$":0'

--- a/tests/test_4108_namedaxis_broadcast_where.py
+++ b/tests/test_4108_namedaxis_broadcast_where.py
@@ -19,7 +19,7 @@ def _option_of_regular(values):
 
 
 def test_where_regular_2d_option_of_regular():
-    # Verified crash: ValueError: zip() argument 2 is shorter than argument 1
+    # Crashed with: ValueError: zip() argument 2 is shorter than argument 1
     cond = ak.to_regular(ak.Array([[True, False], [False, True]]))
     x = _option_of_regular([[1, 2], [3, 4]])
     assert str(x.type) == "2 * option[2 * int64]"
@@ -27,43 +27,6 @@ def test_where_regular_2d_option_of_regular():
 
     result = ak.where(cond, x, y)
     assert result.to_list() == [[1, 20], [30, 4]]
-
-
-def test_where_irregular_option_still_works():
-    # The var-length (irregular) branch must keep working too.
-    cond = ak.Array([[True, False], [False, True, True]])
-    x = ak.mask(
-        ak.Array([[1, 2], [3, 4, 5]]),
-        ak.Array([[True, True], [True, True, True]]),
-    )
-    y = ak.Array([[10, 20], [30, 40, 50]])
-    result = ak.where(cond, x, y)
-    assert result.to_list() == [[1, 20], [30, 4, 5]]
-
-
-def test_where_named_axis_survives_regular():
-    # Named axes survive a regular (non-option) where.
-    cond = ak.to_regular(
-        ak.Array([[True, False], [False, True]], named_axis=("x", "y"))
-    )
-    x = ak.to_regular(ak.Array([[1, 2], [3, 4]], named_axis=("x", "y")))
-    y = ak.to_regular(ak.Array([[10, 20], [30, 40]], named_axis=("x", "y")))
-    result = ak.where(cond, x, y)
-    assert result.named_axis == {"x": 0, "y": 1}
-    assert result.to_list() == [[1, 20], [30, 4]]
-
-
-def test_where_named_axis_survives_var_option():
-    # Named axes survive a var-length option where (the option branch).
-    cond = ak.Array([[True, False], [False, True, True]], named_axis=("x", "y"))
-    x = ak.mask(
-        ak.Array([[1, 2], [3, 4, 5]], named_axis=("x", "y")),
-        ak.Array([[True, True], [True, True, True]]),
-    )
-    y = ak.Array([[10, 20], [30, 40, 50]], named_axis=("x", "y"))
-    result = ak.where(cond, x, y)
-    assert result.named_axis == {"x": 0, "y": 1}
-    assert result.to_list() == [[1, 20], [30, 4, 5]]
 
 
 def test_prepare_contexts_independent():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR fixes a verified crash in `ak.where` plus several related named-axis / broadcasting bugs surfaced by an automated multi-agent code review.

## Fixes

### 1. `ak.where` crash on regular 2D condition + option-of-regular input
`src/awkward/_broadcasting.py` (`broadcast_any_option_akwhere`, steps 3/4)

The internal `apply_step` calls that OR the condition/result masks and re-apply the mask passed 2-element input tuples but reused the *outer* `depth_context` / `lateral_context`, which carry one named-axis entry per *original* input (x, y, cond = 3). The regular-list branch then does `zip(named_axes_with_ndims, inputs, strict=True)` and raised:

```
ValueError: zip() argument 2 is shorter than argument 1
```

for `ak.where(cond_regular_2d, x_option_of_regular, y_regular)`. These internal calls now build fresh, correctly-sized contexts via `NamedAxesWithDims.prepare_contexts`.

### 2. Depth/lateral named-axis contexts shared storage
`src/awkward/_namedaxis.py` (`NamedAxesWithDims.prepare_contexts`)

Both contexts were built from the *same* list objects, so mutating one was visible in the other. They now get independent copies. The broadcast right/left loops that relied on the old shared storage now mirror the updated depth named axis into the lateral context explicitly (the now-unused `_export_named_axis_from_depth_to_lateral` helper is removed).

### 3. `strict=True` in the irregular list branch
`src/awkward/_broadcasting.py` — with the contexts now correctly sized, the irregular branch zips named axes against inputs with `strict=True`, matching the regular branch.

### 4. Broadcasting records with zero fields
`src/awkward/_broadcasting.py` (`broadcast_any_record`)

When all records had zero fields, the field loop never ran, `numoutputs` stayed `None`, and `parameters_factory(..., None)` raised `TypeError: can't multiply sequence by non-int`. `numoutputs` now defaults to 1 for the empty-fields case.

### 5. Prettifying non-identifier axis names
`src/awkward/_namedaxis.py` (`_prettify_named_axes`)

An unanchored regex let names like `"x y"` print unquoted. Now uses `str.isidentifier()` so only valid Python identifiers are printed bare; everything else is JSON-quoted.

## Tests

New regression test file with one focused test per fix: the verified `ak.where` crash, depth/lateral context independence, broadcasting two zero-field record arrays, and prettifying non-identifier axis names. Existing named-axis / broadcasting / where test suites pass.

## AI assistance

This change was developed with Claude Code as part of an automated multi-agent review (findings #1 and #2 were independently verified before fixing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
