### PR TITLE
chore: remove Gitter chat and StackOverflow links from README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,3 @@ contact_links:
     - name: "Start a discussion (GitHub)"
       about: "How do I…?"
       url: https://github.com/scikit-hep/awkward-1.0/discussions
-    - name: "StackOverflow: [awkward-array] tag"
-      about: "How do I…?"
-      url: https://stackoverflow.com/questions/tagged/awkward-array
-    - name: "Gitter: Scikit-HEP/awkward-array room"
-      about: "Getting help in real-time…"
-      url: https://gitter.im/Scikit-HEP/awkward-array

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -12,8 +12,6 @@ body:
         The following links might help:
 
            * [awkward-array.org](https://awkward-array.org/)
-           * [StackOverflow: [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array)
-           * [Gitter: Scikit-HEP/awkward-array room](https://gitter.im/Scikit-HEP/awkward-array)
 
   - type: textarea
     id: feature

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4341376.svg)](https://doi.org/10.5281/zenodo.4341376)
 [![Documentation](https://img.shields.io/badge/docs-online-success)](https://awkward-array.org/)
-[![Gitter](https://img.shields.io/badge/chat-online-success)](https://gitter.im/Scikit-HEP/awkward-array)
 
 [![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)
 [![NSF-2103945](https://img.shields.io/badge/NSF-2103945-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2103945)
@@ -81,8 +80,6 @@ See the [Getting started](https://awkward-array.org/doc/main/getting-started/ind
    * View the documentation on [awkward-array.org](https://awkward-array.org/).
    * Report bugs, request features, and ask for additional documentation on [GitHub Issues](https://github.com/scikit-hep/awkward/issues).
    * If you have a "How do I...?" question, start a [GitHub Discussion](https://github.com/scikit-hep/awkward/discussions) with category "Q&A".
-   * Alternatively, ask about it on [StackOverflow with the [awkward-array] tag](https://stackoverflow.com/questions/tagged/awkward-array). Be sure to include tags for any other libraries that you use, such as Pandas or PyTorch.
-   * To ask questions in real time, try the Gitter [Scikit-HEP/awkward-array](https://gitter.im/Scikit-HEP/awkward-array) chat room.
 
 # Installation
 

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -53,7 +53,6 @@ Documentation = "https://awkward-array.org"
 "Source Code" = "https://github.com/scikit-hep/awkward-1.0"
 "Bug Tracker" = "https://github.com/scikit-hep/awkward-1.0/issues"
 Discussions = "https://github.com/scikit-hep/awkward-1.0/discussions"
-Chat = "https://gitter.im/Scikit-HEP/awkward-array"
 Releases = "https://github.com/scikit-hep/awkward-1.0/releases"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,11 +271,6 @@ html_theme_options = {
             "url": "https://pypi.org/project/awkward",
             "icon": "fa-brands fa-python",
         },
-        {
-            "name": "Gitter",
-            "url": "https://gitter.im/Scikit-HEP/awkward-array",
-            "icon": "fa-brands fa-gitter",
-        },
     ],
     "use_edit_page_button": True,
     "external_links": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ init = "awkward.numba:_register"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scikit-hep/awkward-1.0/issues"
-"Chat" = "https://gitter.im/Scikit-HEP/awkward-array"
 "Discussions" = "https://github.com/scikit-hep/awkward-1.0/discussions"
 "Documentation" = "https://awkward-array.org"
 "Homepage" = "https://github.com/scikit-hep/awkward-1.0"


### PR DESCRIPTION
Avoid directing users to archived channels:
 - Removed Gitter chat room link from README -- it's been archived.
 - StackOverflow is not active either.