### PR TITLE
test: add known-issue predicates for #4278 and #4280 to property tests

### DIFF
--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -18,6 +18,10 @@ intended behavior instead, the exclusion moves into the design
 predicate (`_should_not_raise`) of each affected operation.
 """
 
+import re
+
+import numpy as np
+
 import awkward as ak
 
 
@@ -102,9 +106,11 @@ def has_issue_4261(a: ak.Array) -> bool:
 
     The families are modeled on NumPy's documented promotion rules,
     not on the current implementation, except that datetimes with
-    timedeltas, which NumPy promotes, are grouped as non-promotable;
-    `np.result_type` is still not a substitute (it fails on extreme
-    unit pairs that merge). Unprobed combinations may still fail the
+    timedeltas, which NumPy promotes but the merge rejects with
+    `TypeError`, are grouped as non-promotable; that divergence is
+    why `np.result_type` is not a substitute. A unit pair of one
+    family that NumPy itself cannot convert is `has_issue_4278`'s
+    trigger, not this one. Unprobed combinations may still fail the
     tests; such a failure indicates this trigger is missing a
     combination.
     Reported: https://github.com/scikit-hep/awkward/issues/4261
@@ -209,6 +215,95 @@ def has_issue_4264(a: ak.Array) -> bool:
     return False
 
 
+def has_issue_4278(a: ak.Array) -> bool:
+    """Return `True` if one family's temporal units need an overflowing conversion.
+
+    `ak.flatten(axis=None)`, `ak.ravel`, and `axis=None` reductions
+    merge the collected leaves with `ak._do.mergemany`; two
+    timedelta or two datetime leaves merge through NumPy's unit
+    conversion, which refuses a factor of 2**56 or more (any of the
+    factor's top eight bits set) with `OverflowError` ("Integer
+    overflow getting a common metadata divisor") — `[as]` with `[s]`
+    or coarser, `[fs]` with `[h]` or coarser, and `[ps]` with `[D]`
+    or coarser, for timedeltas and datetimes alike, and `[M]` or
+    `[Y]` datetimes with `[ps]` or finer. An intermediate unit
+    does not change the outcome, and other leaves in the array do
+    not prevent the failure (`int64` beside such a pair, a
+    promotable mix, still fails). The trigger computes the factor
+    between the extreme base units present, per family, exactly in
+    attoseconds (`_overflowing_unit_span`); merge failures across
+    families are `has_issue_4261`'s. Reported:
+    https://github.com/scikit-hep/awkward/issues/4278
+    """
+    form = a.layout.form
+    return _contains_record_or_union(form) and _overflowing_unit_span(form)
+
+
+def has_issue_4280(a: ak.Array) -> bool:
+    """Return `True` if a temporal value is too large for its family's finest unit.
+
+    Merging temporal leaves of one family converts every value to
+    the finest unit present (`ak.flatten(axis=None)`, `ak.ravel`,
+    and `axis=None` reductions reach the merge); a value of
+    magnitude above `(2**63 - 1) // f`, with `f` the conversion
+    factor from the value's unit to the finest one, overflows int64,
+    and the merge raises `OverflowError` ("Overflow when converting
+    between datetime64 units") instead of building a union or
+    raising a documented error. The bound is symmetric in sign, and
+    `NaT` converts safely. The dtype pair alone stays under
+    `has_issue_4278`'s factor bound, so the stored values decide.
+    Every value in each temporal leaf's buffer counts, reachable or
+    not — an over-match, which is harmless. A datetime calendar unit
+    is not counted: NumPy converts calendar values without an
+    overflow check, so an out-of-range value wraps silently and no
+    exception reports it. NumPy 2.5.0 added the linear-unit value
+    check; on earlier versions that cast also wraps silently and the
+    operation succeeds, so the skip is an over-match there. Reported:
+    https://github.com/scikit-hep/awkward/issues/4280
+    """
+    form = a.layout.form
+    if not _contains_record_or_union(form):
+        return False
+    leaves: dict[str, list[tuple[int, np.ndarray]]] = {
+        "datetime64": [],
+        "timedelta64": [],
+    }
+    stack = [a.layout]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif node.is_numpy:
+            matched = re.fullmatch(
+                r"(datetime64|timedelta64)\[(\d*)([a-zA-Z]+)\]", str(node.dtype)
+            )
+            if matched is None:
+                continue
+            kind, multiplier, unit = matched.groups()
+            attos = _ATTOSECONDS_PER_UNIT.get(unit)
+            if attos is not None:
+                data = np.asarray(node.data).ravel().view(np.int64)
+                leaves[kind].append((int(multiplier or "1") * attos, data))
+        elif not node.is_unknown:
+            stack.append(node.content)
+    nat = np.iinfo(np.int64).min
+    for family in leaves.values():
+        if len(family) < 2:
+            continue
+        finest = min(attos for attos, _ in family)
+        for attos, data in family:
+            factor = attos // finest
+            if factor == 1:
+                continue
+            limit = (2**63 - 1) // factor
+            values = data[data != nat]
+            if values.size and np.abs(values).max() > limit:
+                return True
+    return False
+
+
 def _is_variable_length_list(form: ak.forms.Form) -> bool:
     """Return `True` if the node has `var` type.
 
@@ -272,6 +367,85 @@ def _leaf_families(form: ak.forms.Form) -> set[str]:
         elif not node.is_unknown:
             stack.append(node.content)
     return families
+
+
+# The linear datetime units, as exact attosecond multiples; the
+# calendar units month and year are separate, because only datetimes
+# convert with them.
+_ATTOSECONDS_PER_UNIT = {
+    "as": 1,
+    "fs": 10**3,
+    "ps": 10**6,
+    "ns": 10**9,
+    "us": 10**12,
+    "ms": 10**15,
+    "s": 10**18,
+    "m": 60 * 10**18,
+    "h": 3600 * 10**18,
+    "D": 86400 * 10**18,
+    "W": 604800 * 10**18,
+}
+
+# A datetime — not a timedelta — converts with the calendar units
+# month and year; their average Gregorian lengths, as exact
+# attosecond multiples, reproduce NumPy's accept/reject boundary at
+# every probed unit pair.
+_DATETIME_CALENDAR_ATTOSECONDS = {
+    "M": 2629746 * 10**18,
+    "Y": 31556952 * 10**18,
+}
+
+# NumPy's `get_datetime_units_factor` treats a unit-conversion factor
+# with any of its top eight bits set as an overflow, so the bound is
+# 2**56, far below `int64`'s 2**63 - 1. The factor multiplies base
+# units only: a unit multiplier (as in `datetime64[10s]`) never
+# enters it.
+_UNIT_FACTOR_BOUND = 2**56
+
+
+def _overflowing_unit_span(form: ak.forms.Form) -> bool:
+    """Return `True` if one family's extreme temporal units would fail to convert.
+
+    Judged per family — datetimes and timedeltas separately, matching
+    the grouping in `_leaf_families` — although a form containing
+    both datetimes and timedeltas already matches the family check in
+    `has_issue_4261`, so the split never decides. The factor between
+    the extreme base units present is computed exactly in attoseconds
+    and compared against `_UNIT_FACTOR_BOUND`; a unit multiplier is
+    ignored, as NumPy's check ignores it. A timedelta calendar unit
+    (month, year) does not convert to a linear unit and is left to
+    the family grouping; a datetime calendar unit is counted at its
+    average length (`_DATETIME_CALENDAR_ATTOSECONDS`), which
+    reproduces the observed boundary. A string's character content
+    is not walked.
+    """
+    spans: dict[str, set[int]] = {"datetime64": set(), "timedelta64": set()}
+    stack = [form]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif node.is_numpy:
+            matched = re.fullmatch(
+                r"(datetime64|timedelta64)\[\d*([a-zA-Z]+)\]", node.primitive
+            )
+            if matched is None:
+                continue
+            kind, unit = matched.groups()
+            attos = _ATTOSECONDS_PER_UNIT.get(unit)
+            if attos is None and kind == "datetime64":
+                attos = _DATETIME_CALENDAR_ATTOSECONDS.get(unit)
+            if attos is not None:
+                spans[kind].add(attos)
+        elif not node.is_unknown:
+            stack.append(node.content)
+    return any(
+        max(units) // min(units) >= _UNIT_FACTOR_BOUND
+        for units in spans.values()
+        if units
+    )
 
 
 def _reaches_empty_union(layout: ak.contents.Content) -> bool:

--- a/tests/properties/operations/test_flatten.py
+++ b/tests/properties/operations/test_flatten.py
@@ -165,6 +165,10 @@ def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
                 return True
             if known_issues.has_issue_4263(a):
                 return True
+            if known_issues.has_issue_4278(a):
+                return True
+            if known_issues.has_issue_4280(a):
+                return True
         case int() if axis < 0:
             if known_issues.has_issue_4260(a):
                 return True


### PR DESCRIPTION
The Property Tests nightly run of 2026-07-31 ([log](https://github.com/scikit-hep/awkward/actions/runs/30609891151)) failed on `tests/properties/operations/test_flatten.py::test_properties`: `ak.flatten(axis=None)` on `1 * union[timedelta64[as], timedelta64[m]]` raises `OverflowError: Integer overflow getting a common metadata divisor for NumPy datetime metadata [as] and [m].`

Two issues came out of the finding, and each gets its own predicate. #4278 is decided by the units at the form level: NumPy rejects a conversion factor between two temporal units once the factor reaches `2**56`, so leaves of one family whose units span such a factor cannot promote. #4280 is decided by the stored values and cannot be told from the form: with the factor in bounds, a value outside the finest unit's int64 range overflows at the cast (found while verifying the #4278 predicate). Both are distinct from the cross-family merge failures of #4261, whose `has_issue_4261` trigger deliberately models families, not units.

Changes, in `tests/properties/operations/`:

- `known_issues.py`: new predicate `has_issue_4278` — a record or union whose temporal leaves of one family span an overflowing conversion factor. The helper `_overflowing_unit_span` computes the exact factor between the extreme base units present from an attosecond table against NumPy's bound of `2**56`; datetime calendar units count at their average lengths (2629746 s per month, 31556952 s per year), timedelta calendar units do not convert and stay with `has_issue_4261`'s family grouping, and a unit multiplier (as in `datetime64[10s]`) is ignored, as NumPy's factor check ignores it.
- `known_issues.py`: new predicate `has_issue_4280` — a record or union with a temporal value of magnitude above `(2**63 - 1) // f`, `f` being the factor to the family's finest unit present. `NaT` is exempt, datetime calendar units are excluded (their value conversion wraps silently instead of raising), and the check reads every value in each temporal leaf's buffer, an over-match.
- `known_issues.py`: one correction in `has_issue_4261`'s docstring — its `np.result_type` parenthetical claimed extreme unit pairs merge, which #4278's probing disproved; the corrected text names the actual divergence (`np.result_type` promotes datetimes with timedeltas, which the merge rejects with `TypeError`) and points unit-span failures to `has_issue_4278`.
- `test_flatten.py`: both predicates join the `axis=None` clause of `_would_raise_from_known_issue`. `test_all.py` needs no wiring: its `_reducible` refuses every union, so the affected draws never reach `ak.all`.

Verification:

- 893 truth checks pass: 532 compare `has_issue_4278` against the exact-factor prediction (55 linear timedelta pairs and 78 datetime pairs including the calendar units, on union and record layouts in both orders), 312 compare the three predicates' disjunction against the observed outcome (skip exactly when `ak.flatten(axis=None)` raises, for all 78 pairs of the 13 units per kind on unions in both orders), 26 cover `has_issue_4280`'s value boundaries (`(2**63 - 1) // f` and one past it for two unit pairs, negative symmetry, `NaT`, same-unit, record and nested layouts, calendar wraparound), and 23 cover the falsifying layouts and structural variants.
- Replaying the nightly failure blob (`@reproduce_failure`, hypothesis 6.164.0 as in the CI run) reproduces the `OverflowError` on the unmodified tests and raises `DidNotReproduce` with `has_issue_4278` wired in; the locally found value-overflow example replays as filtered by `has_issue_4280` the same way.
- `tests/properties/operations` passes at the default profile. A nightly-profile run (10,000 examples) then surfaced a further, unrelated defect — a regular list of plain leaves under a union breaks the interleaving broadcast (the machinery of #4262, whose trigger matches only variable-length-list content) — deferred to a follow-up; its stored example keeps a local replay failing until then.

Issues #4278 and #4280 stay open; each predicate is deleted in the pull request that fixes its issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
