### PR TITLE
fix: complete target_link_libraries for test_4087 header-only test

### DIFF
--- a/header-only/tests/CMakeLists.txt
+++ b/header-only/tests/CMakeLists.txt
@@ -29,5 +29,6 @@ target_link_libraries(test_1560-builder-options
 target_link_libraries(test_3091-layout-builder-is-valid
                       PRIVATE awkward::layout-builder)
 target_link_libraries(test_4087-bitmasked-growablebuffer
+                      PRIVATE awkward::layout-builder)
 target_link_libraries(test_4088-layoutbuilder-form-fixes
                       PRIVATE awkward::layout-builder)


### PR DESCRIPTION
Targets `henryiii/fix-bitmasked-growablebuffer` (#4098). This implements the one-line CMake fix suggested in [this comment](https://github.com/scikit-hep/awkward/pull/4098#issuecomment-4860366060).

On that branch, `header-only/tests/CMakeLists.txt` has a `target_link_libraries(test_4087-bitmasked-growablebuffer` call missing its `PRIVATE awkward::layout-builder)` line, so it swallows the next command and the header-only test suite fails to configure. That is why `header-only-tests` is red on #4098 — a CMake configure error, distinct from the use-after-free that #4098 itself fixes.

Adding the missing line lets the suite configure. Validated locally on macOS/arm64 under ASan against #4098's headers: both `test_1494-layout-builder` and `test_4087-bitmasked-growablebuffer` build and pass with no ASan error.

Merging this into `henryiii/fix-bitmasked-growablebuffer` should turn #4098's `header-only-tests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
