### PR TITLE
ci: automate release-note categorization with type labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# Configuration for GitHub's automatically generated release notes
+# ("Generate release notes" button / the generate-notes REST API).
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# The type/* labels are applied automatically from the conventional-commit
+# type in each PR title by .github/workflows/pr-type-label.yml.
+changelog:
+  categories:
+    - title: New features
+      labels:
+        - type/feat
+    - title: Bug-fixes and performance
+      labels:
+        - type/fix
+        - type/perf
+    - title: Other
+      labels:
+        - "*"

--- a/.github/workflows/pr-type-label.yml
+++ b/.github/workflows/pr-type-label.yml
@@ -1,0 +1,73 @@
+name: PR Type Label
+
+# SECURITY: pull_request_target grants a write token, so this workflow must
+# never check out or execute code from the PR. It only parses the PR title
+# (via the same pinned action used by semantic-pr-title.yml) and calls the
+# GitHub REST API to reconcile labels.
+on: # zizmor: ignore[dangerous-triggers] This privileged workflow never checks out or runs PR code; it only parses the PR title and edits labels via the REST API.
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+permissions: {}
+
+concurrency:
+  group: pr-type-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Reconcile type label from PR title
+    runs-on: ubuntu-latest
+    # Run on open, and only on edits that changed the title.
+    if: github.event.action == 'opened' || github.event.changes.title.from != null
+    permissions:
+      pull-requests: write # Required to add/remove labels on the PR.
+    steps:
+      - id: parse
+        name: Parse conventional-commit type from PR title
+        # Same action+pin as semantic-pr-title.yml. On an invalid title this
+        # step fails; continue-on-error lets the reconcile step still run with
+        # an empty type, which removes any stale type/ label.
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile type/<type> label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPE: ${{ steps.parse.outputs.type }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # One label per conventional-commit type; .github/release.yml groups
+          # them into release-note sections.
+          if [ -n "$TYPE" ]; then
+            desired="type/${TYPE}"
+          else
+            desired=''
+          fi
+          echo "PR #${PR_NUMBER}: type='${TYPE:-none}' -> label='${desired:-none}'"
+
+          # Current labels in the type/ namespace (queried live, not from the
+          # possibly stale event payload).
+          current=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            --jq '.[].name | select(startswith("type/"))')
+
+          # Remove stale type/ labels; never touch other labels.
+          while IFS= read -r label; do
+            [ -n "$label" ] || continue
+            if [ "$label" != "$desired" ]; then
+              encoded=$(jq -rn --arg l "$label" '$l | @uri')
+              echo "Removing stale label '$label'"
+              gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/${encoded}"
+            fi
+          done <<< "$current"
+
+          # Add the desired label if missing (POST is additive and idempotent).
+          if [ -n "$desired" ] && ! grep -qxF "$desired" <<< "$current"; then
+            echo "Adding label '$desired'"
+            gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/labels" -f "labels[]=$desired"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ To make an `awkward-cpp` release:
 #### `awkward` releases
 To make an `awkward` release:
 1. A commit to `main` should increase the version number in `pyproject.toml`
-2. A new GitHub release must be published.
+2. A new GitHub release must be published. "Generate release notes" produces categorized notes automatically: a workflow labels each PR `type/<type>` from its conventional-commit title, and `.github/release.yml` groups those labels into sections.
 3. A `docs/switcher.json` entry must be added for new minor/major versions.
 
 Pushes that modify `docs/switcher.json` on `main` will automatically be synchronised with AWS.


### PR DESCRIPTION
## What this does

Makes "Generate release notes" produce the categorized format directly, eliminating the manual reorganization the release manager does today (e.g. for v2.9.1):

1. **`.github/workflows/pr-type-label.yml`** (new) — labels every PR `type/<type>` from its conventional-commit title (parsed by the same SHA-pinned `amannn/action-semantic-pull-request` already used by the title check). One label per commit type; no release-note semantics in the labels.
2. **`.github/release.yml`** (new) — groups those labels into the established sections: `type/feat` → **New features**; `type/fix`, `type/perf` → **Bug-fixes and performance**; everything else (incl. unlabeled) → **Other** via the `*` catch-all.

## Design notes for review

- **`pull_request_target`**: required so labeling works on fork PRs (plain `pull_request` gets a read-only token). Mitigations: the workflow never checks out or executes PR code; the parsed type reaches the script only via `env:`; top-level `permissions: {}` with job-level `pull-requests: write` only. zizmor ignore is justified inline, following the existing `docs-preview.yml` convention.
- The existing `semantic-pr-title.yml` required check is untouched.
- `synchronize` is deliberately not a trigger: pushes can't change a title, so it could never change the label.
- Reconciliation is idempotent and only ever touches `type/*` labels — human labels (`bug`, `feature`, `pr-next-release`, …) are never modified.
- **Heading shape changes slightly**: GitHub's generator emits `## What's Changed` with `###` category subsections, vs. the bare `##` sections of past hand-written notes.

## Not in this PR (follow-ups after merge)

- **Create the 11 labels** (repo metadata): `type/feat` `type/fix` `type/perf` `type/docs` `type/test` `type/build` `type/ci` `type/chore` `type/refactor` `type/style` `type/revert` — naming feedback welcome before they're created.
- **One-time backfill** labeling merged PRs since v2.9.1 and currently-open PRs, so the next release's notes are complete from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
