### PR TITLE
docs: move description text out of Examples: sections in merged files

### DIFF
--- a/src/awkward/operations/ak_argcartesian.py
+++ b/src/awkward/operations/ak_argcartesian.py
@@ -27,6 +27,9 @@ def argcartesian(
 ):
     """Computes the Cartesian product of arrays, returning integer indexes.
 
+    All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
+    so see the #ak.cartesian documentation for a more complete description.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -97,9 +100,6 @@ def argcartesian(
         <Array [1.1, 1.1, 2.2, 2.2, 3.3, 3.3] type='6 * float64'>
         >>> two[two_index]
         <Array ['a', 'b', 'a', 'b', 'a', 'b'] type='6 * string'>
-
-        All of the parameters for #ak.cartesian apply equally to #ak.argcartesian,
-        so see the #ak.cartesian documentation for a more complete description.
     """
     # Dispatch
     if isinstance(arrays, Mapping):

--- a/src/awkward/operations/ak_broadcast_arrays.py
+++ b/src/awkward/operations/ak_broadcast_arrays.py
@@ -38,6 +38,39 @@ def broadcast_arrays(
 ):
     """Broadcasts arrays together so they can be combined element-by-element.
 
+    One typically wants single-item-per-element data to be duplicated to
+    match multiple-items-per-element data. Operations on the broadcasted
+    arrays like::
+
+        one_dimensional + nested_lists
+
+    would then have the same effect as the procedural code::
+
+        for x, outer in zip(one_dimensional, nested_lists):
+            output = []
+            for inner in outer:
+                output.append(x + inner)
+            yield output
+
+    where `x` has the same value for each `inner` in the inner loop.
+
+    Awkward Array's broadcasting manages to have it both ways by applying the
+    following rules:
+
+    * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
+      implicit broadcasting aligns to the right, like NumPy.
+    * If any dimension is variable (i.e. #ak.types.ListType), which can
+      never be true of NumPy, implicit broadcasting aligns to the left.
+    * Explicit broadcasting with a length-1 regular dimension always
+      broadcasts, like NumPy.
+
+    Thus, it is important to be aware of the distinction between a dimension
+    that is declared to be regular in the type specification and a dimension
+    that is allowed to be variable (even if it happens to have the same length
+    for all elements). This distinction is can be accessed through the
+    #ak.Array.type, but it is lost when converting an array into JSON or
+    Python objects.
+
     Args:
         arrays: Array-like data (anything #ak.to_layout recognizes).
         depth_limit (None or int, default is None): If None, attempt to fully
@@ -131,39 +164,6 @@ def broadcast_arrays(
         ...                     [[1.1, 2.2, 3.3],    [], [4.4, 5.5]])
         [<Array [[100, 100, 100], [], [300, 300]] type='3 * var * int64'>,
          <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>]
-
-        One typically wants single-item-per-element data to be duplicated to
-        match multiple-items-per-element data. Operations on the broadcasted
-        arrays like::
-
-            one_dimensional + nested_lists
-
-        would then have the same effect as the procedural code::
-
-            for x, outer in zip(one_dimensional, nested_lists):
-                output = []
-                for inner in outer:
-                    output.append(x + inner)
-                yield output
-
-        where `x` has the same value for each `inner` in the inner loop.
-
-        Awkward Array's broadcasting manages to have it both ways by applying the
-        following rules:
-
-        * If all dimensions are regular (i.e. #ak.types.RegularType), like NumPy,
-          implicit broadcasting aligns to the right, like NumPy.
-        * If any dimension is variable (i.e. #ak.types.ListType), which can
-          never be true of NumPy, implicit broadcasting aligns to the left.
-        * Explicit broadcasting with a length-1 regular dimension always
-          broadcasts, like NumPy.
-
-        Thus, it is important to be aware of the distinction between a dimension
-        that is declared to be regular in the type specification and a dimension
-        that is allowed to be variable (even if it happens to have the same length
-        for all elements). This distinction is can be accessed through the
-        #ak.Array.type, but it is lost when converting an array into JSON or
-        Python objects.
 
         If arrays have the same depth but different lengths of nested
         lists, attempting to broadcast them together is a broadcasting error.

--- a/src/awkward/operations/ak_cartesian.py
+++ b/src/awkward/operations/ak_cartesian.py
@@ -45,6 +45,19 @@ def cartesian(
     `arrays` is another kind of iterable) that hold the combinations of
     elements, and it can introduce new levels of nesting.
 
+    The order of the output is fixed: it is always lexicographical in the
+    order that the `arrays` are written.
+
+    To emulate an SQL or Pandas "group by" operation, put the keys that you
+    wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by
+    unique n-tuples. If necessary, record keys can later be reordered with a
+    list of strings in #ak.Array.__getitem__.
+
+    To get list index positions in the tuples/records, rather than data from
+    the original `arrays`, use #ak.argcartesian instead of #ak.cartesian. The
+    #ak.argcartesian form can be particularly useful as nested indexing in
+    #ak.Array.__getitem__.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -206,19 +219,6 @@ def cartesian(
          [(4, 1.1, 'a'), (4, 1.1, 'b')],
          [(4, 2.2, 'a'), (4, 2.2, 'b')],
          [(4, 3.3, 'a'), (4, 3.3, 'b')]]
-
-        The order of the output is fixed: it is always lexicographical in the
-        order that the `arrays` are written.
-
-        To emulate an SQL or Pandas "group by" operation, put the keys that you
-        wish to group by *first* and use `nested=[0]` or `nested=[n]` to group by
-        unique n-tuples. If necessary, record keys can later be reordered with a
-        list of strings in #ak.Array.__getitem__.
-
-        To get list index positions in the tuples/records, rather than data from
-        the original `arrays`, use #ak.argcartesian instead of #ak.cartesian. The
-        #ak.argcartesian form can be particularly useful as nested indexing in
-        #ak.Array.__getitem__.
     """
     # Dispatch
     if isinstance(arrays, Mapping):

--- a/src/awkward/operations/ak_combinations.py
+++ b/src/awkward/operations/ak_combinations.py
@@ -37,6 +37,11 @@ def combinations(
     these represent the "upper triangle" of sets without repetition. If
     `replacement=True`, the diagonal of this "upper triangle" is included.
 
+    To get list index positions in the tuples/records, rather than data from
+    the original `array`, use #ak.argcombinations instead of #ak.combinations.
+    The #ak.argcombinations form can be particularly useful as nested indexing
+    in #ak.Array.__getitem__.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         n (int): The number of items to choose in each list: `2` chooses
@@ -191,11 +196,6 @@ def combinations(
 
         but it is frequently needed for data analysis, and the logic of which
         indexes to `keep` (above) gets increasingly complicated for large `n`.
-
-        To get list index positions in the tuples/records, rather than data from
-        the original `array`, use #ak.argcombinations instead of #ak.combinations.
-        The #ak.argcombinations form can be particularly useful as nested indexing
-        in #ak.Array.__getitem__.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_copy.py
+++ b/src/awkward/operations/ak_copy.py
@@ -26,6 +26,26 @@ def copy(array):
     change an array in-place, but the data in the array might be owned by
     another library that can change it in-place.
 
+    There is an exception to this rule: you can add fields to records in an
+    #ak.Array in-place. However, this changes the #ak.Array wrapper without
+    affecting the underlying layout data (it *replaces* its layout), so a
+    shallow copy will do:
+
+        >>> import copy
+        >>> original = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}])
+        >>> shallow_copy = copy.copy(original)
+        >>> shallow_copy["y"] = original.x**2
+        >>> shallow_copy
+        <Array [{x: 1, y: 1}, {...}, {x: 3, y: 9}] type='3 * {x: int64, y: int64}'>
+        >>> original
+        <Array [{x: 1}, {x: 2}, {x: 3}] type='3 * {x: int64}'>
+
+    This is key to Awkward Array's efficiency (memory and speed): operations that
+    only change part of a structure reuse pieces from the original ("structural
+    sharing"). Changing data in-place would result in many surprising long-distance
+    changes, so we don't support it. However, an #ak.Array's data might come from
+    a mutable third-party library, so this function allows you to make a true copy.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
 
@@ -45,26 +65,6 @@ def copy(array):
         <Array [1.1, 2.2, 123, 4.4, 5.5] type='5 * float64'>
         >>> duplicate
         <Array [1.1, 2.2, 3.3, 4.4, 5.5] type='5 * float64'>
-
-        There is an exception to this rule: you can add fields to records in an
-        #ak.Array in-place. However, this changes the #ak.Array wrapper without
-        affecting the underlying layout data (it *replaces* its layout), so a
-        shallow copy will do:
-
-        >>> import copy
-        >>> original = ak.Array([{"x": 1}, {"x": 2}, {"x": 3}])
-        >>> shallow_copy = copy.copy(original)
-        >>> shallow_copy["y"] = original.x**2
-        >>> shallow_copy
-        <Array [{x: 1, y: 1}, {...}, {x: 3, y: 9}] type='3 * {x: int64, y: int64}'>
-        >>> original
-        <Array [{x: 1}, {x: 2}, {x: 3}] type='3 * {x: int64}'>
-
-        This is key to Awkward Array's efficiency (memory and speed): operations that
-        only change part of a structure reuse pieces from the original ("structural
-        sharing"). Changing data in-place would result in many surprising long-distance
-        changes, so we don't support it. However, an #ak.Array's data might come from
-        a mutable third-party library, so this function allows you to make a true copy.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -43,6 +43,38 @@ def from_buffers(
 ):
     """Reconstitutes an Awkward Array from a Form, length, and memory buffers.
 
+    The first three arguments of this function are the return values of
+    #ak.to_buffers, so a full round-trip is
+
+        >>> reconstituted = ak.from_buffers(*ak.to_buffers(original))
+
+    The `container` argument lets you specify your own Mapping, which might be
+    an interface to some storage format or device (e.g. h5py). It's okay if
+    the `container` dropped NumPy's `dtype` and `shape` information, leaving
+    raw bytes, since `dtype` and `shape` can be reconstituted from the
+    #ak.forms.NumpyForm.
+    If the values of `container` are recognised as arrays by the given backend,
+    a view over their existing data will be used, where possible.
+    The `container` values are allowed to be callables with no arguments.
+    If that's the case, they will be turned into `VirtualNDArray` buffers whose generator
+    function is the callable and is used to materialize the buffer when required.
+
+    The `buffer_key` should be the same as the one used in #ak.to_buffers.
+
+    When `allow_noncanonical_form` is set to True, this function readily accepts
+    non-simplified forms, i.e. forms which will be simplified by Awkward Array
+    into "canonical" representations, e.g. `option[option[...]]` → `option[...]`.
+    Such forms can be produced by the low-level ArrayBuilder `snapshot()` method.
+    Given that Awkward Arrays must have canonical layouts, it follows that
+    invoking this function with `allow_noncanonical_form` may produce arrays
+    whose forms differ to the input form.
+
+    In order for a non-simplified form to be considered valid, it should be one
+    that the #ak.contents.Content layout classes could produce iff. the
+    simplification rules were removed.
+
+    See #ak.to_buffers for examples.
+
     Args:
         form (#ak.forms.Form or str/dict equivalent): The form of the Awkward
             Array to reconstitute from named buffers.
@@ -84,40 +116,6 @@ def from_buffers(
         An #ak.Array reconstituted from a Form, length, and a collection of memory
         buffers, so that data can be losslessly read from file formats and storage
         devices that only map names to binary blobs (such as a filesystem directory).
-
-    Examples:
-        The first three arguments of this function are the return values of
-        #ak.to_buffers, so a full round-trip is
-
-        >>> reconstituted = ak.from_buffers(*ak.to_buffers(original))
-
-        The `container` argument lets you specify your own Mapping, which might be
-        an interface to some storage format or device (e.g. h5py). It's okay if
-        the `container` dropped NumPy's `dtype` and `shape` information, leaving
-        raw bytes, since `dtype` and `shape` can be reconstituted from the
-        #ak.forms.NumpyForm.
-        If the values of `container` are recognised as arrays by the given backend,
-        a view over their existing data will be used, where possible.
-        The `container` values are allowed to be callables with no arguments.
-        If that's the case, they will be turned into `VirtualNDArray` buffers whose generator
-        function is the callable and is used to materialize the buffer when required.
-
-        The `buffer_key` should be the same as the one used in #ak.to_buffers.
-
-        When `allow_noncanonical_form` is set to True, this function readily accepts
-        non-simplified forms, i.e. forms which will be simplified by Awkward Array
-        into "canonical" representations, e.g. `option[option[...]]` → `option[...]`.
-        Such forms can be produced by the low-level ArrayBuilder `snapshot()` method.
-        Given that Awkward Arrays must have canonical layouts, it follows that
-        invoking this function with `allow_noncanonical_form` may produce arrays
-        whose forms differ to the input form.
-
-        In order for a non-simplified form to be considered valid, it should be one
-        that the #ak.contents.Content layout classes could produce iff. the
-        simplification rules were removed.
-
-
-        See #ak.to_buffers for examples.
     """
     return _impl(
         form,

--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -24,6 +24,8 @@ def from_feather(
 ):
     """Reads a Feather file as an Awkward Array (through pyarrow).
 
+    See also #ak.to_feather.
+
     Args:
         path (str or file-like object): Feather file to read as an Awkward Array,
             passed directly to [pyarrow.feather.read_table](https://arrow.apache.org/docs/python/generated/pyarrow.feather.read_table.html).
@@ -49,9 +51,6 @@ def from_feather(
     Examples:
         >>> ak.from_feather("file_name.feather")
         <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>
-
-
-        See also #ak.to_feather.
     """
 
     return _impl(

--- a/src/awkward/operations/ak_from_json.py
+++ b/src/awkward/operations/ak_from_json.py
@@ -62,6 +62,53 @@ def from_json(
     line-delimited documents must adhere to the strict
     [JSON schema](https://www.json.org/).
 
+    If this function opens a file or network connection (because it is passed as
+    a `pathlib.Path`), then this function will also close that file or connection.
+
+    If this function is provided a file-like object with a `read(num_bytes)` method,
+    this function will not close it. (It might not even have a `close` method.)
+
+    Note that JSON interpreted with `line_delimited` doesn't actually need delimiters
+    between JSON documents or an absence of delimiters within each document. Parsing
+    with `line_delimited=True` continues to the end of a JSON document and starts
+    again with the next JSON document. It may be necessary to require actual delimiters
+    between and never within JSON documents to split a large source for
+    parallel-processing, but that consideration is beyond this function.
+
+    JSONSchemas
+    ===========
+
+    This function supports a subset of JSONSchema (see the
+    [JSONSchema specification](https://json-schema.org/)). The schemas may be passed
+    as JSON text or as Python lists and dicts representing JSON, but the following
+    conditions apply:
+
+    * The root of the schema must be `"type": "array"` or `"type": "object"`.
+    * Every level must have a `"type"`, which can only name one type (as a string
+      or length-1 list) or one type and `"null"` (as a length-2 list).
+    * `"type": "boolean"` \u2192 1-byte boolean values.
+    * `"type": "integer"` \u2192 8-byte integer values. If a part of the schema
+      is declared to have integer type but the JSON numbers are expressed as
+      floating-point, such as `3.14`, `3.0`, or `3e0`, this function raises an
+      error.
+    * `"type": "number"` \u2192 8-byte floating-point values. If used with
+      this function's `nan_string`, `posinf_string`, and/or `neginf_string`, the
+      value in the JSON could be a string, as long as it matches one of these
+      three.
+    * `"type": "string"` \u2192 UTF-8 encoded strings. All JSON escape sequences are
+      supported. Remember that the `source` data are ASCII; Unicode is derived from
+      "`\\uXXXX`" escape sequences. If an `"enum"` is given, strings are represented
+      as categorical values (#ak.contents.IndexedArray or #ak.contents.IndexedOptionArray).
+    * `"type": "array"` \u2192 nested lists. The `"items"` must be specified. If
+      `"minItems"` and `"maxItems"` are specified and equal to each other, the
+      list has regular-type (#ak.types.RegularType); otherwise, it has variable-length
+      type (#ak.types.ListType).
+    * `"type": "object"` \u2192 nested records. The `"properties"` must be specified,
+      and any properties in the data not described by `"properties"` will not
+      appear in the output.
+
+    See also #ak.to_json.
+
     Args:
         source (bytes/str, pathlib.Path, or file-like object): Data source of the
             JSON-formatted string(s). If bytes/str, the string is parsed. If a
@@ -139,12 +186,6 @@ def from_json(
         >>> ak.from_json(filelike_obj)
         <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>
 
-        If this function opens a file or network connection (because it is passed as
-        a `pathlib.Path`), then this function will also close that file or connection.
-
-        If this function is provided a file-like object with a `read(num_bytes)` method,
-        this function will not close it. (It might not even have a `close` method.)
-
         Data structures
         ===============
 
@@ -184,13 +225,6 @@ def from_json(
         >>> ak.from_json("", line_delimited=True)
         <Array [] type='0 * unknown'>
 
-        Note that JSON interpreted with `line_delimited` doesn't actually need delimiters
-        between JSON documents or an absence of delimiters within each document. Parsing
-        with `line_delimited=True` continues to the end of a JSON document and starts
-        again with the next JSON document. It may be necessary to require actual delimiters
-        between and never within JSON documents to split a large source for
-        parallel-processing, but that consideration is beyond this function.
-
         If a JSONSchema is provided, the schema describes the structure of the JSON
         document, regardless of whether there's only one of them (may be an #ak.Record)
         or many of them (must be an #ak.Array).
@@ -218,38 +252,6 @@ def from_json(
         <Array [{x: 1.1, y: [1]}, ..., {x: 3.3, ...}] type='3 * {x: float64, y: var...'>
 
         All numbers in the final array are signed 64-bit (integers and floating-point).
-
-        JSONSchemas
-        ===========
-
-        This function supports a subset of JSONSchema (see the
-        [JSONSchema specification](https://json-schema.org/)). The schemas may be passed
-        as JSON text or as Python lists and dicts representing JSON, but the following
-        conditions apply:
-
-        * The root of the schema must be `"type": "array"` or `"type": "object"`.
-        * Every level must have a `"type"`, which can only name one type (as a string
-          or length-1 list) or one type and `"null"` (as a length-2 list).
-        * `"type": "boolean"` \u2192 1-byte boolean values.
-        * `"type": "integer"` \u2192 8-byte integer values. If a part of the schema
-          is declared to have integer type but the JSON numbers are expressed as
-          floating-point, such as `3.14`, `3.0`, or `3e0`, this function raises an
-          error.
-        * `"type": "number"` \u2192 8-byte floating-point values. If used with
-          this function's `nan_string`, `posinf_string`, and/or `neginf_string`, the
-          value in the JSON could be a string, as long as it matches one of these
-          three.
-        * `"type": "string"` \u2192 UTF-8 encoded strings. All JSON escape sequences are
-          supported. Remember that the `source` data are ASCII; Unicode is derived from
-          "`\\uXXXX`" escape sequences. If an `"enum"` is given, strings are represented
-          as categorical values (#ak.contents.IndexedArray or #ak.contents.IndexedOptionArray).
-        * `"type": "array"` \u2192 nested lists. The `"items"` must be specified. If
-          `"minItems"` and `"maxItems"` are specified and equal to each other, the
-          list has regular-type (#ak.types.RegularType); otherwise, it has variable-length
-          type (#ak.types.ListType).
-        * `"type": "object"` \u2192 nested records. The `"properties"` must be specified,
-          and any properties in the data not described by `"properties"` will not
-          appear in the output.
 
         Substitutions for non-finite and complex numbers
         ================================================
@@ -332,8 +334,6 @@ def from_json(
         ...     },
         ... )
         <Array [1+1.1j, 2+2.2j] type='2 * complex128'>
-
-        See also #ak.to_json.
     """
     if schema is None:
         return _no_schema(

--- a/src/awkward/operations/ak_from_regular.py
+++ b/src/awkward/operations/ak_from_regular.py
@@ -18,6 +18,8 @@ np = NumpyMetadata.instance()
 def from_regular(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
     """Converts one or all regular axes into irregular ones.
 
+    See also #ak.to_regular.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         axis (int or None): The dimension at which this operation is applied.
@@ -45,8 +47,6 @@ def from_regular(array, axis=1, *, highlevel=True, behavior=None, attrs=None):
         2 * 3 * var * int64
         >>> ak.from_regular(regular, axis=-1).type.show()
         2 * 3 * var * int64
-
-        See also #ak.to_regular.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_pad_none.py
+++ b/src/awkward/operations/ak_pad_none.py
@@ -23,6 +23,18 @@ def pad_none(
 ):
     """Increases the lengths of lists to a target length by adding None values.
 
+    Note that the `clip` parameter not only determines whether the lengths are
+    at least `target` or exactly `target`, it also determines the type of the
+    output:
+
+    * `clip=True` returns regular lists (#ak.types.RegularType), and
+    * `clip=False` returns in-principle variable lengths
+      (#ak.types.ListType).
+
+    The in-principle variable-length lists might, in fact, all have the same
+    length, but the type difference is significant, for instance in
+    broadcasting rules (see #ak.broadcast_arrays).
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         target (int): The intended length of the lists. If `clip=True`,
@@ -86,18 +98,6 @@ def pad_none(
         [[[1.1, 2.2, 3.3], [None, None], [4.4, 5.5], [6.6, None]],
          [],
          [[7.7, None], [8.8, 9.9]]]
-
-        Note that the `clip` parameter not only determines whether the lengths are
-        at least `target` or exactly `target`, it also determines the type of the
-        output:
-
-        * `clip=True` returns regular lists (#ak.types.RegularType), and
-        * `clip=False` returns in-principle variable lengths
-          (#ak.types.ListType).
-
-        The in-principle variable-length lists might, in fact, all have the same
-        length, but the type difference is significant, for instance in
-        broadcasting rules (see #ak.broadcast_arrays).
 
         The difference between
 

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -17,6 +17,9 @@ np = NumpyMetadata.instance()
 def ravel(array, *, highlevel=True, behavior=None, attrs=None):
     """Returns an array with all levels of nesting removed.
 
+    Missing values are not eliminated by flattening. See #ak.flatten with
+    `axis=None` for an equivalent function that eliminates the option type.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         highlevel (bool): If True, return an #ak.Array; otherwise, return
@@ -56,9 +59,6 @@ def ravel(array, *, highlevel=True, behavior=None, attrs=None):
          7.7,
          8.8,
          9.9]
-
-        Missing values are not eliminated by flattening. See #ak.flatten with
-        `axis=None` for an equivalent function that eliminates the option type.
     """
     # Dispatch
     yield (array,)

--- a/src/awkward/operations/ak_transform.py
+++ b/src/awkward/operations/ak_transform.py
@@ -47,6 +47,18 @@ def transform(
     This is a public interface to the infrastructure that is used to implement
     most Awkward Array operations. As such, it's very powerful, but low-level.
 
+    The primary purpose of this function is to allow you to edit one level of
+    structure without having to worry about what it's embedded in. Suppose, for
+    instance, you want to apply NumPy's `np.round` function to numerical data,
+    regardless of what lists or other structures they're embedded in.
+
+    The return value must be a subclass of #ak.contents.Content (to replace the
+    array node) or None (to leave the array node unchanged).
+
+    If you pass multiple arrays to this function (`more_arrays`), those arrays
+    will be broadcasted and all inputs, at the same level of depth and structure,
+    will be passed to the `transformation` function as a group.
+
     Args:
         transformation (callable): Function to apply to each node of the array.
             See below for details.
@@ -124,14 +136,6 @@ def transform(
         different types. The data types are low-level "layouts," subclasses of
         #ak.contents.Content, rather than high-level #ak.Array.
 
-        The primary purpose of this function is to allow you to edit one level of
-        structure without having to worry about what it's embedded in. Suppose, for
-        instance, you want to apply NumPy's `np.round` function to numerical data,
-        regardless of what lists or other structures they're embedded in.
-
-        The return value must be a subclass of #ak.contents.Content (to replace the
-        array node) or None (to leave the array node unchanged).
-
         >>> def rounder(layout, **kwargs):
         ...     if layout.is_numpy:
         ...         return ak.contents.NumpyArray(
@@ -146,10 +150,6 @@ def transform(
         type: 2 * var * var * option[var * var * int32]
         [[[[[1, 2, 3], []], None], []],
          [[[[4, 6]]]]]
-
-        If you pass multiple arrays to this function (`more_arrays`), those arrays
-        will be broadcasted and all inputs, at the same level of depth and structure,
-        will be passed to the `transformation` function as a group.
 
         Here is an example with broadcasting:
 

--- a/src/awkward/operations/ak_unflatten.py
+++ b/src/awkward/operations/ak_unflatten.py
@@ -26,6 +26,14 @@ numpy_backend = NumpyBackend.instance()
 def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=None):
     """Returns an array with an additional level of nesting.
 
+    An inner dimension can be unflattened by setting the `axis` parameter, but
+    operations like this constrain the `counts` more tightly.
+
+    Also note that new lists created by this function cannot cross partitions
+    (which is only possible at `axis=0`, anyway).
+
+    See also #ak.num and #ak.flatten.
+
     Args:
         array: Array-like data (anything #ak.to_layout recognizes).
         counts (int or array): Number of elements the new level should have.
@@ -65,9 +73,6 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
         >>> ak.unflatten(array, counts)
         <Array [[0, 1, 2], [], [3, ...], [5], [6, 7, 8, 9]] type='5 * var * int64'>
 
-        An inner dimension can be unflattened by setting the `axis` parameter, but
-        operations like this constrain the `counts` more tightly.
-
         For example, we can subdivide an already divided list:
 
         >>> original = ak.Array([[1, 2, 3, 4], [], [5, 6, 7], [8, 9]])
@@ -90,11 +95,6 @@ def unflatten(array, counts, axis=0, *, highlevel=True, behavior=None, attrs=Non
                 behavior = None
             )
         Error details: structure imposed by 'counts' does not fit in the array or partition at axis=1
-
-        Also note that new lists created by this function cannot cross partitions
-        (which is only possible at `axis=0`, anyway).
-
-        See also #ak.num and #ak.flatten.
     """
     # Dispatch
     yield array, counts

--- a/src/awkward/operations/ak_zip.py
+++ b/src/awkward/operations/ak_zip.py
@@ -39,6 +39,10 @@ def zip(
     #ak.Array.__getitem__, which extracts fields one at a time, or #ak.unzip,
     which extracts them all in one call.
 
+    As an extreme, `depth_limit=1` is a handy way to make a record structure
+    at the outermost level, regardless of whether the fields have matching
+    structure or not.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -126,10 +130,6 @@ def zip(
         [([[1, 2, 3], [], [4, ...], [6]], [[1.1, ...], ...]),
          ([], []),
          ([[7, 8]], [[6.6]])]
-
-        As an extreme, `depth_limit=1` is a handy way to make a record structure
-        at the outermost level, regardless of whether the fields have matching
-        structure or not.
 
         When zipping together arrays with optional values, it can be useful to create
         the #ak.contents.RecordArray node after the option types. By default, #ak.zip

--- a/src/awkward/operations/ak_zip_no_broadcast.py
+++ b/src/awkward/operations/ak_zip_no_broadcast.py
@@ -36,6 +36,8 @@ def zip_no_broadcast(
     #ak.Array.__getitem__, which extracts fields one at a time, or #ak.unzip,
     which extracts them all in one call.
 
+    See also #ak.zip and #ak.unzip.
+
     Args:
         arrays (mapping or sequence of arrays): Each value in this mapping or
             sequence can be any array-like data that #ak.to_layout recognizes.
@@ -77,8 +79,6 @@ def zip_no_broadcast(
          [],
          [(4.4, 'd')],
          []]
-
-        See also #ak.zip and #ak.unzip.
     """
     # Dispatch
     if isinstance(arrays, Mapping):


### PR DESCRIPTION
The docstring conversions of the #3980 rollout placed some main-description text under `Examples:` headers, found in [a review comment on PR #4139](https://github.com/scikit-hep/awkward/pull/4139#discussion_r3632561324) and tracked in #4233. This PR applies the [`Examples:`-section checklist](https://github.com/scikit-hep/awkward/issues/3980#issuecomment-5058339499) to the 17 already-merged files: description paragraphs (behavior, arguments, history) move above `Args:` into the extended description, relocated verbatim (only re-indented and re-wrapped); `Examples:` keeps only doctest walkthroughs and their connecting prose; "See also" lines sit directly above `Args:`.

All changes are docstring-only (verified by comparing docstring-stripped ASTs against the previous revision) and every doctest line is byte-identical (verified by comparing the multiset of `>>>`/`...` lines per file).

## Per-file decisions

| Operation | Decision |
|---|---|
| `ak.copy` | Moved: the "exception to this rule" paragraph (with its embedded shallow-copy doctest kept as a literal block) and the closing "key to Awkward Array's efficiency" advice. |
| `ak.transform` | Moved: the "primary purpose", "return value must be a subclass", and `more_arrays` paragraphs. |
| `ak.from_buffers` | Moved: the round-trip note, `container`, `buffer_key`, and `allow_noncanonical_form` paragraphs; the `Examples:` header is removed because nothing example-like remained (mirrors `ak.to_buffers` after the fix on #4139). |
| `ak.from_feather` | Moved: "See also #ak.to_feather." |
| `ak.from_json` | Moved: the file/network-connection paragraphs, the line-delimited note, the JSONSchemas subsection (it contains no doctests), and "See also #ak.to_json." |
| `ak.from_regular` | Moved: "See also #ak.to_regular." |
| `ak.argcartesian` | Moved: "All of the parameters for #ak.cartesian apply equally…" |
| `ak.broadcast_arrays` | Moved: the single-item-per-element discussion (with its `::` blocks), the broadcasting-rules bullet list, and the "aware of the distinction" paragraph. |
| `ak.broadcast_fields` | No change — `Examples:` contains only a doctest. |
| `ak.cartesian` | Moved: the output-order, "group by", and index-positions paragraphs. |
| `ak.combinations` | Moved: the index-positions paragraph (parallel to `ak.cartesian`). |
| `ak.pad_none` | Moved: the `clip` behavior note (with its bullet list) and the variable-length caveat. |
| `ak.ravel` | Moved: the missing-values note referencing #ak.flatten. |
| `ak.unflatten` | Moved: the `axis` note, the partition caveat, and "See also #ak.num and #ak.flatten." |
| `ak.unzip` | No change — both prose paragraphs directly introduce the snippets they precede. |
| `ak.zip` | Moved: the `depth_limit=1` advice. |
| `ak.zip_no_broadcast` | Moved: "See also #ak.zip and #ak.unzip." |

Drafts were generated with Claude Code and reviewed manually, per the process agreed for #3980.

Closes #4233. Refs #3980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
