### PR TITLE
test: add a property-based kernel test with CPU and GPU backends

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -116,6 +116,7 @@ jobs:
             src/awkward/_connect/cuda/**
             src/awkward/_kernels.py
             tests-cuda/**
+            tests/properties/**
       - name: Set a flag for running the GPU tests
         if: steps.changed-gpu-files.outputs.added_modified_renamed != '[]'
         id: gpu-changes

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -269,6 +269,10 @@ jobs:
         if: ${{ fromJSON(inputs.run-gpu-kernel-tests) }}
         run: python -m pytest -vv -rs tests-cuda-kernels-explicit
 
+      - name: Test kernel property-based tests
+        if: ${{ fromJSON(inputs.run-gpu-kernel-tests) }}
+        run: python -m pytest -vv -rs tests/properties -m cuda
+
       - name: Test CUDA non-kernel (Python)
         run: >-
           python -m pytest -vv -rs tests-cuda --ignore=tests-cuda/test_3459_virtualarray_with_cuda.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ addopts = [
     "--strict-config",
 ]
 xfail_strict = true
+markers = [
+    "cuda: marks tests that require a CUDA-capable GPU",
+]
 filterwarnings = [
     "error",
     "ignore:the imp module is deprecated in favour of importlib:DeprecationWarning",

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -8,5 +8,6 @@ pyarrow>=12.0.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist
+PyYAML
 safetensors>=0.6.2
 uproot>=5

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -5,8 +5,10 @@
 # cupy-cuda12x>=14
 # cuda-cccl[cu12]
 fsspec>=2022.11.0
+hypothesis-awkward==0.18.0
 numba>=0.60
 numba-cuda>=0.25.0
 pyarrow
 pytest>=6
+PyYAML
 uproot>=5

--- a/tests/properties/kernels/test_BitMaskedArray_to_ByteMaskedArray.py
+++ b/tests/properties/kernels/test_BitMaskedArray_to_ByteMaskedArray.py
@@ -1,0 +1,117 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Property-based test for the ``awkward_BitMaskedArray_to_ByteMaskedArray`` kernel.
+
+Prototype for replacing the frozen samples in ``kernel-test-data.json`` with
+Hypothesis-generated inputs. The property is::
+
+    backend_kernel(inputs) == reference_definition(inputs)   for all valid inputs
+
+The same property runs against every available backend: the compiled CPU kernel
+always, and the CUDA kernel when a GPU is present (selected in CI with
+``-m cuda``). The kernel's pure-Python reference implementation is taken
+straight from ``kernel-specification.yml`` (the single source of truth),
+so the test never depends on the generated ``awkward-cpp/tests-spec/kernels.py``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+yaml = pytest.importorskip("yaml")
+
+KERNEL = "awkward_BitMaskedArray_to_ByteMaskedArray"
+SPEC_PATH = Path(__file__).parents[3] / "kernel-specification.yml"
+
+
+def _load_reference(name: str):
+    """Exec the kernel's reference ``definition`` from the spec and return it.
+
+    Each reference implementation mutates its output argument(s) in place and
+    needs only ``uint8`` in scope (mirroring the prelude that
+    ``dev/generate-tests.py`` injects into the generated ``kernels.py``).
+    """
+    import numpy
+
+    spec = yaml.safe_load(SPEC_PATH.read_text())
+    definition = next(k["definition"] for k in spec["kernels"] if k["name"] == name)
+    namespace: dict = {"numpy": numpy, "uint8": numpy.uint8}
+    exec(definition, namespace)
+    return namespace[name]
+
+
+reference = _load_reference(KERNEL)
+
+
+def _run_cpu(
+    frombitmask: list[int], bitmasklength: int, validwhen: bool, lsb_order: bool
+) -> list[int]:
+    """Run the compiled CPU kernel via ctypes; return ``tobytemask`` as 0/1 ints."""
+    from awkward_cpp.cpu_kernels import lib
+
+    n_out = bitmasklength * 8
+    tobytemask = (ctypes.c_int8 * n_out)()
+    c_frombitmask = (ctypes.c_uint8 * bitmasklength)(*frombitmask)
+    ret = getattr(lib, KERNEL)(
+        tobytemask, c_frombitmask, bitmasklength, validwhen, lsb_order
+    )
+    assert not ret.str, ret.str  # error message is falsy on success
+    return [int(bool(x)) for x in tobytemask]
+
+
+def _run_cuda(
+    frombitmask: list[int], bitmasklength: int, validwhen: bool, lsb_order: bool
+) -> list[int]:
+    """Run the compiled CUDA kernel via the CuPy backend; return 0/1 ints."""
+    import cupy
+
+    import awkward._connect.cuda as ak_cu
+    from awkward._backends.cupy import CupyBackend
+
+    n_out = bitmasklength * 8
+    tobytemask = cupy.empty(n_out, dtype=cupy.int8)
+    c_frombitmask = cupy.array(frombitmask, dtype=cupy.uint8)
+    func_cuda = CupyBackend.instance()[KERNEL, cupy.int8, cupy.uint8]
+    func_cuda(tobytemask, c_frombitmask, bitmasklength, validwhen, lsb_order)
+    ak_cu.synchronize_cuda()  # kernel errors surface here
+    return [int(bool(x)) for x in cupy.asnumpy(tobytemask)]
+
+
+def _available_backends():
+    """CPU always; CUDA only when a GPU device is actually present."""
+    backends = [pytest.param(_run_cpu, id="cpu")]
+    try:
+        import cupy
+
+        if cupy.cuda.runtime.getDeviceCount() > 0:
+            backends.append(pytest.param(_run_cuda, id="cuda", marks=pytest.mark.cuda))
+    except Exception:
+        pass
+    return backends
+
+
+@pytest.mark.parametrize("run", _available_backends())
+@given(
+    frombitmask=st.lists(st.integers(min_value=0, max_value=255), max_size=64),
+    validwhen=st.booleans(),
+    lsb_order=st.booleans(),
+)
+def test_matches_reference(
+    run, frombitmask: list[int], validwhen: bool, lsb_order: bool
+) -> None:
+    """Each backend kernel must agree with the spec's reference implementation."""
+    bitmasklength = len(frombitmask)
+
+    # Reference implementation: pure-Python, mutating a plain list in place.
+    expected: list = [0] * (bitmasklength * 8)
+    reference(expected, frombitmask, bitmasklength, validwhen, lsb_order)
+
+    got = run(frombitmask, bitmasklength, validwhen, lsb_order)
+
+    # Reference yields numpy.bool_, the kernels write int8 0/1 — normalise both.
+    assert got == [int(bool(x)) for x in expected]


### PR DESCRIPTION
## Summary

As discussed in the awkward–uproot meeting, this is a pilot for property-based testing of the compiled kernels. Instead of the frozen samples in `kernel-test-data.json`, inputs are Hypothesis-generated and the kernel is checked against its pure-Python reference implementation in `kernel-specification.yml` (the single source of truth).

This starts with one kernel, `awkward_BitMaskedArray_to_ByteMaskedArray`, plus the CPU/GPU infrastructure. If the approach works well, it will be extended to the remaining kernels.

## What's here

- **`tests/properties/kernels/test_BitMaskedArray_to_ByteMaskedArray.py`** — parametrized over backends:
  - `cpu`: compiled kernel via `awkward_cpp.cpu_kernels` (ctypes), always run.
  - `cuda`: compiled kernel via the CuPy backend, added only when a GPU is present and marked `@pytest.mark.cuda`.

  The reference implementation is loaded from `kernel-specification.yml`, so the test does not depend on the generated `awkward-cpp/tests-spec/kernels.py`.
- **`pyproject.toml`** — registers the `cuda` marker (`--strict-markers`).
- **`reusable-test.yml`** — new GPU step `pytest tests/properties -m cuda`, gated on `run-gpu-kernel-tests`.
- **`reusable-change-detection.yml`** — `tests/properties/**` added to the GPU change filter, so property-test changes trigger the GPU job.
- **requirements** — `hypothesis-awkward` + `PyYAML` in `requirements-test-gpu.txt`; `PyYAML` in `requirements-test-full.txt`.

## Dependency on #4128

This test intentionally carries no `@settings` (no `max_examples`, no `deadline`). The example budget and per-example deadline are expected to come from the central Hypothesis profile in #4128. Until that lands, the GPU run uses Hypothesis defaults (200 ms deadline), which GPU launch latency can exceed; #4128 is the intended source of a GPU-appropriate profile.

## Test plan

- [x] `pytest tests/properties/kernels` — `cpu` param passes.
- [x] `pytest tests/properties/kernels -m cuda` deselects cleanly with no GPU; `cuda` marker registered.
- [x] pre-commit on changed files: ruff, codespell, workflow validation, zizmor.
- [ ] GPU job on this PR (self-hosted runner) runs the CuPy kernel against the spec's reference implementation. (Validated in CI; see #4128 note re: deadline.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
