### PR TITLE
test: add property-based roundtrip tests for `to_arrow`/`from_arrow`

### DIFF
--- a/tests/properties/operations/test_to_from_arrow.py
+++ b/tests/properties/operations/test_to_from_arrow.py
@@ -48,86 +48,174 @@ def arrow_dtypes() -> st.SearchStrategy[np.dtype]:
     return st.sampled_from(SUPPORTED_ARROW_DTYPES)
 
 
-def arrow_writable(a: ak.Array) -> bool:
-    return _nodes_writable(a.layout)
+def arrow_compatible(a: ak.Array) -> bool:
+    """Arrays whose type the Arrow conversion preserves.
+
+    The clauses in `_loses_type` are limits of the conversion itself and
+    stay even when every cited issue is fixed.
+    """
+    return not _loses_type(a.layout)
 
 
-def _nodes_writable(
-    layout: ak.contents.Content,
-    nullable: bool = False,
-    sliced: bool = False,
-    lossless: bool = True,
-) -> bool:
-    """Exclude layouts that `to_arrow` or `from_arrow` currently mishandles.
+def _loses_type(layout: ak.contents.Content, nullable: bool = False) -> bool:
+    """The roundtrip changes the array's type without corrupting values.
 
-    `nullable` tracks whether Arrow validity bytes flow into this node from
-    an enclosing option: they start at option nodes, pass through records
-    and indexed nodes, and stop below lists. A var-length list receiving
-    validity bytes whose offsets do not start at zero is compacted against
-    unshifted content in `ListOffsetArray._to_arrow`, shifting every list
-    by `offsets[0]` (data corruption, #4222).
-
-    `sliced` tracks whether `to_arrow` reaches this node through a
-    transformation that can move list offsets away from zero even if they
-    were constructed zero-based: a list trims its content to
-    `offsets[0]:offsets[length]`, an indexed node projects its content, a
-    `ListArray` may be compacted from anywhere, and a union selects each
-    child through its index; such nodes can present any list below an
-    option with nonzero offsets, triggering #4222.
-
-    `lossless` distinguishes exact reconstruction from mere convertibility:
-    layouts whose type the roundtrip changes without crashing or corrupting
-    values (mergeable union contents, unknown-type fields under an option)
-    are excluded only when `lossless` is true.
+    `nullable` tracks whether Arrow validity bytes flow into this node
+    from an enclosing option: they start at option nodes, pass through
+    records and indexed nodes, and stop below lists.
     """
     if layout.is_union:
-        if nullable:
-            # `UnionArray._to_arrow` scatters incoming validity bytes with
-            # a per-child index that it misapplies when the index skips
-            # values (IndexError, #4228)
-            return False
-        if lossless and any(
+        if any(
             ak._do.mergeable(x, y, mergebool=False)
             for x, y in itertools.combinations(layout.contents, 2)
         ):
             # `from_arrow` rebuilds unions with `UnionArray.simplified`,
             # which merges mergeable contents (e.g. `union[float64, int64]`
             # reads back as `float64`)
-            return False
-        return all(_nodes_writable(x, False, True, lossless) for x in layout.contents)
+            return True
+        return any(_loses_type(x, False) for x in layout.contents)
     if layout.is_record:
-        return all(
-            _nodes_writable(x, nullable, sliced, lossless) for x in layout.contents
-        )
+        return any(_loses_type(x, nullable) for x in layout.contents)
     if layout.is_regular:
-        # `from_arrow` loses the length of a size-0 fixed-size list (a
-        # `3 * 0 * float64` array reads back with length 0, #4229)
-        return layout.size > 0 and _nodes_writable(
-            layout.content, False, sliced, lossless
-        )
+        return _loses_type(layout.content, False)
+    if layout.is_option:
+        return _loses_type(layout.content, True)
+    if layout.is_indexed:
+        return _loses_type(layout.content, nullable)
+    if layout.is_list:
+        return _loses_type(layout.content, False)
+    if layout.is_unknown:
+        # Arrow's null type is intrinsically nullable: an unknown-type
+        # record field under an option reads back as `?unknown`
+        return nullable
+    return False
+
+
+def has_issues(a: ak.Array) -> bool:
+    """Arrays affected by a known issue in the conversion.
+
+    One function per known issue, each named after the issue whose
+    released fix deletes it; with all of them gone the test filters
+    reduce to `arrow_compatible` and `table_compatible`.
+    """
+    if _has_issue_4221(a.layout):
+        return True
+    if _has_issue_4222(a.layout):
+        return True
+    if _has_issue_4228(a.layout):
+        return True
+    if _has_issue_4229(a.layout):
+        return True
+    return False
+
+
+def _has_issue_4221(layout: ak.contents.Content) -> bool:
+    """`to_arrow` crashes projecting nulls over a zero-length content
+    (IndexError in `ListOffsetArray._to_arrow`, #4221)."""
+    if (
+        isinstance(layout, ak.contents.IndexedOptionArray)
+        and layout.length > 0
+        and layout.content.length == 0
+    ):
+        return True
+    return any(_has_issue_4221(x) for x in _children(layout))
+
+
+def _has_issue_4222(
+    layout: ak.contents.Content,
+    nullable: bool = False,
+    sliced: bool = False,
+) -> bool:
+    """A nullable var-length list whose offsets do not start at zero is
+    compacted against unshifted content in `ListOffsetArray._to_arrow`,
+    shifting every list by `offsets[0]` (data corruption, #4222).
+
+    `nullable` tracks whether Arrow validity bytes flow into this node
+    from an enclosing option: they start at option nodes, pass through
+    records and indexed nodes, and stop below lists.
+
+    `sliced` tracks whether `to_arrow` reaches this node through a
+    transformation that can move list offsets away from zero even if
+    they were constructed zero-based: a list trims its content to
+    `offsets[0]:offsets[length]`, an indexed node projects its content,
+    a `ListArray` may be compacted from anywhere, and a union selects
+    each child through its index; such nodes can present any list below
+    an option with nonzero offsets.
+    """
+    if layout.is_union:
+        return any(_has_issue_4222(x, False, True) for x in layout.contents)
+    if layout.is_record:
+        return any(_has_issue_4222(x, nullable, sliced) for x in layout.contents)
+    if layout.is_regular:
+        return _has_issue_4222(layout.content, False, sliced)
     if layout.is_option:
         if isinstance(layout, ak.contents.IndexedOptionArray):
-            if layout.length > 0 and layout.content.length == 0:
-                # `to_arrow` crashes projecting nulls over a zero-length
-                # content (IndexError in `ListOffsetArray._to_arrow`, #4221)
-                return False
-            return _nodes_writable(layout.content, True, True, lossless)
-        return _nodes_writable(layout.content, True, sliced, lossless)
+            return _has_issue_4222(layout.content, True, True)
+        return _has_issue_4222(layout.content, True, sliced)
     if layout.is_indexed:
-        return _nodes_writable(layout.content, nullable, True, lossless)
+        return _has_issue_4222(layout.content, nullable, True)
     if layout.is_list:
         if nullable and layout.length > 0 and (sliced or layout.starts[0] != 0):
-            return False
+            return True
         if isinstance(layout, ak.contents.ListOffsetArray):
             child_sliced = sliced or bool(layout.offsets[0] != 0)
         else:
             child_sliced = True
-        return _nodes_writable(layout.content, False, child_sliced, lossless)
-    if layout.is_unknown:
-        # Arrow's null type is intrinsically nullable: an unknown-type
-        # record field under an option reads back as `?unknown`
-        return not (lossless and nullable)
-    return True
+        return _has_issue_4222(layout.content, False, child_sliced)
+    return False
+
+
+def _has_issue_4228(layout: ak.contents.Content, nullable: bool = False) -> bool:
+    """`UnionArray._to_arrow` scatters incoming validity bytes with a
+    per-child index that it misapplies when the index skips values
+    (IndexError, #4228).
+
+    `nullable` tracks validity bytes as in `_has_issue_4222`.
+    """
+    if layout.is_union:
+        if nullable:
+            return True
+        return any(_has_issue_4228(x, False) for x in layout.contents)
+    if layout.is_record:
+        return any(_has_issue_4228(x, nullable) for x in layout.contents)
+    if layout.is_regular:
+        return _has_issue_4228(layout.content, False)
+    if layout.is_option:
+        return _has_issue_4228(layout.content, True)
+    if layout.is_indexed:
+        return _has_issue_4228(layout.content, nullable)
+    if layout.is_list:
+        return _has_issue_4228(layout.content, False)
+    return False
+
+
+def _has_issue_4229(layout: ak.contents.Content) -> bool:
+    """`from_arrow` loses the length of a size-0 fixed-size list (a
+    `3 * 0 * float64` array reads back with length 0, #4229)."""
+    if layout.is_regular and layout.size == 0:
+        return True
+    return any(_has_issue_4229(x) for x in _children(layout))
+
+
+def _children(layout: ak.contents.Content) -> list[ak.contents.Content]:
+    """The direct child layouts of a node."""
+    if layout.is_record or layout.is_union:
+        return list(layout.contents)
+    if layout.is_option or layout.is_indexed or layout.is_list:
+        return [layout.content]
+    return []
+
+
+def _strip_options(
+    layout: ak.contents.Content,
+) -> tuple[ak.contents.Content, bool]:
+    """Strip option and indexed wrappers, reporting whether an option
+    was among them."""
+    is_option = False
+    while layout.is_option or layout.is_indexed:
+        is_option = is_option or layout.is_option
+        layout = layout.content
+    return layout, is_option
 
 
 @suppress_too_slow
@@ -138,7 +226,7 @@ def _nodes_writable(
         allow_byte_masked=False,
         allow_bit_masked=False,
         allow_unmasked=False,
-    ).filter(arrow_writable)
+    ).filter(lambda a: arrow_compatible(a) and not has_issues(a))
 )
 def test_roundtrip(a: ak.Array) -> None:
     """`to_arrow` followed by `from_arrow` reconstructs the array."""
@@ -155,7 +243,7 @@ def test_roundtrip(a: ak.Array) -> None:
         # index reference crashes `to_arrow` (IndexError in
         # `ListOffsetArray._to_arrow` via `UnionArray._to_arrow`, #4228)
         allow_union=False,
-    ).filter(arrow_writable)
+    ).filter(lambda a: arrow_compatible(a) and not has_issues(a))
 )
 def test_roundtrip_masked(a: ak.Array) -> None:
     """Option-type arrays roundtrip through Arrow validity bitmaps.
@@ -168,11 +256,15 @@ def test_roundtrip_masked(a: ak.Array) -> None:
     assert ak.array_equal(a, returned, equal_nan=True, same_content_types=False)
 
 
-def table_writable(a: ak.Array) -> bool:
-    layout, is_option = a.layout, False
-    while layout.is_option or layout.is_indexed:
-        is_option = is_option or layout.is_option
-        layout = layout.content
+def table_compatible(a: ak.Array) -> bool:
+    """Arrays that additionally survive the table wrapping of
+    `to_arrow_table`.
+
+    Like `arrow_compatible`, which this extends, the clauses here are
+    limits of the representation and stay even when every cited issue is
+    fixed.
+    """
+    layout, is_option = _strip_options(a.layout)
     if layout.is_record:
         if layout.fields == [""]:
             # collides with the anonymous column that `to_arrow_table` uses
@@ -185,7 +277,7 @@ def table_writable(a: ak.Array) -> bool:
             # a valid row whose fields are all null reads back as a null
             # row (outermost struct validity is not stored)
             return False
-    return _nodes_writable(a.layout)
+    return arrow_compatible(a)
 
 
 @suppress_too_slow
@@ -197,7 +289,7 @@ def table_writable(a: ak.Array) -> bool:
         # schema comparison
         allow_empty=False,
         allow_union=False,
-    ).filter(table_writable)
+    ).filter(lambda a: table_compatible(a) and not has_issues(a))
 )
 def test_roundtrip_table(a: ak.Array) -> None:
     """Arrays roundtrip through `to_arrow_table`, and `from_arrow_schema`
@@ -214,10 +306,6 @@ def test_roundtrip_table(a: ak.Array) -> None:
     assert ak.from_arrow_schema(table.schema) == returned.layout.form
 
 
-def stable_writable(a: ak.Array) -> bool:
-    return _nodes_writable(a.layout, lossless=False)
-
-
 @suppress_too_slow
 @given(
     a=st_ak.constructors.arrays(
@@ -225,7 +313,7 @@ def stable_writable(a: ak.Array) -> bool:
         # pyarrow's `Array.equals` counts NaN as unequal to itself and has
         # no `equal_nan` option; NaN coverage lives in the tests above
         allow_nan=False,
-    ).filter(stable_writable)
+    ).filter(lambda a: not has_issues(a))
 )
 def test_roundtrip_stable(a: ak.Array) -> None:
     """One roundtrip brings the conversion to a fixed point.
@@ -235,8 +323,8 @@ def test_roundtrip_stable(a: ak.Array) -> None:
     read side (`from_arrow` merges mergeable union contents), so neither
     the array nor the first Arrow conversion is reproducible in general.
     After one full roundtrip both normalizations have happened: converting
-    the reconstruction again yields an identical Arrow array. Layouts that
-    `to_arrow` crashes on or corrupts (#4219, #4221, #4222) are still
+    the reconstruction again yields an identical Arrow array. Layouts
+    affected by `has_issues` (or by #4219, in the dtype filter) are still
     excluded: this test does not vouch for them.
     """
     r = ak.from_arrow(ak.to_arrow(a))

--- a/tests/properties/operations/test_to_from_arrow.py
+++ b/tests/properties/operations/test_to_from_arrow.py
@@ -1,0 +1,245 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import itertools
+
+import hypothesis_awkward.strategies as st_ak
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis_awkward.util.dtype import SUPPORTED_DTYPES
+
+import awkward as ak
+
+pytest.importorskip("pyarrow")
+
+# An unlucky draw sequence can spend ~1 s in discarded generation attempts
+# (entropy-overrun retries inside hypothesis-awkward's recursive strategies),
+# tripping the health check. Hypothesis' built-in "ci" profile, from which
+# this suite's profiles inherit on GitHub Actions, already suppresses it.
+suppress_too_slow = settings(suppress_health_check=[HealthCheck.too_slow])
+
+
+def arrow_dtype(dtype: np.dtype) -> bool:
+    if dtype.kind == "c":
+        # pyarrow has no complex numbers (ArrowNotImplementedError)
+        return False
+    if dtype.kind == "f" and dtype.itemsize == 16:
+        # pyarrow has no extended-precision floats, which exist on some
+        # platforms (e.g. float128 on Linux)
+        return False
+    if dtype.kind == "M":
+        # units coarser than "s" are unsupported, except "D", whose values
+        # `to_arrow` corrupts (int64 buffer reinterpreted as date32, #4219)
+        return np.datetime_data(dtype)[0] in {"s", "ms", "us", "ns"}
+    if dtype.kind == "m":
+        # pyarrow durations support only seconds and finer units
+        return np.datetime_data(dtype)[0] in {"s", "ms", "us", "ns"}
+    return True
+
+
+SUPPORTED_ARROW_DTYPES = tuple(d for d in SUPPORTED_DTYPES if arrow_dtype(d))
+
+
+def arrow_dtypes() -> st.SearchStrategy[np.dtype]:
+    """Strategy for dtypes that survive the Arrow roundtrip."""
+    return st.sampled_from(SUPPORTED_ARROW_DTYPES)
+
+
+def arrow_writable(a: ak.Array) -> bool:
+    return _nodes_writable(a.layout)
+
+
+def _nodes_writable(
+    layout: ak.contents.Content,
+    nullable: bool = False,
+    sliced: bool = False,
+    lossless: bool = True,
+) -> bool:
+    """Exclude layouts that `to_arrow` or `from_arrow` currently mishandles.
+
+    `nullable` tracks whether Arrow validity bytes flow into this node from
+    an enclosing option: they start at option nodes, pass through records
+    and indexed nodes, and stop below lists. A var-length list receiving
+    validity bytes whose offsets do not start at zero is compacted against
+    unshifted content in `ListOffsetArray._to_arrow`, shifting every list
+    by `offsets[0]` (data corruption, #4222).
+
+    `sliced` tracks whether `to_arrow` reaches this node through a
+    transformation that can move list offsets away from zero even if they
+    were constructed zero-based: a list trims its content to
+    `offsets[0]:offsets[length]`, an indexed node projects its content, a
+    `ListArray` may be compacted from anywhere, and a union selects each
+    child through its index; such nodes can present any list below an
+    option with nonzero offsets, triggering #4222.
+
+    `lossless` distinguishes exact reconstruction from mere convertibility:
+    layouts whose type the roundtrip changes without crashing or corrupting
+    values (mergeable union contents, unknown-type fields under an option)
+    are excluded only when `lossless` is true.
+    """
+    if layout.is_union:
+        if nullable:
+            # `UnionArray._to_arrow` scatters incoming validity bytes with
+            # a per-child index that it misapplies when the index skips
+            # values (IndexError, #4228)
+            return False
+        if lossless and any(
+            ak._do.mergeable(x, y, mergebool=False)
+            for x, y in itertools.combinations(layout.contents, 2)
+        ):
+            # `from_arrow` rebuilds unions with `UnionArray.simplified`,
+            # which merges mergeable contents (e.g. `union[float64, int64]`
+            # reads back as `float64`)
+            return False
+        return all(_nodes_writable(x, False, True, lossless) for x in layout.contents)
+    if layout.is_record:
+        return all(
+            _nodes_writable(x, nullable, sliced, lossless) for x in layout.contents
+        )
+    if layout.is_regular:
+        # `from_arrow` loses the length of a size-0 fixed-size list (a
+        # `3 * 0 * float64` array reads back with length 0, #4229)
+        return layout.size > 0 and _nodes_writable(
+            layout.content, False, sliced, lossless
+        )
+    if layout.is_option:
+        if isinstance(layout, ak.contents.IndexedOptionArray):
+            if layout.length > 0 and layout.content.length == 0:
+                # `to_arrow` crashes projecting nulls over a zero-length
+                # content (IndexError in `ListOffsetArray._to_arrow`, #4221)
+                return False
+            return _nodes_writable(layout.content, True, True, lossless)
+        return _nodes_writable(layout.content, True, sliced, lossless)
+    if layout.is_indexed:
+        return _nodes_writable(layout.content, nullable, True, lossless)
+    if layout.is_list:
+        if nullable and layout.length > 0 and (sliced or layout.starts[0] != 0):
+            return False
+        if isinstance(layout, ak.contents.ListOffsetArray):
+            child_sliced = sliced or bool(layout.offsets[0] != 0)
+        else:
+            child_sliced = True
+        return _nodes_writable(layout.content, False, child_sliced, lossless)
+    if layout.is_unknown:
+        # Arrow's null type is intrinsically nullable: an unknown-type
+        # record field under an option reads back as `?unknown`
+        return not (lossless and nullable)
+    return True
+
+
+@suppress_too_slow
+@given(
+    a=st_ak.constructors.arrays(
+        dtypes=arrow_dtypes(),
+        allow_indexed_option=False,
+        allow_byte_masked=False,
+        allow_bit_masked=False,
+        allow_unmasked=False,
+    ).filter(arrow_writable)
+)
+def test_roundtrip(a: ak.Array) -> None:
+    """`to_arrow` followed by `from_arrow` reconstructs the array."""
+    arr = ak.to_arrow(a)
+    returned = ak.from_arrow(arr)
+    assert ak.array_equal(a, returned, equal_nan=True)
+
+
+@suppress_too_slow
+@given(
+    a=st_ak.constructors.arrays(
+        dtypes=arrow_dtypes(),
+        # a union with an option-type child that is longer than its last
+        # index reference crashes `to_arrow` (IndexError in
+        # `ListOffsetArray._to_arrow` via `UnionArray._to_arrow`, #4228)
+        allow_union=False,
+    ).filter(arrow_writable)
+)
+def test_roundtrip_masked(a: ak.Array) -> None:
+    """Option-type arrays roundtrip through Arrow validity bitmaps.
+
+    `from_arrow` returns every option layout as a `BitMaskedArray` (or
+    `UnmaskedArray`), so content classes are not compared.
+    """
+    arr = ak.to_arrow(a)
+    returned = ak.from_arrow(arr)
+    assert ak.array_equal(a, returned, equal_nan=True, same_content_types=False)
+
+
+def table_writable(a: ak.Array) -> bool:
+    layout, is_option = a.layout, False
+    while layout.is_option or layout.is_indexed:
+        is_option = is_option or layout.is_option
+        layout = layout.content
+    if layout.is_record:
+        if layout.fields == [""]:
+            # collides with the anonymous column that `to_arrow_table` uses
+            # for non-record arrays; reads back unwrapped
+            return False
+        if not layout.is_tuple and len(layout.fields) == 0:
+            # becomes a zero-column table, losing the length
+            return False
+        if is_option and all(x.is_option for x in layout.contents):
+            # a valid row whose fields are all null reads back as a null
+            # row (outermost struct validity is not stored)
+            return False
+    return _nodes_writable(a.layout)
+
+
+@suppress_too_slow
+@given(
+    a=st_ak.constructors.arrays(
+        dtypes=arrow_dtypes(),
+        # a bare unknown type crashes `from_arrow` (AttributeError in
+        # `form_remove_optiontype`, #4230), and a nested one breaks the
+        # schema comparison
+        allow_empty=False,
+        allow_union=False,
+    ).filter(table_writable)
+)
+def test_roundtrip_table(a: ak.Array) -> None:
+    """Arrays roundtrip through `to_arrow_table`, and `from_arrow_schema`
+    predicts the form that `from_arrow` returns.
+
+    Without `generate_bitmasks=True`, an all-valid nullable field reads
+    back as an `UnmaskedArray`, whereas the schema, which cannot know
+    whether a validity buffer is present, converts to a `BitMaskedArray`
+    form.
+    """
+    table = ak.to_arrow_table(a)
+    returned = ak.from_arrow(table, generate_bitmasks=True)
+    assert ak.array_equal(a, returned, equal_nan=True, same_content_types=False)
+    assert ak.from_arrow_schema(table.schema) == returned.layout.form
+
+
+def stable_writable(a: ak.Array) -> bool:
+    return _nodes_writable(a.layout, lossless=False)
+
+
+@suppress_too_slow
+@given(
+    a=st_ak.constructors.arrays(
+        dtypes=arrow_dtypes(),
+        # pyarrow's `Array.equals` counts NaN as unequal to itself and has
+        # no `equal_nan` option; NaN coverage lives in the tests above
+        allow_nan=False,
+    ).filter(stable_writable)
+)
+def test_roundtrip_stable(a: ak.Array) -> None:
+    """One roundtrip brings the conversion to a fixed point.
+
+    The roundtrip can lose type information on the write side (an
+    unknown-type record field under an option gains an option) or on the
+    read side (`from_arrow` merges mergeable union contents), so neither
+    the array nor the first Arrow conversion is reproducible in general.
+    After one full roundtrip both normalizations have happened: converting
+    the reconstruction again yields an identical Arrow array. Layouts that
+    `to_arrow` crashes on or corrupts (#4219, #4221, #4222) are still
+    excluded: this test does not vouch for them.
+    """
+    r = ak.from_arrow(ak.to_arrow(a))
+    m = ak.to_arrow(r)
+    m2 = ak.to_arrow(ak.from_arrow(m))
+    assert m2.equals(m)


### PR DESCRIPTION
This adds Hypothesis roundtrip tests for `ak.to_arrow` / `ak.from_arrow`, the fourth member of the roundtrip property-test family after `test_to_from_buffers.py`, #4215/#4225, and #4218. The Arrow pair is the layer beneath parquet and feather and needs no I/O; an example takes about 5 ms. Four tests:

**`test_roundtrip`** — strict `ak.array_equal` after the roundtrip, with option types disabled but **unions enabled**: unions roundtrip exactly through Arrow (they cannot be stored in parquet, so no sibling test covers them). Union contents must be pairwise non-mergeable, because `from_arrow` rebuilds unions with `UnionArray.simplified`, which merges mergeable contents; the predicate mirrors that with `ak._do.mergeable`.

**`test_roundtrip_masked`** — option types enabled, compared with `same_content_types=False` (every option layout returns as `BitMaskedArray` or `UnmaskedArray`). Unlike the parquet sibling, `allow_regular` stays on: option-over-regular works through pure Arrow (ARROW-14547 is a parquet-write limitation). Unions are off here because of #4228.

**`test_roundtrip_table`** — the same roundtrip through `to_arrow_table`, with `generate_bitmasks=True`, plus a schema assertion: `ak.from_arrow_schema(table.schema)` must equal the returned array's form.

**`test_roundtrip_stable`** — a fixed-point test for the lossy domain the others exclude (mergeable unions, unknown-type fields under an option, unions with option-type children). The roundtrip loses type information on the write side (nullable unknown gains an option) or the read side (union simplification), so the test asserts that after one full roundtrip the conversion has stabilized, comparing the second and third conversions on the Arrow side with `Array.equals`. NaN generation is disabled in this test only (`Array.equals` has no `equal_nan`); NaN coverage lives in the other three.

Generation restrictions, each with the observed failure in a comment: complex and extended-precision floats are unrepresentable in pyarrow; datetime64/timedelta64 are limited to `s`/`ms`/`us`/`ns` (`datetime64[D]` values are corrupted by #4219; unlike parquet, `s`/`ms`/`us` and NaT are fine through pure Arrow). A layout predicate excludes the known conversion defects: #4221, #4222 (including a newly found trigger where conversion-time offset shifts reach the corrupting branch — reported in a comment on that issue), #4228, #4229, and #4230. The last three were found while developing this test.

All four tests pass 10,000 Hypothesis examples each (nightly profile, ~4 min) and 200 examples in ~5 s (default profile); the file carries a `suppress_too_slow` settings decorator because hypothesis-awkward's recursive generation occasionally trips Hypothesis' `too_slow` health check under fixed seeds (the built-in "ci" profile already suppresses it on GitHub Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)