### PR TITLE
perf: delete `__slots__` from `VirtualNDArray` for a small memory footprint improvement

### DIFF
--- a/src/awkward/_nplikes/virtual.py
+++ b/src/awkward/_nplikes/virtual.py
@@ -64,17 +64,6 @@ class VirtualNDArray(NDArrayOperatorsMixin, MaterializableArray):
     Subsequent virtual arrays that originate from some virtual array will hit the cache of their parents if there is any.
     """
 
-    __slots__ = (
-        "__enable_caching__",
-        "_array",
-        "_buffer_key",
-        "_dtype",
-        "_generator",
-        "_nplike",
-        "_shape",
-        "_shape_generator",
-    )
-
     def __init__(
         self,
         nplike: NumpyLike,

--- a/src/awkward/index.py
+++ b/src/awkward/index.py
@@ -327,8 +327,6 @@ class Index64(Index):
 
 
 class LazyIndex:
-    __slots__ = ("_dtype", "_factory", "_index", "_length", "_nplike")
-
     def __init__(
         self, factory, length: ShapeItem, nplike: NumpyLike, dtype: DType | None = None
     ):


### PR DESCRIPTION
Because of what virtual arrays inherit from, `__slots__` increases a tiny bit their memory foot print (measured with memray). I'm deleting `__slots__` here. While I'm at it, I'm also removing it from `LazyIndex` as its subclasses `ZeroIndex` and `EmptyIndex` don't re-define it so they get `__slots__` and `__dict__` actually creating more memory. Since `LazyIndex` will probably be removed soon and it's also created as way lower rates than virtual arrays are, let's just delete it.