### PR TITLE
ci: limit thread pools in the coverage job

### DIFF
--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -29,6 +29,15 @@ jobs:
     env:
       PIP_ONLY_BINARY: cmake
       PYTHON_VERSION: "3.10"
+      # The runner has many cores; without these limits, JAX/XLA, OpenBLAS,
+      # OpenMP, and numexpr each spawn a worker thread per core in the one
+      # test process. PJRT_NPROC caps the XLA CPU client's thread pools
+      # (xla/pjrt/utils.cc, DefaultThreadPoolSize).
+      PJRT_NPROC: "2"
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      NUMEXPR_MAX_THREADS: "4"
 
     # Required for miniconda to activate conda
     defaults:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to the thread-count observation in #4236: the self-hosted coverage job runs JAX, NumPy/OpenBLAS, and numexpr in one pytest process, and each library sizes its worker pool to the machine's full core count.

Adds job-level environment variables to clamp them. The `*_NUM_THREADS` variables and the legacy `XLA_FLAGS` recipe do not affect modern jaxlib; the working knob is `PJRT_NPROC`, which XLA reads to size the PJRT CPU client pools ([`xla/pjrt/utils.cc`, `DefaultThreadPoolSize`](https://github.com/openxla/xla/blob/main/xla/pjrt/utils.cc)). Verified locally on jax 0.11.0 that `PJRT_NPROC=2` shrinks the per-core pools and that the JAX test files pass with all of these variables set.

The GPU jobs do not install `jax`, so only the coverage workflow needs the change.