### PR TITLE
ci: run property-based tests nightly with a large max_examples

### DIFF
--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -1,0 +1,88 @@
+name: Property Tests
+
+on:
+  schedule:
+    - cron: '34 3 * * *'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Leverage reproducible builds by setting a constant SOURCE_DATE_EPOCH
+  # This will ensure that the hash of the awkward-cpp directory remains
+  # constant for unchanged files, meaning that it can be used for caching
+  SOURCE_DATE_EPOCH: "1668811211"
+
+jobs:
+  property-tests:
+    name: Run Property Tests
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    env:
+      PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Python 3.14
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Generate build files
+        run: pipx run nox -s prepare -- --headers --signatures --tests
+
+      - name: Cache awkward-cpp wheel
+        id: cache-awkward-cpp-wheel
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: awkward-cpp/dist
+          key: ${{ github.job }}-ubuntu-latest-3.14-${{ hashFiles('awkward-cpp/**') }}
+
+      - name: Build awkward-cpp wheel
+        if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install build
+          python -m build -w awkward-cpp
+
+      - name: Find built wheel
+        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
+        id: find-wheel
+        with:
+          files: |
+            awkward-cpp/dist/*.whl
+
+      - name: Install awkward, awkward-cpp, and dependencies
+        run: >-
+          python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
+          -r requirements-test-full.txt
+        shell: bash
+        env:
+          STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
+
+      - name: Print versions
+        run: python -m pip list
+
+      - name: Run property-based tests
+        run: python -m pytest -vv -rs tests/properties
+        env:
+          HYPOTHESIS_PROFILE: nightly
+
+      - name: Run property-based tests in multiple threads
+        if: ${{ !cancelled() }}
+        run: |
+          python -m pip install 'pytest-run-parallel>=0.8.2'
+          python -m pytest -vv -rs tests/properties --parallel-threads 4
+        env:
+          HYPOTHESIS_PROFILE: default

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/awkward)](https://github.com/conda-forge/awkward-feedstock)
 [![Python 3.10‒3.14](https://img.shields.io/badge/python-3.10%E2%80%923.14-blue)](https://www.python.org)
 [![BSD-3 Clause License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/test.yml)
+[![Build Test](https://github.com/scikit-hep/awkward/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/ci.yml)
+[![Property Tests](https://github.com/scikit-hep/awkward/actions/workflows/property-tests.yml/badge.svg?branch=main)](https://github.com/scikit-hep/awkward/actions/workflows/property-tests.yml)
 
 [![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4341376.svg)](https://doi.org/10.5281/zenodo.4341376)

--- a/tests/properties/conftest.py
+++ b/tests/properties/conftest.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 
+import os
+
 collect_ignore_glob = []
 
 try:
     import hypothesis_awkward  # noqa: F401
 except ModuleNotFoundError:
     collect_ignore_glob.append("**/test_*.py")
+else:
+    from hypothesis import settings
+
+    # Settings not given here fall back to the profile active at registration
+    # time. On GitHub Actions, hypothesis auto-loads its built-in "ci" profile
+    # (derandomize=True, deadline=None, database=None, print_blob=True).
+    settings.register_profile("default", max_examples=200)
+    settings.register_profile(
+        "nightly",
+        max_examples=10_000,
+        deadline=None,
+        print_blob=True,
+        # The inherited "ci" value (True) would test the same examples nightly.
+        derandomize=False,
+    )
+    settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))

--- a/tests/properties/operations/test_array_equal.py
+++ b/tests/properties/operations/test_array_equal.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 import hypothesis_awkward.strategies as st_ak
-from hypothesis import given, settings
+from hypothesis import given
 
 import awkward as ak
 
 
-@settings(max_examples=200)
 @given(a=st_ak.constructors.arrays())
 def test_reflexivity(a: ak.Array) -> None:
     """An array must be equal to itself."""
     assert ak.array_equal(a, a, equal_nan=True)
 
 
-@settings(max_examples=200)
 @given(
     a1=st_ak.constructors.arrays(),
     a2=st_ak.constructors.arrays(),

--- a/tests/properties/operations/test_to_from_buffers.py
+++ b/tests/properties/operations/test_to_from_buffers.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import hypothesis_awkward.strategies as st_ak
-from hypothesis import given, settings
+from hypothesis import given
 
 import awkward as ak
 
 
-@settings(max_examples=1000)
 @given(a=st_ak.constructors.arrays())
 def test_roundtrip(a: ak.Array) -> None:
     """`to_buffers` followed by `from_buffers` reconstructs the array."""


### PR DESCRIPTION
As discussed in https://github.com/scikit-hep/awkward/pull/3962#issuecomment-4214688903: keep Hypothesis `max_examples` small for PR CI, and run the property-based tests on a schedule with a large `max_examples`. The bug fixed in #3962 was within reach of the existing property tests but was only stumbled on locally — PR-level example counts are too small for discovery, and raising them for every PR (and every matrix entry) would be too slow.

## What this does

- **Hypothesis settings profiles** in `tests/properties/conftest.py` replace the hardcoded per-test `@settings(max_examples=...)`:
  - `default`: `max_examples=200` — used by PR CI and local runs (~4 s for the current suite, measured ~5.4 ms/example).
  - `nightly`: `max_examples=10_000`, `deadline=None`, `print_blob=True`, `derandomize=False` — ~1 min/test locally, an estimated ~6–9 min on a CI runner.
  - Selected via the `HYPOTHESIS_PROFILE` environment variable. (The `--hypothesis-profile` CLI flag can't be used: profiles registered in a sub-conftest aren't visible at `pytest_configure` time.)
  - `derandomize=False` is explicit because on GitHub Actions Hypothesis auto-loads its built-in `ci` profile (`derandomize=True`), which the nightly profile would otherwise inherit — and then every nightly run would test the same 10,000 examples. PR CI stays derandomized, same as before.
- **New scheduled workflow** `property-tests.yml` (daily at 3:34 UTC + `workflow_dispatch`):
  - Builds/caches the `awkward-cpp` wheel with the same steps and pinned action SHAs as `reusable-test.yml`, then runs `pytest tests/properties` at the `nightly` profile.
  - A second pass runs under `pytest-run-parallel --parallel-threads 4` at the `default` profile — this is how the bug behind #3962 was originally found, and the property tests currently never run threaded in CI (the 3.14t matrix entries use `requirements-test-nogil.txt`, which doesn't include `hypothesis-awkward`). It runs even if the serial pass fails, so one night reports both results.
- **README badge** for the new workflow, so scheduled failures are visible. While editing that line: the existing "Build Test" badge has pointed at the deleted `test.yml` (HTTP 404) since the reusable-workflows split in #3969 — it now points at `ci.yml`.

## Net effect on PR CI

`test_to_from_buffers.py::test_roundtrip` drops from 1000 to 200 examples in PR runs; the `array_equal` tests stay at 200. Deep exploration moves to the nightly run, which uses fresh random seeds each night (~3.6 M examples/test/year cumulatively).

## Test plan

- [x] `pytest tests/properties` passes at the default profile (3.74 s vs 7.99 s before — confirms 200/test)
- [x] `HYPOTHESIS_PROFILE=nightly` runs 10,000 examples (56 s for one test)
- [x] An unknown `HYPOTHESIS_PROFILE` value fails loudly (`InvalidArgument`)
- [x] pre-commit green (incl. workflow schema validation and zizmor); actionlint reports only the same info-level SC2086 already present in `reusable-test.yml`
- [ ] After merge: smoke-test with `gh workflow run property-tests.yml` (the cron only fires from the default branch)

## Possible follow-ups (not in this PR)

- Persist a Hypothesis example database across nightly runs so past failures are replayed first (currently `database=None` via the inherited `ci` profile; `print_blob=True` already gives `@reproduce_failure` blobs for local reproduction).
- Run the threaded pass on free-threaded 3.14t for more aggressive concurrency coverage.
