### PR TITLE
test: add property-based roundtrip test for `to_numpy`/`from_numpy`

### DIFF
--- a/tests/properties/operations/test_to_from_numpy.py
+++ b/tests/properties/operations/test_to_from_numpy.py
@@ -1,0 +1,57 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import hypothesis_awkward.strategies as st_ak
+from hypothesis import given
+
+import awkward as ak
+
+
+@given(
+    a=st_ak.constructors.arrays(
+        allow_empty=False,
+        allow_string=False,
+        allow_bytestring=False,
+        allow_list=False,
+        allow_list_offset=False,
+        allow_record=False,
+        allow_union=False,
+        allow_indexed_option=False,
+        allow_byte_masked=False,
+        allow_bit_masked=False,
+        allow_unmasked=False,
+    )
+)
+def test_roundtrip(a: ak.Array) -> None:
+    """`to_numpy` followed by `from_numpy` reconstructs the array."""
+    n = ak.to_numpy(a)
+    returned = ak.from_numpy(n)
+    assert ak.array_equal(a, returned, equal_nan=True)
+
+
+@given(
+    a=st_ak.constructors.arrays(
+        # to_numpy(allow_missing=True) raises on timedelta64 with missing
+        # values (create_missing_data calls np.iinfo on the "m8" dtype)
+        dtypes=st_ak.supported_dtypes().filter(lambda d: d.kind != "m"),
+        allow_empty=False,
+        allow_string=False,
+        allow_bytestring=False,
+        allow_regular=False,
+        allow_list=False,
+        allow_list_offset=False,
+        allow_record=False,
+        allow_union=False,
+    )
+)
+def test_roundtrip_masked(a: ak.Array) -> None:
+    """Option-type arrays roundtrip through `np.ma.MaskedArray`.
+
+    `from_numpy` normalizes option layouts (e.g., `BitMaskedArray` returns
+    as `ByteMaskedArray`, an all-valid mask as `UnmaskedArray`), so content
+    classes are not compared.
+    """
+    n = ak.to_numpy(a, allow_missing=True)
+    returned = ak.from_numpy(n)
+    assert ak.array_equal(a, returned, equal_nan=True, same_content_types=False)


### PR DESCRIPTION
This adds a Hypothesis roundtrip test for `ak.to_numpy` / `ak.from_numpy`, analogous to `tests/properties/operations/test_to_from_buffers.py`.

**`test_roundtrip`** generates arrays with hypothesis-awkward's `arrays()` strategy restricted to layouts that `ak.to_numpy` can convert, and asserts `ak.array_equal(a, from_numpy(to_numpy(a)), equal_nan=True)`. Excluded layouts and why:

- unions: `to_numpy` always raises
- variable-length lists: ragged lists raise; even equal-length ones return as regular dimensions and fail `check_regular=True`
- records: 2-D fields raise (#3690); `RegularArray(RecordArray)` returns with record/dimension order swapped; tuples return as named records; zero-field and nested records crash `from_numpy`
- strings/bytestrings: NumPy `U`/`S` dtypes silently drop trailing NUL characters (`"a\x00"` becomes `"a"`), and `arrays()` has no alphabet control
- `EmptyArray`: converts to float64 and returns as `0 * float64`, unequal to `0 * unknown`
- option types: covered by the second test instead

Regular arrays (including size-0 dimensions), indexed arrays, NaN, and all supported dtypes (including datetime64 and timedelta64) remain enabled.

**`test_roundtrip_masked`** covers option-type layouts through `to_numpy(allow_missing=True)`, which returns an `np.ma.MaskedArray`, and back with `from_numpy`. It compares with `same_content_types=False` because `from_numpy` normalizes option layouts (`ByteMaskedArray` for masked input, `UnmaskedArray` when NumPy shrinks an all-valid mask); values and dtypes are still compared exactly. Two additional restrictions: regular arrays are excluded because an option node above a regular node returns with the option at the leaf, and timedelta64 is excluded because `to_numpy(allow_missing=True)` with actual missing values raises `ValueError` from `create_missing_data` (`np.iinfo` on an `m8` dtype).

Both tests pass with the default profile (200 examples) and the nightly profile (10,000 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)