### PR TITLE
fix: `any_backend_is_delayed` should only be iterating over sequences of arrays for now

### DIFF
--- a/src/awkward/_errors.py
+++ b/src/awkward/_errors.py
@@ -185,8 +185,11 @@ class OperationErrorContext(ErrorContext):
             backend = backend_of_obj(obj, default=None)
             # Do we not recognise this as an object with a backend?
             if backend is None:
-                # Is this an iterable object, and are we permitted to recurse?
-                if isinstance(obj, Collection) and depth != depth_limit:
+                # Only recurse into list/tuple (e.g. the arrays passed to
+                # ak.concatenate/ak.zip), never arbitrary containers: a Mapping
+                # yields only keys, and a user container (e.g. from_buffers'
+                # `container`) may not be iterable or may trigger data reads.
+                if isinstance(obj, (list, tuple)) and depth != depth_limit:
                     if self.any_backend_is_delayed(
                         obj, depth=depth + 1, depth_limit=depth_limit
                     ):

--- a/tests/test_4106_fix_core_misc.py
+++ b/tests/test_4106_fix_core_misc.py
@@ -56,6 +56,54 @@ def test_any_backend_is_delayed_nested_non_delayed_continues():
     assert result is False
 
 
+def test_any_backend_is_delayed_only_iterates_list_and_tuple(monkeypatch):
+    import awkward._backends.dispatch as dispatch
+
+    class Delayed:
+        pass
+
+    class FakeBackend:
+        class nplike:
+            is_eager = False
+
+    def fake_backend_of_obj(obj, default=None):
+        return FakeBackend if isinstance(obj, Delayed) else default
+
+    monkeypatch.setattr(dispatch, "backend_of_obj", fake_backend_of_obj)
+
+    ctx = OperationErrorContext.__new__(OperationErrorContext)
+    # list/tuple are recursed into, so a nested delayed backend is detected
+    assert ctx.any_backend_is_delayed([[Delayed()]]) is True
+    assert ctx.any_backend_is_delayed([(Delayed(),)]) is True
+    # a Mapping is not recursed: iterating it yields keys, never the values
+    assert ctx.any_backend_is_delayed([{"key": Delayed()}]) is False
+
+
+def test_any_backend_is_delayed_does_not_iterate_foreign_containers():
+    from collections.abc import Mapping, Sequence
+
+    class RaisingMapping(Mapping):
+        def __getitem__(self, key):
+            raise AssertionError("must not be accessed")
+
+        def __iter__(self):
+            raise AssertionError("must not be iterated")
+
+        def __len__(self):
+            return 0
+
+    class RaisingSequence(Sequence):
+        def __getitem__(self, index):
+            raise AssertionError("must not be accessed")
+
+        def __len__(self):
+            raise AssertionError("must not be measured")
+
+    ctx = OperationErrorContext.__new__(OperationErrorContext)
+    assert ctx.any_backend_is_delayed([RaisingMapping()]) is False
+    assert ctx.any_backend_is_delayed([RaisingSequence()]) is False
+
+
 def _make_custom_str_array(n=5):
     class MyPoint(ak.Record):
         def __str__(self):


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/4205