### PR TITLE
feat: implement `awkward_argsort` on the CUDA (`cuda.compute`) backend

### DIFF
--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -182,6 +182,7 @@ class CupyBackend(Backend):
 
         return {
             "awkward_sort": cuda_compute.segmented_sort,
+            "awkward_argsort": cuda_compute.segmented_argsort,
             "awkward_reduce_sum": cuda_compute.awkward_reduce_sum,
             "awkward_reduce_sum_bool": cuda_compute.awkward_reduce_sum_bool,
             "awkward_reduce_sum_int32_bool_64": cuda_compute.awkward_reduce_sum_int32_bool_64,

--- a/src/awkward/_backends/cupy.py
+++ b/src/awkward/_backends/cupy.py
@@ -112,6 +112,7 @@ class CupyBackend(Backend):
             "awkward_index_rpad_and_clip_axis1",
             # sort
             "awkward_sort",
+            "awkward_argsort",
             # other kernels
             "awkward_RegularArray_getitem_carry",
             "awkward_NumpyArray_subrange_equal",

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -192,6 +192,31 @@ def segmented_sort(
 
     order = SortOrder.ASCENDING if ascending else SortOrder.DESCENDING
 
+    # NaN parity with the CPU kernel: NaNs must sort to the *front* of each
+    # segment in both directions. Radix sort orders them by bit pattern (they end
+    # up misplaced), so sort by a NaN-remapped key (-inf ascending / +inf
+    # descending) while carrying the *original* values, so the output keeps real
+    # NaNs but positions them correctly. Only floats with NaNs need this.
+    if num_items > 0 and fromptr.dtype.kind == "f":
+        nan_mask = cp.isnan(fromptr)
+        if bool(nan_mask.any()):
+            keys = fromptr.copy()
+            keys[nan_mask] = -cp.inf if ascending else cp.inf
+            keys_out = cp.empty_like(keys)
+            segmented_sort(
+                d_in_keys=keys,
+                d_out_keys=keys_out,
+                d_in_values=fromptr,
+                d_out_values=toptr,
+                num_items=num_items,
+                num_segments=num_segments,
+                start_offsets_in=start_o,
+                end_offsets_in=end_o,
+                order=order,
+                stream=None,
+            )
+            return
+
     segmented_sort(
         d_in_keys=fromptr,
         d_out_keys=toptr,

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -206,6 +206,94 @@ def segmented_sort(
     )
 
 
+def segmented_argsort(
+    toptr,
+    fromptr,
+    length,
+    offsets,
+    offsetslength,
+    ascending,
+    stable,
+):
+    """Per-segment argsort on the ``cuda.compute`` path.
+
+    Runs a key--value ``segmented_sort`` where the keys are the data and the
+    values are global element indices; the permuted values are the argsort
+    carry. Indices are then made segment-local, matching the CPU
+    ``awkward_argsort`` kernel (which does ``iota`` then ``j - start_off``).
+
+    Notes on parity with the CPU kernel:
+
+    * Floating-point NaNs must sort to the *front* of each segment in both
+      directions (the CPU comparator treats NaN as "less than everything"). A
+      fixed sentinel cannot do this because its position flips with the sort
+      order, so NaN keys are remapped to ``-inf`` for ascending and ``+inf`` for
+      descending in a private key copy -- either way they land first. The
+      sentinel never reaches the output, which holds indices only.
+    * CCCL's segmented radix sort is stable on keys; because the seeded values
+      are strictly increasing indices, equal keys retain their original order,
+      so ``stable=True`` is satisfied inherently and ``stable=False`` is still
+      deterministic.
+    """
+    from cuda.compute import SortOrder, segmented_sort
+
+    cupy_nplike = Cupy.instance()
+    cp = cupy_nplike._module
+
+    # Ensure offsets are int64 as expected by segmented_sort
+    if offsets.dtype != cp.int64:
+        offsets = offsets.astype(cp.int64, copy=False)
+
+    num_segments = offsetslength - 1
+    num_items = int(offsets[-1]) if len(offsets) > 0 else 0
+    if num_items == 0:
+        return
+
+    start_o, end_o = make_segment_views(offsets)
+    order = SortOrder.ASCENDING if ascending else SortOrder.DESCENDING
+
+    # Keys to sort by. datetime/timedelta compare as their int64 payload (the
+    # layout already reports int64 for the kernel signature).
+    keys_in = fromptr
+    if keys_in.dtype.kind in "Mm":
+        keys_in = keys_in.view(cp.int64)
+
+    # NaN parity: the CPU comparator sends NaNs to the *front* of each segment
+    # in both directions. A fixed sentinel would flip sides with `order`, so use
+    # -inf for ascending and +inf for descending; both land NaNs first. Done in
+    # a private copy so the sentinel never leaks to the output (indices only).
+    if keys_in.dtype.kind == "f":
+        nan_mask = cp.isnan(keys_in)
+        if bool(nan_mask.any()):
+            keys_in = keys_in.copy()
+            keys_in[nan_mask] = -cp.inf if ascending else cp.inf
+
+    # Values = global indices; after the sort these are the argsort carry.
+    values_in = cp.arange(num_items, dtype=cp.int64)
+
+    # segmented_sort also emits sorted keys, which we discard; the API still
+    # requires an output buffer, so hand it scratch.
+    keys_out = cp.empty_like(keys_in)
+
+    segmented_sort(
+        d_in_keys=keys_in,
+        d_out_keys=keys_out,
+        d_in_values=values_in,
+        d_out_values=toptr,
+        num_items=num_items,
+        num_segments=num_segments,
+        start_offsets_in=start_o,
+        end_offsets_in=end_o,
+        order=order,
+        stream=None,
+    )
+
+    # Convert global indices to segment-local (CPU kernel does `j - start_off`).
+    seg_sizes = end_o - start_o
+    seg_start_per_position = cp.repeat(start_o, seg_sizes)
+    toptr -= seg_start_per_position
+
+
 def awkward_reduce_argmax(
     result,
     input_data,

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -167,6 +167,56 @@ def _nonzero_for_reduce(input_data, out_dtype):
     )
 
 
+# Fused elementwise kernels that turn IEEE float bits into an order-preserving
+# unsigned key in a single launch (built lazily, once, per float width). See
+# `_float_order_keys` for the semantics. Working on the raw uint bit-view means
+# the whole transform -- signed-zero canonicalisation, bit-based NaN detection,
+# sign transform, and NaN sentinel -- is pure integer arithmetic with no
+# temporaries.
+_FLOAT_ORDER_KEY_KERNELS: dict[int, object] = {}
+
+_FLOAT_ORDER_KEY_SOURCE = {
+    64: (
+        "uint64",
+        "unsigned long long",
+        "0x8000000000000000ULL",
+        "0x7FF0000000000000ULL",
+        "0x000FFFFFFFFFFFFFULL",
+        "0ULL",
+        63,
+    ),
+    32: (
+        "uint32",
+        "unsigned int",
+        "0x80000000U",
+        "0x7F800000U",
+        "0x007FFFFFU",
+        "0U",
+        31,
+    ),
+}
+
+
+def _float_order_key_kernel(cp, width):
+    kernel = _FLOAT_ORDER_KEY_KERNELS.get(width)
+    if kernel is None:
+        ctype, c, signbit, exp, mant, zero, top = _FLOAT_ORDER_KEY_SOURCE[width]
+        kernel = cp.ElementwiseKernel(
+            f"{ctype} u_in, {ctype} nan_sentinel",
+            f"{ctype} out",
+            f"""
+            {c} u = u_in;
+            if (u == {signbit}) u = {zero};              // -0.0 -> +0.0
+            bool is_nan = ((u & {exp}) == {exp}) && ((u & {mant}) != {zero});
+            {c} key = (u >> {top}) ? (~u) : (u ^ {signbit});
+            out = is_nan ? nan_sentinel : key;
+            """,
+            f"awkward_float{width}_order_key",
+        )
+        _FLOAT_ORDER_KEY_KERNELS[width] = kernel
+    return kernel
+
+
 def _float_order_keys(cp, values, ascending):
     """Order-preserving unsigned keys that reproduce the CPU float ordering.
 
@@ -175,8 +225,7 @@ def _float_order_keys(cp, values, ascending):
     ``-inf`` (there is no float below ``-inf``). This maps each float to an
     unsigned integer whose ascending order is the exact CPU ordering:
 
-    * ``-0.0`` is canonicalised to ``+0.0`` (they compare equal on the CPU), via
-      ``x + 0.0`` -- an IEEE identity for every other value, including inf/NaN.
+    * ``-0.0`` is canonicalised to ``+0.0`` (they compare equal on the CPU).
     * The bit pattern is transformed so signed floats sort in true numeric order
       (negatives flip all bits; others flip only the sign bit).
     * NaNs are sent to the *front* in both directions: their transform is the
@@ -184,20 +233,14 @@ def _float_order_keys(cp, values, ascending):
       or all-ones for descending (unique maximum, first under DESCENDING order).
 
     The keys are sorted; the actual values/indices are carried separately, so the
-    sentinels never appear in the output.
+    sentinels never appear in the output. The transform is a single fused
+    elementwise kernel over the (zero-copy) uint bit-view -- no temporaries.
     """
     width = values.dtype.itemsize * 8
     uint_dtype = cp.uint32 if width == 32 else cp.uint64
-    signbit = uint_dtype(1 << (width - 1))
-    allones = uint_dtype((1 << width) - 1)
-
-    canon = values + values.dtype.type(0.0)  # -0.0 -> +0.0
-    u = canon.view(uint_dtype)
-    negative = (u >> (width - 1)).astype(cp.bool_)
-    key = cp.where(negative, u ^ allones, u ^ signbit).astype(uint_dtype)
-
-    nan_sentinel = uint_dtype(0) if ascending else allones
-    return cp.where(cp.isnan(canon), nan_sentinel, key).astype(uint_dtype)
+    u = values.view(uint_dtype)  # zero-copy bit reinterpretation
+    nan_sentinel = uint_dtype(0) if ascending else uint_dtype((1 << width) - 1)
+    return _float_order_key_kernel(cp, width)(u, nan_sentinel)
 
 
 def segmented_sort(

--- a/src/awkward/_connect/cuda/_compute.py
+++ b/src/awkward/_connect/cuda/_compute.py
@@ -167,6 +167,39 @@ def _nonzero_for_reduce(input_data, out_dtype):
     )
 
 
+def _float_order_keys(cp, values, ascending):
+    """Order-preserving unsigned keys that reproduce the CPU float ordering.
+
+    A plain radix sort of raw float bits mis-orders NaNs (by bit pattern) and,
+    with a simple sentinel remap, cannot place NaN *strictly before* a real
+    ``-inf`` (there is no float below ``-inf``). This maps each float to an
+    unsigned integer whose ascending order is the exact CPU ordering:
+
+    * ``-0.0`` is canonicalised to ``+0.0`` (they compare equal on the CPU), via
+      ``x + 0.0`` -- an IEEE identity for every other value, including inf/NaN.
+    * The bit pattern is transformed so signed floats sort in true numeric order
+      (negatives flip all bits; others flip only the sign bit).
+    * NaNs are sent to the *front* in both directions: their transform is the
+      unique maximum, so they are remapped to 0 for ascending (unique minimum)
+      or all-ones for descending (unique maximum, first under DESCENDING order).
+
+    The keys are sorted; the actual values/indices are carried separately, so the
+    sentinels never appear in the output.
+    """
+    width = values.dtype.itemsize * 8
+    uint_dtype = cp.uint32 if width == 32 else cp.uint64
+    signbit = uint_dtype(1 << (width - 1))
+    allones = uint_dtype((1 << width) - 1)
+
+    canon = values + values.dtype.type(0.0)  # -0.0 -> +0.0
+    u = canon.view(uint_dtype)
+    negative = (u >> (width - 1)).astype(cp.bool_)
+    key = cp.where(negative, u ^ allones, u ^ signbit).astype(uint_dtype)
+
+    nan_sentinel = uint_dtype(0) if ascending else allones
+    return cp.where(cp.isnan(canon), nan_sentinel, key).astype(uint_dtype)
+
+
 def segmented_sort(
     toptr,
     fromptr,
@@ -192,30 +225,26 @@ def segmented_sort(
 
     order = SortOrder.ASCENDING if ascending else SortOrder.DESCENDING
 
-    # NaN parity with the CPU kernel: NaNs must sort to the *front* of each
-    # segment in both directions. Radix sort orders them by bit pattern (they end
-    # up misplaced), so sort by a NaN-remapped key (-inf ascending / +inf
-    # descending) while carrying the *original* values, so the output keeps real
-    # NaNs but positions them correctly. Only floats with NaNs need this.
+    # Float parity with the CPU kernel: sort by an order-preserving unsigned key
+    # (correct NaN placement, -0.0 == +0.0) while carrying the *original* values,
+    # so the output keeps real NaNs but positions everything as the CPU does.
+    # Non-float dtypes sort natively (CCCL handles signed integers correctly).
     if num_items > 0 and fromptr.dtype.kind == "f":
-        nan_mask = cp.isnan(fromptr)
-        if bool(nan_mask.any()):
-            keys = fromptr.copy()
-            keys[nan_mask] = -cp.inf if ascending else cp.inf
-            keys_out = cp.empty_like(keys)
-            segmented_sort(
-                d_in_keys=keys,
-                d_out_keys=keys_out,
-                d_in_values=fromptr,
-                d_out_values=toptr,
-                num_items=num_items,
-                num_segments=num_segments,
-                start_offsets_in=start_o,
-                end_offsets_in=end_o,
-                order=order,
-                stream=None,
-            )
-            return
+        keys = _float_order_keys(cp, fromptr, ascending)
+        keys_out = cp.empty_like(keys)
+        segmented_sort(
+            d_in_keys=keys,
+            d_out_keys=keys_out,
+            d_in_values=fromptr,
+            d_out_values=toptr,
+            num_items=num_items,
+            num_segments=num_segments,
+            start_offsets_in=start_o,
+            end_offsets_in=end_o,
+            order=order,
+            stream=None,
+        )
+        return
 
     segmented_sort(
         d_in_keys=fromptr,
@@ -249,12 +278,12 @@ def segmented_argsort(
 
     Notes on parity with the CPU kernel:
 
-    * Floating-point NaNs must sort to the *front* of each segment in both
-      directions (the CPU comparator treats NaN as "less than everything"). A
-      fixed sentinel cannot do this because its position flips with the sort
-      order, so NaN keys are remapped to ``-inf`` for ascending and ``+inf`` for
-      descending in a private key copy -- either way they land first. The
-      sentinel never reaches the output, which holds indices only.
+    * Floating-point keys go through :func:`_float_order_keys`, an
+      order-preserving unsigned transform that places NaNs at the *front* in both
+      directions and treats ``-0.0 == +0.0`` -- a plain sentinel cannot do this
+      because NaN must sort strictly below a real ``-inf``. The transformed keys
+      are sorted; the indices are carried separately, so the transform never
+      reaches the output.
     * CCCL's segmented radix sort is stable on keys; because the seeded values
       are strictly increasing indices, equal keys retain their original order,
       so ``stable=True`` is satisfied inherently and ``stable=False`` is still
@@ -277,21 +306,17 @@ def segmented_argsort(
     start_o, end_o = make_segment_views(offsets)
     order = SortOrder.ASCENDING if ascending else SortOrder.DESCENDING
 
-    # Keys to sort by. datetime/timedelta compare as their int64 payload (the
-    # layout already reports int64 for the kernel signature).
+    # Keys to sort by. Floats use an order-preserving unsigned key so NaNs land
+    # at the front (both directions) and -0.0 == +0.0, matching the CPU kernel;
+    # a plain sentinel remap cannot place NaN below a real -inf. datetime and
+    # timedelta compare as their int64 payload (the layout already reports int64
+    # for the kernel signature). Signed integers sort natively (CCCL handles the
+    # sign correctly).
     keys_in = fromptr
     if keys_in.dtype.kind in "Mm":
         keys_in = keys_in.view(cp.int64)
-
-    # NaN parity: the CPU comparator sends NaNs to the *front* of each segment
-    # in both directions. A fixed sentinel would flip sides with `order`, so use
-    # -inf for ascending and +inf for descending; both land NaNs first. Done in
-    # a private copy so the sentinel never leaks to the output (indices only).
-    if keys_in.dtype.kind == "f":
-        nan_mask = cp.isnan(keys_in)
-        if bool(nan_mask.any()):
-            keys_in = keys_in.copy()
-            keys_in[nan_mask] = -cp.inf if ascending else cp.inf
+    elif keys_in.dtype.kind == "f":
+        keys_in = _float_order_keys(cp, keys_in, ascending)
 
     # Values = global indices; after the sort these are the argsort carry.
     values_in = cp.arange(num_items, dtype=cp.int64)

--- a/tests-cuda/test_3459_virtualarray_with_cuda.py
+++ b/tests-cuda/test_3459_virtualarray_with_cuda.py
@@ -507,7 +507,6 @@ def test_numpyarray_sort(numpyarray, virtual_numpyarray):
     assert virtual_numpyarray.is_all_materialized
 
 
-@pytest.mark.xfail(reason="awkward_argsort is not implemented")
 def test_numpyarray_argsort(numpyarray, virtual_numpyarray):
     assert not virtual_numpyarray.is_any_materialized
     assert ak.array_equal(
@@ -1236,7 +1235,6 @@ def test_listoffsetarray_sort(listoffsetarray, virtual_listoffsetarray):
     assert virtual_listoffsetarray.is_all_materialized
 
 
-@pytest.mark.xfail(reason="awkward_argsort is not implemented")
 def test_listoffsetarray_argsort(listoffsetarray, virtual_listoffsetarray):
     assert not virtual_listoffsetarray.is_any_materialized
     assert ak.array_equal(
@@ -2228,7 +2226,6 @@ def test_listarray_sort(listarray, virtual_listarray):
     assert virtual_listarray.is_all_materialized
 
 
-@pytest.mark.xfail(reason="awkward_argsort is not implemented")
 def test_listarray_argsort(listarray, virtual_listarray):
     assert not virtual_listarray.is_any_materialized
     assert ak.array_equal(
@@ -3342,7 +3339,6 @@ def test_recordarray_sort_y_field(recordarray, virtual_recordarray):
     assert virtual_recordarray.is_any_materialized
 
 
-@pytest.mark.xfail(reason="awkward_argsort is not implemented")
 def test_recordarray_argsort_x_field(recordarray, virtual_recordarray):
     # Test argsort on the x field (ListOffsetArray)
     assert not virtual_recordarray.is_any_materialized
@@ -3356,7 +3352,6 @@ def test_recordarray_argsort_x_field(recordarray, virtual_recordarray):
     assert virtual_recordarray.is_any_materialized
 
 
-@pytest.mark.xfail(reason="awkward_argsort is not implemented")
 def test_recordarray_argsort_y_field(recordarray, virtual_recordarray):
     # Test argsort on the y field (NumpyArray)
     assert not virtual_recordarray.is_any_materialized

--- a/tests-cuda/test_4240_cuda_argsort.py
+++ b/tests-cuda/test_4240_cuda_argsort.py
@@ -1,0 +1,109 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+cp = pytest.importorskip("cupy")
+
+
+INTEGER_DTYPES = [
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+]
+FLOAT_DTYPES = ["float32", "float64"]
+
+
+def _cpu_array(dtype):
+    """A ragged array with empty lists, duplicates, and (for floats) NaNs."""
+    if dtype == "bool":
+        segs = [[True, False, True, True], [], [False, False], [True]]
+        return ak.Array(segs)
+    if dtype in FLOAT_DTYPES:
+        nan = float("nan")
+        # Finite values + NaN. (A real +-inf alongside NaN hits a documented
+        # sentinel-collision edge case and is intentionally excluded here.)
+        segs = [
+            [3.0, nan, 1.0, 1.0],
+            [],
+            [nan, nan, 4.0],
+            [2.0],
+            [9.0, 0.0, 0.0, 7.0, 7.0],
+        ]
+        return ak.values_astype(ak.Array(segs), dtype)
+    # signed/unsigned integers: keep values non-negative so uint is valid
+    segs = [[3, 1, 2, 1], [], [5, 5, 4], [2], [9, 0, 0, 7, 7]]
+    return ak.values_astype(ak.Array(segs), dtype)
+
+
+def _nan_aware_equal(a, b):
+    """Compare nested lists treating NaN == NaN."""
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(
+            _nan_aware_equal(x, y) for x, y in zip(a, b, strict=True)
+        )
+    if isinstance(a, float) and isinstance(b, float):
+        return a == b or (np.isnan(a) and np.isnan(b))
+    return a == b
+
+
+@pytest.mark.parametrize("dtype", ["bool", *INTEGER_DTYPES, *FLOAT_DTYPES])
+@pytest.mark.parametrize("ascending", [True, False])
+def test_argsort_matches_cpu_stable(dtype, ascending):
+    # stable=True gives a deterministic permutation, so CUDA and CPU must return
+    # the exact same indices (including NaN placement at the front).
+    cpu = _cpu_array(dtype)
+    gpu = ak.to_backend(cpu, "cuda")
+
+    out_cpu = ak.argsort(cpu, axis=-1, ascending=ascending, stable=True)
+    out_gpu = ak.argsort(gpu, axis=-1, ascending=ascending, stable=True)
+
+    assert ak.to_list(ak.to_backend(out_gpu, "cpu")) == ak.to_list(out_cpu)
+
+
+@pytest.mark.parametrize("dtype", ["bool", *INTEGER_DTYPES, *FLOAT_DTYPES])
+@pytest.mark.parametrize("ascending", [True, False])
+@pytest.mark.parametrize("stable", [True, False])
+def test_argsort_carry_reproduces_sort(dtype, ascending, stable):
+    # Regardless of tie-breaking, gathering with the argsort result must yield
+    # the same ordering as ak.sort — this validates the permutation even when
+    # stable=False (where exact indices may legitimately differ).
+    gpu = ak.to_backend(_cpu_array(dtype), "cuda")
+
+    carry = ak.argsort(gpu, axis=-1, ascending=ascending, stable=stable)
+    via_carry = ak.to_list(ak.to_backend(gpu[carry], "cpu"))
+    sorted_gpu = ak.to_list(
+        ak.to_backend(ak.sort(gpu, axis=-1, ascending=ascending, stable=stable), "cpu")
+    )
+
+    assert _nan_aware_equal(via_carry, sorted_gpu)
+
+
+@pytest.mark.parametrize("dtype", ["bool", *INTEGER_DTYPES, *FLOAT_DTYPES])
+@pytest.mark.parametrize("ascending", [True, False])
+def test_sort_matches_cpu(dtype, ascending):
+    # Cross-check the sibling awkward_sort (segmented_sort) path too.
+    cpu = _cpu_array(dtype)
+    gpu = ak.to_backend(cpu, "cuda")
+
+    out_cpu = ak.to_list(ak.sort(cpu, axis=-1, ascending=ascending, stable=True))
+    out_gpu = ak.to_list(
+        ak.to_backend(ak.sort(gpu, axis=-1, ascending=ascending, stable=True), "cpu")
+    )
+
+    assert _nan_aware_equal(out_gpu, out_cpu)
+
+
+def test_argsort_all_empty():
+    gpu = ak.to_backend(ak.Array([[], [], []]), "cuda")
+    out = ak.to_list(ak.to_backend(ak.argsort(gpu, axis=-1), "cpu"))
+    assert out == [[], [], []]

--- a/tests-cuda/test_4240_cuda_argsort.py
+++ b/tests-cuda/test_4240_cuda_argsort.py
@@ -75,17 +75,17 @@ def test_argsort_matches_cpu_stable(dtype, ascending):
 @pytest.mark.parametrize("stable", [True, False])
 def test_argsort_carry_reproduces_sort(dtype, ascending, stable):
     # Regardless of tie-breaking, gathering with the argsort result must yield
-    # the same ordering as ak.sort — this validates the permutation even when
-    # stable=False (where exact indices may legitimately differ).
-    gpu = ak.to_backend(_cpu_array(dtype), "cuda")
+    # the same ordering as ak.sort. Compare against the CPU backend (the source
+    # of truth) so this validates the GPU permutation even when stable=False,
+    # where exact indices may legitimately differ.
+    cpu = _cpu_array(dtype)
+    gpu = ak.to_backend(cpu, "cuda")
 
     carry = ak.argsort(gpu, axis=-1, ascending=ascending, stable=stable)
     via_carry = ak.to_list(ak.to_backend(gpu[carry], "cpu"))
-    sorted_gpu = ak.to_list(
-        ak.to_backend(ak.sort(gpu, axis=-1, ascending=ascending, stable=stable), "cpu")
-    )
+    sorted_cpu = ak.to_list(ak.sort(cpu, axis=-1, ascending=ascending, stable=stable))
 
-    assert _nan_aware_equal(via_carry, sorted_gpu)
+    assert _nan_aware_equal(via_carry, sorted_cpu)
 
 
 @pytest.mark.parametrize("dtype", ["bool", *INTEGER_DTYPES, *FLOAT_DTYPES])

--- a/tests-cuda/test_4240_cuda_argsort.py
+++ b/tests-cuda/test_4240_cuda_argsort.py
@@ -107,3 +107,42 @@ def test_argsort_all_empty():
     gpu = ak.to_backend(ak.Array([[], [], []]), "cuda")
     out = ak.to_list(ak.to_backend(ak.argsort(gpu, axis=-1), "cpu"))
     assert out == [[], [], []]
+
+
+def test_segmented_argsort_non_int64_offsets():
+    # Directly exercise the offsets-dtype normalization: when offsets are not
+    # int64 they must be cast before segmented_sort (segmented_argsort's
+    # `offsets.astype(int64)` branch).
+    from awkward._connect.cuda import _compute
+
+    fromptr = cp.asarray([3.0, 1.0, 2.0, 5.0, 4.0], dtype=cp.float64)
+    offsets = cp.asarray([0, 3, 5], dtype=cp.int32)  # <- non-int64 offsets
+    toptr = cp.empty(5, dtype=cp.int64)
+
+    _compute.segmented_argsort(toptr, fromptr, 5, offsets, len(offsets), True, True)
+
+    # segment [3,1,2] -> local [1,2,0]; segment [5,4] -> local [1,0]
+    assert cp.asnumpy(toptr).tolist() == [1, 2, 0, 1, 0]
+
+
+def test_segmented_argsort_datetime_keys():
+    # Directly exercise the datetime/timedelta branch, which views the keys as
+    # int64 before sorting (segmented_argsort's `keys_in.view(int64)`). cupy has
+    # no datetime dtype on some builds, so skip cleanly if it can't be created.
+    from awkward._connect.cuda import _compute
+
+    np_dates = np.array(
+        ["2021-01-03", "2021-01-01", "2021-01-02"], dtype="datetime64[D]"
+    )
+    try:
+        fromptr = cp.asarray(np_dates)
+    except (TypeError, ValueError):
+        pytest.skip("cupy build does not support datetime64 arrays")
+
+    offsets = cp.asarray([0, 3], dtype=cp.int64)
+    toptr = cp.empty(3, dtype=cp.int64)
+
+    _compute.segmented_argsort(toptr, fromptr, 3, offsets, len(offsets), True, True)
+
+    # ascending by date: Jan-01 (idx 1), Jan-02 (idx 2), Jan-03 (idx 0)
+    assert cp.asnumpy(toptr).tolist() == [1, 2, 0]

--- a/tests-cuda/test_4240_cuda_argsort.py
+++ b/tests-cuda/test_4240_cuda_argsort.py
@@ -142,24 +142,26 @@ def test_segmented_argsort_non_int64_offsets():
     assert cp.asnumpy(toptr).tolist() == [1, 2, 0, 1, 0]
 
 
-def test_segmented_argsort_datetime_keys():
-    # Directly exercise the datetime/timedelta branch, which views the keys as
-    # int64 before sorting (segmented_argsort's `keys_in.view(int64)`). cupy has
-    # no datetime dtype on some builds, so skip cleanly if it can't be created.
+@pytest.mark.parametrize("kind_dtype", ["datetime64[D]", "timedelta64[s]"])
+def test_segmented_argsort_datetime_keys(kind_dtype):
+    # Exercise the datetime/timedelta branch, which views the keys as int64
+    # before sorting (segmented_argsort's `keys_in.view(int64)`). cupy often
+    # cannot *create/compute* datetime arrays, but a datetime64/timedelta64 view
+    # of an int64 buffer (same 8-byte width) is a pure dtype reinterpret and
+    # needs no datetime support -- exactly the shape the layout hands the kernel.
     from awkward._connect.cuda import _compute
 
-    np_dates = np.array(
-        ["2021-01-03", "2021-01-01", "2021-01-02"], dtype="datetime64[D]"
-    )
+    base = cp.asarray([3, 1, 2], dtype=cp.int64)
     try:
-        fromptr = cp.asarray(np_dates)
+        fromptr = base.view(kind_dtype)
     except (TypeError, ValueError):
-        pytest.skip("cupy build does not support datetime64 arrays")
+        pytest.skip(f"cupy build cannot view arrays as {kind_dtype}")
+    assert fromptr.dtype.kind in "Mm"
 
     offsets = cp.asarray([0, 3], dtype=cp.int64)
     toptr = cp.empty(3, dtype=cp.int64)
 
     _compute.segmented_argsort(toptr, fromptr, 3, offsets, len(offsets), True, True)
 
-    # ascending by date: Jan-01 (idx 1), Jan-02 (idx 2), Jan-03 (idx 0)
+    # payloads 3, 1, 2 ascending -> local indices [1, 2, 0]
     assert cp.asnumpy(toptr).tolist() == [1, 2, 0]

--- a/tests-cuda/test_4240_cuda_argsort.py
+++ b/tests-cuda/test_4240_cuda_argsort.py
@@ -30,14 +30,17 @@ def _cpu_array(dtype):
         return ak.Array(segs)
     if dtype in FLOAT_DTYPES:
         nan = float("nan")
-        # Finite values + NaN. (A real +-inf alongside NaN hits a documented
-        # sentinel-collision edge case and is intentionally excluded here.)
+        inf = float("inf")
+        # Mix of finite values, duplicates, NaN, +-inf, and signed zero -- all of
+        # which must match the CPU ordering (NaN to the front, -0.0 == +0.0).
         segs = [
             [3.0, nan, 1.0, 1.0],
             [],
             [nan, nan, 4.0],
             [2.0],
             [9.0, 0.0, 0.0, 7.0, 7.0],
+            [-inf, nan, 0.0, inf],
+            [inf, -inf, -0.0, 0.0, nan, -2.5],
         ]
         return ak.values_astype(ak.Array(segs), dtype)
     # signed/unsigned integers: keep values non-negative so uint is valid
@@ -101,6 +104,20 @@ def test_sort_matches_cpu(dtype, ascending):
     )
 
     assert _nan_aware_equal(out_gpu, out_cpu)
+
+
+@pytest.mark.parametrize("ascending", [True, False])
+def test_argsort_nan_with_real_infinities(ascending):
+    # Regression: NaN must sort strictly before a real -inf (ascending) and stay
+    # at the front for descending too -- the case a single -inf/+inf sentinel
+    # could not express. e.g. [-inf, nan, 0, inf] ascending -> indices [1,0,2,3].
+    cpu = ak.Array([[-float("inf"), float("nan"), 0.0, float("inf")]])
+    gpu = ak.to_backend(cpu, "cuda")
+
+    out_cpu = ak.argsort(cpu, axis=-1, ascending=ascending, stable=True)
+    out_gpu = ak.argsort(gpu, axis=-1, ascending=ascending, stable=True)
+
+    assert ak.to_list(ak.to_backend(out_gpu, "cpu")) == ak.to_list(out_cpu)
 
 
 def test_argsort_all_empty():


### PR DESCRIPTION
`ak.argsort` was unsupported on the cuda backend (raised "not supported"). This adds it via `cuda.compute`, matching the CPU kernel's semantics, and fixes a NaN bug in the existing `ak.sort` along the way.

**What's added**
- `segmented_argsort` in `_connect/cuda/_compute.py` — a key–value `segmented_sort` (keys = data, values = global indices), with indices made segment-local to match the CPU `awkward_argsort`.
- Dispatch wired in `_backends/cupy.py` (both the `_supports_cuda_compute` allow-list and the impl table).
- Removed five now-obsolete `xfail("awkward_argsort is not implemented")` markers in `test_3459`.

**Float ordering parity (also fixes `ak.sort`)**
The existing `segmented_sort` mis-ordered NaNs. A sentinel remap can't fix it (NaN must sort strictly below a real `-inf`), so both paths now sort by an order-preserving unsigned key (`_float_order_keys`): NaNs to the front in both directions, `-0.0 == +0.0`, correct signed ordering. It's a single fused `cp.ElementwiseKernel` over the zero-copy uint bit-view (no temporaries), cached per float width.

**Tests** — `tests-cuda/test_4240_cuda_argsort.py`: argsort vs CPU (all dtypes, both directions, stable); carry-reproduces-sort; the `[-inf, nan, 0, inf]` regression; `sort` cross-check; and direct-call coverage for the non-int64-offsets and datetime/timedelta branches. Validated against CPU over 4000+ random ragged cases (mixed ±inf/NaN/±0.0/duplicates).

## AI disclosure

Parts of this PR were developed with AI assistance (per CONTRIBUTING.md).