### PR TITLE
test: add no-raise property tests for `ak.flatten` and `ak.all`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   - id: trailing-whitespace
   - id: name-tests-test
     args: ["--pytest-test-first"]
+    exclude: ^tests/properties/
 
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: e2c2116d86a80e72e7146a06e68b7c228afc6319  # frozen: v0.6.13

--- a/tests/properties/operations/__init__.py
+++ b/tests/properties/operations/__init__.py
@@ -1,0 +1,29 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Property tests for awkward operations, one module per operation.
+
+The operation modules (`test_flatten.py`, `test_all.py`) follow one
+template, and either is a complete example to copy. The identifiers
+are operation-invariant — only the module name and the called
+operation say what is under test. `Kwargs`, `DEFAULTS`, and
+`RelatedKwargs` declare the operation's options;
+`test_kwargs_match_signature` checks them against the signature
+(through `util`); `st_kwargs` draws an option dict in which every
+option is optional, so the defaults are exercised too; and
+`test_properties`, the single property test, draws an array and
+options, keeps only the draws expected to succeed, and calls the
+operation.
+
+Two predicates decide which draws are kept. `_should_not_raise`
+models the design — what the operation deliberately accepts and
+refuses — and is re-derived for each operation.
+`_would_raise_from_known_issue` skips draws that meet an open issue;
+its clauses select predicates from `known_issues` and are deleted as
+the issues are fixed. Both are conservative, and their safe
+directions differ: a needlessly skipped draw costs only coverage
+while a missing skip fails the suite, so narrow `_should_not_raise`
+toward `False` and widen a `known_issues` trigger.
+
+The `test_to_from_*` and `test_array_equal` modules are an earlier
+family with their own pattern.
+"""

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -50,7 +50,7 @@ def has_issue_4260(a: ak.Array) -> bool:
 
 
 def has_issue_4259(a: ak.Array) -> bool:
-    """Return `True` if a `float16` leaf is in the array.
+    """Return `True` if a `float16` or `float128` leaf is in the array.
 
     `ak.sort`, `ak.argsort`, and every reducer except `ak.count`
     raise `KeyError` from the kernel-table lookup when a `float16`
@@ -59,17 +59,21 @@ def has_issue_4259(a: ak.Array) -> bool:
     NumPy path): awkward-cpp has no `float16` kernels, and the dtype
     is neither mapped onto an existing kernel
     (`KernelReducer._dtype_for_kernel` does this for datetimes and
-    complex numbers) nor refused with a documented error. Which
-    leaves reach a kernel depends on the operation and the layout, so
-    every `float16` leaf matches here, although one that never
-    reaches a kernel works. Reported:
+    complex numbers) nor refused with a documented error. `float128`
+    fails the same lookup (as `numpy.longdouble` in the kernel key)
+    on the platforms where NumPy provides it — continuous
+    integration on Linux found it; macOS NumPy has no `float128`.
+    Which leaves reach a kernel depends on the operation and the
+    layout, so every matching leaf counts here, although one that
+    never reaches a kernel works. Reported (for `float16`; the #392
+    roadmap pairs the two dtypes):
     https://github.com/scikit-hep/awkward/issues/4259
     """
     stack = [a.layout.form]
     while stack:
         node = stack.pop()
         if node.is_numpy:
-            if node.primitive == "float16":
+            if node.primitive in ("float16", "float128"):
                 return True
         elif node.is_record or node.is_union:
             stack.extend(node.contents)

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -84,10 +84,12 @@ def has_issue_4261(a: ak.Array) -> bool:
     `ak.flatten(axis=None)` and `ak.ravel` flatten every branch to
     its leaves and merge them with `ak._do.mergemany`. A record or
     union in the form can combine leaves from different families:
-    integers (with bool), floats (with complex), linear-unit
-    timedeltas, calendar-unit timedeltas (months, years), datetimes
-    (all units), and strings (with bytestrings). Integers promote
-    with floats and with either timedelta family; any other
+    integers (with bool, without `uint64`), `uint64` on its own,
+    floats (with complex), linear-unit timedeltas, calendar-unit
+    timedeltas (months, years), datetimes (all units), and strings
+    (with bytestrings). Integers promote with floats and with either
+    timedelta family; `uint64` promotes with the integers and the
+    floats but with neither timedelta family; any other
     combination of two or more families makes the merge fail with a
     bare `AssertionError` ("cannot merge NumpyArray with
     ListOffsetArray"), an `AttributeError`, NumPy's
@@ -98,9 +100,10 @@ def has_issue_4261(a: ak.Array) -> bool:
     The families are modeled on NumPy's documented promotion rules,
     not on the current implementation, except that datetimes with
     timedeltas, which NumPy promotes, are grouped as non-promotable;
-    `np.result_type` is not a substitute (it also refuses `uint64`
-    with timedeltas). Unprobed combinations may still fail the tests;
-    such a failure indicates this trigger is missing a combination.
+    `np.result_type` is still not a substitute (it fails on extreme
+    unit pairs that merge). Unprobed combinations may still fail the
+    tests; such a failure indicates this trigger is missing a
+    combination.
     Reported: https://github.com/scikit-hep/awkward/issues/4261
     """
     form = a.layout.form
@@ -108,7 +111,7 @@ def has_issue_4261(a: ak.Array) -> bool:
         return False
     families = _leaf_families(form)
     promotable_pairs = (
-        {"integer", "float"},
+        {"integer", "uint64", "float"},
         {"integer", "timedelta"},
         {"integer", "timedelta-calendar"},
     )
@@ -170,6 +173,39 @@ def has_issue_4263(a: ak.Array) -> bool:
     return _reaches_empty_union(a.layout)
 
 
+def has_issue_4264(a: ak.Array) -> bool:
+    """Return `True` if an option type sits under an untrimmed regular list.
+
+    The caller applies the option condition (for `ak.all`, an integer
+    `axis`). A `RegularArray` may validly carry content longer than
+    `size * length`, and the reducers mishandle an option node inside
+    such untrimmed content: an option directly above a list fails a
+    bare `AssertionError` in `RegularArray._reduce_next` on every
+    run, and an option above a leaf raises `IndexError` from an
+    out-of-range carry index nondeterministically (`ak.all`,
+    `ak.any`, `ak.sum`, `ak.count`, and `ak.min` are all affected).
+    With content trimmed to `size * length` the same reductions
+    succeed. Reported:
+    https://github.com/scikit-hep/awkward/issues/4264
+    """
+    stack = [(a.layout, False)]
+    while stack:
+        node, in_untrimmed = stack.pop()
+        if node.is_numpy or node.is_unknown:
+            continue
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_option and in_untrimmed:
+            return True
+        if node.is_regular and node.content.length > node.size * node.length:
+            in_untrimmed = True
+        if node.is_record or node.is_union:
+            stack.extend((c, in_untrimmed) for c in node.contents)
+        else:
+            stack.append((node.content, in_untrimmed))
+    return False
+
+
 def _is_variable_length_list(form: ak.forms.Form) -> bool:
     """Return `True` if the node has `var` type.
 
@@ -217,7 +253,9 @@ def _leaf_families(form: ak.forms.Form) -> set[str]:
         elif node.is_record or node.is_union:
             stack.extend(node.contents)
         elif node.is_numpy:
-            if node.primitive.startswith("datetime64"):
+            if node.primitive == "uint64":
+                families.add("uint64")
+            elif node.primitive.startswith("datetime64"):
                 families.add("datetime")
             elif node.primitive.startswith("timedelta64"):
                 if node.primitive.endswith(("[M]", "[Y]")):

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -1,0 +1,258 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Predicates for known issues; the property tests skip affected draws.
+
+Each issue has one public predicate, named `has_issue_<number>` after
+the issue it detects, with the description and link in its docstring;
+an issue not yet reported takes a placeholder number (`NNN1`, `NNN2`,
+...). A predicate takes only the array — nothing else decides whether
+an array is affected — so any operation's test module can use it. A
+test module calls the predicates it needs from its private
+`_would_raise_from_known_issue` function and applies any option
+conditions there (a negative `axis` for `ak.flatten`, for example). A
+predicate may over-match — an extra skipped draw is harmless, and a
+missed one fails the tests — so widen a trigger rather than narrow
+it. Delete a predicate in the pull request that fixes its issue: the
+skipped draws are then tested again. If an issue is resolved as
+intended behavior instead, the exclusion moves into the design
+predicate (`_should_not_raise`) of each affected operation.
+"""
+
+import awkward as ak
+
+
+def has_issue_4260(a: ak.Array) -> bool:
+    """Return `True` if a record spanning more than one depth is in the array.
+
+    Such a record makes the form branch, so a negative `axis` does
+    not resolve; `ak.flatten` then skips its documented
+    `AxisError`/`ValueError` paths, and
+    `RecordArray._offsets_and_flattened` raises a bare
+    `AssertionError` ("RecordArray content with axis > depth + 1
+    returned a non-empty offsets from offsets_and_flattened"). The
+    depths are those of each record's whole subtree, so a union of
+    unequal depths below a record counts. Reported:
+    https://github.com/scikit-hep/awkward/issues/4260
+    """
+    stack = [a.layout.form]
+    while stack:
+        node = stack.pop()
+        if node.is_record:
+            lo, hi = node.minmax_depth
+            if lo != hi:
+                return True
+            stack.extend(node.contents)
+        elif node.is_union:
+            stack.extend(node.contents)
+        elif not (node.is_numpy or node.is_unknown):
+            stack.append(node.content)
+    return False
+
+
+def has_issue_4259(a: ak.Array) -> bool:
+    """Return `True` if a `float16` leaf is in the array.
+
+    `ak.sort`, `ak.argsort`, and every reducer except `ak.count`
+    raise `KeyError` from the kernel-table lookup when a `float16`
+    leaf reaches a kernel (`ak.sum`, `ak.min`, and `ak.max` reach one
+    only in a partial reduction; a whole-array reduction takes a
+    NumPy path): awkward-cpp has no `float16` kernels, and the dtype
+    is neither mapped onto an existing kernel
+    (`KernelReducer._dtype_for_kernel` does this for datetimes and
+    complex numbers) nor refused with a documented error. Which
+    leaves reach a kernel depends on the operation and the layout, so
+    every `float16` leaf matches here, although one that never
+    reaches a kernel works. Reported:
+    https://github.com/scikit-hep/awkward/issues/4259
+    """
+    stack = [a.layout.form]
+    while stack:
+        node = stack.pop()
+        if node.is_numpy:
+            if node.primitive == "float16":
+                return True
+        elif node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif not node.is_unknown:
+            stack.append(node.content)
+    return False
+
+
+def has_issue_4261(a: ak.Array) -> bool:
+    """Return `True` if flattening all levels would merge non-promotable leaves.
+
+    `ak.flatten(axis=None)` and `ak.ravel` flatten every branch to
+    its leaves and merge them with `ak._do.mergemany`. A record or
+    union in the form can combine leaves from different families:
+    integers (with bool), floats (with complex), linear-unit
+    timedeltas, calendar-unit timedeltas (months, years), datetimes
+    (all units), and strings (with bytestrings). Integers promote
+    with floats and with either timedelta family; any other
+    combination of two or more families makes the merge fail with a
+    bare `AssertionError` ("cannot merge NumpyArray with
+    ListOffsetArray"), an `AttributeError`, NumPy's
+    `DTypePromotionError`, or a `TypeError` from datetime-unit
+    metadata, depending on the layout, instead of building a union or
+    raising a documented error.
+
+    The families are modeled on NumPy's documented promotion rules,
+    not on the current implementation, except that datetimes with
+    timedeltas, which NumPy promotes, are grouped as non-promotable;
+    `np.result_type` is not a substitute (it also refuses `uint64`
+    with timedeltas). Unprobed combinations may still fail the tests;
+    such a failure indicates this trigger is missing a combination.
+    Reported: https://github.com/scikit-hep/awkward/issues/4261
+    """
+    form = a.layout.form
+    if not _contains_record_or_union(form):
+        return False
+    families = _leaf_families(form)
+    promotable_pairs = (
+        {"integer", "float"},
+        {"integer", "timedelta"},
+        {"integer", "timedelta-calendar"},
+    )
+    return len(families) > 1 and not any(families <= pair for pair in promotable_pairs)
+
+
+def has_issue_4262(a: ak.Array) -> bool:
+    """Return `True` if a regular list of variable-length lists is under a union.
+
+    To restore the interleaving order of a union,
+    `UnionArray._remove_structure` broadcasts each branch against its
+    elements' positions with `ak.broadcast_arrays`
+    (`ak.flatten(axis=None)` and `ak.ravel` reach it), and the
+    broadcast raises `ValueError` ("cannot broadcast ListArray of
+    length 3 with NumpyArray of length 1") on a regular list of
+    variable-length lists. The failure is in the broadcasting itself,
+    with no union among its inputs (related to issue #4247); only a
+    union causes the flattening to broadcast. The trigger is such a
+    regular list anywhere under a union node, descending through
+    list, option, indexed, and record nodes; a string does not count
+    as a variable-length list. Which configurations reach the
+    broadcast depends on the current implementation's internals, so
+    every such union matches here, although a regular list of size 1,
+    or one that no values reach, happens to work. Reported:
+    https://github.com/scikit-hep/awkward/issues/4262
+    """
+    stack = [(a.layout.form, False)]
+    while stack:
+        node, in_union = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_union:
+            stack.extend((c, True) for c in node.contents)
+        elif node.is_record:
+            stack.extend((c, in_union) for c in node.contents)
+        elif node.is_numpy or node.is_unknown:
+            continue
+        else:
+            if in_union and node.is_regular and _is_variable_length_list(node.content):
+                return True
+            stack.append((node.content, in_union))
+    return False
+
+
+def has_issue_4263(a: ak.Array) -> bool:
+    """Return `True` if a union that no values reach is in the array.
+
+    `ak.flatten(axis=None)` and `ak.ravel` collect the values of
+    every branch and merge them with `ak._do.mergemany`; a union that
+    no values reach — judged on reachable values, so an option mask
+    or an empty list above the union counts — contributes no parts,
+    and the merge fails its `assert len(contents) != 0` instead of
+    returning an empty result. Which branch types the collection
+    keeps depends on the current implementation's internals, so every
+    such union matches here, although one with only plain numeric
+    branches happens to work. Reported:
+    https://github.com/scikit-hep/awkward/issues/4263
+    """
+    return _reaches_empty_union(a.layout)
+
+
+def _is_variable_length_list(form: ak.forms.Form) -> bool:
+    """Return `True` if the node has `var` type.
+
+    Descends through option and indexed nodes; a string is not a
+    list here (the `__array__` parameter overrides the structure).
+    """
+    node = form
+    while node.is_option or node.is_indexed:
+        node = node.content
+    if node.parameter("__array__") in ("string", "bytestring"):
+        return False
+    return node.is_list and not node.is_regular
+
+
+def _contains_record_or_union(form: ak.forms.Form) -> bool:
+    """Return `True` if a record or union is somewhere in the tree.
+
+    A string node is a leaf, not structure: the descent stops there.
+    """
+    stack = [form]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_record or node.is_union:
+            return True
+        if not (node.is_numpy or node.is_unknown):
+            stack.append(node.content)
+    return False
+
+
+def _leaf_families(form: ak.forms.Form) -> set[str]:
+    """Return the merge families of the leaf types.
+
+    The family names and their groupings are described in
+    `has_issue_4261`. A string counts as one leaf, not as a list of
+    characters.
+    """
+    families = set()
+    stack = [form]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            families.add("string")
+        elif node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif node.is_numpy:
+            if node.primitive.startswith("datetime64"):
+                families.add("datetime")
+            elif node.primitive.startswith("timedelta64"):
+                if node.primitive.endswith(("[M]", "[Y]")):
+                    families.add("timedelta-calendar")
+                else:
+                    families.add("timedelta")
+            elif node.primitive.startswith(("float", "complex")):
+                families.add("float")
+            else:
+                families.add("integer")
+        elif not node.is_unknown:
+            stack.append(node.content)
+    return families
+
+
+def _reaches_empty_union(layout: ak.contents.Content) -> bool:
+    """Return `True` if a union that no values reach is in the layout.
+
+    Descends through reachable values only: option and indexed nodes
+    are projected, union branches are projected one by one, and
+    record, regular, and list contents are trimmed to the range their
+    parent references.
+    """
+    if layout.is_union:
+        return layout.length == 0 or any(
+            _reaches_empty_union(layout.project(i)) for i in range(len(layout.contents))
+        )
+    if layout.is_record:
+        return any(_reaches_empty_union(c[: layout.length]) for c in layout.contents)
+    if layout.is_option or layout.is_indexed:
+        return _reaches_empty_union(layout.project())
+    # A RegularArray is also a list, so this branch must come first.
+    if layout.is_regular:
+        return _reaches_empty_union(layout.content[: layout.length * layout.size])
+    if layout.is_list:
+        lst = layout.to_ListOffsetArray64(False)
+        return _reaches_empty_union(lst.content[lst.offsets[0] : lst.offsets[-1]])
+    return False

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -65,8 +65,7 @@ def has_issue_4259(a: ak.Array) -> bool:
     integration on Linux found it; macOS NumPy has no `float128`.
     Which leaves reach a kernel depends on the operation and the
     layout, so every matching leaf counts here, although one that
-    never reaches a kernel works. Reported (for `float16`; the #392
-    roadmap pairs the two dtypes):
+    never reaches a kernel works. Reported:
     https://github.com/scikit-hep/awkward/issues/4259
     """
     stack = [a.layout.form]

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -50,7 +50,7 @@ def has_issue_4260(a: ak.Array) -> bool:
 
 
 def has_issue_4259(a: ak.Array) -> bool:
-    """Return `True` if a `float16` or `float128` leaf is in the array.
+    """Return `True` if a `float16`, `float128`, or `complex256` leaf is in the array.
 
     `ak.sort`, `ak.argsort`, and every reducer except `ak.count`
     raise `KeyError` from the kernel-table lookup when a `float16`
@@ -60,19 +60,19 @@ def has_issue_4259(a: ak.Array) -> bool:
     is neither mapped onto an existing kernel
     (`KernelReducer._dtype_for_kernel` does this for datetimes and
     complex numbers) nor refused with a documented error. `float128`
-    fails the same lookup (as `numpy.longdouble` in the kernel key)
-    on the platforms where NumPy provides it — continuous
-    integration on Linux found it; macOS NumPy has no `float128`.
-    Which leaves reach a kernel depends on the operation and the
-    layout, so every matching leaf counts here, although one that
-    never reaches a kernel works. Reported:
+    and `complex256` fail the same lookup (as `numpy.longdouble` and
+    `numpy.clongdouble` in the kernel key) on the platforms where
+    NumPy provides them — continuous integration on Linux found both;
+    macOS NumPy has neither. Which leaves reach a kernel depends on
+    the operation and the layout, so every matching leaf counts here,
+    although one that never reaches a kernel works. Reported:
     https://github.com/scikit-hep/awkward/issues/4259
     """
     stack = [a.layout.form]
     while stack:
         node = stack.pop()
         if node.is_numpy:
-            if node.primitive in ("float16", "float128"):
+            if node.primitive in ("float16", "float128", "complex256"):
                 return True
         elif node.is_record or node.is_union:
             stack.extend(node.contents)

--- a/tests/properties/operations/test_all.py
+++ b/tests/properties/operations/test_all.py
@@ -1,0 +1,211 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Property tests for `ak.all`.
+
+The module follows the template described in the package docstring.
+"""
+
+from typing import Any, TypedDict, cast
+
+import hypothesis_awkward.strategies as st_ak
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+import awkward as ak
+from tests.properties.operations import known_issues, util
+
+
+class Kwargs(TypedDict, total=False):
+    """Options for `ak.all`."""
+
+    axis: int | None
+    keepdims: bool
+    mask_identity: bool
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+DEFAULTS = Kwargs(
+    axis=None,
+    keepdims=False,
+    mask_identity=False,
+    highlevel=True,
+    behavior=None,
+    attrs=None,
+)
+
+
+class RelatedKwargs(TypedDict, total=False):
+    """Options drawn together: `behavior` and `attrs` depend on `highlevel`."""
+
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+def test_kwargs_match_signature() -> None:
+    """Assert the option declarations agree with `ak.all`'s parameters."""
+    util.assert_kwargs_match_signature(
+        func=ak.all,
+        data_param_names={"array"},
+        kwargs_cls=Kwargs,
+        defaults=DEFAULTS,
+        related_cls=RelatedKwargs,
+    )
+
+
+@st.composite
+def st_kwargs(draw: st.DrawFn, array: ak.Array) -> Kwargs:
+    """Strategy for options of `ak.all` on `array`.
+
+    Every option is optional in the drawn dict, so the defaults are
+    exercised as well; whether each option appears is drawn separately
+    from its value. `behavior` and `attrs` affect only a high-level
+    output, so they are drawn only when `highlevel` is not `False`.
+    Only `None` and an empty `dict` are drawn for `behavior` (a
+    mapping from names to classes) and `attrs`.
+    """
+
+    @st.composite
+    def _st_related_kwargs(draw: st.DrawFn) -> RelatedKwargs:
+        """Strategy for `highlevel` and the options that depend on it."""
+        ret = RelatedKwargs()
+        if draw(st.booleans()):
+            ret["highlevel"] = draw(st.booleans())
+
+        if ret.get("highlevel", DEFAULTS["highlevel"]) is not False:
+            if draw(st.booleans()):
+                # TODO: generate non-empty `behavior`. An entry is
+                # inert unless its key matches a lookup for the drawn
+                # array; a matching entry can change what raises (a
+                # registered record reducer makes records reducible),
+                # so `_should_not_raise` must then model the drawn
+                # entries.
+                ret["behavior"] = draw(st_ak.none_or(st.builds(dict)))
+            if draw(st.booleans()):
+                # TODO: generate non-empty `attrs`. Any value is inert
+                # except under the reserved `__named_axis__` key
+                # (`awkward._namedaxis.NAMED_AXIS_KEY`), which holds
+                # the named-axis mapping: generate that key only with
+                # a valid mapping, or not at all.
+                ret["attrs"] = draw(st_ak.none_or(st.builds(dict)))
+        return ret
+
+    def _st_axes() -> st.SearchStrategy[int | None]:
+        """Strategy for the option `axis` on `array`.
+
+        Draws `None` or an integer in `[-depth, depth)` for the
+        array's maximum depth; an axis that does not exist for the
+        drawn form is left to `_should_not_raise`.
+        """
+        depth = array.layout.minmax_depth[1]
+        return st_ak.none_or(st.integers(min_value=-depth, max_value=depth - 1))
+
+    related = draw(_st_related_kwargs())
+
+    optional_independent = draw(
+        st.fixed_dictionaries(
+            {},
+            optional={
+                "axis": _st_axes(),
+                "keepdims": st.booleans(),
+                "mask_identity": st.booleans(),
+            },
+        )
+    )
+
+    return cast(Kwargs, {**related, **optional_independent})
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(data=st.data())
+def test_properties(data: st.DataObject) -> None:
+    """Assert `ak.all` does not raise on a draw expected to succeed."""
+    a = data.draw(st_ak.constructors.arrays(), label="a")
+    kwargs = data.draw(st_kwargs(a), label="kwargs")
+
+    assume(_should_not_raise(a.layout.form, kwargs))
+
+    assume(not _would_raise_from_known_issue(a, kwargs))
+
+    ak.all(a, **kwargs)
+
+    # TODO: assert properties
+
+
+def _should_not_raise(form: ak.forms.Form, kwargs: Kwargs) -> bool:
+    """Return `True` if the operation should be successful.
+
+    Conservative: `False` makes no statement — the call may still
+    succeed; a rule shown too permissive by a failure is narrowed
+    toward `False`. Only `axis` decides: the other options, as they
+    are drawn, never affect whether `ak.all` raises.
+
+    The rules, written against `ak.all`'s deliberate error paths
+    (records, irreducible unions, axis beyond depth):
+
+    - A form `ak.all` refuses to run on (see `_reducible`): never
+      `True`, whatever the axis.
+    - On an accepted form: `axis=None` (reduce everything) always
+      succeeds, and an integer axis is `True` when it resolves to
+      `0 <= axis < depth`. No level type is excluded: a string is a
+      reducible leaf — `ak.all` runs over its characters, and
+      `minmax_depth` counts it as one level.
+    """
+    if not _reducible(form):
+        return False
+    axis = kwargs.get("axis", DEFAULTS["axis"])
+    if axis is None:
+        return True
+    axis = _normalize_axis(axis, form)
+    if axis < 0:
+        return False
+    return axis < form.minmax_depth[1]
+
+
+def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
+    """Return `True` if an open issue affects the operation.
+
+    One clause per issue; the predicates and their descriptions are
+    in `known_issues`, and this function applies any option
+    conditions.
+    """
+    if known_issues.has_issue_4259(a):
+        return True
+    return False
+
+
+def _normalize_axis(axis: int, form: ak.forms.Form) -> int:
+    """Resolve a negative `axis` against the form's depth.
+
+    A non-negative `axis` is already resolved and passes through. A
+    resolved axis is non-negative, so a negative result indicates that
+    none exists: a negative axis is ambiguous on a branching form
+    (the axis is returned unchanged), and an axis below `-depth` is
+    beyond the form (the resolution stays negative).
+    """
+    if axis >= 0:
+        return axis
+    branches, depth = form.branch_depth
+    if branches:
+        return axis
+    return axis + depth
+
+
+def _reducible(form: ak.forms.Form) -> bool:
+    """Return `True` if `ak.all` runs on this form at every axis it has.
+
+    A record anywhere makes `ak.all` raise at every axis, `None` and
+    `0` included; a union raises only in some configurations, and
+    deciding them is left out, so both are refused and the accepted
+    forms are single chains of list, option, and indexed nodes down
+    to a leaf.
+    """
+    node = form
+    while True:
+        if node.is_record or node.is_union:
+            return False
+        if node.is_numpy or node.is_unknown:
+            return True
+        node = node.content

--- a/tests/properties/operations/test_all.py
+++ b/tests/properties/operations/test_all.py
@@ -173,6 +173,13 @@ def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
     """
     if known_issues.has_issue_4259(a):
         return True
+
+    axis = kwargs.get("axis", DEFAULTS["axis"])
+
+    match axis:
+        case int():
+            if known_issues.has_issue_4264(a):
+                return True
     return False
 
 

--- a/tests/properties/operations/test_flatten.py
+++ b/tests/properties/operations/test_flatten.py
@@ -1,0 +1,212 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Property tests for `ak.flatten`.
+
+The module follows the template described in the package docstring.
+"""
+
+from typing import Any, TypedDict, cast
+
+import hypothesis_awkward.strategies as st_ak
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+import awkward as ak
+from tests.properties.operations import known_issues, util
+
+
+class Kwargs(TypedDict, total=False):
+    """Options for `ak.flatten`."""
+
+    axis: int | None
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+DEFAULTS = Kwargs(axis=1, highlevel=True, behavior=None, attrs=None)
+
+
+class RelatedKwargs(TypedDict, total=False):
+    """Options drawn together: `behavior` and `attrs` depend on `highlevel`."""
+
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+def test_kwargs_match_signature() -> None:
+    """Assert the option declarations agree with `ak.flatten`'s parameters."""
+    util.assert_kwargs_match_signature(
+        func=ak.flatten,
+        data_param_names={"array"},
+        kwargs_cls=Kwargs,
+        defaults=DEFAULTS,
+        related_cls=RelatedKwargs,
+    )
+
+
+@st.composite
+def st_kwargs(draw: st.DrawFn, array: ak.Array) -> Kwargs:
+    """Strategy for options of `ak.flatten` on `array`.
+
+    Every option is optional in the drawn dict, so the defaults are
+    exercised as well; whether each option appears is drawn separately
+    from its value. `behavior` and `attrs` affect only a high-level
+    output, so they are drawn only when `highlevel` is not `False`.
+    Only `None` and an empty `dict` are drawn for `behavior` (a
+    mapping from names to classes) and `attrs`.
+    """
+
+    @st.composite
+    def _st_related_kwargs(draw: st.DrawFn) -> RelatedKwargs:
+        """Strategy for `highlevel` and the options that depend on it."""
+        ret = RelatedKwargs()
+        if draw(st.booleans()):
+            ret["highlevel"] = draw(st.booleans())
+
+        if ret.get("highlevel", DEFAULTS["highlevel"]) is not False:
+            if draw(st.booleans()):
+                # TODO: generate non-empty `behavior`. An entry is
+                # inert unless its key matches a lookup for the drawn
+                # array; `ak.flatten`'s observed lookups select only
+                # output classes, without affecting what raises.
+                ret["behavior"] = draw(st_ak.none_or(st.builds(dict)))
+            if draw(st.booleans()):
+                # TODO: generate non-empty `attrs`. Any value is inert
+                # except under the reserved `__named_axis__` key
+                # (`awkward._namedaxis.NAMED_AXIS_KEY`), which holds
+                # the named-axis mapping: generate that key only with
+                # a valid mapping, or not at all.
+                ret["attrs"] = draw(st_ak.none_or(st.builds(dict)))
+        return ret
+
+    def _st_axes() -> st.SearchStrategy[int | None]:
+        """Strategy for the option `axis` on `array`.
+
+        Draws `None` or an integer in `[-depth, depth)` for the
+        array's maximum depth; an axis that does not exist for the
+        drawn form is left to `_should_not_raise`.
+        """
+        depth = array.layout.minmax_depth[1]
+        return st_ak.none_or(st.integers(min_value=-depth, max_value=depth - 1))
+
+    related = draw(_st_related_kwargs())
+
+    optional_independent = draw(
+        st.fixed_dictionaries({}, optional={"axis": _st_axes()})
+    )
+
+    return cast(Kwargs, {**related, **optional_independent})
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(data=st.data())
+def test_properties(data: st.DataObject) -> None:
+    """Assert `ak.flatten` does not raise on a draw expected to succeed."""
+    a = data.draw(st_ak.constructors.arrays(), label="a")
+    kwargs = data.draw(st_kwargs(a), label="kwargs")
+
+    assume(_should_not_raise(a.layout.form, kwargs))
+
+    assume(not _would_raise_from_known_issue(a, kwargs))
+
+    ak.flatten(a, **kwargs)
+
+    # TODO: assert properties
+
+
+def _should_not_raise(form: ak.forms.Form, kwargs: Kwargs) -> bool:
+    """Return `True` if the operation should be successful.
+
+    Conservative: `False` makes no statement — the call may still
+    succeed; a rule shown too permissive by a failure is narrowed
+    toward `False`. Only `axis` decides: the other options never
+    affect whether `ak.flatten` raises.
+
+    The rules, written against `ak.flatten`'s deliberate error paths
+    (axis beyond depth, strings, records):
+
+    - `axis=None`: always `True`.
+    - Any other axis is first resolved against the depth (see
+      `_normalize_axis`); an axis that stays negative is `False`.
+    - A resolved `0`: always `True`.
+    - A resolved positive axis: `True` when plain lists occupy every
+      level of the form down to it (see `_all_lists_down_to`). The
+      descent stops at a record or a union, although `ak.flatten`
+      also flattens a union whose branches are all lists at that
+      level, and the fields of a record above the axis.
+    """
+    axis = kwargs.get("axis", DEFAULTS["axis"])
+    if axis is None:
+        return True
+    axis = _normalize_axis(axis, form)
+    if axis == 0:
+        return True
+    if axis < 0:
+        return False
+    return _all_lists_down_to(axis, form)
+
+
+def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
+    """Return `True` if an open issue affects the operation.
+
+    One clause per issue; the predicates and their descriptions are
+    in `known_issues`, and this function applies any option
+    conditions.
+    """
+    axis = kwargs.get("axis", DEFAULTS["axis"])
+
+    match axis:
+        case None:
+            if known_issues.has_issue_4261(a):
+                return True
+            if known_issues.has_issue_4262(a):
+                return True
+            if known_issues.has_issue_4263(a):
+                return True
+        case int() if axis < 0:
+            if known_issues.has_issue_4260(a):
+                return True
+    return False
+
+
+def _normalize_axis(axis: int, form: ak.forms.Form) -> int:
+    """Resolve a negative `axis` against the form's depth.
+
+    A non-negative `axis` is already resolved and passes through. A
+    resolved axis is non-negative, so a negative result indicates that
+    none exists: a negative axis is ambiguous on a branching form
+    (the axis is returned unchanged), and an axis below `-depth` is
+    beyond the form (the resolution stays negative).
+    """
+    if axis >= 0:
+        return axis
+    branches, depth = form.branch_depth
+    if branches:
+        return axis
+    return axis + depth
+
+
+def _all_lists_down_to(axis: int, form: ak.forms.Form) -> bool:
+    """Return `True` if plain lists occupy every level down to `axis`.
+
+    Descends only through option, indexed, and list nodes (regular
+    lists included), none of which may carry an `__array__` parameter
+    (that parameter overrides structural semantics: a string is a
+    list of characters only structurally); a record, union, or leaf
+    ends the descent. `axis` must be positive.
+    """
+    node = form
+    levels = 0
+    while levels < axis:
+        if node.parameter("__array__") is not None:
+            return False
+        if node.is_option or node.is_indexed:
+            node = node.content
+        elif node.is_list:
+            node = node.content
+            levels += 1
+        else:
+            return False
+    return True

--- a/tests/properties/operations/util.py
+++ b/tests/properties/operations/util.py
@@ -1,0 +1,37 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Helpers shared by the operation test modules."""
+
+import inspect
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+def assert_kwargs_match_signature(
+    func: Callable[..., Any],
+    data_param_names: set[str],
+    kwargs_cls: type,
+    defaults: Mapping[str, Any],
+    related_cls: type,
+) -> None:
+    """Raise unless the option declarations agree with `func`'s parameters.
+
+    `kwargs_cls` and `related_cls` are the module's `TypedDict`
+    classes and `defaults` its `DEFAULTS`. Asserts that `kwargs_cls`
+    has exactly the parameters of `func` other than
+    `data_param_names`, that `defaults` equals the signature's
+    default values, and that `related_cls`'s keys are a subset of
+    `kwargs_cls`'s.
+    """
+    option_params = {
+        name: p.default
+        for name, p in inspect.signature(func).parameters.items()
+        if name not in data_param_names
+    }
+    keys = kwargs_cls.__required_keys__ | kwargs_cls.__optional_keys__
+    assert keys == set(option_params)
+
+    assert defaults == option_params
+
+    related_keys = related_cls.__required_keys__ | related_cls.__optional_keys__
+    assert related_keys <= keys


### PR DESCRIPTION
Adds a per-operation property-test family under `tests/properties/operations/`: each module draws arrays (with [hypothesis-awkward](https://pypi.org/project/hypothesis-awkward/)) and option dicts, keeps only the draws expected to succeed, and asserts that the operation does not raise.

Most findings from property tests appear as exceptions raised before any output property is checked, and a no-raise test needs no operation-specific analysis of the output, so the same module template applies to further operations.

## Scope: a pilot

- `test_flatten.py` and `test_all.py` are the template — same structure and identifier names, so either can be copied for the next operation; the package docstring in `__init__.py` describes it.
- Similar tests will follow for the other applicable operations; the earlier property-test family (the six `test_to_from_*` modules and `test_array_equal`) keeps its own pattern.
- Two deferrals, both marked `# TODO` in the modules: output-property assertions, and non-empty `behavior`/`attrs` (only `None` and `{}` are drawn for them today).

## How a module works

- `Kwargs`, `DEFAULTS`, and `RelatedKwargs` declare the operation's options, `test_kwargs_match_signature` checks them against the signature (`util.assert_kwargs_match_signature`), and `st_kwargs` draws an option dict in which every option is optional, so the defaults are exercised too; a signature change fails the check until the declarations are updated.
- `test_properties`, the single property test, draws an array and options, filters the draws with two predicates that err toward skipping (a skipped draw costs coverage; a missing skip fails the suite), and calls the operation:
  - `_should_not_raise` models the operation's deliberate error behavior and is derived for each operation, not copied.
  - `_would_raise_from_known_issue` skips draws affected by an open issue, selecting from the shared `has_issue_*` predicates in `known_issues.py`; each predicate links its issue in its docstring, and both the clause and the predicate are deleted in the pull request that fixes it.

## Issues found

Six issues were found while developing and validating these tests; each is reported, still open, and skipped by a `known_issues` predicate:

- #4259 — `ak.sort`, `ak.argsort`, and every reducer except `ak.count` raise `KeyError` on `float16` leaves
- #4260 — `ak.flatten` with a negative `axis` raises an internal `AssertionError` when a record's fields have different depths
- #4261 — `ak.flatten(axis=None)` and `ak.ravel` raise `AssertionError`, `AttributeError`, or `DTypePromotionError` when the collected leaves cannot merge
- #4262 — `ak.broadcast_arrays` raises `ValueError` when broadcasting a flat array against a regular list of variable-length lists, reached from `ak.flatten(axis=None)`
- #4263 — `ak.flatten(axis=None)` and `ak.ravel` raise an `AssertionError` with no message on a union that no values reach
- #4264 — the reducers fail, sometimes nondeterministically, on an option node inside a `RegularArray`'s untrimmed content (found by the nightly profile while validating this pull request)

## Other changes

- `name-tests-test` now excludes `tests/properties/`, so the directory may contain non-test helper modules (`known_issues.py` and `util.py`).
- `known_issues.py` is shared across the operation modules; the `test_to_from_*` modules keep their per-module issue predicates.
- `filter_too_much` is suppressed on `test_properties` in both modules: the `assume` lines reject enough draws to trip it on some seeds (the nightly workflow's `--hypothesis-show-statistics` reports the rates).
- In ordinary PR CI, `pytest tests` collects `tests/properties` at the default profile (200 examples per test) wherever hypothesis-awkward is installed, and hypothesis's built-in "ci" profile applies (`deadline=None`); the two modules add about four seconds per job. The nightly property-tests workflow runs them at 10,000 examples per test (`HYPOTHESIS_PROFILE=nightly`); both modules pass it in about three minutes together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
