### PR TITLE
fix: passing a non-Collection iterable to pytest.parametrize is deprecated

### DIFF
--- a/tests-cuda/test_3065a_cuda_kernels.py
+++ b/tests-cuda/test_3065a_cuda_kernels.py
@@ -1260,7 +1260,7 @@ layouts = [
         ],
     ),
 ]
-cuda_layouts = ak.to_backend(layouts, "cuda", highlevel=False)
+cuda_layouts = [ak.to_backend(layout, "cuda", highlevel=False) for layout in layouts]
 
 
 @pytest.mark.parametrize("left", cuda_layouts)


### PR DESCRIPTION
fixes the error for the new pytest version: `pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated`

this is how the variable `cuda_layouts` is changed:
```
     BEFORE (type): <class 'awkward.contents.listoffsetarray.ListOffsetArray'>
     BEFORE (value):
     <ListOffsetArray len='2'>
         <offsets><Index dtype='int64' len='3'>[0 2 4]</Index></offsets>
         <content><ListOffsetArray len='4'>
             <offsets><Index dtype='int64' len='5'>[ 0  3  6  9 12]</Index></offsets>
             <content><NumpyArray dtype='int64' len='12'>[0 1 2 3 4 5 0 1 2 3 4 5]</NumpyArray></content>
         </ListOffsetArray></content>
     </ListOffsetArray>

     AFTER (type): <class 'list'>
     AFTER (value):
     [<ListArray len='2'>
         <starts><Index dtype='int64' len='2'>[0 3]</Index></starts>
         <stops><Index dtype='int64' len='2'>[3 6]</Index></stops>
         <content><NumpyArray dtype='int64' len='6'>[0 1 2 3 4 5]</NumpyArray></content>
     </ListArray>, <ListOffsetArray len='2'>
         <offsets><Index dtype='int64' len='3'>[0 3 6]</Index></offsets>
         <content><NumpyArray dtype='int64' len='6'>[0 1 2 3 4 5]</NumpyArray></content>
     </ListOffsetArray>]
```