### PR TITLE
fix: require pyarrow>=17.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,7 +23,7 @@ scipy
 numba>=0.50.0;python_version<"3.11"
 pandas>=0.24.0
 numexpr
-pyarrow>=7.0.0
+pyarrow>=17.0.0
 fsspec
 fsspec-xrootd
 hist[plot]

--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -4,7 +4,7 @@ jax[cpu]>=0.2.15;sys_platform != "win32"
 numba>=0.50.0;sys_platform != "win32"
 numexpr>=2.7
 pandas>=0.24.0;sys_platform != "win32"
-pyarrow>=12.0.0;sys_platform != "win32"
+pyarrow>=17.0.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,7 +1,7 @@
 fsspec>=2022.11.0;sys_platform != "win32"
 numpy==1.21.3
 pandas==1.3.4
-pyarrow==14.0.0
+pyarrow==17.0.0
 pytest>=6
 pytest-cov
 pytest-xdist

--- a/requirements-test-nogil.txt
+++ b/requirements-test-nogil.txt
@@ -2,7 +2,7 @@ fsspec>=2022.11.0;sys_platform != "win32"
 jax[cpu]>=0.2.15;sys_platform != "win32"
 numexpr>=2.7
 pandas>=0.24.0;sys_platform != "win32"
-pyarrow>=12.0.0;sys_platform != "win32"
+pyarrow>=17.0.0;sys_platform != "win32"
 pytest>=6
 pytest-cov
 pytest-xdist

--- a/src/awkward/_connect/pyarrow/__init__.py
+++ b/src/awkward/_connect/pyarrow/__init__.py
@@ -46,9 +46,9 @@ or
 """
 
 else:
-    if parse_version(pyarrow.__version__) < parse_version("7.0.0"):
+    if parse_version(pyarrow.__version__) < parse_version("17.0.0"):
         pyarrow = None
-        error_message = "pyarrow 7.0.0 or later required for {0}"
+        error_message = "pyarrow 17.0.0 or later required for {0}"
 
 if error_message is None:
     from .conversions import (

--- a/tests/test_2650_arrow_array_highlevel.py
+++ b/tests/test_2650_arrow_array_highlevel.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from packaging.version import parse as parse_version
 
 import awkward as ak
 
@@ -27,10 +26,6 @@ def test_simple_conversion():
     assert arrow_array.tolist() == array.to_list()
 
 
-@pytest.mark.skipif(
-    parse_version(pyarrow.__version__) < parse_version("12.0.0"),
-    reason="pyarrow >= 12.0.0 required for casting test",
-)
 def test_type_cast():
     array = ak.mask(np.array([1, 2, 3], dtype=np.uint8), [True, False, False])
     arrow_array = pyarrow.array(array, type=pyarrow.float64())


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #4151.

### What

Raise the supported pyarrow floor to **17.0.0** (runtime guard in `_connect/pyarrow/__init__.py`, plus `requirements-test-{minimal,full,nogil}.txt`).

### Why

`tests/test_2616_use_pyarrow_for_strings.py::test_split_whitespace` flaked on the `minimal` CI job (Python 3.10, `pyarrow==14.0.0`), mis-splitting `"      abc      "` as `['', 'abc', ' ']` instead of `['', 'abc', '', '']`.

Root cause is an upstream pyarrow kernel over-read: `utf8_split_whitespace` (`SplitWhitespaceUtf8Finder::Find` → `arrow::util::UTF8Decode`) reads **one byte past the end of the input values buffer**. Awkward's `to_arrow` hands pyarrow exactly-sized, zero-copy numpy buffers (not 64-byte padded as Arrow recommends), so the over-read lands in adjacent heap memory rather than zero padding. When that byte is non-whitespace, the trailing whitespace run is mis-split — a rare, memory-state-dependent flake (and a genuine correctness bug for any user on pyarrow 12–16).

Confirmed with `MALLOC_PERTURB_=255` + allocator churn (deterministic reproduction) and valgrind (`Invalid read of size 1 at UTF8Decode … StringSplitExec<LargeStringType,…>`, "0 bytes after a block of size 86" — awkward's input char buffer). Bisected: wrong on 14.0.0 / 15.0.2 / 16.1.0, fixed in **17.0.0+**.

### Notes

- pyarrow <17 now raises a clear `pyarrow 17.0.0 or later required` error instead of silently producing wrong results.
- A defensive alternative (padding buffers in `to_arrow`) was considered but is a broader change on a hot path for what is a fixed-upstream bug; bumping the floor is the simpler fix. See #4151 for the full investigation.

AI-assisted (Claude Code): diagnosis and this change.
