### PR TITLE
ci: fix docs-preview PR comment failing without a checkout

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -95,6 +95,7 @@ jobs:
       if: steps.fc.outputs.comment-id == ''
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
         PREVIEW_URL: ${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}
-      run: gh pr comment "${PR_NUMBER}" --body "The documentation preview is ready to be viewed at <${PREVIEW_URL}>"
+      run: gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "The documentation preview is ready to be viewed at <${PREVIEW_URL}>"


### PR DESCRIPTION
## Problem

Docs-preview comments stopped appearing on PRs. The `docs-preview` job has no `actions/checkout`, so the final `gh pr comment` step aborts with `fatal: not a git repository` — `gh` infers the repo from the git remote, which isn't there. Regression from #4075, which swapped the `peter-evans/create-or-update-comment` action (API token, no git) for the `gh` CLI.

The docs still deploy (`aws s3 sync` runs before the failing step), so the preview URL is live — only the PR comment is missing. The step is gated on "no existing comment," so new PRs never get their first comment.

## Fix

Pass the repo explicitly, mirroring the `pr-type-label.yml` idiom: `REPO: ${{ github.repository }}` in `env:` + `--repo "${REPO}"`. Keeps #4075's hardening — no checkout, no third-party action, no new permissions, trusted value kept out of the inline `run:`.

## Verification

`zizmor` and `check-github-workflows` pass. Can't be validated on this PR (`workflow_run` uses the default-branch copy); takes effect after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
