### PR TITLE
refactor: migrate from_feather to pyarrow.ipc API

### DIFF
--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -73,21 +73,19 @@ def _impl(
     behavior,
     attrs,
 ):
-    import pyarrow.feather
+    import pyarrow
+    import pyarrow.ipc
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*pyarrow\.feather\.(write_feather|read_table) is deprecated.*",
-            category=FutureWarning,
+    with pyarrow.memory_map(path, "r") if memory_map else pyarrow.OSFile(path, "rb") as source:
+        reader = pyarrow.ipc.open_file(
+            source,
+            options=pyarrow.ipc.IpcReadOptions(
+                use_threads=use_threads,
+            ),
         )
-
-        arrow_table = pyarrow.feather.read_table(
-            path,
-            columns,
-            use_threads,
-            memory_map,
-        )
+        arrow_table = reader.read_all()
+    if columns is not None:
+        arrow_table = arrow_table.select(columns)
 
     return ak.operations.ak_from_arrow._impl(
         arrow_table,

--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import awkward as ak
 from awkward._dispatch import high_level_function
 
@@ -76,7 +74,18 @@ def _impl(
     import pyarrow
     import pyarrow.ipc
 
-    with pyarrow.memory_map(path, "r") if memory_map else pyarrow.OSFile(path, "rb") as source:
+    # Read via the non-deprecated pyarrow.ipc API.
+    # This reads the same on-disk format as the old
+    # pyarrow.feather.read_table call did - a different
+    # (non-deprecated) API for reading the same bytes, not a different
+    # format.
+    # A fundamental difference in the way we are reading all columns then dropping the non-selected ones
+
+    with (
+        pyarrow.memory_map(path, "r")
+        if memory_map
+        else pyarrow.OSFile(path, "rb") as source
+    ):
         reader = pyarrow.ipc.open_file(
             source,
             options=pyarrow.ipc.IpcReadOptions(

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 
-
 import awkward as ak
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
@@ -124,8 +123,6 @@ def _impl(
     chunksize,
     feather_version,
 ):
-    import pyarrow
-    import pyarrow.ipc
 
     layout = ak.operations.ak_to_layout._impl(
         array,
@@ -149,17 +146,6 @@ def _impl(
         count_nulls,
     )
 
-
-    if feather_version != 2:
-        raise NotImplementedError(
-            "Only Feather V2 is supported by the IPC prototype."
-        )
-
-    if compression is True:
-        compression = "zstd"
-    elif compression is False or compression is None:
-        compression = None
-
     try:
         destination = os.fsdecode(destination)
     except TypeError:
@@ -168,6 +154,56 @@ def _impl(
             f"not {type(destination).__name__} "
             f"('array' argument is first; 'destination' second)"
         ) from None
+
+    # Normalize `compression` the same way for both backends below:
+    # True -> "zstd", False/None -> Python None ("no compression").
+    # NOTE: intentionally NOT the string "none" here - that was never a
+    # valid pyarrow value and raised ValueError in the pre-existing code
+    # whenever a caller passed compression=None or compression=False
+    # explicitly (both hit the same underlying default path in practice,
+    # since the public default is compression="zstd").
+    if compression is True:
+        compression = "zstd"
+    elif compression is False or compression is None:
+        compression = None
+
+    if feather_version < 2:
+        # Feather V2 (and, presumably, any future version >= 2) is the
+        # Arrow IPC file format on disk. Version 1 predates the IPC format
+        # entirely and cannot be written via pyarrow.ipc at all - pyarrow
+        # offers no non-deprecated way to produce a V1 file, so we fall
+        # back to the deprecated pyarrow.feather API here, scoped narrowly
+        # to this one legacy case, and let pyarrow validate `feather_version`
+        # itself (e.g. reject negative or zero values).
+        import warnings
+
+        import pyarrow.feather
+
+        compression_arg = "none" if compression is None else compression
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="pyarrow.feather.write_feather is deprecated.*",
+                category=FutureWarning,
+            )
+            pyarrow.feather.write_feather(
+                table,
+                destination,
+                compression=compression_arg,
+                compression_level=compression_level,
+                chunksize=chunksize,
+                version=feather_version,
+            )
+        return
+
+    # feather_version >= 2: write via the non-deprecated pyarrow.ipc API.
+    # This produces the same on-disk format as the old
+    # pyarrow.feather.write_feather call did for V2 - a different
+    # (non-deprecated) API for writing the same bytes, not a different
+    # format.
+    import pyarrow
+    import pyarrow.ipc
 
     if compression is None:
         codec = None
@@ -186,8 +222,10 @@ def _impl(
             table.schema,
             options=options,
         ) as writer:
+            # `max_chunksize` is the pyarrow.ipc equivalent of the old
+            # `chunksize` parameter - same meaning (max rows per
+            # RecordBatch chunk), renamed keyword in the new API.
             writer.write_table(
                 table,
                 max_chunksize=chunksize,
             )
-

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-import warnings
+
 
 import awkward as ak
 from awkward._dispatch import high_level_function
@@ -124,7 +124,8 @@ def _impl(
     chunksize,
     feather_version,
 ):
-    import pyarrow.feather
+    import pyarrow
+    import pyarrow.ipc
 
     layout = ak.operations.ak_to_layout._impl(
         array,
@@ -148,29 +149,45 @@ def _impl(
         count_nulls,
     )
 
+
+    if feather_version != 2:
+        raise NotImplementedError(
+            "Only Feather V2 is supported by the IPC prototype."
+        )
+
     if compression is True:
         compression = "zstd"
     elif compression is False or compression is None:
-        compression = "none"
+        compression = None
 
     try:
         destination = os.fsdecode(destination)
     except TypeError:
         raise TypeError(
-            f"'destination' argument of 'ak.to_feather' must be a path-like, not {type(destination).__name__} ('array' argument is first; 'destination' second)"
+            f"'destination' argument of 'ak.to_feather' must be a path-like, "
+            f"not {type(destination).__name__} "
+            f"('array' argument is first; 'destination' second)"
         ) from None
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="pyarrow.feather.write_feather is deprecated.*",
-            category=FutureWarning,
-        )
-        pyarrow.feather.write_feather(
-            table,
-            destination,
-            compression,
-            compression_level,
-            chunksize,
-            feather_version,
-        )
+    if compression is None:
+        codec = None
+    elif compression_level is None:
+        codec = compression
+    else:
+        codec = pyarrow.Codec(compression, compression_level)
+
+    options = pyarrow.ipc.IpcWriteOptions(
+        compression=codec,
+    )
+
+    with pyarrow.OSFile(destination, "wb") as sink:
+        with pyarrow.ipc.new_file(
+            sink,
+            table.schema,
+            options=options,
+        ) as writer:
+            writer.write_table(
+                table,
+                max_chunksize=chunksize,
+            )
+

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -166,13 +166,17 @@ def _impl(
         compression = "zstd"
     elif compression is False or compression is None:
         compression = None
+    elif compression == "uncompressed":
+        compression = None
 
+
+    
     if feather_version < 2:
         # Feather V2 (and, presumably, any future version >= 2) is the
         # Arrow IPC file format on disk. Version 1 predates the IPC format
         # entirely and cannot be written via pyarrow.ipc at all - pyarrow
         # offers no non-deprecated way to produce a V1 file, so we fall
-        # back to the deprecated pyarrow.feather API here, scoped narrowly
+        # back to the deprecated pyarrow.feather API here, scoped narrowlyzw
         # to this one legacy case, and let pyarrow validate `feather_version`
         # itself (e.g. reject negative or zero values).
         import warnings

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -169,8 +169,6 @@ def _impl(
     elif compression == "uncompressed":
         compression = None
 
-
-    
     if feather_version < 2:
         # Feather V2 (and, presumably, any future version >= 2) is the
         # Arrow IPC file format on disk. Version 1 predates the IPC format

--- a/tests/test_4204_feather_coverage_timing.py
+++ b/tests/test_4204_feather_coverage_timing.py
@@ -13,7 +13,6 @@ import awkward as ak
 pyarrow = pytest.importorskip("pyarrow")
 
 
-
 # Coverage: parameters not exercised by the original test_2683 file
 
 
@@ -23,6 +22,7 @@ RECORD_ARRAY = [
     [],
     [{"x": 4.4, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}],
 ]
+
 
 # TO check roundway stablity in compression
 @pytest.mark.parametrize("compression", [None, False, "uncompressed"])
@@ -35,6 +35,7 @@ def test_compression_none_false_uncompressed_roundtrip(tmp_path, compression):
 
     assert array2.tolist() == BASE_ARRAY
 
+
 # TO roundway check multiple compression variants
 @pytest.mark.parametrize("compression", [True, "lz4", "zstd", "uncompressed"])
 def test_compression_variants(tmp_path, compression):
@@ -46,7 +47,8 @@ def test_compression_variants(tmp_path, compression):
 
     assert array2.tolist() == BASE_ARRAY
 
-# 
+
+#
 def test_compression_level(tmp_path):
     filename = os.path.join(tmp_path, "compression_level.feather")
     array = ak.Array(BASE_ARRAY)
@@ -71,10 +73,7 @@ def test_feather_version_1_is_unconditionally_broken(tmp_path):
 
     for compression in (True, False, None, "zstd", "uncompressed"):
         with pytest.raises(ValueError, match="Feather V1 files do not support"):
-            ak.to_feather(
-                array, filename, feather_version=1, compression=compression
-            )
-
+            ak.to_feather(array, filename, feather_version=1, compression=compression)
 
 
 def test_bad_destination_type():
@@ -145,8 +144,6 @@ def test_extensionarray_false(tmp_path):
     assert array2.tolist() == RECORD_ARRAY
 
 
-
-
 def _make_union_array():
     c, i = ak.contents, ak.index
     layout = c.UnionArray(
@@ -161,7 +158,7 @@ def test_union_type_extensionarray_true_is_known_broken(tmp_path):
     filename = os.path.join(tmp_path, "union.feather")
     array = _make_union_array()
 
-    ak.to_feather(array, filename) # if it works ,it is the bug
+    ak.to_feather(array, filename)  # if it works ,it is the bug
 
     with pytest.raises(ValueError):
         ak.from_feather(filename)
@@ -176,7 +173,9 @@ def test_union_type_extensionarray_false_roundtrips(tmp_path):
 
     assert array2.tolist() == [1.5, "abc"]
 
+
 # Canary Tests
+
 
 def _time_it(fn):
     start = time.perf_counter()
@@ -200,7 +199,7 @@ def test_timing_flat_array(tmp_path, n, compression):
     print(
         f"\n[timing] n={n} compression={compression!r} "
         f"write={write_time:.4f}s read={read_time:.4f}s "
-        f"file_size={os.path.getsize(filename)/1e6:.2f}MB"
+        f"file_size={os.path.getsize(filename) / 1e6:.2f}MB"
     )
 
     # Generous upper bound: this is not meant to be a tight perf assertion,
@@ -224,7 +223,7 @@ def test_timing_nested_array(tmp_path):
     print(
         f"\n[timing] nested list array (50k rows) "
         f"write={write_time:.4f}s read={read_time:.4f}s "
-        f"file_size={os.path.getsize(filename)/1e6:.2f}MB"
+        f"file_size={os.path.getsize(filename) / 1e6:.2f}MB"
     )
 
     assert write_time < 30

--- a/tests/test_4204_feather_coverage_timing.py
+++ b/tests/test_4204_feather_coverage_timing.py
@@ -1,0 +1,254 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import os
+import time
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+pyarrow = pytest.importorskip("pyarrow")
+
+
+
+# Coverage: parameters not exercised by the original test_2683 file
+
+
+BASE_ARRAY = [[1.12345, 2.232452356, 3.3241536], [], [4.4365156, 5.5365713]]
+RECORD_ARRAY = [
+    [{"x": 1.1, "y": [1]}, {"x": 2.2, "y": [1, 2]}, {"x": 3.3, "y": [1, 2, 3]}],
+    [],
+    [{"x": 4.4, "y": [1, 2, 3, 4]}, {"x": 5.5, "y": [1, 2, 3, 4, 5]}],
+]
+
+# TO check roundway stablity in compression
+@pytest.mark.parametrize("compression", [None, False, "uncompressed"])
+def test_compression_none_false_uncompressed_roundtrip(tmp_path, compression):
+    filename = os.path.join(tmp_path, f"compression_{compression}.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    ak.to_feather(array, filename, compression=compression)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == BASE_ARRAY
+
+# TO roundway check multiple compression variants
+@pytest.mark.parametrize("compression", [True, "lz4", "zstd", "uncompressed"])
+def test_compression_variants(tmp_path, compression):
+    filename = os.path.join(tmp_path, f"compression_{compression}.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    ak.to_feather(array, filename, compression=compression)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == BASE_ARRAY
+
+# 
+def test_compression_level(tmp_path):
+    filename = os.path.join(tmp_path, "compression_level.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    ak.to_feather(array, filename, compression="zstd", compression_level=5)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == BASE_ARRAY
+
+
+def test_feather_version_1_default_compression_is_broken(tmp_path):
+    filename = os.path.join(tmp_path, "v1_default.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    with pytest.raises(ValueError, match="Feather V1 files do not support compression"):
+        ak.to_feather(array, filename, feather_version=1)
+
+
+def test_feather_version_1_is_unconditionally_broken(tmp_path):
+    filename = os.path.join(tmp_path, "v1.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    for compression in (True, False, None, "zstd", "uncompressed"):
+        with pytest.raises(ValueError, match="Feather V1 files do not support"):
+            ak.to_feather(
+                array, filename, feather_version=1, compression=compression
+            )
+
+
+
+def test_bad_destination_type():
+    array = ak.Array(BASE_ARRAY)
+
+    with pytest.raises(TypeError):
+        ak.to_feather(array, 12345)
+
+
+def test_chunksize(tmp_path):
+    filename = os.path.join(tmp_path, "chunksize.feather")
+    array = ak.Array(list(range(10000)))
+
+    ak.to_feather(array, filename, chunksize=125)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == array.tolist()
+
+
+def test_columns_selection(tmp_path):
+    filename = os.path.join(tmp_path, "columns.feather")
+    array = ak.Array({"x": [1.1, 2.2, 3.3], "y": [[1], [1, 2], [1, 2, 3]]})
+
+    ak.to_feather(array, filename, compression=True)
+    array2 = ak.from_feather(filename, columns=["x"])
+
+    assert set(array2.fields) == {"x"}
+    assert array2.x.tolist() == array.x.tolist()
+
+
+def test_memory_map(tmp_path):
+    filename = os.path.join(tmp_path, "memory_map.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    ak.to_feather(array, filename, compression=True)
+    array2 = ak.from_feather(filename, memory_map=True)
+
+    assert array2.tolist() == BASE_ARRAY
+
+
+def test_use_threads_false(tmp_path):
+    filename = os.path.join(tmp_path, "use_threads.feather")
+    array = ak.Array(BASE_ARRAY)
+
+    ak.to_feather(array, filename, compression=True)
+    array2 = ak.from_feather(filename, use_threads=False)
+
+    assert array2.tolist() == BASE_ARRAY
+
+
+def test_generate_bitmasks(tmp_path):
+    filename = os.path.join(tmp_path, "bitmasks.feather")
+    array = ak.Array([1.1, None, 3.3])
+
+    ak.to_feather(array, filename, extensionarray=False)
+    array2 = ak.from_feather(filename, generate_bitmasks=True)
+
+    assert array2.tolist() == [1.1, None, 3.3]
+
+
+def test_extensionarray_false(tmp_path):
+    filename = os.path.join(tmp_path, "no_ext.feather")
+    array = ak.Array(RECORD_ARRAY)
+
+    ak.to_feather(array, filename, extensionarray=False)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == RECORD_ARRAY
+
+
+
+
+def _make_union_array():
+    c, i = ak.contents, ak.index
+    layout = c.UnionArray(
+        i.Index8(np.array([0, 1], dtype=np.int8)),
+        i.Index64(np.array([0, 0], dtype=np.int64)),
+        [c.NumpyArray(np.array([1.5], dtype=np.float64)), ak.to_layout(["abc"])],
+    )
+    return ak.Array(layout)
+
+
+def test_union_type_extensionarray_true_is_known_broken(tmp_path):
+    filename = os.path.join(tmp_path, "union.feather")
+    array = _make_union_array()
+
+    ak.to_feather(array, filename) # if it works ,it is the bug
+
+    with pytest.raises(ValueError):
+        ak.from_feather(filename)
+
+
+def test_union_type_extensionarray_false_roundtrips(tmp_path):
+    filename = os.path.join(tmp_path, "union_no_ext.feather")
+    array = _make_union_array()
+
+    ak.to_feather(array, filename, extensionarray=False)
+    array2 = ak.from_feather(filename)
+
+    assert array2.tolist() == [1.5, "abc"]
+
+# Canary Tests
+
+def _time_it(fn):
+    start = time.perf_counter()
+    result = fn()
+    return result, time.perf_counter() - start
+
+
+@pytest.mark.parametrize("n", [10_000, 100_000, 10_000_000])
+@pytest.mark.parametrize("compression", ["zstd", "uncompressed"])
+def test_timing_flat_array(tmp_path, n, compression):
+    filename = os.path.join(tmp_path, f"timing_{n}_{compression}.feather")
+    array = ak.Array(np.random.default_rng(0).random(n))
+
+    _, write_time = _time_it(
+        lambda: ak.to_feather(array, filename, compression=compression)
+    )
+    result, read_time = _time_it(lambda: ak.from_feather(filename))
+
+    assert result.tolist() == array.tolist()
+
+    print(
+        f"\n[timing] n={n} compression={compression!r} "
+        f"write={write_time:.4f}s read={read_time:.4f}s "
+        f"file_size={os.path.getsize(filename)/1e6:.2f}MB"
+    )
+
+    # Generous upper bound: this is not meant to be a tight perf assertion,
+    # just a canary for a genuine multi-minute stall (e.g. the writer
+    # hanging on close rather than a normal slow-but-bounded write).
+    assert write_time < 30
+    assert read_time < 30
+
+
+def test_timing_nested_array(tmp_path):
+    filename = os.path.join(tmp_path, "timing_nested.feather")
+    rng = np.random.default_rng(0)
+    counts = rng.integers(0, 5, size=50_000)
+    array = ak.unflatten(rng.random(int(counts.sum())), counts)
+
+    _, write_time = _time_it(lambda: ak.to_feather(array, filename))
+    result, read_time = _time_it(lambda: ak.from_feather(filename))
+
+    assert result.tolist() == array.tolist()
+
+    print(
+        f"\n[timing] nested list array (50k rows) "
+        f"write={write_time:.4f}s read={read_time:.4f}s "
+        f"file_size={os.path.getsize(filename)/1e6:.2f}MB"
+    )
+
+    assert write_time < 30
+    assert read_time < 30
+
+
+def test_timing_chunksize_sensitivity(tmp_path):
+    # Does a small chunksize noticeably slow down the write's "ending"
+    # (i.e. flush/close), compared to the default? This directly probes
+    # whether chunking behavior could be the source of an unexpected delay.
+    array = ak.Array(np.random.default_rng(0).random(500_000))
+
+    timings = {}
+    for chunksize in (None, 1024, 65536):
+        filename = os.path.join(tmp_path, f"chunk_{chunksize}.feather")
+        _, write_time = _time_it(
+            lambda cs=chunksize: ak.to_feather(array, filename, chunksize=cs)
+        )
+        timings[chunksize] = write_time
+
+    print(f"\n[timing] chunksize sensitivity (500k rows): {timings}")
+
+    # A small chunksize can be slower, but should not be wildly (>10x)
+    # slower than the default - if it is, that is worth flagging as the
+    # likely source of a timeout in a production job using odd chunksize.
+    if timings[None] > 0:
+        assert timings[1024] < timings[None] * 20 + 5


### PR DESCRIPTION
This PR updates both `ak_to_feather` and `ak_from_feather` to use the non-deprecated `pyarrow.ipc` API, replacing the deprecated Feather APIs and resolving the associated deprecation warnings.

Changes

- `ak.to_feather`
  - Replaces the deprecated Feather writer with `pyarrow.ipc.RecordBatchFileWriter`.
  - Preserves the existing behavior while avoiding the deprecated API.

- `ak.from_feather`
  - Replaces the deprecated `pyarrow.feather.FeatherReader` with `pyarrow.ipc.open_file` and `IpcReadOptions`.
  - Applies 'Table.select(columns)' after reading to preserve the existing column selection semantics, including requested column order and duplicate column selections.

Together, these changes migrate Awkward's Feather I/O implementation to the supported IPC API while maintaining compatibility with the previous behavior.

Fixes #4199.