### PR TITLE
feat: allow row group size in bytes as a string in the to_parquet family of functions

### DIFF
--- a/src/awkward/_util.py
+++ b/src/awkward/_util.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import numbers
 import os
+import re
 import struct
 import sys
 from collections.abc import Collection
@@ -27,6 +29,55 @@ kMaxUInt32 = 4294967295  # 2**32 - 1
 kMaxInt64 = 9223372036854775806  # 2**63 - 2: see below
 kSliceNone = kMaxInt64 + 1  # for Slice::none()
 kMaxLevels = 48
+
+
+_memory_size_pattern = re.compile(
+    r"^\s*([+-]?(\d+(\.\d*)?|\.\d+)(e[+-]?\d+)?)\s*([kmgtpezy]?i?b)\s*$",
+    re.I,
+)
+
+_memory_size_units = {
+    "B": 1,
+    "KB": 1000,
+    "MB": 1000**2,
+    "GB": 1000**3,
+    "TB": 1000**4,
+    "PB": 1000**5,
+    "EB": 1000**6,
+    "ZB": 1000**7,
+    "YB": 1000**8,
+    "KIB": 1024,
+    "MIB": 1024**2,
+    "GIB": 1024**3,
+    "TIB": 1024**4,
+    "PIB": 1024**5,
+    "EIB": 1024**6,
+    "ZIB": 1024**7,
+    "YIB": 1024**8,
+}
+
+
+def parse_memory_size(data) -> int:
+    """
+    Regularizes strings like ``'## kB'`` and plain integer numbers of bytes to
+    an integer number of bytes.
+
+    Both decimal (``kB``, ``MB``, ``GB``, ...) and binary (``kiB``, ``MiB``,
+    ``GiB``, ...) unit prefixes are recognized, case-insensitively.
+    """
+    if isinstance(data, str):
+        match = _memory_size_pattern.match(data)
+        if match is not None:
+            target, unit = float(match.group(1)), match.group(5).upper()
+            return int(target * _memory_size_units[unit])
+
+    elif not isinstance(data, bool) and isinstance(data, numbers.Integral):
+        return int(data)
+
+    raise TypeError(
+        "a number of bytes or a memory-size string with units "
+        f"(such as '100 MiB') is required, not {data!r}"
+    )
 
 
 def in_module(obj, modulename: str) -> bool:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -91,8 +91,12 @@ def to_parquet(
             Compression levels have different meanings for different compression
             algorithms: GZIP ranges from 1 to 9, but ZSTD ranges from -7 to 22, for
             example. Generally, higher numbers provide slower but smaller compression.
-        row_group_size (int or None): Maximum number of rows in each row group,
-            passed to [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
+        row_group_size (int, str, or None): If an integer, the maximum number of
+            rows in each row group; if a string, the maximum memory size of each
+            row group. The string must be a number followed by a memory unit, such
+            as `"100 MB"`, and is converted into the number of rows that fit into
+            that many bytes based on the in-memory size of the data. Passed to
+            [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
             If None, PyArrow's default of at most 1024 * 1024 rows is used.
         data_page_size (None or int): Number of bytes in each data page, passed to
             [pyarrow.parquet.ParquetWriter](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html).
@@ -445,11 +449,17 @@ def _impl(
     ) as writer:
         try:
             if not write_iteratively:
-                writer.write_table(table, row_group_size=row_group_size)
+                writer.write_table(
+                    table,
+                    row_group_size=_row_group_size_for_table(row_group_size, table),
+                )
 
             else:
                 # this `table` is JUST for the first array
-                writer.write_table(table, row_group_size=row_group_size)
+                writer.write_table(
+                    table,
+                    row_group_size=_row_group_size_for_table(row_group_size, table),
+                )
 
                 # this `data` is an iterator (not iterable), starting AFTER the first array
                 # a `for` loop implicitly calls `next` and stops at `StopIteration`
@@ -457,7 +467,10 @@ def _impl(
                     layout, table = get_layout_and_table(item)
                     if extensionarray:
                         table = convert_awkward_arrow_table_to_native(table)
-                    writer.write_table(table, row_group_size=row_group_size)
+                    writer.write_table(
+                        table,
+                        row_group_size=_row_group_size_for_table(row_group_size, table),
+                    )
 
         finally:
             # ensure that the ParquetWriter is closed for iterative and non-iterative cases
@@ -466,6 +479,28 @@ def _impl(
     meta = metalist[0]
     meta.set_file_path(destination.rsplit("/", 1)[-1])
     return meta
+
+
+def _row_group_size_for_table(row_group_size, table):
+    """Translate a `row_group_size` argument into a number of rows for `table`.
+
+    If `row_group_size` is an integer (a number of rows) or None, it is returned
+    unchanged. If it is a memory-size string (such as `"100 MiB"`), it is
+    converted into the number of rows of `table` that fit into that many bytes,
+    based on the table's in-memory size.
+    """
+    if row_group_size is None or not isinstance(row_group_size, str):
+        return row_group_size
+
+    target_num_bytes = ak._util.parse_memory_size(row_group_size)
+
+    num_rows = table.num_rows
+    num_bytes = table.nbytes
+    if num_rows == 0 or num_bytes == 0:
+        # nothing to size against; let PyArrow use its default
+        return None
+
+    return max(1, round(target_num_bytes * num_rows / num_bytes))
 
 
 def write_metadata(dir_path, fs, *metas, global_metadata=True):

--- a/src/awkward/operations/ak_to_parquet_row_groups.py
+++ b/src/awkward/operations/ak_to_parquet_row_groups.py
@@ -78,8 +78,12 @@ def to_parquet_row_groups(
             Compression levels have different meanings for different compression
             algorithms: GZIP ranges from 1 to 9, but ZSTD ranges from -7 to 22, for
             example. Generally, higher numbers provide slower but smaller compression.
-        row_group_size (int or None): Maximum number of rows in each row group,
-            passed to [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
+        row_group_size (int, str, or None): If an integer, the maximum number of
+            rows in each row group; if a string, the maximum memory size of each
+            row group. The string must be a number followed by a memory unit, such
+            as `"100 MB"`, and is converted into the number of rows that fit into
+            that many bytes based on the in-memory size of each batch. Passed to
+            [pyarrow.parquet.ParquetWriter.write_table](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table).
             If None, PyArrow's default of at most 1024 * 1024 rows is used.
         data_page_size (None or int): Number of bytes in each data page, passed to
             [pyarrow.parquet.ParquetWriter](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html).

--- a/tests/test_4202_parquet_row_group_size_string.py
+++ b/tests/test_4202_parquet_row_group_size_string.py
@@ -1,0 +1,58 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+from awkward._util import parse_memory_size
+
+pytest.importorskip("pyarrow.parquet")
+
+import pyarrow.parquet as pq
+
+
+def test_parse_memory_size():
+    # decimal and binary units, case-insensitive, flexible whitespace
+    assert parse_memory_size("2 MB") == 2 * 1000**2
+    assert parse_memory_size("  100mib ") == 100 * 1024**2
+    # plain integers pass through unchanged
+    assert parse_memory_size(100) == 100
+
+    # everything else is rejected: bare numbers, unknown units, bool, float
+    for bad in ("100", "100 furlongs", True, 1.5):
+        with pytest.raises(TypeError):
+            parse_memory_size(bad)
+
+
+@pytest.mark.parametrize("iterative", [False, True])
+def test_row_group_size_string(tmp_path, iterative):
+    filename = tmp_path / "row-group-size-string.parquet"
+
+    # 100000 rows of a single int16 column -> 2 bytes/row -> 200000 bytes
+    array = ak.Array({"x": np.arange(100000, dtype=np.int16)})
+
+    if iterative:
+        ak.to_parquet_row_groups(iter((array,)), filename, row_group_size="50 KiB")
+    else:
+        ak.to_parquet(array, filename, row_group_size="50 KiB")
+
+    metadata = pq.read_metadata(filename)
+
+    # 50 KiB = 51200 bytes; at 2 bytes/row that is 25600 rows per group,
+    # so 100000 rows -> 4 row groups (25600, 25600, 25600, 23200)
+    assert metadata.num_row_groups == 4
+    assert metadata.row_group(0).num_rows == 25600
+
+    # data round-trips unchanged
+    assert ak.to_list(ak.from_parquet(filename)["x"]) == ak.to_list(array["x"])
+
+
+def test_row_group_size_string_empty(tmp_path):
+    # an empty table has no rows/bytes to size against; fall back to the default
+    filename = tmp_path / "empty.parquet"
+    array = ak.Array({"x": np.array([], dtype=np.int64)})
+
+    ak.to_parquet(array, filename, row_group_size="50 KiB")
+    assert pq.read_metadata(filename).num_rows == 0


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/4201