### PR TITLE
chore: stop requiring `from __future__ import annotations`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,7 +304,6 @@ ignore = [
 typing-modules = ["awkward._typing"]
 external = []
 mccabe.max-complexity = 100
-isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
 "dev/*" = ["T20", "TID251"]


### PR DESCRIPTION
This PR does Option A of https://github.com/scikit-hep/awkward/issues/4235.
I'll open another PR for Option B.