### PR TITLE
fix: handle `FutureWarning` for deprecated feather

### DIFF
--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import awkward as ak
+import warnings
+
 from awkward._dispatch import high_level_function
 
 __all__ = ("from_feather",)
@@ -73,7 +75,19 @@ def _impl(
 ):
     import pyarrow.feather
 
-    arrow_table = pyarrow.feather.read_table(path, columns, use_threads, memory_map)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r".*pyarrow\.feather\.(write_feather|read_table) is deprecated.*",
+            category=FutureWarning,
+        )
+
+        arrow_table = pyarrow.feather.read_table(
+            path,
+            columns,
+            use_threads,
+            memory_map,
+        )
 
     return ak.operations.ak_from_arrow._impl(
         arrow_table,

--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import awkward as ak
 import warnings
 
+import awkward as ak
 from awkward._dispatch import high_level_function
 
 __all__ = ("from_feather",)

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -159,6 +159,12 @@ def _impl(
             f"'destination' argument of 'ak.to_feather' must be a path-like, not {type(destination).__name__} ('array' argument is first; 'destination' second)"
         ) from None
 
-    pyarrow.feather.write_feather(
-        table, destination, compression, compression_level, chunksize, feather_version
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="pyarrow.feather.write_feather is deprecated.*",
+            category=FutureWarning,
+        )
+            pyarrow.feather.write_feather(
+                table, destination, compression, compression_level, chunksize, feather_version
+            )

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -166,5 +166,10 @@ def _impl(
             category=FutureWarning,
         )
         pyarrow.feather.write_feather(
-            table, destination, compression, compression_level, chunksize, feather_version
+            table,
+            destination,
+            compression,
+            compression_level,
+            chunksize,
+            feather_version,
         )

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 import awkward as ak
 from awkward._dispatch import high_level_function

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -165,6 +165,6 @@ def _impl(
             message="pyarrow.feather.write_feather is deprecated.*",
             category=FutureWarning,
         )
-            pyarrow.feather.write_feather(
-                table, destination, compression, compression_level, chunksize, feather_version
-            )
+        pyarrow.feather.write_feather(
+            table, destination, compression, compression_level, chunksize, feather_version
+        )


### PR DESCRIPTION
Suppress FutureWarning when using deprecated write_feather.