### PR TITLE
fix: include kernel-specification.yml in source distribution 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ include = [
     "/CONTRIBUTING.md",
     "/README.md",
     "/juliapkg.json",
+    "/kernel-specification.yml",
     "/requirements-test-full.txt",
     "/requirements-test-minimal.txt"
 ]


### PR DESCRIPTION
### Fixes #4178 

`tests/test_4056_cuda_compute_signature_consistency.py` reads
`kernel-specification.yml` from the repo root, but that file was not in the
sdist `include` list in `pyproject.toml`, so it was absent from the source
distribution. As a result the test errored with `FileNotFoundError` when the
suite was run against an unpacked sdist (e.g. conda-forge), even though it
passes in a git checkout where the file is present. `tests/` already ships in
the sdist, so this just adds the one data file it depends on.

### Verification
Built the sdist with `python -m build --sdist`:
- **Before:** `tar tzf dist/*.tar.gz | grep kernel-specification.yml` returns
  nothing; `test_4056` errors with `FileNotFoundError` when run from the
  unpacked sdist.
- **After:** the file is present in the tarball and `test_4056` passes against
  the unpacked sdist.

### Suggested follow-up (out of scope here)
This slipped through because no CI job runs the test suite against a built
sdist — the main test job runs `pytest` against the git checkout (where the
file always exists), and `reusable-packaging-test.yml` builds the sdist but only
runs `twine check`. Adding a step that unpacks the built sdist and runs the
tests against it would let the existing tests guard against *any*
missing-from-sdist data file in future, not just this one. Happy to open a
separate PR/issue for that if it's wanted.

---
#### AI assistance disclosure:
this change was prepared with the help of an AI
coding assistant (Claude). I reviewed, tested, and understand the change and
take responsibility for it.