### PR TITLE
ci: run the GPU kernel property tests nightly at the nightly profile

### DIFF
--- a/.github/actions/setup-gpu-env/action.yml
+++ b/.github/actions/setup-gpu-env/action.yml
@@ -1,0 +1,71 @@
+name: Set up GPU test environment
+description: >-
+  Create a micromamba CUDA environment, build the awkward-cpp wheel, and install
+  awkward with the GPU test dependencies. Expects the repository to already be
+  checked out.
+
+inputs:
+  cuda-version:
+    description: CUDA version to install in the micromamba environment (e.g. 12 or 13).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Get micromamba
+      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
+      with:
+        environment-name: test-env
+        init-shell: bash
+        # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
+        create-args: >-
+          python=3.13
+          pandas>=0.24
+          cccl-python
+          cupy>=14
+          cuda-version=${{ inputs.cuda-version }}
+          cxx-compiler
+          numba-cuda
+
+    - name: Generate build files
+      shell: bash -l {0}
+      run: |
+        pip install pipx
+        pipx run nox -s prepare -- --headers --signatures --tests
+
+    - name: Cache awkward-cpp wheel
+      id: cache-awkward-cpp-wheel
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: awkward-cpp/dist
+        key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
+
+    - name: Build awkward-cpp wheel
+      if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
+      shell: bash -l {0}
+      run: |
+        python -m pip install build
+        python -m build -w awkward-cpp
+
+    - name: Find built wheel
+      uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
+      id: find-wheel
+      with:
+        files: |
+          awkward-cpp/dist/*.whl
+
+    - name: Add workaround for 3.13 + cramjam
+      shell: bash
+      run: echo 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1' >> $GITHUB_ENV
+
+    - name: Install awkward, awkward-cpp, and dependencies
+      shell: bash -l {0}
+      run: >-
+        python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
+        -r requirements-test-gpu.txt
+      env:
+        STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
+
+    - name: Print versions
+      shell: bash -l {0}
+      run: python -m pip list

--- a/.github/workflows/property-tests-gpu.yml
+++ b/.github/workflows/property-tests-gpu.yml
@@ -1,0 +1,63 @@
+name: Property Tests (GPU)
+
+on:
+  schedule:
+    - cron: '47 4 * * *'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Leverage reproducible builds by setting a constant SOURCE_DATE_EPOCH
+  # This will ensure that the hash of the awkward-cpp directory remains
+  # constant for unchanged files, meaning that it can be used for caching
+  SOURCE_DATE_EPOCH: "1668811211"
+
+jobs:
+  gpu-property-tests:
+    name: Run GPU Property Tests
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
+    runs-on: self-hosted
+    timeout-minutes: 120
+
+    env:
+      PIP_ONLY_BINARY: numpy,pandas,pyarrow,numexpr,numexpr
+
+    # Required for miniconda to activate conda
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda-version:
+          - 12
+          - 13
+
+    steps:
+      - name: Clean the workspace and mamba
+        run: |
+          rm -rf * .[!.]* || echo "Nothing to clean"
+          rm -rf ~/micromamba* || echo "Nothing to clean"
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Set up GPU test environment
+        uses: ./.github/actions/setup-gpu-env
+        with:
+          cuda-version: ${{ matrix.cuda-version }}
+
+      - name: Run property-based kernel tests on GPU
+        run: python -m pytest -vv -rs tests/properties -m cuda --hypothesis-show-statistics
+        env:
+          HYPOTHESIS_PROFILE: nightly

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -207,59 +207,10 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - name: Get micromamba
-        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
+      - name: Set up GPU test environment
+        uses: ./.github/actions/setup-gpu-env
         with:
-          environment-name: test-env
-          init-shell: bash
-          # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
-          create-args: >-
-            python=3.13
-            pandas>=0.24
-            cccl-python
-            cupy>=14
-            cuda-version=${{ matrix.cuda-version }}
-            cxx-compiler
-            numba-cuda
-
-      - name: Generate build files
-        run: |
-          pip install pipx
-          pipx run nox -s prepare -- --headers --signatures --tests
-
-      - name: Cache awkward-cpp wheel
-        id: cache-awkward-cpp-wheel
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: awkward-cpp/dist
-          key: ${{ github.job }}-${{ hashFiles('awkward-cpp/**') }}
-
-      - name: Build awkward-cpp wheel
-        if: steps.cache-awkward-cpp-wheel.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install build
-          python -m build -w awkward-cpp
-
-      - name: Find built wheel
-        uses: tj-actions/glob@2deae40528141fc53131606d56b4e4ce2a486b29 # v22.0.2
-        id: find-wheel
-        with:
-          files: |
-            awkward-cpp/dist/*.whl
-
-      - name: Add workaround for 3.13 + cramjam
-        run: echo 'PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1' >> $GITHUB_ENV
-        shell: bash
-
-      - name: Install awkward, awkward-cpp, and dependencies
-        run: >-
-          python -m pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
-          -r requirements-test-gpu.txt
-        env:
-          STEPS_FIND_WHEEL_OUTPUTS_PATHS: ${{ steps.find-wheel.outputs.paths }}
-
-      - name: Print versions
-        run: python -m pip list
+          cuda-version: ${{ matrix.cuda-version }}
 
       - name: Test CUDA kernels
         if: ${{ fromJSON(inputs.run-gpu-kernel-tests) }}


### PR DESCRIPTION
Adds a nightly run of the property-based kernel tests on the GPU/CUDA backend, complementing the CPU nightly added in #4128.

### What
- New workflow `property-tests-gpu.yml`: on a nightly schedule (+ `workflow_dispatch`), runs `pytest tests/properties -m cuda --hypothesis-show-statistics` under `HYPOTHESIS_PROFILE=nightly` (`max_examples=10_000`), across the `cuda-version: [12, 13]` matrix on the self-hosted runner.
- New composite action `.github/actions/setup-gpu-env`: encapsulates the micromamba CUDA env → build awkward-cpp → install with `requirements-test-gpu.txt` setup, taking `cuda-version` as input.
- `reusable-test.yml`: its `run-gpu-tests` job now uses the composite action instead of inlining the same setup steps (behaviour-identical — same cache key, same env).

### Why
The existing GPU kernel property tests run only at the `default` profile (200 examples) and on-demand via CI. This gives them the same large-`max_examples` nightly coverage the CPU tests already get, while the composite action avoids duplicating the GPU environment setup between the two workflows.

### Notes
- Like the CPU nightly, the first GPU run happens on the next scheduled tick (or a manual `workflow_dispatch`) after merge.
- `--hypothesis-show-statistics` makes each run log the actual per-test example counts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>