### PR TITLE
ci: enable pyodide build

### DIFF
--- a/.github/workflows/reusable-build-wheels.yml
+++ b/.github/workflows/reusable-build-wheels.yml
@@ -123,6 +123,41 @@ jobs:
         name: awkward-cpp-wheels-${{ matrix.os }}-${{ matrix.arch }}
         path: wheelhouse/*.whl
 
+  build_pyodide_wheels:
+    needs: [determine-source-date-epoch]
+    name: "Wheel awkward-cpp: pyodide"
+    if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_DATE_EPOCH: ${{ needs.determine-source-date-epoch.outputs.source-date-epoch }}
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        submodules: true
+        persist-credentials: false
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+    - name: Prepare build files
+      run: pipx run nox -s prepare
+
+    - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      env:
+        CIBW_PLATFORM: pyodide
+      with:
+        package-dir: awkward-cpp
+
+    - name: Check metadata
+      run: pipx run twine check wheelhouse/*.whl
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: awkward-cpp-wheels-pyodide
+        path: wheelhouse/*.whl
+
   build_awkward_wheel:
     name: "Build awkward sdist and wheel"
     if: github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'

--- a/.github/workflows/reusable-packaging-test.yml
+++ b/.github/workflows/reusable-packaging-test.yml
@@ -86,3 +86,32 @@ jobs:
       with:
         name: awkward-cpp-wheels-${{ matrix.os }}
         path: wheelhouse/*.whl
+
+  build_cpp_pyodide_wheels:
+    name: "Build awkward-cpp: pyodide"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        submodules: true
+        persist-credentials: false
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+    - name: Prepare build files
+      run: pipx run nox -s prepare
+
+    - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      env:
+        CIBW_PLATFORM: pyodide
+        CIBW_BUILD: cp314-pyodide_wasm32
+      with:
+        package-dir: awkward-cpp
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: awkward-cpp-wheels-pyodide
+        path: wheelhouse/*.whl

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -96,6 +96,7 @@ skip = [
 ]
 test-skip = [
     "*musllinux*",
+    "*pyodide*",
 ]
 build-verbosity = 1
 

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -96,7 +96,6 @@ skip = [
 ]
 test-skip = [
     "*musllinux*",
-    "*pyodide*",
 ]
 build-verbosity = 1
 


### PR DESCRIPTION
awkward-cpp WASM (Pyodide, PyEmscripten) wheels were built and tested in [pyodide-recipes](https://github.com/pyodide/pyodide-recipes/blob/main/packages/awkward-cpp/meta.yaml) maintained by @agoose77.

Since [PyPI now accepts WASM wheels](https://discuss.python.org/t/pep-783-emscripten-packaging-is-accepted/107393) + cibuildwheel can build Pyodide wheels, this PR migrates the build job so that it can be built and tested here.