### PR TITLE
fix: flatten(axis=None) dropped data or raised on nested unions

### DIFF
--- a/src/awkward/contents/unionarray.py
+++ b/src/awkward/contents/unionarray.py
@@ -54,6 +54,18 @@ numpy = Numpy.instance()
 MAX_UNION_CONTENTS = 2**7  # We use int8 tags, 0-127
 
 
+def _contains_union(content: Content) -> bool:
+    """True if ``content`` is, or contains at any depth, a union."""
+    if content.is_union:
+        return True
+    elif content.is_record:
+        return any(_contains_union(c) for c in content.contents)
+    elif content.is_numpy or content.is_unknown:
+        return False
+    else:
+        return _contains_union(content.content)
+
+
 @final
 class UnionArray(UnionMeta[Content], Content):
     """
@@ -1656,7 +1668,15 @@ class UnionArray(UnionMeta[Content], Content):
         # mergeable ``NumpyArray``: multi-part contents (records) and whole-kept
         # contents (strings) are order-sensitive in ways the reorder cannot
         # reproduce, so they fall back to the element-wise loop below.
-        if not options["keepdims"]:
+        # Branches whose subtree contains a nested union also fall back:
+        # ``ak.broadcast_arrays`` does not reliably broadcast the position
+        # marker into union branches (mixed-depth unions report a degenerate
+        # ``purelist_depth`` that stops the broadcast early, and
+        # ``broadcast_any_union`` regroups tags/index), so marker and values
+        # can flatten to different lengths or orders (#4214).
+        if not options["keepdims"] and not any(
+            _contains_union(content) for content in self._contents
+        ):
             value_parts: list[Content] = []
             position_parts: list[Content] = []
             fast_path = True

--- a/tests/test_4214_flatten_axis_none_nested_union.py
+++ b/tests/test_4214_flatten_axis_none_nested_union.py
@@ -1,0 +1,114 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+to_list = ak.operations.to_list
+
+
+def test_flatten_nested_union():
+    array = ak.Array([1, [[2, [3]]]])
+    assert to_list(ak.flatten(array, axis=None)) == [1, 2, 3]
+
+
+def test_flatten_nested_union_trailing_empty_lists():
+    # Previously raised IndexError: the merged position marker was longer
+    # than the merged values.
+    array = ak.Array([1, [[2, [3]]], [], []])
+    assert to_list(ak.flatten(array, axis=None)) == [1, 2, 3]
+
+
+def test_ravel_nested_union():
+    # Exercises drop_nones=False.
+    array = ak.Array([1, [[2, [3]]]])
+    assert to_list(ak.ravel(array)) == [1, 2, 3]
+
+
+def test_reduce_axis_none_nested_union_raises():
+    # Restores the 2.10.0 behavior: reducing over an irreducible union
+    # raises. In 2.11.0 this silently returned 3.
+    array = ak.Array([1, [[2, [3]]]])
+    with pytest.raises(ValueError, match="irreducible unions"):
+        ak.sum(array, axis=None)
+
+
+def _nested_union_branch():
+    # union[int64, var * int64]: [100, 200, [1, 2], [3]]
+    inner = ak.concatenate([ak.Array([100, 200]), ak.Array([[1, 2], [3]])]).layout
+    assert inner.is_union
+    return inner
+
+
+def _outer_union(branch):
+    # Elements: branch[0], 999.0, branch[1], 888.0
+    return ak.contents.UnionArray(
+        ak.index.Index8(np.array([0, 1, 0, 1], dtype=np.int8)),
+        ak.index.Index64(np.array([0, 0, 1, 1], dtype=np.int64)),
+        [branch, ak.contents.NumpyArray(np.array([999.0, 888.0]))],
+    )
+
+
+def test_explicit_nested_union_silent_truncation():
+    # var * var * union[int64, var * int64] has purelist_depth == 1 (the
+    # mixed-depth union reports -1), so broadcast_arrays left the position
+    # marker unbroadcast; flatten returned [100.0, 1.0, 200.0, 2.0].
+    inner = _nested_union_branch()
+    lists = ak.contents.ListOffsetArray(
+        ak.index.Index64(np.array([0, 2, 4], dtype=np.int64)), inner
+    )
+    nested_lists = ak.contents.ListOffsetArray(
+        ak.index.Index64(np.array([0, 1, 2], dtype=np.int64)), lists
+    )
+    array = ak.Array(_outer_union(nested_lists))
+    assert to_list(ak.flatten(array, axis=None)) == [
+        100.0,
+        200.0,
+        999.0,
+        1.0,
+        2.0,
+        3.0,
+        888.0,
+    ]
+
+
+def test_regular_of_branching_union():
+    # Previously raised ValueError from broadcast_arrays: "cannot broadcast
+    # UnionArray of length 4 with NumpyArray of length 2".
+    inner = _nested_union_branch()
+    regular = ak.contents.RegularArray(inner, 2)
+    array = ak.Array(_outer_union(regular))
+    assert to_list(ak.flatten(array, axis=None)) == [
+        100.0,
+        200.0,
+        999.0,
+        1.0,
+        2.0,
+        3.0,
+        888.0,
+    ]
+
+
+def test_matches_per_element_reference():
+    # The element-wise fallback must reproduce the historical per-element
+    # flattening exactly, interleaving included.
+    array = ak.Array([1, [[2, [3]]], 4, [[5, [6]]], 7])
+
+    layout = array.layout
+    tags = np.asarray(layout.tags.data)
+    index = np.asarray(layout.index.data)
+    ref = []
+    for i in range(len(tags)):
+        sub = layout.contents[tags[i]][index[i] : index[i] + 1]
+        for p in ak._do.remove_structure(sub, function_name="ak.flatten"):
+            ref.extend(to_list(ak.Array(p)))
+
+    assert to_list(ak.flatten(array, axis=None)) == ref == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_flatten_nested_union_typetracer():
+    array = ak.Array([1, [[2, [3]]]], backend="typetracer")
+    assert ak.flatten(array, axis=None).typestr == "## * int64"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #4214.

### Problem

In 2.11.0, `ak.flatten(axis=None)` drops data or raises `IndexError` when a union branch contains another union — a regression from the vectorized fast path added to `UnionArray._remove_structure` in #4109. `ak.ravel` is affected the same way, and `axis=None` reductions could return silently wrong values (`ak.sum(ak.Array([1, [[2, [3]]]]), axis=None)` returned 3).

### Cause

The fast path restores element interleaving by argsorting a position marker built with `ak.broadcast_arrays` and flattened through the same recursion as the values. But `ak.broadcast_arrays` does not reliably descend into union branches: a mixed-depth union reports `purelist_depth == -1`, which can make an enclosing branch report depth 1 so the broadcast stops before descending (stop condition in `ak_broadcast_arrays.py`), and when broadcasting does enter a union, `broadcast_any_union` regroups tags/index so the marker's structure no longer matches the values recursion. A `RegularArray` of a branching union even raises `ValueError` inside the broadcast. When marker and values flatten to different lengths, the final `_carry` either raises `IndexError` (marker longer) or silently truncates data (marker shorter).

### Fix

Skip the fast path when any branch's subtree contains a nested union and use the pre-existing element-wise fallback, which is the 2.10.0 code path and produces the 2.10.0 results. The common flat-union case keeps the fast path: `ak.flatten(axis=None)` on a 10^5-element union of numbers and var-lists still runs in ~2.4 ms (the pre-#4109 loop took ~0.7 s), and the structural gate costs about 1 µs.

### Behavior change relative to 2.11.0 (restores 2.10.0)

`axis=None` reductions over a nested union again raise `ValueError: cannot use axis=None on an array containing irreducible unions`, as in 2.10.0, instead of returning silently wrong results; #4109 had accidentally made some union reductions "work" by merging the parts. Flat-union reductions keep working (`ak.sum(ak.Array([1, [2, 3]]), axis=None) == 6`). `ak.flatten` and `ak.ravel` merge the fallback's parts themselves, so they return complete, correctly ordered results.

### Tests

New `tests/test_4214_flatten_axis_none_nested_union.py`: both repros from the issue, `ak.ravel`, the reduction `ValueError`, two constructed layouts (silent truncation with misordering, and the `RegularArray`-of-branching-union `ValueError`), a comparison against a per-element reference (pattern from `tests/test_4109_python_perf.py`), and a typetracer check. Full suite: 6403 passed, 55 skipped. All pre-commit hooks pass.

### Follow-ups (not in this PR)

- `ak.broadcast_arrays` silently declines to broadcast into mixed-depth union branches (the degenerate `purelist_depth`); a separate issue will be filed.
- `axis=None` reductions over nested-but-mergeable unions could be made to work by merging all-`NumpyArray` fallback parts in `_do.reduce` — a deliberate semantics extension, separate from this regression fix.

**AI assistance:** This change was developed with Claude Code (disclosed per CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
