### PR TITLE
fix: overflow-safe stats without needless copies

### DIFF
--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -53,7 +53,6 @@ def _has_integral_leaf(layout) -> bool:
         nonlocal found
         if node.is_numpy and node.dtype.kind in "biu":
             found = True
-        return None
 
     ak._do.recursively_apply(layout, action, return_array=False)
     return found

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -43,6 +43,44 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
+def _has_integral_leaf(layout) -> bool:
+    """True if any NumpyArray leaf of ``layout`` is bool/integer (dtype kind b, i, u)."""
+    import awkward as ak
+
+    found = False
+
+    def action(node, **kwargs):
+        nonlocal found
+        if node.is_numpy and node.dtype.kind in "biu":
+            found = True
+        return None
+
+    ak._do.recursively_apply(layout, action, return_array=False)
+    return found
+
+
+def promote_integral_to_float64(array):
+    """Promote bool/integer data to ``float64`` to avoid integer overflow in
+    summations, matching NumPy's reduction dtype for ``mean``/``var``/``std``.
+
+    Floating and complex data is returned unchanged, so there is no copy for the
+    common (already-floating) case. The cast is performed by the array's own
+    backend, so on GPU it stays on device -- no host transfer.
+    """
+    import awkward as ak
+
+    if _has_integral_leaf(array.layout):
+        return ak.operations.ak_values_astype._impl(
+            array,
+            np.float64,
+            including_unknown=False,
+            highlevel=True,
+            behavior=None,
+            attrs=None,
+        )
+    return array
+
+
 def merge_mappings(
     mappings: Sequence[Mapping[K, V]], default: Mapping[K, V] | None = None
 ) -> Mapping[K, V]:

--- a/src/awkward/_layout.py
+++ b/src/awkward/_layout.py
@@ -53,6 +53,8 @@ def _has_integral_leaf(layout) -> bool:
         nonlocal found
         if node.is_numpy and node.dtype.kind in "biu":
             found = True
+            return node  # stop descending this branch; one integral leaf is enough
+        return None
 
     ak._do.recursively_apply(layout, action, return_array=False)
     return found

--- a/src/awkward/operations/ak_mean.py
+++ b/src/awkward/operations/ak_mean.py
@@ -11,6 +11,7 @@ from awkward._layout import (
     ensure_same_backend,
     maybe_highlevel_to_lowlevel,
     maybe_posaxis,
+    promote_integral_to_float64,
 )
 from awkward._namedaxis import (
     NAMED_AXIS_KEY,
@@ -202,6 +203,12 @@ def _impl(x, weight, axis, keepdims, mask_identity, highlevel, behavior, attrs):
 
     x = ctx.wrap(x_layout)
     weight = ctx.wrap(weight_layout, allow_other=True)
+
+    # The weighted mean forms x * weight, which overflows for integer inputs;
+    # promote integral data to float64 (no-op and zero copy for floats). The
+    # unweighted path reduces in int64 and needs no promotion.
+    if weight is not None:
+        x = promote_integral_to_float64(x)
 
     # Handle named axis
     named_axis = _get_named_axis(ctx)

--- a/src/awkward/operations/ak_moment.py
+++ b/src/awkward/operations/ak_moment.py
@@ -9,6 +9,7 @@ from awkward._layout import (
     HighLevelContext,
     ensure_same_backend,
     maybe_highlevel_to_lowlevel,
+    promote_integral_to_float64,
 )
 from awkward._namedaxis import (
     AxisName,
@@ -120,6 +121,10 @@ def _impl(
 
     x = ctx.wrap(x_layout)
     weight = ctx.wrap(weight_layout, allow_other=True)
+
+    # Integer powers (x ** n) overflow before reduction; promote integral data
+    # to float64 once (no-op and zero copy for floating inputs), matching NumPy.
+    x = promote_integral_to_float64(x)
 
     with np.errstate(invalid="ignore", divide="ignore"):
         if weight is None:

--- a/src/awkward/operations/ak_var.py
+++ b/src/awkward/operations/ak_var.py
@@ -11,6 +11,7 @@ from awkward._layout import (
     ensure_same_backend,
     maybe_highlevel_to_lowlevel,
     maybe_posaxis,
+    promote_integral_to_float64,
 )
 from awkward._namedaxis import (
     NAMED_AXIS_KEY,
@@ -198,6 +199,10 @@ def _impl(x, weight, ddof, axis, keepdims, mask_identity, highlevel, behavior, a
 
     x = ctx.wrap(x_layout)
     weight = ctx.wrap(weight_layout, allow_other=True)
+
+    # Integer squares (x * x) overflow before reduction; promote integral data
+    # to float64 once (no-op and zero copy for floating inputs), matching NumPy.
+    x = promote_integral_to_float64(x)
 
     # Handle named axis
     named_axis = _get_named_axis(ctx)

--- a/tests/test_4223_descriptive_statistics_overflow.py
+++ b/tests/test_4223_descriptive_statistics_overflow.py
@@ -44,7 +44,11 @@ def test_mean_weighted_integer_no_overflow():
 def test_var_jagged_integer_no_overflow():
     array = ak.Array([[100000, 200000, 300000], [], [400000, 500000]])
     result = ak.var(array, axis=-1)
-    expected = [np.var([100000.0, 200000.0, 300000.0]), np.nan, np.var([400000.0, 500000.0])]
+    expected = [
+        np.var([100000.0, 200000.0, 300000.0]),
+        np.nan,
+        np.var([400000.0, 500000.0]),
+    ]
     assert result[0] == pytest.approx(expected[0])
     assert np.isnan(result[1])
     assert result[2] == pytest.approx(expected[2])

--- a/tests/test_4223_descriptive_statistics_overflow.py
+++ b/tests/test_4223_descriptive_statistics_overflow.py
@@ -1,0 +1,57 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+def test_var_integer_no_overflow():
+    # int32 squares overflow int32 (100000**2 = 1e10 > 2**31 - 1)
+    data = np.array([100000, 200000, 300000], dtype=np.int32)
+    result = ak.var(ak.Array(data))
+    expected = np.var(data.astype(np.float64))
+    assert result == pytest.approx(expected)
+    assert np.dtype(np.asarray(result).dtype) == np.dtype(np.float64)
+
+
+def test_std_integer_no_overflow():
+    data = np.array([100000, 200000, 300000], dtype=np.int32)
+    result = ak.std(ak.Array(data))
+    expected = np.std(data.astype(np.float64))
+    assert result == pytest.approx(expected)
+
+
+def test_moment_integer_no_overflow():
+    data = np.array([100000, 200000, 300000], dtype=np.int32)
+    result = ak.moment(ak.Array(data), 2)
+    expected = np.mean(data.astype(np.float64) ** 2)
+    assert result == pytest.approx(expected)
+
+
+def test_mean_weighted_integer_no_overflow():
+    # x * weight overflows int32
+    x = np.array([100000, 200000, 300000], dtype=np.int32)
+    weight = np.array([100000, 200000, 300000], dtype=np.int32)
+    result = ak.mean(ak.Array(x), weight=ak.Array(weight))
+    xf, wf = x.astype(np.float64), weight.astype(np.float64)
+    expected = np.sum(xf * wf) / np.sum(wf)
+    assert result == pytest.approx(expected)
+
+
+def test_var_jagged_integer_no_overflow():
+    array = ak.Array([[100000, 200000, 300000], [], [400000, 500000]])
+    result = ak.var(array, axis=-1)
+    expected = [np.var([100000.0, 200000.0, 300000.0]), np.nan, np.var([400000.0, 500000.0])]
+    assert result[0] == pytest.approx(expected[0])
+    assert np.isnan(result[1])
+    assert result[2] == pytest.approx(expected[2])
+
+
+def test_float_input_unchanged():
+    # Floating input must still work and match NumPy (helper is a no-op here).
+    data = np.array([1.5, 2.5, 3.5], dtype=np.float64)
+    assert ak.var(ak.Array(data)) == pytest.approx(np.var(data))
+    assert ak.mean(ak.Array(data)) == pytest.approx(np.mean(data))

--- a/tests/test_4223_descriptive_statistics_overflow.py
+++ b/tests/test_4223_descriptive_statistics_overflow.py
@@ -14,7 +14,7 @@ def test_var_integer_no_overflow():
     result = ak.var(ak.Array(data))
     expected = np.var(data.astype(np.float64))
     assert result == pytest.approx(expected)
-    assert np.dtype(np.asarray(result).dtype) == np.dtype(np.float64)
+    assert np.asarray(result).dtype == np.dtype(np.float64)
 
 
 def test_std_integer_no_overflow():
@@ -42,7 +42,11 @@ def test_mean_weighted_integer_no_overflow():
 
 
 def test_var_jagged_integer_no_overflow():
-    array = ak.Array([[100000, 200000, 300000], [], [400000, 500000]])
+    # int32 leaves, so x*x overflows int32 without the promotion (values entered
+    # as the default int64 would only square to ~2.5e11 and pass on main too).
+    array = ak.values_astype(
+        ak.Array([[100000, 200000, 300000], [], [400000, 500000]]), np.int32
+    )
     result = ak.var(array, axis=-1)
     expected = [
         np.var([100000.0, 200000.0, 300000.0]),
@@ -59,3 +63,23 @@ def test_float_input_unchanged():
     data = np.array([1.5, 2.5, 3.5], dtype=np.float64)
     assert ak.var(ak.Array(data)) == pytest.approx(np.var(data))
     assert ak.mean(ak.Array(data)) == pytest.approx(np.mean(data))
+
+
+def test_var_int64_no_overflow_issue_3525():
+    # Resolves #3525: the squares overflow int64 (the reducer's accumulator), so
+    # on main the variance goes negative and ak.std returns nan. The new int32
+    # tests do not exercise the int64 accumulator path.
+    data = np.array([3_000_000_000, 4_000_000_000, 5_000_000_000], dtype=np.int64)
+    result = ak.var(ak.Array(data))
+    assert result == pytest.approx(np.var(data.astype(np.float64)))
+    assert not np.isnan(ak.std(ak.Array(data)))
+
+
+def test_typetracer_promotion():
+    # The promotion must work on typetracer layouts (protects the dask-awkward
+    # path): integer input still yields float64 output types.
+    base = ak.values_astype(ak.Array([[1, 2, 3], [4, 5]]), np.int32)
+    tt = ak.to_backend(base, "typetracer")
+    assert str(ak.var(tt, axis=-1).type) == "2 * float64"
+    assert str(ak.mean(tt, axis=-1).type) == "2 * float64"
+    assert ak.moment(tt, 2, axis=-1).layout.dtype == np.dtype(np.float64)


### PR DESCRIPTION
Resolves #3525

## Where the overflow actually is

`ak.sum`'s reducer already promotes integer/bool leaves to the platform integer
(`int64`/`uint64`) accumulator — see `_promote_integer_rank` in
`src/awkward/_reducers.py` and the `awkward_reduce_sum<result, input, offsets>`
kernel templated separately on accumulator and input dtype. So:

- `ak.sum(int32_array)` already accumulates in `int64`. A plain integer **mean
  without weights** (`sum(x) / count`) is overflow-safe up to `int64` today and
  needs no cast.
- The real overflow is the **element-wise products** computed in Python *before*
  the reduction: `x * x`, `x * weight`, `x * x * weight` in `var`, `std`,
  `covar`, `corr`, `moment`. `int32 * int32` stays `int32` and overflows
  per-element — long before `int64` accumulation can help.

So the original https://github.com/scikit-hep/awkward/pull/3527 PR's "cast the whole input to `float64` up front, always" is
heavier than needed: it copies floating inputs that never overflow, and it casts
in a spot that isn't the only thing that matters.

## The two objections on the https://github.com/scikit-hep/awkward/pull/3527 PR, addressed

1. **"Binary floats can't represent decimals exactly."** True, but that's an
   argument against floating-point in general — it applies equally to `x / 2`,
   which we already promote. The alternative here is *silent integer overflow*,
   which is strictly worse than rounding error. NumPy makes exactly this choice
   for `mean`/`var`/`std`.
2. **"The cast triggers device-to-host copies on GPU."** A dtype cast via
   `ak.values_astype` runs on the array's own backend — `cupy.ndarray.astype` on
   the cuda backend. It stays on-device; there is no host round-trip. The cost on
   GPU is `float64` memory (2× an `int32` buffer) and lower `float64` throughput,
   not a D2H transfer. The solution below only pays that cost for **integral
   inputs** and only **once per call**.

## Solution

Two tiers. Tier 1 is a small, self-contained Python PR. Tier 2 is the fully
copy-free version and needs a reducer tweak -- a separate PR to follow.

### Tier 1 — promote only integral leaves, once, on-backend

A shared helper (e.g. in `src/awkward/_layout.py`):

```python
import awkward as ak
from awkward._nplikes.numpy_like import NumpyMetadata

np = NumpyMetadata.instance()


def _has_integral_leaf(layout) -> bool:
    """True if any NumpyArray leaf is bool/integer (kinds 'b', 'i', 'u')."""
    found = False

    def action(node, **kwargs):
        nonlocal found
        if node.is_numpy and node.dtype.kind in "biu":
            found = True
        return None

    ak._do.recursively_apply(layout, action, return_array=False)
    return found


def promote_integral_to_float64(array):
    """Cast bool/integer data to float64 to avoid overflow in summations,
    matching NumPy's reduction dtype.

    Floating and complex data is returned unchanged (no copy). The cast runs on
    the array's own backend, so on GPU it stays on device — no host transfer.
    """
    if _has_integral_leaf(array.layout):
        return ak.operations.values_astype(array, np.float64, highlevel=True)
    return array
```

Then, in each statistic that forms products, promote **once** and reuse the
result across every reduction. For `ak.var` (`src/awkward/operations/ak_var.py`),
the change is one line plus reuse:

```python
    x = ctx.wrap(x_layout)
    weight = ctx.wrap(weight_layout, allow_other=True)

    # Overflow guard: integer squares/products overflow before reduction.
    # Promote integral leaves to float64 once (no-op + zero copy for floats).
    x = promote_integral_to_float64(x)
    if weight is not None:
        weight = promote_integral_to_float64(weight)

    ...
    # sumwx, sumwxx (and sumw) now reduce float64 data — one promotion, reused.
```

The actual scope is smaller than "every stat," because most paths are already
safe:

- **`ak_var.py`** — needs it (`sum(x*x)`). **`ak_std.py`** inherits the fix for
  free: it just calls `ak.var` and takes `sqrt`.
- **`ak_moment.py`** — needs it (`sum(x**n)`).
- **`ak_mean.py`** — needs it only in the **weighted** branch (`sum(x*weight)`).
  The unweighted path (`sum(x)/count`) is already overflow-safe to `int64` via
  the reducer's `int64` accumulator, and the final division yields `float64`, so
  it is left copy-free.
- **`ak_covar.py` / `ak_corr.py`** — need **nothing**. They center first,
  `(x - xmean) * (y - ymean)`, and `xmean` is already `float64` (it comes from
  `ak.mean`), so the products are float before any multiply. Their internal
  `ak.mean` call inherits the weighted-branch fix if integer weights are passed.

So the real change is three files: `ak_var.py`, `ak_moment.py`, and the weighted
branch of `ak_mean.py` — plus the shared helper.

If you additionally want unweighted integer `mean` to match NumPy's
`float64`-accumulator behavior (guarding `int64` overflow too), use Tier 2 rather
than adding a copy.

Net effect vs. the https://github.com/scikit-hep/awkward/pull/3527 PR: floating inputs are untouched (zero copy — the common
case in analysis), integral inputs are promoted exactly once instead of
implicitly re-cast inside each `x*x` / `x*weight`, and the cast provably stays on
the GPU backend.
