### PR TITLE
fix: undo an assignment that `__awkward_validation__` rejects

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -377,11 +377,19 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     def __dask_tokenize__(self):
         return id(self)
 
-    def _update_class(self):
+    def _update_class(self, restore=None):
         self._numbaview = None
+        previous_class = self.__class__
         self.__class__ = get_array_class(self._layout, self._behavior)
         if hasattr(self, "__awkward_validation__"):
-            self.__awkward_validation__()
+            try:
+                self.__awkward_validation__()
+            except Exception:
+                # a rejected assignment must not be left applied
+                if restore is not None:
+                    self.__dict__.update(restore)
+                    self.__class__ = previous_class
+                raise
 
     @property
     def attrs(self) -> Attrs:
@@ -450,8 +458,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.contents.Content):
+            restore = {"_layout": self._layout}
             self._layout = layout
-            self._update_class()
+            self._update_class(restore)
         else:
             raise TypeError("layout must be a subclass of ak.contents.Content")
 
@@ -477,8 +486,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
+            restore = {"_behavior": self._behavior}
             self._behavior = behavior
-            self._update_class()
+            self._update_class(restore)
         else:
             raise TypeError("behavior must be None or a dict")
 
@@ -1920,11 +1930,19 @@ class Record(NDArrayOperatorsMixin):
 
         ak.jax.register_behavior_class(cls)
 
-    def _update_class(self):
+    def _update_class(self, restore=None):
         self._numbaview = None
+        previous_class = self.__class__
         self.__class__ = get_record_class(self._layout, self._behavior)
         if hasattr(self, "__awkward_validation__"):
-            self.__awkward_validation__()
+            try:
+                self.__awkward_validation__()
+            except Exception:
+                # a rejected assignment must not be left applied
+                if restore is not None:
+                    self.__dict__.update(restore)
+                    self.__class__ = previous_class
+                raise
 
     @property
     def attrs(self) -> Attrs:
@@ -1987,8 +2005,9 @@ class Record(NDArrayOperatorsMixin):
     @layout.setter
     def layout(self, layout):
         if isinstance(layout, ak.record.Record):
+            restore = {"_layout": self._layout}
             self._layout = layout
-            self._update_class()
+            self._update_class(restore)
         else:
             raise TypeError("layout must be a subclass of ak.record.Record")
 
@@ -2014,8 +2033,9 @@ class Record(NDArrayOperatorsMixin):
     @behavior.setter
     def behavior(self, behavior):
         if behavior is None or isinstance(behavior, Mapping):
+            restore = {"_behavior": self._behavior}
             self._behavior = behavior
-            self._update_class()
+            self._update_class(restore)
         else:
             raise TypeError("behavior must be None or a dict")
 
@@ -2167,7 +2187,7 @@ class Record(NDArrayOperatorsMixin):
 
             # make the property setting explicit (it triggers self._update_class(), which in turn triggers validation)
             layout = self.layout
-            layout._array = ak.operations.ak_with_field._impl(
+            new_array = ak.operations.ak_with_field._impl(
                 layout._array,
                 what,
                 where,
@@ -2175,7 +2195,9 @@ class Record(NDArrayOperatorsMixin):
                 behavior=self._behavior,
                 attrs=self._attrs,
             )
-            self.layout = layout
+            # rebind to a fresh record rather than mutating the shared layout in
+            # place, so that the setter above can restore it
+            self.layout = ak.record.Record(new_array, layout.at)
 
     def __delitem__(self, where):
         """

--- a/tests/test_4212_behavior_validation_rollback.py
+++ b/tests/test_4212_behavior_validation_rollback.py
@@ -1,0 +1,63 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward-1.0/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+
+class NoNewFieldsError(Exception):
+    pass
+
+
+class OnlyXY:
+    def __awkward_validation__(self) -> None:
+        if set(self.fields) != {"x", "y"}:
+            raise NoNewFieldsError(f"got fields: {sorted(self.fields)}")
+
+
+class OnlyXYArray(OnlyXY, ak.Array):
+    pass
+
+
+class OnlyXYRecord(OnlyXY, ak.Record):
+    pass
+
+
+behavior = {"xy": OnlyXYRecord, ("*", "xy"): OnlyXYArray}
+
+
+def make_array():
+    return ak.Array([{"x": 1.1, "y": 2.2}], with_name="xy", behavior=behavior)
+
+
+def test_setitem():
+    array = make_array()
+    with pytest.raises(NoNewFieldsError):
+        array["z"] = [3.3]
+    assert array.fields == ["x", "y"]
+    assert array.to_list() == [{"x": 1.1, "y": 2.2}]
+
+
+def test_delitem():
+    array = make_array()
+    with pytest.raises(NoNewFieldsError):
+        del array["y"]
+    assert array.fields == ["x", "y"]
+
+
+def test_behavior_setter():
+    array = ak.Array([{"x": 1.1, "y": 2.2, "z": 3.3}], with_name="xy")
+    with pytest.raises(NoNewFieldsError):
+        array.behavior = behavior
+    assert array.behavior is None
+    assert not isinstance(array, OnlyXYArray)
+
+
+def test_record_setitem():
+    record = make_array()[0]
+    with pytest.raises(NoNewFieldsError):
+        record["z"] = 3.3
+    assert record.fields == ["x", "y"]
+    assert record.to_list() == {"x": 1.1, "y": 2.2}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `layout` and `behavior` setters assign before `_update_class()` runs `__awkward_validation__`, so a rejected assignment raises and is applied anyway:

```python
>>> jets = ak.zip({"pt": pt, "phi": phi, "eta": eta, "mass": mass}, with_name="Momentum4D")
>>> jets["rho"] = rho
TypeError: 'pt' and 'rho' both map to 'rho'
>>> jets.pt      # rejected, and applied
<Array [999, 999, ...] type='...'>
```

`_update_class` takes an optional `restore` mapping now and puts it back if the hook raises. That covers `__setitem__` and `__delitem__` too, since #3710 routed those through the `layout` property.

`Record.__setitem__` needed one more fix for the record case: it mutated `layout._array` in place, so the setter's "previous" layout was the already-modified one and there was nothing to restore.

Found while adding coordinate validation to scikit-hep/vector#659.