### PR TITLE
fix: transient attrs should not be written to parquet

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -270,7 +270,7 @@ def _load(
         return wrap_layout(
             arrays[0],
             highlevel=highlevel,
-            attrs=(attrs if attrs else {}) | arrays[0].attrs,
+            attrs=arrays[0].attrs | (attrs if attrs else {}),
             behavior=behavior,
         )
     else:
@@ -281,7 +281,7 @@ def _load(
         file_attrs = {}
         for array in arrays:
             file_attrs |= getattr(array, "attrs", None) or {}
-        merged_attrs = (attrs if attrs else {}) | file_attrs
+        merged_attrs = file_attrs | (attrs if attrs else {})
         return ak.operations.ak_concatenate._impl(
             arrays,
             axis=0,

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -412,12 +412,12 @@ def _impl(
         table = convert_awkward_arrow_table_to_native(table)
 
     if hasattr(array, "attrs") and array.attrs:
-        serialisable_attrs = without_transient_attrs(array.attrs.to_dict())
-        if serialisable_attrs:
-            df_metadata = {"AWKWARD_ATTRS": json.dumps(serialisable_attrs)}
-            existing_metadata = table.schema.metadata or {}
-            merged_metadata = {**existing_metadata, **df_metadata}
-            table = table.replace_schema_metadata(merged_metadata)
+        df_metadata = {
+            "AWKWARD_ATTRS": json.dumps(without_transient_attrs(array.attrs.to_dict()))
+        }
+        existing_metadata = table.schema.metadata or {}
+        merged_metadata = {**existing_metadata, **df_metadata}
+        table = table.replace_schema_metadata(merged_metadata)
 
     if parquet_extra_options is None:
         parquet_extra_options = {}

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -412,12 +412,16 @@ def _impl(
         table = convert_awkward_arrow_table_to_native(table)
 
     if hasattr(array, "attrs") and array.attrs:
-        df_metadata = {
-            "AWKWARD_ATTRS": json.dumps(without_transient_attrs(array.attrs.to_dict()))
-        }
-        existing_metadata = table.schema.metadata or {}
-        merged_metadata = {**existing_metadata, **df_metadata}
-        table = table.replace_schema_metadata(merged_metadata)
+        serializable_attrs = without_transient_attrs(array.attrs.to_dict())
+
+        # Only modify table metadata if there are actual non-transient attrs
+        if serializable_attrs:
+            existing_metadata = table.schema.metadata or {}
+            merged_metadata = {
+                **existing_metadata,
+                b"AWKWARD_ATTRS": json.dumps(serializable_attrs).encode("utf-8"),
+            }
+            table = table.replace_schema_metadata(merged_metadata)
 
     if parquet_extra_options is None:
         parquet_extra_options = {}

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -10,6 +10,7 @@ import fsspec
 
 import awkward as ak
 import awkward._connect.pyarrow
+from awkward._attrs import without_transient_attrs
 from awkward._connect.pyarrow import convert_awkward_arrow_table_to_native
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
@@ -411,10 +412,12 @@ def _impl(
         table = convert_awkward_arrow_table_to_native(table)
 
     if hasattr(array, "attrs") and array.attrs:
-        df_metadata = {"AWKWARD_ATTRS": json.dumps(array.attrs.to_dict())}
-        existing_metadata = table.schema.metadata
-        merged_metadata = {**existing_metadata, **df_metadata}
-        table = table.replace_schema_metadata(merged_metadata)
+        serialisable_attrs = without_transient_attrs(array.attrs.to_dict())
+        if serialisable_attrs:
+            df_metadata = {"AWKWARD_ATTRS": json.dumps(serialisable_attrs)}
+            existing_metadata = table.schema.metadata or {}
+            merged_metadata = {**existing_metadata, **df_metadata}
+            table = table.replace_schema_metadata(merged_metadata)
 
     if parquet_extra_options is None:
         parquet_extra_options = {}

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -928,6 +928,27 @@ def test_awkward_attr_serialisation(generate_datafiles):
     assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property": "value"}
 
 
+def test_transient_attrs_not_serialised(tmp_path):
+    # attrs whose key starts with "@" are transient: they may hold arbitrary
+    # (non-JSON-serialisable) objects, so they must be dropped when writing
+    class NotSerialisable:
+        pass
+
+    array = ak.from_iter(
+        [[1, 2, 3], [4, 5]],
+        attrs={"property": "value", "@transient": NotSerialisable()},
+    )
+    filename = os.path.join(tmp_path, f"transient-{threading.get_ident()}.parq")
+    ak.to_parquet(array, filename)
+    assert ak.from_parquet(filename).attrs == {"property": "value"}
+
+    # only transient attrs: nothing to write, but it must not raise
+    array = ak.from_iter([[1, 2, 3], [4, 5]], attrs={"@transient": NotSerialisable()})
+    filename = os.path.join(tmp_path, f"transient-only-{threading.get_ident()}.parq")
+    ak.to_parquet(array, filename)
+    assert ak.from_parquet(filename).attrs == {}
+
+
 def test_pandas_attr_serialisation(generate_datafiles):
 
     pd = pytest.importorskip("pandas", "2.1.0")

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -928,25 +928,26 @@ def test_awkward_attr_serialisation(generate_datafiles):
     assert ak.from_parquet(f"{path}/data1.parq").attrs == {"property": "value"}
 
 
-def test_transient_attrs_not_serialised(tmp_path):
-    # attrs whose key starts with "@" are transient: they may hold arbitrary
-    # (non-JSON-serialisable) objects, so they must be dropped when writing
-    class NotSerialisable:
+def test_transient_attrs_not_written(tmp_path):
+    # transient attrs may hold arbitrary, non-JSON-serializable objects
+    class NotSerializable:
         pass
 
     array = ak.from_iter(
         [[1, 2, 3], [4, 5]],
-        attrs={"property": "value", "@transient": NotSerialisable()},
+        attrs={"property": "value", "@transient": NotSerializable()},
     )
     filename = os.path.join(tmp_path, f"transient-{threading.get_ident()}.parq")
     ak.to_parquet(array, filename)
     assert ak.from_parquet(filename).attrs == {"property": "value"}
 
-    # only transient attrs: nothing to write, but it must not raise
-    array = ak.from_iter([[1, 2, 3], [4, 5]], attrs={"@transient": NotSerialisable()})
-    filename = os.path.join(tmp_path, f"transient-only-{threading.get_ident()}.parq")
-    ak.to_parquet(array, filename)
-    assert ak.from_parquet(filename).attrs == {}
+
+def test_attrs_without_extensionarray(tmp_path):
+    # here the table has no schema metadata for the attrs to be merged into
+    array = ak.from_iter([[1, 2, 3], [4, 5]], attrs={"property": "value"})
+    filename = os.path.join(tmp_path, f"no-extn-{threading.get_ident()}.parq")
+    ak.to_parquet(array, filename, extensionarray=False)
+    assert ak.from_parquet(filename).attrs == {"property": "value"}
 
 
 def test_pandas_attr_serialisation(generate_datafiles):

--- a/tests/test_1294_to_and_from_parquet.py
+++ b/tests/test_1294_to_and_from_parquet.py
@@ -942,6 +942,17 @@ def test_transient_attrs_not_written(tmp_path):
     assert ak.from_parquet(filename).attrs == {"property": "value"}
 
 
+def test_explicit_attrs_take_precedence(generate_datafiles):
+    # both files store {"property": "value"}, which the caller asks to override
+    path, _mdlist, _fs = generate_datafiles
+
+    one_file = ak.from_parquet(f"{path}/data1.parq", attrs={"property": "other"})
+    assert one_file.attrs == {"property": "other"}
+
+    both_files = ak.from_parquet(path, attrs={"property": "other"})
+    assert both_files.attrs == {"property": "other"}
+
+
 def test_attrs_without_extensionarray(tmp_path):
     # here the table has no schema metadata for the attrs to be merged into
     array = ak.from_iter([[1, 2, 3], [4, 5]], attrs={"property": "value"})


### PR DESCRIPTION
https://github.com/scikit-hep/awkward/pull/4079 introduced attrs serialization to parquet. However, transient attrs should not be serialized. Users are seeing errors writing root files loaded with coffea to disk. This fails with awkward 2.10.0
```python
from coffea.nanoevents import NanoEventsFactory
import awkward as ak

file = "foo.root"
events = NanoEventsFactory.from_root(
file, treepath="Events").events()
ak.to_parquet(events.Jet.pt, "pt.parquet")
```
with 
```
TypeError: Object of type NanoEventsFactory is not JSON serializable
when serializing dict item '@events_factory'

This error occurred while calling

    ak.to_parquet(
        <Array [[89.9, 41, ..., 16.6, 16], ...] type='146910 * var * float3...'>
        'pt.parquet'
    )
```

A patch release is needed ASAP as users cannot write to parquet in all analysis frameworks if they use awkward 2.10.0.