### PR TITLE
feat: write attrs when writing parquet row groups iteratively

### DIFF
--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -56,7 +56,7 @@ def from_parquet(
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
         attrs (None or dict): Custom attributes for the output array, if
-            high-level. These take precedence over any attrs stored in the file.
+            high-level. These take precedence over any `attrs` stored in the file.
 
     Reads data from a local or remote Parquet file or collection of files.
 

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -56,7 +56,7 @@ def from_parquet(
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
         attrs (None or dict): Custom attributes for the output array, if
-            high-level.
+            high-level. These take precedence over any attrs stored in the file.
 
     Reads data from a local or remote Parquet file or collection of files.
 
@@ -64,6 +64,9 @@ def from_parquet(
     and/or `row_groups` to select and filter manageable subsets of the data, and
     use #ak.metadata_from_parquet to find column names and the range of row groups
     that a dataset has.
+
+    Any attrs that #ak.to_parquet stored in the file are restored (as are those
+    written by pandas), unless overridden by the `attrs` argument.
 
     See also #ak.to_parquet, #ak.metadata_from_parquet.
     """

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -411,8 +411,10 @@ def _impl(
     if extensionarray:
         table = convert_awkward_arrow_table_to_native(table)
 
-    if hasattr(array, "attrs") and array.attrs:
-        serializable_attrs = without_transient_attrs(array.attrs.to_dict())
+    # when writing row groups iteratively, the attrs are those of the first array
+    attrs_from = first_array if write_iteratively else array
+    if hasattr(attrs_from, "attrs") and attrs_from.attrs:
+        serializable_attrs = without_transient_attrs(attrs_from.attrs.to_dict())
 
         # Only modify table metadata if there are actual non-transient attrs
         if serializable_attrs:

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -170,6 +170,11 @@ def to_parquet(
           format_version: 2.6
           serialized_size: 0
 
+    The array's #ak.Array.attrs are written into the file's metadata, so that
+    #ak.from_parquet can restore them. They must therefore be JSON-compatible.
+    Transient attrs (those whose keys start with `"@"`) are not written, just as
+    they are not written when pickling.
+
     If the `array` does not contain records at top-level, the Arrow table will consist
     of one field whose name is `""` iff. `extensionarray` is False.
 

--- a/src/awkward/operations/ak_to_parquet_row_groups.py
+++ b/src/awkward/operations/ak_to_parquet_row_groups.py
@@ -156,6 +156,12 @@ def to_parquet_row_groups(
           format_version: 2.6
           serialized_size: 0
 
+    As in #ak.to_parquet, the arrays' #ak.Array.attrs are written into the file's
+    metadata. The file-level `attrs` are defined by the first array, just as the
+    schema is, and the `attrs` of subsequent arrays are not merged into them. If
+    you need the `attrs` of every array to be combined, do so explicitly before
+    passing the iterator to this function.
+
     If the `array` does not contain records at top-level, the Arrow table will consist
     of one field whose name is `""` iff. `extensionarray` is False.
 

--- a/tests/test_2968_to_parquet_row_groups.py
+++ b/tests/test_2968_to_parquet_row_groups.py
@@ -229,3 +229,15 @@ def test_params(tmp_path):
         [1, 14],
         [9, 2],
     ]
+
+
+def test_attrs(tmp_path):
+    # the attrs are those of the first array; the rest only add row groups
+    arrays = [
+        ak.Array([[1, 2, 3], [4]], attrs={"property": "value"}),
+        ak.Array([[5], [6, 7]], attrs={"property": "ignored"}),
+    ]
+    filename = os.path.join(tmp_path, "attrs.parquet")
+    ak.to_parquet_row_groups(iter(arrays), filename)
+
+    assert ak.from_parquet(filename).attrs == {"property": "value"}


### PR DESCRIPTION
Follow-up of https://github.com/scikit-hep/awkward/pull/4079.
Adds attrs serialization to `ak.to_parquet_row_groups.py` by getting the attrs from the first array in the same way the schema is built from the first array.
Waits for https://github.com/scikit-hep/awkward/pull/4209 and will be rebased once its merged.