### PR TITLE
chore: drop the over-broad files override on the zizmor hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,5 +85,4 @@ repos:
   rev: e3eebf65325ccc992422292cb7a4baee967cf815  # frozen: v1.26.1
   hooks:
     - id: zizmor
-      files: "^\\.github"
       args: [--persona=pedantic]


### PR DESCRIPTION
**TL;DR:**

- This PR deletes one line — the zizmor pre-commit hook's `files: "^\\.github"` override — so the hook inherits the upstream default file pattern.
- It will allow a commit to modify only non-auditable `.github` files (for example `release.yml`); such commits currently fail locally with `no inputs collected`.
- Audit coverage is unchanged, locally and on CI.

## Details

### Problem

zizmor audits three kinds of files: workflows, action definitions (`action.yml`), and `dependabot.yml`. The override, added together with the hook in #4075, matches every YAML file under `.github/`, including files zizmor cannot parse, such as `release.yml` and the issue templates. A local commit that touches only such a file hands zizmor nothing it can audit, and zizmor treats that as a fatal error instead of a pass, blocking the commit:

```text
WARN collect_inputs: zizmor::registry::input: failed to validate file://.github/release.yml as workflow: input does not match expected validation schema
fatal: no audit was performed
error: no inputs collected
```

The failure never appears on CI because pre-commit.ci runs with `--all-files`, so zizmor always receives the workflow files there.

### Effects of this change

- The hook inherits the upstream default pattern, `(\.github/(workflows/.*|dependabot.ya?ml))|(action\.ya?ml)$`, which matches exactly what zizmor can audit; its `action.ya?ml` clause covers the composite actions under `.github/actions/`.
- Audit coverage is unchanged: all workflows, actions, and `dependabot.yml` are still checked, locally and on CI, at the same `--persona=pedantic` strictness.
- Local commits touching only non-auditable `.github` files now skip the hook ("no files to check") instead of failing.

Verified locally: `pre-commit run zizmor --files .github/release.yml` reports "no files to check", and running the hook on all workflows, the composite actions, and `dependabot.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
