### PR TITLE
fix: `test_pandas_attr_serialisation` should have unique parquet path per thread

### DIFF
--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os.path
+import threading
 
 import fsspec
 import numpy as np
@@ -935,6 +936,10 @@ def test_pandas_attr_serialisation(generate_datafiles):
 
     df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     df.attrs = {"property": "value", 1: 2}
-    df.to_parquet(f"{path}/data3.parq")
+    # Under pytest-run-parallel this test body runs concurrently on multiple
+    # threads sharing one tmp_path, so use a per-thread filename to avoid one
+    # thread reading the file while another is still writing it.
+    filename = f"{path}/data3-{threading.get_ident()}.parq"
+    df.to_parquet(filename)
 
-    assert ak.from_parquet(f"{path}/data3.parq").attrs == {"property": "value", "1": 2}
+    assert ak.from_parquet(filename).attrs == {"property": "value", "1": 2}


### PR DESCRIPTION
Introduced in https://github.com/scikit-hep/awkward/pull/4079, this test shares a path where all threads write and read from under pytest-run-parallel. We make the path unique per thread.