### PR TITLE
fix: default row group size is very big and not what pyarrow defaults to

### DIFF
--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -33,7 +33,7 @@ def to_parquet(
     count_nulls=True,
     compression="zstd",
     compression_level=None,
-    row_group_size=64 * 1024 * 1024,
+    row_group_size=1024 * 1024,
     data_page_size=None,
     parquet_flavor=None,
     parquet_version="2.4",
@@ -91,9 +91,9 @@ def to_parquet(
             Compression levels have different meanings for different compression
             algorithms: GZIP ranges from 1 to 9, but ZSTD ranges from -7 to 22, for
             example. Generally, higher numbers provide slower but smaller compression.
-        row_group_size (int or None): Number of entries in each row group (except the last),
+        row_group_size (int or None): Maximum number of rows in each row group,
             passed to [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
-            If None, the Parquet default of 64 MiB is used.
+            If None, PyArrow's default of at most 1024 * 1024 rows is used.
         data_page_size (None or int): Number of bytes in each data page, passed to
             [pyarrow.parquet.ParquetWriter](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html).
             If None, the Parquet default of 1 MiB is used.

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -33,7 +33,7 @@ def to_parquet(
     count_nulls=True,
     compression="zstd",
     compression_level=None,
-    row_group_size=1024 * 1024,
+    row_group_size=None,
     data_page_size=None,
     parquet_flavor=None,
     parquet_version="2.4",

--- a/src/awkward/operations/ak_to_parquet_row_groups.py
+++ b/src/awkward/operations/ak_to_parquet_row_groups.py
@@ -20,7 +20,7 @@ def to_parquet_row_groups(
     count_nulls=True,
     compression="zstd",
     compression_level=None,
-    row_group_size=1024 * 1024,
+    row_group_size=None,
     data_page_size=None,
     parquet_flavor=None,
     parquet_version="2.4",

--- a/src/awkward/operations/ak_to_parquet_row_groups.py
+++ b/src/awkward/operations/ak_to_parquet_row_groups.py
@@ -20,7 +20,7 @@ def to_parquet_row_groups(
     count_nulls=True,
     compression="zstd",
     compression_level=None,
-    row_group_size=64 * 1024 * 1024,
+    row_group_size=1024 * 1024,
     data_page_size=None,
     parquet_flavor=None,
     parquet_version="2.4",
@@ -78,9 +78,9 @@ def to_parquet_row_groups(
             Compression levels have different meanings for different compression
             algorithms: GZIP ranges from 1 to 9, but ZSTD ranges from -7 to 22, for
             example. Generally, higher numbers provide slower but smaller compression.
-        row_group_size (int or None): Maximum number of entries in each row group (except the last),
+        row_group_size (int or None): Maximum number of rows in each row group,
             passed to [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
-            If None, the Parquet default of 64 MiB is used.
+            If None, PyArrow's default of at most 1024 * 1024 rows is used.
         data_page_size (None or int): Number of bytes in each data page, passed to
             [pyarrow.parquet.ParquetWriter](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html).
             If None, the Parquet default of 1 MiB is used.

--- a/tests/test_4191_parquet_default_row_group_size.py
+++ b/tests/test_4191_parquet_default_row_group_size.py
@@ -1,0 +1,23 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+pytest.importorskip("pyarrow.parquet")
+
+
+@pytest.mark.parametrize("iterative", [False, True])
+def test_default_row_group_size(tmp_path, iterative):
+    filename = tmp_path / "default-row-group-size.parquet"
+    array = ak.Array(np.zeros(1024 * 1024 + 1, dtype=np.int8))
+
+    if iterative:
+        metadata = ak.to_parquet_row_groups(iter((array,)), filename)
+    else:
+        metadata = ak.to_parquet(array, filename)
+
+    assert metadata.num_row_groups == 2


### PR DESCRIPTION
The `row_group_size` argument for to parquet conversions is not in bytes, it's in rows (see https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_table.html). Therefore the default we had of 64 * 1024 * 1024 created very big row groups that were really hard to read because you cannot read less than a row group in parquet. We switch to 1024 * 1024 which is what pyarrow defaults to.