### PR TITLE
fix: properly error on conversion of `IndexedOptionArray` with an `EmptyArray` content and `length > 0` to a `ByteMaskedArray`

### DIFF
--- a/src/awkward/contents/indexedoptionarray.py
+++ b/src/awkward/contents/indexedoptionarray.py
@@ -285,7 +285,22 @@ class IndexedOptionArray(IndexedOptionMeta[Content], Content):
             carry[too_negative] = -1
         carry = ak.index.Index(carry)
 
-        if self._content.length is not unknown_length and self._content.length == 0:
+        if (
+            self._content.length is not unknown_length
+            and self._content.length == 0
+            and carry.length is not unknown_length
+            and carry.length != 0
+        ):
+            # The content is empty but the mask is not, so the (clamped) carry
+            # only references the missing values that we are about to mask out.
+            # We need a length-one dummy content for those carry entries to point
+            # at; an EmptyArray has no such representation, so the conversion is
+            # genuinely impossible.
+            if self._content.is_unknown:
+                raise ValueError(
+                    "cannot convert an IndexedOptionArray with an EmptyArray "
+                    "content and length > 0 to a ByteMaskedArray"
+                )
             content = self._content.form.length_one_array(backend=self._backend)._carry(
                 carry, False
             )

--- a/tests/test_4127_emptyarray_option_to_bytemasked.py
+++ b/tests/test_4127_emptyarray_option_to_bytemasked.py
@@ -1,0 +1,60 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_array_equal_empty_option_union():
+    layout = ak.contents.UnionArray(
+        ak.index.Index8(np.empty(0, dtype=np.int8)),
+        ak.index.Index64(np.empty(0, dtype=np.int64)),
+        [
+            ak.contents.BitMaskedArray(
+                ak.index.IndexU8(np.empty(0, dtype=np.uint8)),
+                ak.contents.EmptyArray(),
+                valid_when=True,
+                length=0,
+                lsb_order=False,
+            ),
+            ak.contents.BitMaskedArray(
+                ak.index.IndexU8(np.empty(0, dtype=np.uint8)),
+                ak.contents.EmptyArray(),
+                valid_when=True,
+                length=0,
+                lsb_order=False,
+            ),
+        ],
+    )
+    assert ak.array_equal(layout, layout)
+
+
+def test_indexedoption_emptyarray_length_zero():
+    # An empty option-of-unknown converts fine: the carry is empty, so there are
+    # no missing values that need a dummy length-one content to point at.
+    layout = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.empty(0, dtype=np.int64)),
+        ak.contents.EmptyArray(),
+    )
+    byte_masked = layout.to_ByteMaskedArray(True)
+    assert byte_masked.length == 0
+    assert byte_masked.content.is_unknown
+
+    bit_masked = layout.to_BitMaskedArray(True, False)
+    assert bit_masked.length == 0
+    assert bit_masked.content.is_unknown
+
+
+def test_indexedoption_emptyarray_length_nonzero_raises():
+    # A non-empty all-None option-of-unknown cannot be a ByteMaskedArray, because
+    # the content would have to be at least as long as the mask and an EmptyArray
+    # is always empty. We expect a clear error rather than an internal one.
+    layout = ak.contents.IndexedOptionArray(
+        ak.index.Index64(np.full(3, -1, dtype=np.int64)),
+        ak.contents.EmptyArray(),
+    )
+    with pytest.raises(ValueError, match="cannot convert an IndexedOptionArray"):
+        layout.to_ByteMaskedArray(True)


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/4126

Guard and properly error on conversion of `IndexedOptionArray` with an `EmptyArray` content and `length > 0` to a `ByteMaskedArray`