### PR TITLE
test: add stability roundtrip test for `to_numpy`/`from_numpy`

### DIFF
--- a/tests/properties/operations/test_to_from_numpy.py
+++ b/tests/properties/operations/test_to_from_numpy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hypothesis_awkward.strategies as st_ak
+import numpy as np
 from hypothesis import given
 
 import awkward as ak
@@ -28,6 +29,42 @@ def test_roundtrip(a: ak.Array) -> None:
     n = ak.to_numpy(a)
     returned = ak.from_numpy(n)
     assert ak.array_equal(a, returned, equal_nan=True)
+
+
+@given(
+    a=st_ak.constructors.arrays(
+        # to_numpy(allow_missing=True) raises on timedelta64 with missing
+        # values (create_missing_data calls np.iinfo on the "m8" dtype)
+        dtypes=st_ak.supported_dtypes().filter(lambda d: d.kind != "m"),
+        # from_numpy crashes on multidimensional MaskedArrays that to_numpy
+        # builds from option-of-regular layouts: with no mask and a string
+        # dtype it calls `.size` on a `ListArray`; with a mask, ndim >= 3,
+        # and a zero-length dimension it attempts a `reshape(-1, 0)`
+        allow_regular=False,
+        allow_list=False,
+        allow_list_offset=False,
+        allow_record=False,
+        allow_union=False,
+    )
+)
+def test_roundtrip_stable(a: ak.Array) -> None:
+    """`from_numpy` then `to_numpy` reproduces `to_numpy`'s output.
+
+    `to_numpy` can lose type information (an unknown type becomes
+    `float64`, trailing NULs are stripped from strings, tuples become named
+    records), so `from_numpy` cannot always reconstruct the original array,
+    but the converted form is a fixed point: converting the reconstruction
+    yields the same NumPy array.
+    """
+    n = ak.to_numpy(a)
+    r = ak.from_numpy(n)
+    m = ak.to_numpy(r)
+    # itemsize of "U"/"S" dtypes is not stable: trailing NULs widen `n`'s
+    # dtype but are stripped in the roundtrip, narrowing `m`'s
+    np.testing.assert_array_equal(n, m, strict=(n.dtype.kind not in "SU"))
+    # assert_array_equal treats masked positions as equal to anything (even
+    # under differing masks), so the masks must be compared separately
+    np.testing.assert_array_equal(np.ma.getmaskarray(n), np.ma.getmaskarray(m))
 
 
 @given(

--- a/tests/properties/operations/test_to_from_numpy.py
+++ b/tests/properties/operations/test_to_from_numpy.py
@@ -38,8 +38,9 @@ def test_roundtrip(a: ak.Array) -> None:
         dtypes=st_ak.supported_dtypes().filter(lambda d: d.kind != "m"),
         # from_numpy crashes on multidimensional MaskedArrays that to_numpy
         # builds from option-of-regular layouts: with no mask and a string
-        # dtype it calls `.size` on a `ListArray`; with a mask, ndim >= 3,
-        # and a zero-length dimension it attempts a `reshape(-1, 0)`
+        # dtype it calls `.size` on a `ListArray` (#4226); with a mask,
+        # ndim >= 3, and a zero-length dimension it attempts a
+        # `reshape(-1, 0)` (#4227)
         allow_regular=False,
         allow_list=False,
         allow_list_offset=False,


### PR DESCRIPTION
This adds a third property test to `tests/properties/operations/test_to_from_numpy.py`, inserted between the two existing tests from #4215.

The strict roundtrip tests must exclude every layout that `ak.to_numpy` converts lossily (an unknown type becomes `float64`, trailing NULs are stripped from strings, tuples become named records, option flavors are normalized), because `ak.from_numpy` cannot reconstruct the original array from the lossy output. **`test_roundtrip_stable`** covers that domain with the standard weaker property: the converted form is a fixed point. With `n = to_numpy(a)`, `r = from_numpy(n)`, `m = to_numpy(r)`, it asserts that `n` and `m` are the same NumPy array.

Comparison details:

- `np.testing.assert_array_equal(n, m, strict=True)` enforces dtype and shape and treats NaN/NaT as equal; `strict` is relaxed only for `U`/`S` dtypes, where trailing-NUL stripping legitimately narrows the itemsize (values and shape are still compared).
- Masks are compared separately via `np.ma.getmaskarray`, because `assert_array_equal` treats masked positions as equal to anything, even under differing masks (`np.ma.testutils` ORs the masks, so it is equally blind). `getmaskarray` returns all-False for plain ndarrays, so no isinstance branch is needed.

The strategy enables what the strict tests exclude — `EmptyArray`, strings and bytestrings (including masked strings), all four option flavors, masked datetimes with NaT — and keeps off: unions and ragged lists (`to_numpy` raises), records (zero-field records crash `from_numpy`; reconstructed 2-D fields re-raise #3690), timedelta64 (#4217), and regular arrays. The last exclusion is because option-over-regular layouts produce multidimensional `np.ma.MaskedArray`s that crash `from_numpy` in two distinct ways (an `AttributeError` for no-mask multidimensional string arrays and a `ValueError` for ndim>=3 with a zero-length dimension); I will file both as separate issues and then update the comment here to cite them.

Verified: 200 examples (default profile, ~2.3 s for the whole file), 10,000 examples per test (nightly profile, ~105 s), full `tests/properties` directory passes, `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)