### PR TITLE
docs: add summary lines to 19 reducer operation docstrings

### DIFF
--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -31,7 +31,8 @@ def all(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns whether all elements are True over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,17 +58,18 @@ def all(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns True in each group of elements from `array` (many types supported,
-    including all Awkward Arrays and Records) if all values are True; False
-    otherwise. Thus, it represents reduction over the "logical and" operation,
-    whose identity is True (i.e. asking if all the values are True in an
-    empty list results in True). This operation is the same as NumPy's
-    [all](https://docs.scipy.org/doc/numpy/reference/generated/numpy.all.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Returns True in each group of elements from `array` (many types supported,
+        including all Awkward Arrays and Records) if all values are True; False
+        otherwise. Thus, it represents reduction over the "logical and" operation,
+        whose identity is True (i.e. asking if all the values are True in an
+        empty list results in True). This operation is the same as NumPy's
+        [all](https://docs.scipy.org/doc/numpy/reference/generated/numpy.all.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -59,7 +59,7 @@ def all(
             high-level.
 
     Returns:
-        Returns True in each group of elements from `array` (many types supported,
+        True in each group of elements from `array` (many types supported,
         including all Awkward Arrays and Records) if all values are True; False
         otherwise. Thus, it represents reduction over the "logical and" operation,
         whose identity is True (i.e. asking if all the values are True in an

--- a/src/awkward/operations/ak_all.py
+++ b/src/awkward/operations/ak_all.py
@@ -33,6 +33,17 @@ def all(
 ):
     """Returns whether all elements are True over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. Thus,
+    it represents reduction over the "logical and" operation, whose identity
+    is True (i.e. asking if all the values are True in an empty list results
+    in True). This operation is the same as NumPy's
+    [all](https://docs.scipy.org/doc/numpy/reference/generated/numpy.all.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -59,17 +70,8 @@ def all(
             high-level.
 
     Returns:
-        True in each group of elements from `array` (many types supported,
-        including all Awkward Arrays and Records) if all values are True; False
-        otherwise. Thus, it represents reduction over the "logical and" operation,
-        whose identity is True (i.e. asking if all the values are True in an
-        empty list results in True). This operation is the same as NumPy's
-        [all](https://docs.scipy.org/doc/numpy/reference/generated/numpy.all.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
+        True in each group of elements from `array` if all values are True;
+        False otherwise.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -59,7 +59,7 @@ def any(
             high-level.
 
     Returns:
-        Returns True in each group of elements from `array` (many types supported,
+        True in each group of elements from `array` (many types supported,
         including all Awkward Arrays and Records) if any values are True; False
         otherwise. Thus, it represents reduction over the "logical or" operation,
         whose identity is False (i.e. asking if there are any True values in an

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -31,7 +31,8 @@ def any(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns whether any elements are True over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,17 +58,18 @@ def any(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns True in each group of elements from `array` (many types supported,
-    including all Awkward Arrays and Records) if any values are True; False
-    otherwise. Thus, it represents reduction over the "logical or" operation,
-    whose identity is False (i.e. asking if there are any True values in an
-    empty list results in False). This operation is the same as NumPy's
-    [any](https://docs.scipy.org/doc/numpy/reference/generated/numpy.any.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Returns True in each group of elements from `array` (many types supported,
+        including all Awkward Arrays and Records) if any values are True; False
+        otherwise. Thus, it represents reduction over the "logical or" operation,
+        whose identity is False (i.e. asking if there are any True values in an
+        empty list results in False). This operation is the same as NumPy's
+        [any](https://docs.scipy.org/doc/numpy/reference/generated/numpy.any.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_any.py
+++ b/src/awkward/operations/ak_any.py
@@ -33,6 +33,17 @@ def any(
 ):
     """Returns whether any elements are True over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. Thus,
+    it represents reduction over the "logical or" operation, whose identity is
+    False (i.e. asking if there are any True values in an empty list results in
+    False). This operation is the same as NumPy's
+    [any](https://docs.scipy.org/doc/numpy/reference/generated/numpy.any.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -59,17 +70,8 @@ def any(
             high-level.
 
     Returns:
-        True in each group of elements from `array` (many types supported,
-        including all Awkward Arrays and Records) if any values are True; False
-        otherwise. Thus, it represents reduction over the "logical or" operation,
-        whose identity is False (i.e. asking if there are any True values in an
-        empty list results in False). This operation is the same as NumPy's
-        [any](https://docs.scipy.org/doc/numpy/reference/generated/numpy.any.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
+        True in each group of elements from `array` if any values are True;
+        False otherwise.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -59,7 +59,7 @@ def argmax(
             high-level.
 
     Returns:
-        Returns the index position of the maximum value in each group of elements
+        The index position of the maximum value in each group of elements
         from `array` (many types supported, including all Awkward Arrays and
         Records). The identity of maximization would be negative infinity, but
         argmax must return the position of the maximum element, which has no value

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -31,7 +31,8 @@ def argmax(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the index of the maximum value over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,24 +58,25 @@ def argmax(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns the index position of the maximum value in each group of elements
-    from `array` (many types supported, including all Awkward Arrays and
-    Records). The identity of maximization would be negative infinity, but
-    argmax must return the position of the maximum element, which has no value
-    for empty lists. Therefore, the identity should be masked: the argmax of
-    an empty list is None. If `mask_identity=False`, the result would be `-1`,
-    which is distinct from all valid index positions, but care should be taken
-    that it is not misinterpreted as "the last element of the list."
+    Returns:
+        Returns the index position of the maximum value in each group of elements
+        from `array` (many types supported, including all Awkward Arrays and
+        Records). The identity of maximization would be negative infinity, but
+        argmax must return the position of the maximum element, which has no value
+        for empty lists. Therefore, the identity should be masked: the argmax of
+        an empty list is None. If `mask_identity=False`, the result would be `-1`,
+        which is distinct from all valid index positions, but care should be taken
+        that it is not misinterpreted as "the last element of the list."
 
-    This operation is the same as NumPy's
-    [argmax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmax.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+        This operation is the same as NumPy's
+        [argmax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmax.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    See also #ak.nanargmax.
+        See also #ak.nanargmax.
     """
     # Dispatch
     yield (array,)
@@ -94,7 +96,8 @@ def nanargmax(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the index of the maximum value, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -120,15 +123,16 @@ def nanargmax(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like #ak.argmax, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.argmax, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.argmax(ak.nan_to_none(array))
+            ak.argmax(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.argmax.
+        See also #ak.argmax.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_argmax.py
+++ b/src/awkward/operations/ak_argmax.py
@@ -33,6 +33,24 @@ def argmax(
 ):
     """Returns the index of the maximum value over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of maximization would be negative infinity, but argmax must return
+    the position of the maximum element, which has no value for empty lists.
+    Therefore, the identity should be masked: the argmax of an empty list is
+    None. If `mask_identity=False`, the result would be `-1`, which is distinct
+    from all valid index positions, but care should be taken that it is not
+    misinterpreted as "the last element of the list."
+
+    This operation is the same as NumPy's
+    [argmax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmax.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    See also #ak.nanargmax.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -60,23 +78,7 @@ def argmax(
 
     Returns:
         The index position of the maximum value in each group of elements
-        from `array` (many types supported, including all Awkward Arrays and
-        Records). The identity of maximization would be negative infinity, but
-        argmax must return the position of the maximum element, which has no value
-        for empty lists. Therefore, the identity should be masked: the argmax of
-        an empty list is None. If `mask_identity=False`, the result would be `-1`,
-        which is distinct from all valid index positions, but care should be taken
-        that it is not misinterpreted as "the last element of the list."
-
-        This operation is the same as NumPy's
-        [argmax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmax.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        See also #ak.nanargmax.
+        from `array`.
     """
     # Dispatch
     yield (array,)
@@ -97,6 +99,14 @@ def nanargmax(
     attrs=None,
 ):
     """Returns the index of the maximum value, treating NaN values as missing.
+
+    Equivalent to::
+
+        ak.argmax(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.argmax.
 
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -125,14 +135,6 @@ def nanargmax(
 
     Returns:
         Like #ak.argmax, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.argmax(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.argmax.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -31,7 +31,8 @@ def argmin(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the index of the minimum value over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,24 +58,25 @@ def argmin(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns the index position of the minimum value in each group of elements
-    from `array` (many types supported, including all Awkward Arrays and
-    Records). The identity of minimization would be infinity, but argmin
-    must return the position of the minimum element, which has no value for
-    empty lists. Therefore, the identity should be masked: the argmin of
-    an empty list is None. If `mask_identity=False`, the result would be `-1`,
-    which is distinct from all valid index positions, but care should be taken
-    that it is not misinterpreted as "the last element of the list."
+    Returns:
+        Returns the index position of the minimum value in each group of elements
+        from `array` (many types supported, including all Awkward Arrays and
+        Records). The identity of minimization would be infinity, but argmin
+        must return the position of the minimum element, which has no value for
+        empty lists. Therefore, the identity should be masked: the argmin of
+        an empty list is None. If `mask_identity=False`, the result would be `-1`,
+        which is distinct from all valid index positions, but care should be taken
+        that it is not misinterpreted as "the last element of the list."
 
-    This operation is the same as NumPy's
-    [argmin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmin.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+        This operation is the same as NumPy's
+        [argmin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmin.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    See also #ak.nanargmin.
+        See also #ak.nanargmin.
     """
     # Dispatch
     yield (array,)
@@ -94,7 +96,8 @@ def nanargmin(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the index of the minimum value, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -117,15 +120,16 @@ def nanargmin(
             None (an option type); otherwise, reducing over empty lists
             results in the operation's identity.
 
-    Like #ak.argmin, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.argmin, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.argmin(ak.nan_to_none(array))
+            ak.argmin(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.argmin.
+        See also #ak.argmin.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -59,7 +59,7 @@ def argmin(
             high-level.
 
     Returns:
-        Returns the index position of the minimum value in each group of elements
+        The index position of the minimum value in each group of elements
         from `array` (many types supported, including all Awkward Arrays and
         Records). The identity of minimization would be infinity, but argmin
         must return the position of the minimum element, which has no value for

--- a/src/awkward/operations/ak_argmin.py
+++ b/src/awkward/operations/ak_argmin.py
@@ -33,6 +33,24 @@ def argmin(
 ):
     """Returns the index of the minimum value over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of minimization would be infinity, but argmin must return the
+    position of the minimum element, which has no value for empty lists.
+    Therefore, the identity should be masked: the argmin of an empty list is
+    None. If `mask_identity=False`, the result would be `-1`, which is distinct
+    from all valid index positions, but care should be taken that it is not
+    misinterpreted as "the last element of the list."
+
+    This operation is the same as NumPy's
+    [argmin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmin.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    See also #ak.nanargmin.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -60,23 +78,7 @@ def argmin(
 
     Returns:
         The index position of the minimum value in each group of elements
-        from `array` (many types supported, including all Awkward Arrays and
-        Records). The identity of minimization would be infinity, but argmin
-        must return the position of the minimum element, which has no value for
-        empty lists. Therefore, the identity should be masked: the argmin of
-        an empty list is None. If `mask_identity=False`, the result would be `-1`,
-        which is distinct from all valid index positions, but care should be taken
-        that it is not misinterpreted as "the last element of the list."
-
-        This operation is the same as NumPy's
-        [argmin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argmin.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        See also #ak.nanargmin.
+        from `array`.
     """
     # Dispatch
     yield (array,)
@@ -97,6 +99,14 @@ def nanargmin(
     attrs=None,
 ):
     """Returns the index of the minimum value, treating NaN values as missing.
+
+    Equivalent to::
+
+        ak.argmin(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.argmin.
 
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -122,14 +132,6 @@ def nanargmin(
 
     Returns:
         Like #ak.argmin, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.argmin(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.argmin.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -33,7 +33,8 @@ def corr(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the correlation of x and y over one or all levels of nesting.
+
     Args:
         x: One coordinate to use in the correlation (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the correlation (anything #ak.to_layout recognizes).
@@ -65,22 +66,23 @@ def corr(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the correlation of `x` and `y` (many types supported, including
-    all Awkward Arrays and Records, must be broadcastable to each other).
-    The grouping is performed the same way as for reducers, though this
-    operation is not a reducer and has no identity.
+    Returns:
+        Computes the correlation of `x` and `y` (many types supported, including
+        all Awkward Arrays and Records, must be broadcastable to each other).
+        The grouping is performed the same way as for reducers, though this
+        operation is not a reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the correlation is calculated as::
+        Passing all arguments to the reducers, the correlation is calculated as::
 
-        ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight)
-            / np.sqrt(ak.sum((x - ak.mean(x))**2))
-            / np.sqrt(ak.sum((y - ak.mean(y))**2))
+            ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight)
+                / np.sqrt(ak.sum((x - ak.mean(x))**2))
+                / np.sqrt(ak.sum((y - ak.mean(y))**2))
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -67,7 +67,7 @@ def corr(
             high-level.
 
     Returns:
-        Computes the correlation of `x` and `y` (many types supported, including
+        The correlation of `x` and `y` (many types supported, including
         all Awkward Arrays and Records, must be broadcastable to each other).
         The grouping is performed the same way as for reducers, though this
         operation is not a reducer and has no identity.

--- a/src/awkward/operations/ak_corr.py
+++ b/src/awkward/operations/ak_corr.py
@@ -35,6 +35,22 @@ def corr(
 ):
     """Computes the correlation of x and y over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records, which
+    must be broadcastable to each other. The grouping is performed the same way
+    as for reducers, though this operation is not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the correlation is calculated as::
+
+        ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight)
+            / np.sqrt(ak.sum((x - ak.mean(x))**2))
+            / np.sqrt(ak.sum((y - ak.mean(y))**2))
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: One coordinate to use in the correlation (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the correlation (anything #ak.to_layout recognizes).
@@ -67,22 +83,7 @@ def corr(
             high-level.
 
     Returns:
-        The correlation of `x` and `y` (many types supported, including
-        all Awkward Arrays and Records, must be broadcastable to each other).
-        The grouping is performed the same way as for reducers, though this
-        operation is not a reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the correlation is calculated as::
-
-            ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight)
-                / np.sqrt(ak.sum((x - ak.mean(x))**2))
-                / np.sqrt(ak.sum((y - ak.mean(y))**2))
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The correlation of `x` and `y`.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -30,7 +30,8 @@ def count(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Counts an array's elements over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -56,16 +57,18 @@ def count(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Counts elements of `array` (many types supported, including all
-    Awkward Arrays and Records). The identity of counting is `0` and it is
-    usually not masked.
+    Returns:
+        Counts elements of `array` (many types supported, including all
+        Awkward Arrays and Records). The identity of counting is `0` and it is
+        usually not masked.
 
-    This function has no analog in NumPy because counting values in a
-    rectilinear array would only result in elements of the NumPy array's
-    [shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html).
+    Examples:
+        This function has no analog in NumPy because counting values in a
+        rectilinear array would only result in elements of the NumPy array's
+        [shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html).
 
-    However, for nested lists of variable dimension and missing values, the
-    result of counting is non-trivial. For example, with this
+        However, for nested lists of variable dimension and missing values, the
+        result of counting is non-trivial. For example, with this
 
         >>> array = ak.Array([[ 0.1,  0.2      ],
         ...                   [None, 10.2, None],
@@ -73,43 +76,43 @@ def count(
         ...                   [20.1, 20.2, 20.3],
         ...                   [30.1, 30.2      ]])
 
-    the result of counting over the innermost dimension is
+        the result of counting over the innermost dimension is
 
         >>> ak.count(array, axis=-1)
         <Array [2, 1, None, 3, 2] type='5 * ?int64'>
 
-    the outermost dimension is
+        the outermost dimension is
 
         >>> ak.count(array, axis=0)
         <Array [3, 4, 1] type='3 * int64'>
 
-    and all dimensions is
+        and all dimensions is
 
         >>> ak.count(array, axis=None)
         8
 
-    The gaps and None values are not counted, and if a None value occurs at
-    a higher axis than the one being counted, it is kept as a placeholder
-    so that the outer list length does not change.
+        The gaps and None values are not counted, and if a None value occurs at
+        a higher axis than the one being counted, it is kept as a placeholder
+        so that the outer list length does not change.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    Note also that this function is different from #ak.num, which counts
-    the number of values at a given depth, maintaining structure: #ak.num
-    never counts across different lists the way that reducers do (#ak.num
-    is not a reducer; #ak.count is). For the same `array`,
+        Note also that this function is different from #ak.num, which counts
+        the number of values at a given depth, maintaining structure: #ak.num
+        never counts across different lists the way that reducers do (#ak.num
+        is not a reducer; #ak.count is). For the same `array`,
 
         >>> ak.num(array, axis=0)
         5
         >>> ak.num(array, axis=1)
         <Array [2, 3, None, 3, 2] type='5 * ?int64'>
 
-    If it is desirable to include None values in #ak.count, use #ak.fill_none
-    to turn the None values into something that would be counted.
+        If it is desirable to include None values in #ak.count, use #ak.fill_none
+        to turn the None values into something that would be counted.
 
-    If it is desirable to exclude NaN ("not a number") values from #ak.count,
-    use #ak.nan_to_none to turn them into None, which are not counted.
+        If it is desirable to exclude NaN ("not a number") values from #ak.count,
+        use #ak.nan_to_none to turn them into None, which are not counted.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -58,7 +58,7 @@ def count(
             high-level.
 
     Returns:
-        Counts elements of `array` (many types supported, including all
+        The number of elements of `array` (many types supported, including all
         Awkward Arrays and Records). The identity of counting is `0` and it is
         usually not masked.
 

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -32,6 +32,9 @@ def count(
 ):
     """Counts an array's elements over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of counting is `0` and it is usually not masked.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -58,9 +61,7 @@ def count(
             high-level.
 
     Returns:
-        The number of elements of `array` (many types supported, including all
-        Awkward Arrays and Records). The identity of counting is `0` and it is
-        usually not masked.
+        The number of elements of `array`.
 
     Examples:
         This function has no analog in NumPy because counting values in a

--- a/src/awkward/operations/ak_count.py
+++ b/src/awkward/operations/ak_count.py
@@ -35,6 +35,23 @@ def count(
     Many types are supported, including all Awkward Arrays and Records. The
     identity of counting is `0` and it is usually not masked.
 
+    This function has no analog in NumPy because counting values in a
+    rectilinear array would only result in elements of the NumPy array's
+    [shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html).
+
+    The gaps and None values are not counted, and if a None value occurs at
+    a higher axis than the one being counted, it is kept as a placeholder
+    so that the outer list length does not change.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    If it is desirable to include None values in #ak.count, use #ak.fill_none
+    to turn the None values into something that would be counted.
+
+    If it is desirable to exclude NaN ("not a number") values from #ak.count,
+    use #ak.nan_to_none to turn them into None, which are not counted.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -64,10 +81,6 @@ def count(
         The number of elements of `array`.
 
     Examples:
-        This function has no analog in NumPy because counting values in a
-        rectilinear array would only result in elements of the NumPy array's
-        [shape](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html).
-
         However, for nested lists of variable dimension and missing values, the
         result of counting is non-trivial. For example, with this
 
@@ -92,13 +105,6 @@ def count(
         >>> ak.count(array, axis=None)
         8
 
-        The gaps and None values are not counted, and if a None value occurs at
-        a higher axis than the one being counted, it is kept as a placeholder
-        so that the outer list length does not change.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
         Note also that this function is different from #ak.num, which counts
         the number of values at a given depth, maintaining structure: #ak.num
         never counts across different lists the way that reducers do (#ak.num
@@ -108,12 +114,6 @@ def count(
         5
         >>> ak.num(array, axis=1)
         <Array [2, 3, None, 3, 2] type='5 * ?int64'>
-
-        If it is desirable to include None values in #ak.count, use #ak.fill_none
-        to turn the None values into something that would be counted.
-
-        If it is desirable to exclude NaN ("not a number") values from #ak.count,
-        use #ak.nan_to_none to turn them into None, which are not counted.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -30,7 +30,8 @@ def count_nonzero(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Counts an array's nonzero elements over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -56,19 +57,20 @@ def count_nonzero(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Counts nonzero elements of `array` (many types supported, including all
-    Awkward Arrays and Records). The identity of counting is `0` and it is
-    usually not masked. This operation is the same as NumPy's
-    [count_nonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Counts nonzero elements of `array` (many types supported, including all
+        Awkward Arrays and Records). The identity of counting is `0` and it is
+        usually not masked. This operation is the same as NumPy's
+        [count_nonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    Following the same rules as other reducers, #ak.count_nonzero does not
-    count None values. If it is desirable to count them, use #ak.fill_none
-    to turn them into something that would be counted.
+        Following the same rules as other reducers, #ak.count_nonzero does not
+        count None values. If it is desirable to count them, use #ak.fill_none
+        to turn them into something that would be counted.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -58,7 +58,7 @@ def count_nonzero(
             high-level.
 
     Returns:
-        Counts nonzero elements of `array` (many types supported, including all
+        The number of nonzero elements of `array` (many types supported, including all
         Awkward Arrays and Records). The identity of counting is `0` and it is
         usually not masked. This operation is the same as NumPy's
         [count_nonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html)

--- a/src/awkward/operations/ak_count_nonzero.py
+++ b/src/awkward/operations/ak_count_nonzero.py
@@ -32,6 +32,20 @@ def count_nonzero(
 ):
     """Counts an array's nonzero elements over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of counting is `0` and it is usually not masked. This operation is
+    the same as NumPy's
+    [count_nonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    Following the same rules as other reducers, #ak.count_nonzero does not
+    count None values. If it is desirable to count them, use #ak.fill_none
+    to turn them into something that would be counted.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -58,19 +72,7 @@ def count_nonzero(
             high-level.
 
     Returns:
-        The number of nonzero elements of `array` (many types supported, including all
-        Awkward Arrays and Records). The identity of counting is `0` and it is
-        usually not masked. This operation is the same as NumPy's
-        [count_nonzero](https://docs.scipy.org/doc/numpy/reference/generated/numpy.count_nonzero.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        Following the same rules as other reducers, #ak.count_nonzero does not
-        count None values. If it is desirable to count them, use #ak.fill_none
-        to turn them into something that would be counted.
+        The number of nonzero elements of `array`.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -32,7 +32,8 @@ def covar(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the covariance of x and y over one or all levels of nesting.
+
     Args:
         x: One coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).
@@ -64,20 +65,21 @@ def covar(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the covariance of `x` and `y` (many types supported, including
-    all Awkward Arrays and Records, must be broadcastable to each other).
-    The grouping is performed the same way as for reducers, though this
-    operation is not a reducer and has no identity.
+    Returns:
+        Computes the covariance of `x` and `y` (many types supported, including
+        all Awkward Arrays and Records, must be broadcastable to each other).
+        The grouping is performed the same way as for reducers, though this
+        operation is not a reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the covariance is calculated as::
+        Passing all arguments to the reducers, the covariance is calculated as::
 
-        ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight) / ak.sum(weight)
+            ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight) / ak.sum(weight)
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -66,7 +66,7 @@ def covar(
             high-level.
 
     Returns:
-        Computes the covariance of `x` and `y` (many types supported, including
+        The covariance of `x` and `y` (many types supported, including
         all Awkward Arrays and Records, must be broadcastable to each other).
         The grouping is performed the same way as for reducers, though this
         operation is not a reducer and has no identity.

--- a/src/awkward/operations/ak_covar.py
+++ b/src/awkward/operations/ak_covar.py
@@ -34,6 +34,20 @@ def covar(
 ):
     """Computes the covariance of x and y over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records, which
+    must be broadcastable to each other. The grouping is performed the same way
+    as for reducers, though this operation is not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the covariance is calculated as::
+
+        ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight) / ak.sum(weight)
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: One coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the covariance calculation (anything #ak.to_layout recognizes).
@@ -66,20 +80,7 @@ def covar(
             high-level.
 
     Returns:
-        The covariance of `x` and `y` (many types supported, including
-        all Awkward Arrays and Records, must be broadcastable to each other).
-        The grouping is performed the same way as for reducers, though this
-        operation is not a reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the covariance is calculated as::
-
-            ak.sum((x - ak.mean(x))*(y - ak.mean(y))*weight) / ak.sum(weight)
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The covariance of `x` and `y`.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -60,7 +60,7 @@ def linear_fit(
             high-level.
 
     Returns:
-        Computes the linear fit of `y` with respect to `x` (many types supported,
+        The linear fit of `y` with respect to `x` (many types supported,
         including all Awkward Arrays and Records, must be broadcastable to each
         other). The grouping is performed the same way as for reducers, though
         this operation is not a reducer and has no identity.

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -26,7 +26,8 @@ def linear_fit(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the linear fit of y against x over one or all levels of nesting.
+
     Args:
         x: One coordinate to use in the linear fit (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the linear fit (anything #ak.to_layout recognizes).
@@ -58,35 +59,36 @@ def linear_fit(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the linear fit of `y` with respect to `x` (many types supported,
-    including all Awkward Arrays and Records, must be broadcastable to each
-    other). The grouping is performed the same way as for reducers, though
-    this operation is not a reducer and has no identity.
+    Returns:
+        Computes the linear fit of `y` with respect to `x` (many types supported,
+        including all Awkward Arrays and Records, must be broadcastable to each
+        other). The grouping is performed the same way as for reducers, though
+        this operation is not a reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the linear fit is calculated as::
+        Passing all arguments to the reducers, the linear fit is calculated as::
 
-        sumw            = ak.sum(weight)
-        sumwx           = ak.sum(weight * x)
-        sumwy           = ak.sum(weight * y)
-        sumwxx          = ak.sum(weight * x**2)
-        sumwxy          = ak.sum(weight * x * y)
-        delta           = (sumw*sumwxx) - (sumwx*sumwx)
+            sumw            = ak.sum(weight)
+            sumwx           = ak.sum(weight * x)
+            sumwy           = ak.sum(weight * y)
+            sumwxx          = ak.sum(weight * x**2)
+            sumwxy          = ak.sum(weight * x * y)
+            delta           = (sumw*sumwxx) - (sumwx*sumwx)
 
-        intercept       = ((sumwxx*sumwy) - (sumwx*sumwxy)) / delta
-        slope           = ((sumw*sumwxy) - (sumwx*sumwy))   / delta
-        intercept_error = np.sqrt(sumwxx / delta)
-        slope_error     = np.sqrt(sumw   / delta)
+            intercept       = ((sumwxx*sumwy) - (sumwx*sumwxy)) / delta
+            slope           = ((sumw*sumwxy) - (sumwx*sumwy))   / delta
+            intercept_error = np.sqrt(sumwxx / delta)
+            slope_error     = np.sqrt(sumw   / delta)
 
-    The results, `intercept`, `slope`, `intercept_error`, and `slope_error`,
-    are given as an #ak.Record with four fields. The values of these fields
-    might be arrays or even nested arrays; they match the structure of `x` and
-    `y`.
+        The results, `intercept`, `slope`, `intercept_error`, and `slope_error`,
+        are given as an #ak.Record with four fields. The values of these fields
+        might be arrays or even nested arrays; they match the structure of `x` and
+        `y`.
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_linear_fit.py
+++ b/src/awkward/operations/ak_linear_fit.py
@@ -28,6 +28,35 @@ def linear_fit(
 ):
     """Computes the linear fit of y against x over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records, which
+    must be broadcastable to each other. The grouping is performed the same way
+    as for reducers, though this operation is not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the linear fit is calculated as::
+
+        sumw            = ak.sum(weight)
+        sumwx           = ak.sum(weight * x)
+        sumwy           = ak.sum(weight * y)
+        sumwxx          = ak.sum(weight * x**2)
+        sumwxy          = ak.sum(weight * x * y)
+        delta           = (sumw*sumwxx) - (sumwx*sumwx)
+
+        intercept       = ((sumwxx*sumwy) - (sumwx*sumwxy)) / delta
+        slope           = ((sumw*sumwxy) - (sumwx*sumwy))   / delta
+        intercept_error = np.sqrt(sumwxx / delta)
+        slope_error     = np.sqrt(sumw   / delta)
+
+    The results, `intercept`, `slope`, `intercept_error`, and `slope_error`,
+    are given as an #ak.Record with four fields. The values of these fields
+    might be arrays or even nested arrays; they match the structure of `x` and
+    `y`.
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: One coordinate to use in the linear fit (anything #ak.to_layout recognizes).
         y: The other coordinate to use in the linear fit (anything #ak.to_layout recognizes).
@@ -60,35 +89,7 @@ def linear_fit(
             high-level.
 
     Returns:
-        The linear fit of `y` with respect to `x` (many types supported,
-        including all Awkward Arrays and Records, must be broadcastable to each
-        other). The grouping is performed the same way as for reducers, though
-        this operation is not a reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the linear fit is calculated as::
-
-            sumw            = ak.sum(weight)
-            sumwx           = ak.sum(weight * x)
-            sumwy           = ak.sum(weight * y)
-            sumwxx          = ak.sum(weight * x**2)
-            sumwxy          = ak.sum(weight * x * y)
-            delta           = (sumw*sumwxx) - (sumwx*sumwx)
-
-            intercept       = ((sumwxx*sumwy) - (sumwx*sumwxy)) / delta
-            slope           = ((sumw*sumwxy) - (sumwx*sumwy))   / delta
-            intercept_error = np.sqrt(sumwxx / delta)
-            slope_error     = np.sqrt(sumw   / delta)
-
-        The results, `intercept`, `slope`, `intercept_error`, and `slope_error`,
-        are given as an #ak.Record with four fields. The values of these fields
-        might be arrays or even nested arrays; they match the structure of `x` and
-        `y`.
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The linear fit of `y` with respect to `x`.
     """
     # Dispatch
     yield x, y, weight

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -64,7 +64,7 @@ def max(
             high-level.
 
     Returns:
-        Returns the maximum value in each group of elements from `array` (many
+        The maximum value in each group of elements from `array` (many
         types supported, including all Awkward Arrays and Records). The identity
         of maximization is `-inf` if floating-point or the smallest integer value
         if applied to integers. This identity is usually masked: the maximum of

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -32,7 +32,8 @@ def max(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the maximum value over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -62,20 +63,21 @@ def max(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns the maximum value in each group of elements from `array` (many
-    types supported, including all Awkward Arrays and Records). The identity
-    of maximization is `-inf` if floating-point or the smallest integer value
-    if applied to integers. This identity is usually masked: the maximum of
-    an empty list is None, unless `mask_identity=False`.
-    This operation is the same as NumPy's
-    [amax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amax.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Returns the maximum value in each group of elements from `array` (many
+        types supported, including all Awkward Arrays and Records). The identity
+        of maximization is `-inf` if floating-point or the smallest integer value
+        if applied to integers. This identity is usually masked: the maximum of
+        an empty list is None, unless `mask_identity=False`.
+        This operation is the same as NumPy's
+        [amax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amax.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    See also #ak.nanmax.
+        See also #ak.nanmax.
     """
     # Dispatch
     yield (array,)
@@ -105,7 +107,8 @@ def nanmax(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the maximum value, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -129,15 +132,16 @@ def nanmax(
             None (an option type); otherwise, reducing over empty lists
             results in the operation's identity.
 
-    Like #ak.max, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.max, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.max(ak.nan_to_none(array))
+            ak.max(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.max.
+        See also #ak.max.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_max.py
+++ b/src/awkward/operations/ak_max.py
@@ -34,6 +34,20 @@ def max(
 ):
     """Returns the maximum value over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of maximization is `-inf` if floating-point or the smallest integer
+    value if applied to integers. This identity is usually masked: the maximum
+    of an empty list is None, unless `mask_identity=False`. This operation is
+    the same as NumPy's
+    [amax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amax.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    See also #ak.nanmax.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -64,20 +78,7 @@ def max(
             high-level.
 
     Returns:
-        The maximum value in each group of elements from `array` (many
-        types supported, including all Awkward Arrays and Records). The identity
-        of maximization is `-inf` if floating-point or the smallest integer value
-        if applied to integers. This identity is usually masked: the maximum of
-        an empty list is None, unless `mask_identity=False`.
-        This operation is the same as NumPy's
-        [amax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amax.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        See also #ak.nanmax.
+        The maximum value in each group of elements from `array`.
     """
     # Dispatch
     yield (array,)
@@ -109,6 +110,14 @@ def nanmax(
 ):
     """Returns the maximum value, treating NaN values as missing.
 
+    Equivalent to::
+
+        ak.max(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.max.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -134,14 +143,6 @@ def nanmax(
 
     Returns:
         Like #ak.max, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.max(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.max.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -70,7 +70,7 @@ def mean(
             high-level.
 
     Returns:
-        Computes the mean in each group of elements from `x` (many
+        The mean in each group of elements from `x` (many
         types supported, including all Awkward Arrays and Records). The grouping
         is performed the same way as for reducers, though this operation is not a
         reducer and has no identity. It is the same as NumPy's

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -37,7 +37,8 @@ def mean(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the mean over one or all levels of nesting.
+
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -68,46 +69,48 @@ def mean(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the mean in each group of elements from `x` (many
-    types supported, including all Awkward Arrays and Records). The grouping
-    is performed the same way as for reducers, though this operation is not a
-    reducer and has no identity. It is the same as NumPy's
-    [mean](https://docs.scipy.org/doc/numpy/reference/generated/numpy.mean.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Computes the mean in each group of elements from `x` (many
+        types supported, including all Awkward Arrays and Records). The grouping
+        is performed the same way as for reducers, though this operation is not a
+        reducer and has no identity. It is the same as NumPy's
+        [mean](https://docs.scipy.org/doc/numpy/reference/generated/numpy.mean.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    Passing all arguments to the reducers, the mean is calculated as::
+        Passing all arguments to the reducers, the mean is calculated as::
 
-        ak.sum(x*weight) / ak.sum(weight)
+            ak.sum(x*weight) / ak.sum(weight)
 
-    For example, with an `array` like
+    Examples:
+        For example, with an `array` like
 
         >>> array = ak.Array([[0, 1, 2, 3],
                               [          ],
                               [4, 5      ]])
 
-    The mean of the innermost lists is
+        The mean of the innermost lists is
 
         >>> ak.mean(array, axis=-1)
         <Array [1.5, nan, 4.5] type='3 * float64'>
 
-    because there are three lists, the first has mean `1.5`, the second is
-    empty, and the third has mean `4.5`.
+        because there are three lists, the first has mean `1.5`, the second is
+        empty, and the third has mean `4.5`.
 
-    The mean of the outermost lists is
+        The mean of the outermost lists is
 
         >>> ak.mean(array, axis=0)
         <Array [2, 3, 2, 3] type='4 * float64'>
 
-    because the longest list has length 4, the mean of `0` and `4` is `2.0`,
-    the mean of `1` and `5` is `3.0`, the mean of `2` (by itself) is `2.0`,
-    and the mean of `3` (by itself) is `3.0`. This follows the same grouping
-    behavior as reducers.
+        because the longest list has length 4, the mean of `0` and `4` is `2.0`,
+        the mean of `1` and `5` is `3.0`, the mean of `2` (by itself) is `2.0`,
+        and the mean of `3` (by itself) is `3.0`. This follows the same grouping
+        behavior as reducers.
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers.
 
-    See also #ak.nanmean.
+        See also #ak.nanmean.
     """
     # Dispatch
     yield x, weight
@@ -128,7 +131,8 @@ def nanmean(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the mean, treating NaN values as missing.
+
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -159,15 +163,16 @@ def nanmean(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like #ak.mean, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.mean, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.mean(ak.nan_to_none(array))
+            ak.mean(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.mean.
+        See also #ak.mean.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -50,6 +50,11 @@ def mean(
 
         ak.sum(x*weight) / ak.sum(weight)
 
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers.
+
+    See also #ak.nanmean.
+
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -107,11 +112,6 @@ def mean(
         the mean of `1` and `5` is `3.0`, the mean of `2` (by itself) is `2.0`,
         and the mean of `3` (by itself) is `3.0`. This follows the same grouping
         behavior as reducers.
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers.
-
-        See also #ak.nanmean.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -39,6 +39,17 @@ def mean(
 ):
     """Computes the mean over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation is
+    not a reducer and has no identity. It is the same as NumPy's
+    [mean](https://docs.scipy.org/doc/numpy/reference/generated/numpy.mean.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    Passing all arguments to the reducers, the mean is calculated as::
+
+        ak.sum(x*weight) / ak.sum(weight)
+
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -70,17 +81,7 @@ def mean(
             high-level.
 
     Returns:
-        The mean in each group of elements from `x` (many
-        types supported, including all Awkward Arrays and Records). The grouping
-        is performed the same way as for reducers, though this operation is not a
-        reducer and has no identity. It is the same as NumPy's
-        [mean](https://docs.scipy.org/doc/numpy/reference/generated/numpy.mean.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        Passing all arguments to the reducers, the mean is calculated as::
-
-            ak.sum(x*weight) / ak.sum(weight)
+        The mean in each group of elements from `x`.
 
     Examples:
         For example, with an `array` like
@@ -133,6 +134,14 @@ def nanmean(
 ):
     """Computes the mean, treating NaN values as missing.
 
+    Equivalent to::
+
+        ak.mean(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.mean.
+
     Args:
         x: The data on which to compute the mean (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -165,14 +174,6 @@ def nanmean(
 
     Returns:
         Like #ak.mean, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.mean(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.mean.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -64,7 +64,7 @@ def min(
             high-level.
 
     Returns:
-        Returns the minimum value in each group of elements from `array` (many
+        The minimum value in each group of elements from `array` (many
         types supported, including all Awkward Arrays and Records). The identity
         of minimization is `inf` if floating-point or the largest integer value
         if applied to integers. This identity is usually masked: the minimum of

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -32,7 +32,8 @@ def min(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the minimum value over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -62,20 +63,21 @@ def min(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Returns the minimum value in each group of elements from `array` (many
-    types supported, including all Awkward Arrays and Records). The identity
-    of minimization is `inf` if floating-point or the largest integer value
-    if applied to integers. This identity is usually masked: the minimum of
-    an empty list is None, unless `mask_identity=False`.
-    This operation is the same as NumPy's
-    [amin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amin.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Returns the minimum value in each group of elements from `array` (many
+        types supported, including all Awkward Arrays and Records). The identity
+        of minimization is `inf` if floating-point or the largest integer value
+        if applied to integers. This identity is usually masked: the minimum of
+        an empty list is None, unless `mask_identity=False`.
+        This operation is the same as NumPy's
+        [amin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amin.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    See also #ak.nanmin.
+        See also #ak.nanmin.
     """
     # Dispatch
     yield (array,)
@@ -105,7 +107,8 @@ def nanmin(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the minimum value, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -129,15 +132,16 @@ def nanmin(
             None (an option type); otherwise, reducing over empty lists
             results in the operation's identity.
 
-    Like #ak.min, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.min, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.min(ak.nan_to_none(array))
+            ak.min(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.min.
+        See also #ak.min.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_min.py
+++ b/src/awkward/operations/ak_min.py
@@ -34,6 +34,20 @@ def min(
 ):
     """Returns the minimum value over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of minimization is `inf` if floating-point or the largest integer
+    value if applied to integers. This identity is usually masked: the minimum
+    of an empty list is None, unless `mask_identity=False`. This operation is
+    the same as NumPy's
+    [amin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amin.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    See also #ak.nanmin.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -64,20 +78,7 @@ def min(
             high-level.
 
     Returns:
-        The minimum value in each group of elements from `array` (many
-        types supported, including all Awkward Arrays and Records). The identity
-        of minimization is `inf` if floating-point or the largest integer value
-        if applied to integers. This identity is usually masked: the minimum of
-        an empty list is None, unless `mask_identity=False`.
-        This operation is the same as NumPy's
-        [amin](https://docs.scipy.org/doc/numpy/reference/generated/numpy.amin.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        See also #ak.nanmin.
+        The minimum value in each group of elements from `array`.
     """
     # Dispatch
     yield (array,)
@@ -109,6 +110,14 @@ def nanmin(
 ):
     """Returns the minimum value, treating NaN values as missing.
 
+    Equivalent to::
+
+        ak.min(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.min.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -134,14 +143,6 @@ def nanmin(
 
     Returns:
         Like #ak.min, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.min(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.min.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -70,7 +70,7 @@ def moment(
             high-level.
 
     Returns:
-        Computes the `n`th moment in each group of elements from `x` (many
+        The `n`th moment in each group of elements from `x` (many
         types supported, including all Awkward Arrays and Records). The grouping
         is performed the same way as for reducers, though this operation is not a
         reducer and has no identity.

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -35,7 +35,8 @@ def moment(
     behavior: Mapping | None = None,
     attrs: Mapping | None = None,
 ):
-    """
+    """Computes the `n`th moment over one or all levels of nesting.
+
     Args:
         x: The data on which to compute the moment (anything #ak.to_layout recognizes).
         n (int): The choice of moment: `0` is a sum of weights, `1` is
@@ -68,23 +69,24 @@ def moment(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the `n`th moment in each group of elements from `x` (many
-    types supported, including all Awkward Arrays and Records). The grouping
-    is performed the same way as for reducers, though this operation is not a
-    reducer and has no identity.
+    Returns:
+        Computes the `n`th moment in each group of elements from `x` (many
+        types supported, including all Awkward Arrays and Records). The grouping
+        is performed the same way as for reducers, though this operation is not a
+        reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the moment is calculated as::
+        Passing all arguments to the reducers, the moment is calculated as::
 
-        ak.sum(x**n * weight) / ak.sum(weight)
+            ak.sum(x**n * weight) / ak.sum(weight)
 
-    The `n=2` moment differs from #ak.var in that #ak.var also subtracts the
-    mean (the `n=1` moment).
+        The `n=2` moment differs from #ak.var in that #ak.var also subtracts the
+        mean (the `n=1` moment).
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -37,6 +37,23 @@ def moment(
 ):
     """Computes the `n`th moment over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation is
+    not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the moment is calculated as::
+
+        ak.sum(x**n * weight) / ak.sum(weight)
+
+    The `n=2` moment differs from #ak.var in that #ak.var also subtracts the
+    mean (the `n=1` moment).
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: The data on which to compute the moment (anything #ak.to_layout recognizes).
         n (int): The choice of moment: `0` is a sum of weights, `1` is
@@ -70,23 +87,7 @@ def moment(
             high-level.
 
     Returns:
-        The `n`th moment in each group of elements from `x` (many
-        types supported, including all Awkward Arrays and Records). The grouping
-        is performed the same way as for reducers, though this operation is not a
-        reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the moment is calculated as::
-
-            ak.sum(x**n * weight) / ak.sum(weight)
-
-        The `n=2` moment differs from #ak.var in that #ak.var also subtracts the
-        mean (the `n=1` moment).
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The `n`th moment in each group of elements from `x`.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -31,7 +31,8 @@ def prod(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Multiplies an array's elements over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,17 +58,18 @@ def prod(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Multiplies elements of `array` (many types supported, including all
-    Awkward Arrays and Records). The identity of multiplication is `1` and it
-    is usually not masked. This operation is the same as NumPy's
-    [prod](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Multiplies elements of `array` (many types supported, including all
+        Awkward Arrays and Records). The identity of multiplication is `1` and it
+        is usually not masked. This operation is the same as NumPy's
+        [prod](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
 
-    See also #ak.nanprod.
+        See also #ak.nanprod.
     """
     # Dispatch
     yield (array,)
@@ -87,7 +89,8 @@ def nanprod(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Multiplies an array's elements, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -107,15 +110,16 @@ def nanprod(
             None (an option type); otherwise, reducing over empty lists
             results in the operation's identity.
 
-    Like #ak.prod, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.prod, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.prod(ak.nan_to_none(array))
+            ak.prod(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.prod.
+        See also #ak.prod.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -59,7 +59,7 @@ def prod(
             high-level.
 
     Returns:
-        Multiplies elements of `array` (many types supported, including all
+        The product of the elements of `array` (many types supported, including all
         Awkward Arrays and Records). The identity of multiplication is `1` and it
         is usually not masked. This operation is the same as NumPy's
         [prod](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html)

--- a/src/awkward/operations/ak_prod.py
+++ b/src/awkward/operations/ak_prod.py
@@ -33,6 +33,18 @@ def prod(
 ):
     """Multiplies an array's elements over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of multiplication is `1` and it is usually not masked. This
+    operation is the same as NumPy's
+    [prod](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
+    See also #ak.nanprod.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -59,17 +71,7 @@ def prod(
             high-level.
 
     Returns:
-        The product of the elements of `array` (many types supported, including all
-        Awkward Arrays and Records). The identity of multiplication is `1` and it
-        is usually not masked. This operation is the same as NumPy's
-        [prod](https://docs.scipy.org/doc/numpy/reference/generated/numpy.prod.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
-
-        See also #ak.nanprod.
+        The product of the elements of `array`.
     """
     # Dispatch
     yield (array,)
@@ -90,6 +92,14 @@ def nanprod(
     attrs=None,
 ):
     """Multiplies an array's elements, treating NaN values as missing.
+
+    Equivalent to::
+
+        ak.prod(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.prod.
 
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
@@ -112,14 +122,6 @@ def nanprod(
 
     Returns:
         Like #ak.prod, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.prod(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.prod.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -35,7 +35,8 @@ def ptp(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Returns the range of values over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -55,35 +56,37 @@ def ptp(
             None (an option type); otherwise, reducing over empty lists
             results in the operation's identity of 0.
 
-    Returns the range of values in each group of elements from `array` (many
-    types supported, including all Awkward Arrays and Records). The range of
-    an empty list is None, unless `mask_identity=False`, in which case it is 0.
-    This operation is the same as NumPy's
-    [ptp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ptp.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Returns the range of values in each group of elements from `array` (many
+        types supported, including all Awkward Arrays and Records). The range of
+        an empty list is None, unless `mask_identity=False`, in which case it is 0.
+        This operation is the same as NumPy's
+        [ptp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ptp.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    For example, with
+    Examples:
+        For example, with
 
         >>> array = ak.Array([[0, 1, 2, 3],
         ...                   [          ],
         ...                   [4, 5      ]])
 
-    The range of the innermost lists is
+        The range of the innermost lists is
 
         >>> ak.ptp(array, axis=-1)
         <Array [3, None, 1] type='3 * ?int64'>
 
-    because there are three lists, the first has a range of `3`, the second is
-    `None` because the list is empty, and the third has a range of `1`. Similarly,
+        because there are three lists, the first has a range of `3`, the second is
+        `None` because the list is empty, and the third has a range of `1`. Similarly,
 
         >>> ak.ptp(array, axis=-1, mask_identity=False)
         <Array [3, 0, 1] type='3 * float64'>
 
-    The second value is `0` because the list is empty.
+        The second value is `0` because the list is empty.
 
-    See #ak.sum for a more complete description of nested list and missing
-    value (None) handling in reducers.
+        See #ak.sum for a more complete description of nested list and missing
+        value (None) handling in reducers.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -57,7 +57,7 @@ def ptp(
             results in the operation's identity of 0.
 
     Returns:
-        Returns the range of values in each group of elements from `array` (many
+        The range of values in each group of elements from `array` (many
         types supported, including all Awkward Arrays and Records). The range of
         an empty list is None, unless `mask_identity=False`, in which case it is 0.
         This operation is the same as NumPy's

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -37,6 +37,13 @@ def ptp(
 ):
     """Returns the range of values over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    range of an empty list is None, unless `mask_identity=False`, in which case
+    it is 0. This operation is the same as NumPy's
+    [ptp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ptp.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,13 +64,7 @@ def ptp(
             results in the operation's identity of 0.
 
     Returns:
-        The range of values in each group of elements from `array` (many
-        types supported, including all Awkward Arrays and Records). The range of
-        an empty list is None, unless `mask_identity=False`, in which case it is 0.
-        This operation is the same as NumPy's
-        [ptp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ptp.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
+        The range of values in each group of elements from `array`.
 
     Examples:
         For example, with

--- a/src/awkward/operations/ak_ptp.py
+++ b/src/awkward/operations/ak_ptp.py
@@ -44,6 +44,9 @@ def ptp(
     if all lists at a given dimension have the same length and no None values,
     but it generalizes to cases where they do not.
 
+    See #ak.sum for a more complete description of nested list and missing
+    value (None) handling in reducers.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -85,9 +88,6 @@ def ptp(
         <Array [3, 0, 1] type='3 * float64'>
 
         The second value is `0` because the list is empty.
-
-        See #ak.sum for a more complete description of nested list and missing
-        value (None) handling in reducers.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -34,7 +34,8 @@ def softmax(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the softmax over the innermost level of nesting.
+
     Args:
         x: The data on which to compute the softmax (anything #ak.to_layout recognizes).
         axis (None or int or str): The dimension over which the softmax is
@@ -62,20 +63,21 @@ def softmax(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the softmax in each group of elements from `x` (many
-    types supported, including all Awkward Arrays and Records). The grouping
-    is performed the same way as for reducers, though this operation is not a
-    reducer and has no identity.
+    Returns:
+        Computes the softmax in each group of elements from `x` (many
+        types supported, including all Awkward Arrays and Records). The grouping
+        is performed the same way as for reducers, though this operation is not a
+        reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the softmax is calculated as::
+        Passing all arguments to the reducers, the softmax is calculated as::
 
-        np.exp(x) / ak.sum(np.exp(x))
+            np.exp(x) / ak.sum(np.exp(x))
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield (x,)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -64,7 +64,7 @@ def softmax(
             high-level.
 
     Returns:
-        Computes the softmax in each group of elements from `x` (many
+        The softmax in each group of elements from `x` (many
         types supported, including all Awkward Arrays and Records). The grouping
         is performed the same way as for reducers, though this operation is not a
         reducer and has no identity.

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -65,7 +65,7 @@ def softmax(
             high-level.
 
     Returns:
-        Computes the softmax in each group of elements from `x` (many
+        The softmax in each group of elements from `x` (many
         types supported, including all Awkward Arrays and Records). The grouping
         is performed the same way as for reducers, though this operation is not a
         reducer and has no identity.

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -36,6 +36,20 @@ def softmax(
 ):
     """Computes the softmax over the innermost level of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation is
+    not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the softmax is calculated as::
+
+        np.exp(x) / ak.sum(np.exp(x))
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: The data on which to compute the softmax (anything #ak.to_layout recognizes).
         axis (None or int or str): The dimension over which the softmax is
@@ -64,20 +78,7 @@ def softmax(
             high-level.
 
     Returns:
-        The softmax in each group of elements from `x` (many
-        types supported, including all Awkward Arrays and Records). The grouping
-        is performed the same way as for reducers, though this operation is not a
-        reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the softmax is calculated as::
-
-            np.exp(x) / ak.sum(np.exp(x))
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The softmax in each group of elements from `x`.
     """
     # Dispatch
     yield (x,)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -34,7 +34,8 @@ def softmax(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the softmax over the innermost level of nesting.
+
     Args:
         x: The data on which to compute the softmax (anything #ak.to_layout recognizes).
         axis (int or str): The dimension over which the softmax is
@@ -63,20 +64,21 @@ def softmax(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the softmax in each group of elements from `x` (many
-    types supported, including all Awkward Arrays and Records). The grouping
-    is performed the same way as for reducers, though this operation is not a
-    reducer and has no identity.
+    Returns:
+        Computes the softmax in each group of elements from `x` (many
+        types supported, including all Awkward Arrays and Records). The grouping
+        is performed the same way as for reducers, though this operation is not a
+        reducer and has no identity.
 
-    This function has no NumPy equivalent.
+        This function has no NumPy equivalent.
 
-    Passing all arguments to the reducers, the softmax is calculated as::
+        Passing all arguments to the reducers, the softmax is calculated as::
 
-        np.exp(x) / ak.sum(np.exp(x))
+            np.exp(x) / ak.sum(np.exp(x))
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
     """
     # Dispatch
     yield (x,)

--- a/src/awkward/operations/ak_softmax.py
+++ b/src/awkward/operations/ak_softmax.py
@@ -36,6 +36,20 @@ def softmax(
 ):
     """Computes the softmax over the innermost level of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation is
+    not a reducer and has no identity.
+
+    This function has no NumPy equivalent.
+
+    Passing all arguments to the reducers, the softmax is calculated as::
+
+        np.exp(x) / ak.sum(np.exp(x))
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
     Args:
         x: The data on which to compute the softmax (anything #ak.to_layout recognizes).
         axis (int or str): The dimension over which the softmax is
@@ -65,20 +79,7 @@ def softmax(
             high-level.
 
     Returns:
-        The softmax in each group of elements from `x` (many
-        types supported, including all Awkward Arrays and Records). The grouping
-        is performed the same way as for reducers, though this operation is not a
-        reducer and has no identity.
-
-        This function has no NumPy equivalent.
-
-        Passing all arguments to the reducers, the softmax is calculated as::
-
-            np.exp(x) / ak.sum(np.exp(x))
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
+        The softmax in each group of elements from `x`.
     """
     # Dispatch
     yield (x,)

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -75,7 +75,7 @@ def std(
             high-level.
 
     Returns:
-        Computes the standard deviation in each group of elements from `x`
+        The standard deviation in each group of elements from `x`
         (many types supported, including all Awkward Arrays and Records). The
         grouping is performed the same way as for reducers, though this operation
         is not a reducer and has no identity. It is the same as NumPy's

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -39,7 +39,8 @@ def std(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the standard deviation over one or all levels of nesting.
+
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -73,24 +74,25 @@ def std(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the standard deviation in each group of elements from `x`
-    (many types supported, including all Awkward Arrays and Records). The
-    grouping is performed the same way as for reducers, though this operation
-    is not a reducer and has no identity. It is the same as NumPy's
-    [std](https://docs.scipy.org/doc/numpy/reference/generated/numpy.std.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Computes the standard deviation in each group of elements from `x`
+        (many types supported, including all Awkward Arrays and Records). The
+        grouping is performed the same way as for reducers, though this operation
+        is not a reducer and has no identity. It is the same as NumPy's
+        [std](https://docs.scipy.org/doc/numpy/reference/generated/numpy.std.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    Passing all arguments to the reducers, the standard deviation is
-    calculated as::
+        Passing all arguments to the reducers, the standard deviation is
+        calculated as::
 
-        np.sqrt(ak.var(x, weight))
+            np.sqrt(ak.var(x, weight))
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
 
-    See also #ak.nanstd.
+        See also #ak.nanstd.
     """
     # Dispatch
     yield x, weight
@@ -114,7 +116,8 @@ def nanstd(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the standard deviation, treating NaN values as missing.
+
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -148,15 +151,16 @@ def nanstd(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like #ak.std, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.std, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.std(ak.nan_to_none(array))
+            ak.std(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.std.
+        See also #ak.std.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_std.py
+++ b/src/awkward/operations/ak_std.py
@@ -41,6 +41,24 @@ def std(
 ):
     """Computes the standard deviation over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation
+    is not a reducer and has no identity. It is the same as NumPy's
+    [std](https://docs.scipy.org/doc/numpy/reference/generated/numpy.std.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    Passing all arguments to the reducers, the standard deviation is
+    calculated as::
+
+        np.sqrt(ak.var(x, weight))
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
+    See also #ak.nanstd.
+
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -75,24 +93,7 @@ def std(
             high-level.
 
     Returns:
-        The standard deviation in each group of elements from `x`
-        (many types supported, including all Awkward Arrays and Records). The
-        grouping is performed the same way as for reducers, though this operation
-        is not a reducer and has no identity. It is the same as NumPy's
-        [std](https://docs.scipy.org/doc/numpy/reference/generated/numpy.std.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        Passing all arguments to the reducers, the standard deviation is
-        calculated as::
-
-            np.sqrt(ak.var(x, weight))
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
-
-        See also #ak.nanstd.
+        The standard deviation in each group of elements from `x`.
     """
     # Dispatch
     yield x, weight
@@ -117,6 +118,14 @@ def nanstd(
     attrs=None,
 ):
     """Computes the standard deviation, treating NaN values as missing.
+
+    Equivalent to::
+
+        ak.std(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.std.
 
     Args:
         x: The data on which to compute the standard deviation (anything #ak.to_layout recognizes).
@@ -153,14 +162,6 @@ def nanstd(
 
     Returns:
         Like #ak.std, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.std(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.std.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -31,7 +31,8 @@ def sum(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Sums an array's elements over one or all levels of nesting.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -57,68 +58,70 @@ def sum(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Sums over `array` (many types supported, including all Awkward Arrays
-    and Records). The identity of addition is `0` and it is usually not
-    masked. This operation is the same as NumPy's
-    [sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Sums over `array` (many types supported, including all Awkward Arrays
+        and Records). The identity of addition is `0` and it is usually not
+        masked. This operation is the same as NumPy's
+        [sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    For example, consider this `array`, in which all lists at a given dimension
-    have the same length.
+    Examples:
+        For example, consider this `array`, in which all lists at a given dimension
+        have the same length.
 
         >>> array = ak.Array([[ 0.1,  0.2,  0.3],
         ...                   [10.1, 10.2, 10.3],
         ...                   [20.1, 20.2, 20.3],
         ...                   [30.1, 30.2, 30.3]])
 
-    A sum over `axis=-1` combines the inner lists, leaving one value per
-    outer list:
+        A sum over `axis=-1` combines the inner lists, leaving one value per
+        outer list:
 
         >>> ak.sum(array, axis=-1)
         <Array [0.6, 30.6, 60.6, 90.6] type='4 * float64'>
 
-    while a sum over `axis=0` combines the outer lists, leaving one value
-    per inner list:
+        while a sum over `axis=0` combines the outer lists, leaving one value
+        per inner list:
 
         >>> ak.sum(array, axis=0)
         <Array [60.4, 60.8, 61.2] type='3 * float64'>
 
-    Now with some values missing,
+        Now with some values missing,
 
         >>> array = ak.Array([[ 0.1,  0.2      ],
         ...                   [10.1            ],
         ...                   [20.1, 20.2, 20.3],
         ...                   [30.1, 30.2      ]])
 
-    The sum over `axis=-1` results in
+        The sum over `axis=-1` results in
 
         >>> ak.sum(array, axis=-1)
         <Array [0.3, 10.1, 60.6, 60.3] type='4 * float64'>
 
-    and the sum over `axis=0` results in
+        and the sum over `axis=0` results in
 
         >>> ak.sum(array, axis=0)
         <Array [60.4, 50.6, 20.3] type='3 * float64'>
 
-    How we ought to sum over the innermost lists is unambiguous, but for all
-    other `axis` values, we must choose whether to align contents to the
-    left before summing, to the right before summing, or something else.
-    As suggested by the way the text has been aligned, we choose the
-    left-alignment convention: the first `axis=0` result is the sum of all
-    first elements::
+        How we ought to sum over the innermost lists is unambiguous, but for all
+        other `axis` values, we must choose whether to align contents to the
+        left before summing, to the right before summing, or something else.
+        As suggested by the way the text has been aligned, we choose the
+        left-alignment convention: the first `axis=0` result is the sum of all
+        first elements::
 
-        60.4 = 0.1 + 10.1 + 20.1 + 30.1
+            60.4 = 0.1 + 10.1 + 20.1 + 30.1
 
-    the second is the sum of all second elements::
+        the second is the sum of all second elements::
 
-        50.6 = 0.2 + 20.2 + 30.2
+            50.6 = 0.2 + 20.2 + 30.2
 
-    and the third is the sum of the only third element::
+        and the third is the sum of the only third element::
 
-        20.3 = 20.3
+            20.3 = 20.3
 
-    The same is true if the values were None, rather than gaps:
+        The same is true if the values were None, rather than gaps:
 
         >>> array = ak.Array([[ 0.1,  0.2, None],
         ...                   [10.1, None, None],
@@ -130,76 +133,76 @@ def sum(
         >>> ak.sum(array, axis=0)
         <Array [60.4, 50.6, 20.3] type='3 * float64'>
 
-    However, the missing value placeholder, None, allows us to align the
-    remaining data differently:
+        However, the missing value placeholder, None, allows us to align the
+        remaining data differently:
 
         >>> array = ak.Array([[None,  0.1,  0.2],
         ...                   [None, None, 10.1],
         ...                   [20.1, 20.2, 20.3],
         ...                   [None, 30.1, 30.2]])
 
-    Now the `axis=-1` result is the same but the `axis=0` result has changed:
+        Now the `axis=-1` result is the same but the `axis=0` result has changed:
 
         >>> ak.sum(array, axis=-1)
         <Array [0.3, 10.1, 60.6, 60.3] type='4 * float64'>
         >>> ak.sum(array, axis=0)
         <Array [20.1, 50.4, 60.8] type='3 * float64'>
 
-    because::
+        because::
 
-        20.1 = 20.1
-        50.4 = 0.1 + 20.2 + 30.1
-        60.8 = 0.2 + 10.1 + 20.3 + 30.2
+            20.1 = 20.1
+            50.4 = 0.1 + 20.2 + 30.1
+            60.8 = 0.2 + 10.1 + 20.3 + 30.2
 
-    If, instead of missing numbers, we had missing lists,
+        If, instead of missing numbers, we had missing lists,
 
         >>> array = ak.Array([[ 0.1,  0.2,  0.3],
         ...                   None,
         ...                   [20.1, 20.2, 20.3],
         ...                   [30.1, 30.2, 30.3]])
 
-    then the placeholder would pass through the `axis=-1` sum because summing
-    over the inner dimension shouldn't change the length of the outer
-    dimension.
+        then the placeholder would pass through the `axis=-1` sum because summing
+        over the inner dimension shouldn't change the length of the outer
+        dimension.
 
         >>> ak.sum(array, axis=-1)
         <Array [0.6, None, 60.6, 90.6] type='4 * ?float64'>
 
-    However, the `axis=0` sum loses information about the None value.
+        However, the `axis=0` sum loses information about the None value.
 
         >>> ak.sum(array, axis=0)
         <Array [50.3, 50.6, 50.9] type='3 * float64'>
 
-    which is::
+        which is::
 
-        50.3 = 0.1 + (None) + 20.1 + 30.1
-        50.6 = 0.2 + (None) + 20.2 + 30.2
-        50.9 = 0.3 + (None) + 20.3 + 30.3
+            50.3 = 0.1 + (None) + 20.1 + 30.1
+            50.6 = 0.2 + (None) + 20.2 + 30.2
+            50.9 = 0.3 + (None) + 20.3 + 30.3
 
-    An `axis=0` sum would be reducing that information if it had not been
-    None, anyway. If the None values were replaced with `0`, the result for
-    `axis=0` would be the same. The result for `axis=-1` would not be the
-    same because this None is in the `0` axis, not the axis that `axis=-1`
-    sums over.
+        An `axis=0` sum would be reducing that information if it had not been
+        None, anyway. If the None values were replaced with `0`, the result for
+        `axis=0` would be the same. The result for `axis=-1` would not be the
+        same because this None is in the `0` axis, not the axis that `axis=-1`
+        sums over.
 
-    The `keepdims` parameter ensures that the number of dimensions does not
-    change: scalar results are put into new length-1 dimensions:
+        The `keepdims` parameter ensures that the number of dimensions does not
+        change: scalar results are put into new length-1 dimensions:
 
         >>> ak.sum(array, axis=-1, keepdims=True)
         <Array [[0.6], None, [60.6], [90.6]] type='4 * option[1 * float64]'>
         >>> ak.sum(array, axis=0, keepdims=True)
         <Array [[50.3, 50.6, 50.9]] type='1 * var * float64'>
 
-    and `axis=None` ignores all None values and adds up everything in the
-    array (`keepdims` has no effect).
+        and `axis=None` ignores all None values and adds up everything in the
+        array (`keepdims` has no effect).
 
         >>> ak.sum(array, axis=None)
         151.8
 
-    The `mask_identity`, which has no equivalent in NumPy, inserts None in
-    the output wherever a reduction takes place over zero elements. This is
-    different from reductions that are otherwise equal to the identity or
-    are equal to the identity by cancellation.
+        The `mask_identity`, which has no equivalent in NumPy, inserts None in
+        the output wherever a reduction takes place over zero elements. This is
+        different from reductions that are otherwise equal to the identity or
+        are equal to the identity by cancellation.
 
         >>> array = ak.Array([[2.2, 2.2], [4.4, -2.2, -2.2], [], [0.0]])
         >>> ak.sum(array, axis=-1)
@@ -207,11 +210,11 @@ def sum(
         >>> ak.sum(array, axis=-1, mask_identity=True)
         <Array [4.4, 0, None, 0] type='4 * ?float64'>
 
-    The third list is reduced to `0` if `mask_identity=False` because `0` is
-    the identity of addition, but it is reduced to None if
-    `mask_identity=True`.
+        The third list is reduced to `0` if `mask_identity=False` because `0` is
+        the identity of addition, but it is reduced to None if
+        `mask_identity=True`.
 
-    See also #ak.nansum.
+        See also #ak.nansum.
     """
     # Dispatch
     yield (array,)
@@ -231,7 +234,8 @@ def nansum(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Sums an array's elements, treating NaN values as missing.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -257,15 +261,16 @@ def nansum(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like #ak.sum, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.sum, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.sum(ak.nan_to_none(array))
+            ak.sum(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.sum.
+        See also #ak.sum.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -59,7 +59,7 @@ def sum(
             high-level.
 
     Returns:
-        Sums over `array` (many types supported, including all Awkward Arrays
+        The sum over `array` (many types supported, including all Awkward Arrays
         and Records). The identity of addition is `0` and it is usually not
         masked. This operation is the same as NumPy's
         [sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -33,6 +33,13 @@ def sum(
 ):
     """Sums an array's elements over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    identity of addition is `0` and it is usually not masked. This operation is
+    the same as NumPy's
+    [sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -59,12 +66,7 @@ def sum(
             high-level.
 
     Returns:
-        The sum over `array` (many types supported, including all Awkward Arrays
-        and Records). The identity of addition is `0` and it is usually not
-        masked. This operation is the same as NumPy's
-        [sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
+        The sum over `array`.
 
     Examples:
         For example, consider this `array`, in which all lists at a given dimension
@@ -236,6 +238,14 @@ def nansum(
 ):
     """Sums an array's elements, treating NaN values as missing.
 
+    Equivalent to::
+
+        ak.sum(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.sum.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -263,14 +273,6 @@ def nansum(
 
     Returns:
         Like #ak.sum, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.sum(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.sum.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_sum.py
+++ b/src/awkward/operations/ak_sum.py
@@ -40,6 +40,8 @@ def sum(
     if all lists at a given dimension have the same length and no None values,
     but it generalizes to cases where they do not.
 
+    See also #ak.nansum.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (None or int or str): If None, combine all values from the array into
@@ -215,8 +217,6 @@ def sum(
         The third list is reduced to `0` if `mask_identity=False` because `0` is
         the identity of addition, but it is reduced to None if
         `mask_identity=True`.
-
-        See also #ak.nansum.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -74,7 +74,7 @@ def var(
             high-level.
 
     Returns:
-        Computes the variance in each group of elements from `x` (many
+        The variance in each group of elements from `x` (many
         types supported, including all Awkward Arrays and Records). The grouping
         is performed the same way as for reducers, though this operation is not a
         reducer and has no identity. It is the same as NumPy's

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -38,7 +38,8 @@ def var(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the variance over one or all levels of nesting.
+
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -72,30 +73,31 @@ def var(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Computes the variance in each group of elements from `x` (many
-    types supported, including all Awkward Arrays and Records). The grouping
-    is performed the same way as for reducers, though this operation is not a
-    reducer and has no identity. It is the same as NumPy's
-    [var](https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html)
-    if all lists at a given dimension have the same length and no None values,
-    but it generalizes to cases where they do not.
+    Returns:
+        Computes the variance in each group of elements from `x` (many
+        types supported, including all Awkward Arrays and Records). The grouping
+        is performed the same way as for reducers, though this operation is not a
+        reducer and has no identity. It is the same as NumPy's
+        [var](https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html)
+        if all lists at a given dimension have the same length and no None values,
+        but it generalizes to cases where they do not.
 
-    Passing all arguments to the reducers, the variance is calculated as::
+        Passing all arguments to the reducers, the variance is calculated as::
 
-        ak.sum((x - ak.mean(x))**2 * weight) / ak.sum(weight)
+            ak.sum((x - ak.mean(x))**2 * weight) / ak.sum(weight)
 
-    If `ddof` is not zero, the above is further corrected by a factor of::
+        If `ddof` is not zero, the above is further corrected by a factor of::
 
-        ak.sum(weight) / (ak.sum(weight) - ddof)
+            ak.sum(weight) / (ak.sum(weight) - ddof)
 
-    Even without `ddof`, #ak.var differs from #ak.moment with `n=2` because
-    the mean is subtracted from all points before summing their squares.
+        Even without `ddof`, #ak.var differs from #ak.moment with `n=2` because
+        the mean is subtracted from all points before summing their squares.
 
-    See #ak.sum for a complete description of handling nested lists and
-    missing values (None) in reducers, and #ak.mean for an example with another
-    non-reducer.
+        See #ak.sum for a complete description of handling nested lists and
+        missing values (None) in reducers, and #ak.mean for an example with another
+        non-reducer.
 
-    See also #ak.nanvar.
+        See also #ak.nanvar.
     """
     # Dispatch
     yield x, weight
@@ -119,7 +121,8 @@ def nanvar(
     behavior=None,
     attrs=None,
 ):
-    """
+    """Computes the variance, treating NaN values as missing.
+
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -153,15 +156,16 @@ def nanvar(
         attrs (None or dict): Custom attributes for the output array, if
             high-level.
 
-    Like #ak.var, but treating NaN ("not a number") values as missing.
+    Returns:
+        Like #ak.var, but treating NaN ("not a number") values as missing.
 
-    Equivalent to::
+        Equivalent to::
 
-        ak.var(ak.nan_to_none(array))
+            ak.var(ak.nan_to_none(array))
 
-    with all other arguments unchanged.
+        with all other arguments unchanged.
 
-    See also #ak.var.
+        See also #ak.var.
     """
     # Dispatch
     yield x, weight

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -40,6 +40,30 @@ def var(
 ):
     """Computes the variance over one or all levels of nesting.
 
+    Many types are supported, including all Awkward Arrays and Records. The
+    grouping is performed the same way as for reducers, though this operation is
+    not a reducer and has no identity. It is the same as NumPy's
+    [var](https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html)
+    if all lists at a given dimension have the same length and no None values,
+    but it generalizes to cases where they do not.
+
+    Passing all arguments to the reducers, the variance is calculated as::
+
+        ak.sum((x - ak.mean(x))**2 * weight) / ak.sum(weight)
+
+    If `ddof` is not zero, the above is further corrected by a factor of::
+
+        ak.sum(weight) / (ak.sum(weight) - ddof)
+
+    Even without `ddof`, #ak.var differs from #ak.moment with `n=2` because
+    the mean is subtracted from all points before summing their squares.
+
+    See #ak.sum for a complete description of handling nested lists and
+    missing values (None) in reducers, and #ak.mean for an example with another
+    non-reducer.
+
+    See also #ak.nanvar.
+
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
         weight: Data that can be broadcasted to `x` to give each value a
@@ -74,30 +98,7 @@ def var(
             high-level.
 
     Returns:
-        The variance in each group of elements from `x` (many
-        types supported, including all Awkward Arrays and Records). The grouping
-        is performed the same way as for reducers, though this operation is not a
-        reducer and has no identity. It is the same as NumPy's
-        [var](https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html)
-        if all lists at a given dimension have the same length and no None values,
-        but it generalizes to cases where they do not.
-
-        Passing all arguments to the reducers, the variance is calculated as::
-
-            ak.sum((x - ak.mean(x))**2 * weight) / ak.sum(weight)
-
-        If `ddof` is not zero, the above is further corrected by a factor of::
-
-            ak.sum(weight) / (ak.sum(weight) - ddof)
-
-        Even without `ddof`, #ak.var differs from #ak.moment with `n=2` because
-        the mean is subtracted from all points before summing their squares.
-
-        See #ak.sum for a complete description of handling nested lists and
-        missing values (None) in reducers, and #ak.mean for an example with another
-        non-reducer.
-
-        See also #ak.nanvar.
+        The variance in each group of elements from `x`.
     """
     # Dispatch
     yield x, weight
@@ -122,6 +123,14 @@ def nanvar(
     attrs=None,
 ):
     """Computes the variance, treating NaN values as missing.
+
+    Equivalent to::
+
+        ak.var(ak.nan_to_none(array))
+
+    with all other arguments unchanged.
+
+    See also #ak.var.
 
     Args:
         x: The data on which to compute the variance (anything #ak.to_layout recognizes).
@@ -158,14 +167,6 @@ def nanvar(
 
     Returns:
         Like #ak.var, but treating NaN ("not a number") values as missing.
-
-        Equivalent to::
-
-            ak.var(ak.nan_to_none(array))
-
-        with all other arguments unchanged.
-
-        See also #ak.var.
     """
     # Dispatch
     yield x, weight


### PR DESCRIPTION
## Summary

Rolls the pilot from #3946 out to the 19 operations (28 functions, including the `nan*` variants) in the **Reducers** batch of #3980:

`all`, `any`, `sum`, `prod`, `count`, `count_nonzero`, `min`, `max`, `argmin`, `argmax`, `mean`, `std`, `var`, `moment`, `corr`, `covar`, `ptp`, `linear_fit`, `softmax`.

Each docstring now has:

- A one-line summary on the opening `"""`.
- `Returns:` and `Examples:` section headers (the latter only where examples exist).

Original body text is preserved; only structural edits are applied. The summary lines were reviewed against the checklist posted in #3980.

## Summary lines

| Operation | Summary |
|---|---|
| `ak.all` | Returns whether all elements are True over one or all levels of nesting. |
| `ak.any` | Returns whether any elements are True over one or all levels of nesting. |
| `ak.sum` | Sums an array's elements over one or all levels of nesting. |
| `ak.nansum` | Sums an array's elements, treating NaN values as missing. |
| `ak.prod` | Multiplies an array's elements over one or all levels of nesting. |
| `ak.nanprod` | Multiplies an array's elements, treating NaN values as missing. |
| `ak.count` | Counts an array's elements over one or all levels of nesting. |
| `ak.count_nonzero` | Counts an array's nonzero elements over one or all levels of nesting. |
| `ak.min` | Returns the minimum value over one or all levels of nesting. |
| `ak.nanmin` | Returns the minimum value, treating NaN values as missing. |
| `ak.max` | Returns the maximum value over one or all levels of nesting. |
| `ak.nanmax` | Returns the maximum value, treating NaN values as missing. |
| `ak.argmin` | Returns the index of the minimum value over one or all levels of nesting. |
| `ak.nanargmin` | Returns the index of the minimum value, treating NaN values as missing. |
| `ak.argmax` | Returns the index of the maximum value over one or all levels of nesting. |
| `ak.nanargmax` | Returns the index of the maximum value, treating NaN values as missing. |
| `ak.mean` | Computes the mean over one or all levels of nesting. |
| `ak.nanmean` | Computes the mean, treating NaN values as missing. |
| `ak.std` | Computes the standard deviation over one or all levels of nesting. |
| `ak.nanstd` | Computes the standard deviation, treating NaN values as missing. |
| `ak.var` | Computes the variance over one or all levels of nesting. |
| `ak.nanvar` | Computes the variance, treating NaN values as missing. |
| `ak.moment` | Computes the `n`th moment over one or all levels of nesting. |
| `ak.corr` | Computes the correlation of x and y over one or all levels of nesting. |
| `ak.covar` | Computes the covariance of x and y over one or all levels of nesting. |
| `ak.ptp` | Returns the range of values over one or all levels of nesting. |
| `ak.linear_fit` | Computes the linear fit of y against x over one or all levels of nesting. |
| `ak.softmax` | Computes the softmax over the innermost level of nesting. |

## Notes for reviewers

- Base reducers share the tail "…over one or all levels of nesting." to cover both `axis=None` (scalar result) and `axis=int` (group-wise); `nan*` variants share "…, treating NaN values as missing." and keep the verbatim "Like #ak.X, but…" text in the body.
- `ak.softmax` deviates deliberately ("over the innermost level of nesting"): its implementation only supports the innermost axis and raises `NotImplementedError` otherwise.
- `ak.argmin`/`ak.argmax` read "Returns the index of the minimum/maximum value…"; the "…, returning integer indexes" register of `ak.argcartesian` did not fit the line budget with the modes tail.
- Pre-existing issues left verbatim in the bodies (out of scope here): `nanargmin`'s Args block documents `mask_identity` twice, and `ak.mean`'s first walkthrough doctest is malformed in `main` (missing `...` continuation prefixes).

## Test plan

- [x] pre-commit passes locally on the modified files (ruff check, ruff format, codespell, mypy).
- [x] Mechanical validation: code outside docstrings byte-identical; `Args:` blocks and doctests byte-identical; no original narrative text lost.
- [ ] Sphinx docs build cleanly on CI.
- [ ] Rendered docstrings spot-checked in the docs preview.

Part of #3980. Draft for initial review; will mark ready once CI passes and the preview is checked.

## AI assistance disclosure

Drafted with Claude Code: summaries drafted by Claude Opus 4.8, adversarially verified against the implementations by independent Claude Opus 4.8 agents, mechanically validated (docstring-only changes, original text preserved), and reviewed by a human before submission.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
