### PR TITLE
chore: split generated release notes into finer categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,10 +9,30 @@ changelog:
     - title: New features
       labels:
         - type/feat
-    - title: Bug-fixes and performance
+    - title: Bug Fixes
       labels:
         - type/fix
+    - title: Performance
+      labels:
         - type/perf
+    - title: Documentation
+      labels:
+        - type/docs
+    - title: Refactoring
+      labels:
+        - type/refactor
+        - type/style
+    - title: Testing
+      labels:
+        - type/test
+    - title: Build & CI
+      labels:
+        - type/build
+        - type/ci
+        - type/chore
+    - title: Reverted
+      labels:
+        - type/revert
     - title: Other
       labels:
         - "*"


### PR DESCRIPTION
This PR updates how GitHub's automatically generated release notes group PRs into sections.

The new configuration defines nine sections (a section is omitted when no PR falls into it):

- New features
- Bug Fixes
- Performance
- Documentation
- Refactoring
- Testing
- Build & CI
- Reverted
- Other

This PR does not change the labeling mechanism: a PR's section is chosen by its `type/*` label, which `.github/workflows/pr-type-label.yml` applies from the conventional-commit type in the PR title. In the new configuration, "Refactoring" collects `type/refactor` and `type/style`, "Build & CI" collects `type/build`, `type/ci`, and `type/chore`, and PRs without a `type/*` label fall into "Other".

As an example, the v2.12.0 release notes would have looked like this:

<details>
<summary>Example: v2.12.0 release notes under the new configuration</summary>

(usernames are written as `@ name` and PR links are shortened to `# NNNN`, so this example creates no mentions or PR references)

> ## What's Changed
>
> ### New features
>
> - feat: write attrs when writing parquet row groups iteratively by `@ ikrommyd` in # 4210
> - feat: implement `awkward_argsort` on the CUDA (`cuda.compute`) backend by `@ ianna` in # 4240
> - feat: overflow-safe & numerically-stable ak.var/std/moment/mean/covar/corr via fused two-pass sum-of-squares/powers reducers by `@ ianna` in # 4232
>
> ### Bug Fixes
>
> - fix: Record field assignment mutates shared layouts and stale cppyy cache by `@ henryiii` in # 4095
> - fix: AwkwardForth VM and libawkward correctness issues by `@ henryiii` in # 4105
> - fix: undo an assignment that **awkward_validation** rejects by `@ ikrommyd` in # 4212
> - fix: overflow-safe stats without needless copies by `@ ianna` in # 4223
> - fix: Fix Numba lowering for `ArrayBuilder.append()` with Unicode strings by `@ ianna` in # 4249
>
> ### Performance
>
> - perf: Implement native string lowering for Numba layouts and fix silent data corruption by `@ ianna` in # 4250
>
> ### Documentation
>
> - docs: add summary lines to 5 math/numeric operation docstrings by `@ TaiSakuma` in # 4133
> - docs: add summary lines to 11 from\_\* file/format converter docstrings by `@ TaiSakuma` in # 4137
> - docs: add summary lines to 8 misc operation docstrings by `@ TaiSakuma` in # 4140
> - docs: add summary lines to 19 reducer operation docstrings by `@ TaiSakuma` in # 4129
> - docs: add summary lines to 3 \*\_like operation docstrings by `@ TaiSakuma` in # 4131
> - docs: add summary lines to 5 sorting/indexing operation docstrings by `@ TaiSakuma` in # 4132
> - docs: add summary lines to 10 type/validity operation docstrings by `@ TaiSakuma` in # 4135
> - docs: move description text out of Examples: sections in merged files by `@ TaiSakuma` in # 4234
>
> ### Testing
>
> - test: add property-based roundtrip test for `to_numpy`/`from_numpy` by `@ TaiSakuma` in # 4215
> - test: add property-based roundtrip test for `to_parquet`/`from_parquet` by `@ TaiSakuma` in # 4218
> - test: add stability roundtrip test for `to_numpy`/`from_numpy` by `@ TaiSakuma` in # 4225
> - test: add property-based roundtrip tests for `to_arrow`/`from_arrow` by `@ TaiSakuma` in # 4231
> - test: add property-based roundtrip tests for `to_feather`/`from_feather` by `@ TaiSakuma` in # 4239
> - test: add property-based roundtrip tests for `to_json`/`from_json` by `@ TaiSakuma` in # 4245
>
> ### Build & CI
>
> - chore: remove Gitter chat and StackOverflow links from README by `@ ianna` in # 4213
> - chore: stop requiring `from __future__ import annotations` by `@ TaiSakuma` in # 4253
>
> **Full Changelog**: https://github.com/scikit-hep/awkward/compare/v2.11.0...v2.12.0

</details>
