### PR TITLE
chore: update reviewer list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ Pull requests that do not meet these expectations may be closed without review.
 Currently, we have four regular reviewers of pull requests:
 
   * Ianna Osborne ([ianna](https://github.com/ianna))
-  * Peter Fackeldey ([pfackeldey](https://github.com/pfackeldey))
   * Andres Rios Tascon ([ariostas](https://github.com/ariostas))
   * Iason Krommydas ([ikrommyd](https://github.com/ikrommyd))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Pull requests that do not meet these expectations may be closed without review.
 
 ### Getting your pull request reviewed
 
-Currently, we have four regular reviewers of pull requests:
+Currently, we have three regular reviewers of pull requests:
 
   * Ianna Osborne ([ianna](https://github.com/ianna))
   * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma))
@@ -298,9 +298,10 @@ The `main-v1` branch was split from `main` just before Awkward 1.x code was remo
 
 ### Releases
 
-Currently, only one person can deploy releases:
+Currently, two people can deploy releases:
 
   * Ianna Osborne ([ianna](https://github.com/ianna))
+  * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma))
 
 There are two kinds of releases: (1) `awkward-cpp` updates, which only occur when the C++ is updated (rare) and involves compilation on many platforms (takes hours), and (2) `awkward` updates, which can happen with any bug-fix. The [releases listed in GitHub](https://github.com/scikit-hep/awkward/releases) are `awkward` releases, not `awkward-cpp`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Pull requests that do not meet these expectations may be closed without review.
 Currently, we have four regular reviewers of pull requests:
 
   * Ianna Osborne ([ianna](https://github.com/ianna))
+  * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma)) 
   * Andres Rios Tascon ([ariostas](https://github.com/ariostas))
   * Iason Krommydas ([ikrommyd](https://github.com/ikrommyd))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Pull requests that do not meet these expectations may be closed without review.
 Currently, we have four regular reviewers of pull requests:
 
   * Ianna Osborne ([ianna](https://github.com/ianna))
-  * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma)) 
+  * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma))
   * Andres Rios Tascon ([ariostas](https://github.com/ariostas))
   * Iason Krommydas ([ikrommyd](https://github.com/ikrommyd))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,6 @@ Currently, we have four regular reviewers of pull requests:
   * Ianna Osborne ([ianna](https://github.com/ianna))
   * Tai Sakuma ([TaiSakuma](https://github.com/TaiSakuma))
   * Andres Rios Tascon ([ariostas](https://github.com/ariostas))
-  * Iason Krommydas ([ikrommyd](https://github.com/ikrommyd))
 
 You can request a review from one of us or just comment in GitHub that you want a review and we'll see it. Only one review is required to be allowed to merge a pull request. We'll work with you to get it into shape.
 


### PR DESCRIPTION
* Removed Peter Fackeldey and Iason Krommydas as regular reviewers on their request 
* Add Tai Sakuma as a regular reviewer 

