### PR TITLE
ci: show Hypothesis statistics in the nightly property tests

### DIFF
--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: python -m pip list
 
       - name: Run property-based tests
-        run: python -m pytest -vv -rs tests/properties
+        run: python -m pytest -vv -rs tests/properties --hypothesis-show-statistics
         env:
           HYPOTHESIS_PROFILE: nightly
 


### PR DESCRIPTION
Adds `--hypothesis-show-statistics` to the nightly-profile step of the Property Tests workflow.

### Why
The nightly run uses the `nightly` Hypothesis profile (`max_examples=10_000`), but the log only shows `PASSED` — there's no record of how many examples were actually generated. This flag makes each run emit a per-test "Hypothesis Statistics" block (passing / invalid / failing counts, generate-phase timing), so we can confirm how many samples ran and whether the `max_examples` cap was reached.

### Scope
- Applied to the `nightly`-profile step only.
- The parallel `default`-profile step (`--parallel-threads 4`) is left unchanged — statistics there are noisy and less meaningful under `pytest-run-parallel`.

No behavior change to the tests themselves; log output only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>