### PR TITLE
chore: use scikit-build-core 1.0 for awkward-cpp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ python -m pip install ./awkward-cpp
 If you are working on the C++ components of Awkward Array, it might be more convenient to skip the build isolation step, which involves creating an isolated build environment. First, you must install the build requirements:
 
 ```bash
-python -m pip install "scikit-build-core[pyproject,color]" pybind11 ninja cmake
+python -m pip install "scikit-build-core>=1.0" pybind11 ninja cmake
 ```
 
 Then the installation can be performed without build isolation:

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.11",
+    "scikit-build-core>=1.0",
     "pybind11>=3",
 ]
 build-backend = "scikit_build_core.build"
@@ -59,7 +59,10 @@ Releases = "https://github.com/scikit-hep/awkward-1.0/releases"
 [tool.scikit-build]
 minimum-version = "build-system.requires"
 build-dir = "build/{cache_tag}"
-sdist.reproducible = true
+wheel.reproducible = true
+messages.after-failure = """
+{bold.red}awkward-cpp failed to build.{normal} If you are building from a git checkout, \
+make sure you ran {bold}nox -s prepare{normal} first (see CONTRIBUTING.md)."""
 sdist.include = [
     "header-only",
     "include/awkward/kernels.h",

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -59,7 +59,7 @@ Releases = "https://github.com/scikit-hep/awkward-1.0/releases"
 [tool.scikit-build]
 minimum-version = "build-system.requires"
 build-dir = "build/{cache_tag}"
-wheel.reproducible = true
+sdist.reproducible = true
 messages.after-failure = """
 {bold.red}awkward-cpp failed to build.{normal} If you are building from a git checkout, \
 make sure you ran {bold}nox -s prepare{normal} first (see CONTRIBUTING.md)."""

--- a/header-only/examples/pybind11/pyproject.toml
+++ b/header-only/examples/pybind11/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core[pyproject]", "pybind11"]
+requires = ["scikit-build-core", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the awkward-cpp build requirement to scikit-build-core>=1.0. With `minimum-version = "build-system.requires"`, this picks up the new defaults: sdist symlink resolution and the 0.12 inclusion mode (ignored dirs like `build/` are no longer traversed).

Also:
- Enables the new `wheel.reproducible` setting (`sdist.reproducible` line dropped; true is the default).
- Adds a `messages.after-failure` hint pointing at `nox -s prepare`, shown at the end of pip output on build failure.
- Removes the `pyproject`/`color` extras from CONTRIBUTING.md and the header-only example; they no longer exist in 1.0.

Verified locally on 1.0.3: sdist contains the generated `tests-*` dirs, `header-only`, `kernels.h`, and `_kernel_signatures.py`, and still excludes `build/` and `rapidjson/bin`; a full wheel builds cleanly. No `awkward-cpp` version bump needed — build metadata only, takes effect at the next release.