### PR TITLE
chore: bump default parquet version to 2.6

### DIFF
--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -36,7 +36,7 @@ def to_parquet(
     row_group_size=64 * 1024 * 1024,
     data_page_size=None,
     parquet_flavor=None,
-    parquet_version="2.4",
+    parquet_version="2.6",
     parquet_page_version="1.0",
     parquet_metadata_statistics=True,
     parquet_dictionary_encoding=False,

--- a/src/awkward/operations/ak_to_parquet_row_groups.py
+++ b/src/awkward/operations/ak_to_parquet_row_groups.py
@@ -23,7 +23,7 @@ def to_parquet_row_groups(
     row_group_size=64 * 1024 * 1024,
     data_page_size=None,
     parquet_flavor=None,
-    parquet_version="2.4",
+    parquet_version="2.6",
     parquet_page_version="1.0",
     parquet_metadata_statistics=True,
     parquet_dictionary_encoding=False,


### PR DESCRIPTION
This is what pyarrow defaults to since pyarrow 13 so we do that.
@martindurant is this a good thing to do or no?