### PR TITLE
fix: Fix Numba lowering for `ArrayBuilder.append()` with Unicode strings

### DIFF
--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -587,7 +587,7 @@ def lower_string(context, builder, sig, args):
     pyapi = context.get_python_api(builder)
     gil = pyapi.gil_ensure()
 
-    _is_ok, out, length = pyapi.string_as_string_and_size(xval.value)
+    _is_ok, out, length = pyapi.string_as_string_and_size(xval)
     length = ak._connect.numba.layout.castint(
         context, builder, numba.ssize_t, numba.int64, length
     )

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -651,7 +651,7 @@ def lower_string(context, builder, sig, args):
         builder,
         numba.intp,
         numba.int64,
-        utf8.shape[0],
+        utf8.nitems,
     )
     call(
         context,

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -532,6 +532,8 @@ def lower_complex_from_integer_or_float(context, builder, sig, args):
 
 
 def _unicode_to_utf8(value):
+    # UTF-8 uses at most four bytes per Unicode code point (RFC 3629),
+    # so allocating 4 * len(value) bytes guarantees sufficient space.
     output = numpy.empty(len(value) * 4, dtype=numpy.uint8)
     position = 0
 

--- a/src/awkward/_connect/numba/builder.py
+++ b/src/awkward/_connect/numba/builder.py
@@ -8,6 +8,7 @@ import numba.core.typing.ctypes_utils
 import numpy
 from awkward_cpp import libawkward
 from numba.core.errors import NumbaTypeError
+from numba.cpython.unicode import _get_code_point
 
 import awkward as ak
 
@@ -530,6 +531,44 @@ def lower_complex_from_integer_or_float(context, builder, sig, args):
     return context.get_dummy_value()
 
 
+def _unicode_to_utf8(value):
+    output = numpy.empty(len(value) * 4, dtype=numpy.uint8)
+    position = 0
+
+    for i in range(len(value)):
+        codepoint = _get_code_point(value, i)
+
+        if codepoint <= 0x7F:
+            output[position] = codepoint
+            position += 1
+
+        elif codepoint <= 0x7FF:
+            output[position] = 0xC0 | (codepoint >> 6)
+            output[position + 1] = 0x80 | (codepoint & 0x3F)
+            position += 2
+
+        elif 0xD800 <= codepoint <= 0xDFFF:
+            raise ValueError("cannot encode surrogate code point as UTF-8")
+
+        elif codepoint <= 0xFFFF:
+            output[position] = 0xE0 | (codepoint >> 12)
+            output[position + 1] = 0x80 | ((codepoint >> 6) & 0x3F)
+            output[position + 2] = 0x80 | (codepoint & 0x3F)
+            position += 3
+
+        elif codepoint <= 0x10FFFF:
+            output[position] = 0xF0 | (codepoint >> 18)
+            output[position + 1] = 0x80 | ((codepoint >> 12) & 0x3F)
+            output[position + 2] = 0x80 | ((codepoint >> 6) & 0x3F)
+            output[position + 3] = 0x80 | (codepoint & 0x3F)
+            position += 4
+
+        else:
+            raise ValueError("invalid Unicode code point")
+
+    return output[:position]
+
+
 @numba.extending.lower_builtin("complex", ArrayBuilderType, numba.types.Complex)
 def lower_complex(context, builder, sig, args):
     arraybuildertype, xtype = sig.args
@@ -580,25 +619,56 @@ def lower_timedelta(context, builder, sig, args):
 
 @numba.extending.lower_builtin("string", ArrayBuilderType, numba.types.UnicodeType)
 def lower_string(context, builder, sig, args):
-    arraybuildertype, _xtype = sig.args
-    arraybuilderval, xval = args
-    proxyin = context.make_helper(builder, arraybuildertype, arraybuilderval)
+    arraybuildertype, unicodetype = sig.args
+    arraybuilderval, unicodeval = args
 
-    pyapi = context.get_python_api(builder)
-    gil = pyapi.gil_ensure()
+    proxyin = context.make_helper(
+        builder,
+        arraybuildertype,
+        arraybuilderval,
+    )
 
-    _is_ok, out, length = pyapi.string_as_string_and_size(xval)
+    utf8_array_type = numba.types.Array(
+        numba.types.uint8,
+        1,
+        "C",
+    )
+
+    utf8_array = context.compile_internal(
+        builder,
+        _unicode_to_utf8,
+        utf8_array_type(unicodetype),
+        (unicodeval,),
+    )
+
+    utf8 = context.make_array(utf8_array_type)(
+        context,
+        builder,
+        value=utf8_array,
+    )
     length = ak._connect.numba.layout.castint(
-        context, builder, numba.ssize_t, numba.int64, length
+        context,
+        builder,
+        numba.intp,
+        numba.int64,
+        utf8.shape[0],
     )
     call(
         context,
         builder,
         libawkward.ArrayBuilder_string_length,
-        (proxyin.rawptr, out, length),
+        (
+            proxyin.rawptr,
+            utf8.data,
+            length,
+        ),
     )
 
-    pyapi.gil_release(gil)
+    context.nrt.decref(
+        builder,
+        utf8_array_type,
+        utf8_array,
+    )
 
     return context.get_dummy_value()
 

--- a/tests/test_4249_numba_string_lowering.py
+++ b/tests/test_4249_numba_string_lowering.py
@@ -1,0 +1,24 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import pytest
+
+import awkward as ak
+
+numba = pytest.importorskip("numba")
+
+ak.numba.register_and_check()
+
+
+def test_numba_arraybuilder_append_string():
+    @numba.njit
+    def build(strings, builder):
+        for value in strings:
+            builder.append(value)
+        return builder
+
+    strings = numba.typed.List(["hello", "world"])
+    result = build(strings, ak.ArrayBuilder()).snapshot()
+
+    assert result.to_list() == ["hello", "world"]

--- a/tests/test_4249_numba_string_lowering.py
+++ b/tests/test_4249_numba_string_lowering.py
@@ -11,14 +11,41 @@ numba = pytest.importorskip("numba")
 ak.numba.register_and_check()
 
 
-def test_numba_arraybuilder_append_string():
+@pytest.mark.parametrize(
+    "strings",
+    [
+        ["hello", "world"],
+        ["", "abc"],
+        ["café", "naïve"],  # two-byte UTF-8
+        ["κόσμος", "Привет"],  # two-byte UTF-8
+        ["日本語", "中文"],  # three-byte UTF-8
+        ["🙂", "🚀"],  # four-byte UTF-8
+        ["a🙂é日", ""],  # mixed widths
+    ],
+)
+def test_numba_arraybuilder_append_string(strings):
     @numba.njit
-    def build(strings, builder):
-        for value in strings:
+    def build(values, builder):
+        for value in values:
             builder.append(value)
         return builder
 
-    strings = numba.typed.List(["hello", "world"])
-    result = build(strings, ak.ArrayBuilder()).snapshot()
+    typed_strings = numba.typed.List(strings)
+    result = build(typed_strings, ak.ArrayBuilder()).snapshot()
 
-    assert result.to_list() == ["hello", "world"]
+    assert result.to_list() == strings
+
+
+def test_numba_arraybuilder_string():
+    @numba.njit
+    def build(values, builder):
+        for value in values:
+            builder.string(value)
+        return builder
+
+    strings = ["hello", "café", "日本語", "🙂"]
+    values = numba.typed.List(strings)
+
+    result = build(values, ak.ArrayBuilder()).snapshot()
+
+    assert result.to_list() == strings


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/awkward/issues/4248

This PR restores support for appending native Numba Unicode strings to `ak.ArrayBuilder` inside `@numba.njit` functions.

The previous implementation relied on the Python C API (`PyUnicode_AsUTF8AndSize`) during lowering, which no longer works with recent Numba versions where `unicode_type` is represented as a native value rather than a Python object. This resulted in lowering failures when compiling functions that append strings to an `ArrayBuilder`.

This PR replaces the Python C API path with a fully native implementation:

 * performs UTF-8 encoding directly from Numba's native Unicode representation,
 * avoids acquiring the GIL or boxing Python objects,
 * passes the encoded UTF-8 buffer directly to `ArrayBuilder_string_length`,
 * adds regression tests covering ASCII, empty strings, and multi-byte Unicode characters.

Besides fixing compatibility with newer Numba releases (including Python 3.14), this also removes an unnecessary dependency on the Python runtime during string lowering, making the implementation more robust and consistent with the rest of Awkward's native Numba integration.
