### PR TITLE
test: add known-issue predicates for #4255 and #4274 to property tests

### DIFF
--- a/tests/properties/operations/test_to_from_arrow.py
+++ b/tests/properties/operations/test_to_from_arrow.py
@@ -106,6 +106,10 @@ def has_issues(a: ak.Array) -> bool:
         return True
     if _has_issue_4229(a.layout):
         return True
+    if _has_issue_4255(a.layout):
+        return True
+    if _has_issue_4274(a.layout):
+        return True
     return False
 
 
@@ -195,6 +199,46 @@ def _has_issue_4229(layout: ak.contents.Content) -> bool:
     if layout.is_regular and layout.size == 0:
         return True
     return any(_has_issue_4229(x) for x in _children(layout))
+
+
+def _has_issue_4255(layout: ak.contents.Content, nullable: bool = False) -> bool:
+    """`to_arrow` writes an indexed node over unknown-type content below
+    an enclosing option as a nullable Arrow null type without the
+    revertable stamp, so `from_arrow` cannot strip the option the field
+    metadata says it must (AttributeError in `remove_optiontype`, #4255).
+
+    `nullable` tracks validity bytes as in `_has_issue_4222`.
+    """
+    if layout.is_union:
+        return any(_has_issue_4255(x, False) for x in layout.contents)
+    if layout.is_record:
+        return any(_has_issue_4255(x, nullable) for x in layout.contents)
+    if layout.is_regular:
+        return _has_issue_4255(layout.content, False)
+    if layout.is_option:
+        return _has_issue_4255(layout.content, True)
+    if layout.is_indexed:
+        if nullable and layout.content.is_unknown:
+            return True
+        return _has_issue_4255(layout.content, nullable)
+    if layout.is_list:
+        return _has_issue_4255(layout.content, False)
+    return False
+
+
+def _has_issue_4274(layout: ak.contents.Content) -> bool:
+    """`to_arrow_table` projects each record field through a root
+    `UnmaskedArray` with `to_IndexedOptionArray64`, which passes an
+    `IndexedArray`'s uint32 index into `IndexedOptionArray` unconverted
+    (TypeError, #4274). Only the root takes this path: nested layouts
+    convert through `_to_arrow`, which projects the indexed node away.
+    """
+    if not (isinstance(layout, ak.contents.UnmaskedArray) and layout.content.is_record):
+        return False
+    return any(
+        isinstance(x, ak.contents.IndexedArray) and x.index.dtype == np.dtype(np.uint32)
+        for x in layout.content.contents
+    )
 
 
 def _children(layout: ak.contents.Content) -> list[ak.contents.Content]:

--- a/tests/properties/operations/test_to_from_feather.py
+++ b/tests/properties/operations/test_to_from_feather.py
@@ -109,6 +109,8 @@ def has_issues(a: ak.Array) -> bool:
         return True
     if _has_issue_4229(a.layout):
         return True
+    if _has_issue_4274(a.layout):
+        return True
     return False
 
 
@@ -171,6 +173,21 @@ def _has_issue_4229(layout: ak.contents.Content) -> bool:
     if layout.is_regular and layout.size == 0:
         return True
     return any(_has_issue_4229(x) for x in _children(layout))
+
+
+def _has_issue_4274(layout: ak.contents.Content) -> bool:
+    """`to_arrow_table` projects each record field through a root
+    `UnmaskedArray` with `to_IndexedOptionArray64`, which passes an
+    `IndexedArray`'s uint32 index into `IndexedOptionArray` unconverted
+    (TypeError, #4274). Only the root takes this path: nested layouts
+    convert through `_to_arrow`, which projects the indexed node away.
+    """
+    if not (isinstance(layout, ak.contents.UnmaskedArray) and layout.content.is_record):
+        return False
+    return any(
+        isinstance(x, ak.contents.IndexedArray) and x.index.dtype == np.dtype(np.uint32)
+        for x in layout.content.contents
+    )
 
 
 def _children(layout: ak.contents.Content) -> list[ak.contents.Content]:

--- a/tests/properties/operations/test_to_from_parquet.py
+++ b/tests/properties/operations/test_to_from_parquet.py
@@ -62,6 +62,16 @@ def parquet_dtypes() -> st.SearchStrategy[np.dtype]:
 
 
 def parquet_writable(a: ak.Array) -> bool:
+    if isinstance(a.layout, ak.contents.UnmaskedArray) and a.layout.content.is_record:
+        if any(
+            isinstance(x, ak.contents.IndexedArray)
+            and x.index.dtype == np.dtype(np.uint32)
+            for x in a.layout.content.contents
+        ):
+            # `to_parquet` projects each record field through the root
+            # `UnmaskedArray` with `to_IndexedOptionArray64`, which passes
+            # the uint32 index through unconverted (TypeError, #4274)
+            return False
     layout, is_option = a.layout, False
     while layout.is_option or layout.is_indexed:
         is_option = is_option or layout.is_option


### PR DESCRIPTION
The nightly Property Tests workflow has been red since 2026-07-28 on `tests/properties/operations/test_to_from_arrow.py`, redrawing two open conversion defects. This adds the known-issue predicates that skip the affected draws, so the nightly reports new defects again while the library fixes proceed separately.

- `_has_issue_4255` (arrow module): an indexed node directly over unknown-type content, under option validity, crashes `ak.from_arrow` in `remove_optiontype` (#4255). The boundary was probed on a clean 2.12.0 install: all four option wrappers trigger it, while an indexed node over a record over unknown does not, so the walker flags only the direct case.
- `_has_issue_4274` (arrow and feather modules, plus an inline `parquet_writable` clause in the parquet module, which keeps its defects inline): a root `UnmaskedArray` of records with a uint32-indexed `IndexedArray` field crashes `ak.to_arrow_table`'s field projection (#4274); `ak.to_feather` and `ak.to_parquet` route through the same implementation.

Each predicate is named after its issue and is meant to be deleted by the pull request that releases the fix, per the module convention.

Verification:

- On a CI-matched environment (Python 3.14.6, hypothesis 6.163.0, hypothesis-awkward 0.19.0, numpy 2.5.1, pyarrow 25.0.0), the `@reproduce_failure` blobs from the failing nightly runs (30427564516, 30518689855) reproduce the original crashes against the unmodified modules and are rejected by the filters with these changes.
- 30 handmade boundary layouts, probed on clean 2.12.0 and 2.11.0 installs, assert the expected predicate truth value each.
- Default and nightly Hypothesis profiles pass on all three modules (arrow: 4 passed at 10,000 examples per test; feather and parquet: 6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
