### PR TITLE
test: add a no-raise property-test module for ak.ravel

### DIFF
--- a/tests/properties/operations/__init__.py
+++ b/tests/properties/operations/__init__.py
@@ -2,8 +2,9 @@
 
 """Property tests for awkward operations, one module per operation.
 
-The operation modules (`test_flatten.py`, `test_all.py`) follow one
-template, and either is a complete example to copy. The identifiers
+The operation modules (`test_flatten.py`, `test_all.py`,
+`test_ravel.py`) follow one template, and each is a complete example
+to copy. The identifiers
 are operation-invariant — only the module name and the called
 operation say what is under test. `Kwargs`, `DEFAULTS`, and
 `RelatedKwargs` declare the operation's options;

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -304,6 +304,99 @@ def has_issue_4280(a: ak.Array) -> bool:
     return False
 
 
+def has_issue_4282(a: ak.Array) -> bool:
+    """Return `True` if a regular list with no variable-length dimension below it is under a union.
+
+    To restore the interleaving order of a union,
+    `UnionArray._remove_structure` broadcasts each branch against its
+    rows' positions (`ak.flatten(axis=None)`, `ak.ravel`, and
+    `axis=None` reductions reach it), which relies on the
+    replicate-per-row semantics of variable-length broadcasting; a
+    branch with only regular dimensions broadcasts by NumPy's
+    right-aligned rules instead, treating the flat positions as one
+    inner vector. An innermost regular size of 1 raises `IndexError`
+    ("cannot slice NumpyArray ...") from a position marker longer
+    than the values, another innermost size differing from the
+    branch's row count raises `ValueError` ("cannot broadcast
+    RegularArray ..."), and an innermost size equal to the row count
+    succeeds with a silently wrong order, which a no-raise test does
+    not observe. The trigger is a regular list with no
+    variable-length list anywhere below it, itself anywhere under a
+    union node, descending through list, option, indexed, and
+    record nodes; a regular list of variable-length lists is
+    `has_issue_4262`'s trigger. Which configurations reach the
+    broadcast depends on the current implementation's internals, so
+    every such regular list counts here, although multi-field-record
+    or string content, or a single-row or innermost-size-0 branch,
+    happens to work (a single-field record still flattens to one
+    leaf and stays on the affected path).
+    Reported: https://github.com/scikit-hep/awkward/issues/4282
+    """
+    stack = [(a.layout.form, False)]
+    while stack:
+        node, in_union = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_union:
+            stack.extend((c, True) for c in node.contents)
+        elif node.is_record:
+            stack.extend((c, in_union) for c in node.contents)
+        elif node.is_numpy or node.is_unknown:
+            continue
+        else:
+            if (
+                in_union
+                and node.is_regular
+                and not _contains_variable_length_list(node.content)
+            ):
+                return True
+            stack.append((node.content, in_union))
+    return False
+
+
+def has_issue_4283(a: ak.Array) -> bool:
+    """Return `True` if a record sits directly under an option node.
+
+    `ak.ravel` removes structure with `drop_nones=False`, and an
+    option node then keeps itself whole when its content does not
+    branch and has depth 1 — a test meant to identify a leaf, which
+    a record of leaves also passes. The record then survives into
+    the merge inside the kept option, and a leaf part beside it
+    makes `ak._do.mergemany` fail, depending on the first part's
+    type, with `AssertionError` ("cannot merge NumpyArray with
+    RecordArray"; with the record part first, "cannot merge
+    RecordArray with NumpyArray") or `ValueError` ("cannot merge
+    ListArray with RecordArray."). With only record parts the merge succeeds and the record
+    layer survives the flattening, which a no-raise test does not
+    observe. `ak.flatten(axis=None)` projects options away
+    (`drop_nones=True`) and is unaffected, so `test_flatten` does
+    not use this predicate. The trigger is a record as the direct
+    content of an option node, anywhere in the form (an option
+    cannot hold an indexed node, so nothing sits between); an
+    option above a list is descended and its records split into
+    their fields. Every such record counts here, although one with
+    a non-leaf field gives the option a depth above 1, so the
+    option projects and the call happens to work.
+    Reported: https://github.com/scikit-hep/awkward/issues/4283
+    """
+    stack = [a.layout.form]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_option:
+            if node.content.is_record:
+                return True
+            stack.append(node.content)
+        elif node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif node.is_numpy or node.is_unknown:
+            continue
+        else:
+            stack.append(node.content)
+    return False
+
+
 def _is_variable_length_list(form: ak.forms.Form) -> bool:
     """Return `True` if the node has `var` type.
 
@@ -316,6 +409,25 @@ def _is_variable_length_list(form: ak.forms.Form) -> bool:
     if node.parameter("__array__") in ("string", "bytestring"):
         return False
     return node.is_list and not node.is_regular
+
+
+def _contains_variable_length_list(form: ak.forms.Form) -> bool:
+    """Return `True` if a `var`-type list is somewhere in the tree.
+
+    A string node is a leaf, not a list: the descent stops there.
+    """
+    stack = [form]
+    while stack:
+        node = stack.pop()
+        if node.parameter("__array__") in ("string", "bytestring"):
+            continue
+        if node.is_list and not node.is_regular:
+            return True
+        if node.is_record or node.is_union:
+            stack.extend(node.contents)
+        elif not (node.is_numpy or node.is_unknown):
+            stack.append(node.content)
+    return False
 
 
 def _contains_record_or_union(form: ak.forms.Form) -> bool:

--- a/tests/properties/operations/test_flatten.py
+++ b/tests/properties/operations/test_flatten.py
@@ -169,6 +169,8 @@ def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
                 return True
             if known_issues.has_issue_4280(a):
                 return True
+            if known_issues.has_issue_4282(a):
+                return True
         case int() if axis < 0:
             if known_issues.has_issue_4260(a):
                 return True

--- a/tests/properties/operations/test_ravel.py
+++ b/tests/properties/operations/test_ravel.py
@@ -1,0 +1,138 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+"""Property tests for `ak.ravel`.
+
+The module follows the template described in the package docstring.
+"""
+
+from typing import Any, TypedDict, cast
+
+import hypothesis_awkward.strategies as st_ak
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+import awkward as ak
+from tests.properties.operations import known_issues, util
+
+
+class Kwargs(TypedDict, total=False):
+    """Options for `ak.ravel`."""
+
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+DEFAULTS = Kwargs(highlevel=True, behavior=None, attrs=None)
+
+
+class RelatedKwargs(TypedDict, total=False):
+    """Options drawn together: `behavior` and `attrs` depend on `highlevel`."""
+
+    highlevel: bool
+    behavior: dict[str, Any] | None
+    attrs: dict[str, Any] | None
+
+
+def test_kwargs_match_signature() -> None:
+    """Assert the option declarations agree with `ak.ravel`'s parameters."""
+    util.assert_kwargs_match_signature(
+        func=ak.ravel,
+        data_param_names={"array"},
+        kwargs_cls=Kwargs,
+        defaults=DEFAULTS,
+        related_cls=RelatedKwargs,
+    )
+
+
+@st.composite
+def st_kwargs(draw: st.DrawFn, array: ak.Array) -> Kwargs:
+    """Strategy for options of `ak.ravel` on `array`.
+
+    Every option is optional in the drawn dict, so the defaults are
+    exercised as well; whether each option appears is drawn separately
+    from its value. `behavior` and `attrs` affect only a high-level
+    output, so they are drawn only when `highlevel` is not `False`.
+    Only `None` and an empty `dict` are drawn for `behavior` (a
+    mapping from names to classes) and `attrs`.
+    """
+
+    @st.composite
+    def _st_related_kwargs(draw: st.DrawFn) -> RelatedKwargs:
+        """Strategy for `highlevel` and the options that depend on it."""
+        ret = RelatedKwargs()
+        if draw(st.booleans()):
+            ret["highlevel"] = draw(st.booleans())
+
+        if ret.get("highlevel", DEFAULTS["highlevel"]) is not False:
+            if draw(st.booleans()):
+                # TODO: generate non-empty `behavior`. An entry is
+                # inert unless its key matches a lookup for the drawn
+                # array; `ak.ravel` reads `behavior` only when
+                # wrapping its output, without affecting what raises.
+                ret["behavior"] = draw(st_ak.none_or(st.builds(dict)))
+            if draw(st.booleans()):
+                # TODO: generate non-empty `attrs`. Any value is inert
+                # except under the reserved `__named_axis__` key
+                # (`awkward._namedaxis.NAMED_AXIS_KEY`), which holds
+                # the named-axis mapping: generate that key only with
+                # a valid mapping, or not at all.
+                ret["attrs"] = draw(st_ak.none_or(st.builds(dict)))
+        return ret
+
+    related = draw(_st_related_kwargs())
+
+    return cast(Kwargs, dict(related))
+
+
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(data=st.data())
+def test_properties(data: st.DataObject) -> None:
+    """Assert `ak.ravel` does not raise on a draw expected to succeed."""
+    a = data.draw(st_ak.constructors.arrays(), label="a")
+    kwargs = data.draw(st_kwargs(a), label="kwargs")
+
+    assume(_should_not_raise(a.layout.form, kwargs))
+
+    assume(not _would_raise_from_known_issue(a, kwargs))
+
+    ak.ravel(a, **kwargs)
+
+    # TODO: assert properties
+
+
+def _should_not_raise(form: ak.forms.Form, kwargs: Kwargs) -> bool:
+    """Return `True` if the operation should be successful.
+
+    Conservative: `False` makes no statement — the call may still
+    succeed; a rule shown too permissive by a failure is narrowed
+    toward `False`. `ak.ravel` has no rule to state: it accepts every
+    array — its deliberate rejections (a scalar primitive, an
+    `ak.Record`) are not arrays — and no option affects whether it
+    raises, so every draw is expected to succeed.
+    """
+    return True
+
+
+def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
+    """Return `True` if an open issue affects the operation.
+
+    One clause per issue; the predicates and their descriptions are
+    in `known_issues`, and this function applies any option
+    conditions — for `ak.ravel`, none.
+    """
+    if known_issues.has_issue_4261(a):
+        return True
+    if known_issues.has_issue_4262(a):
+        return True
+    if known_issues.has_issue_4263(a):
+        return True
+    if known_issues.has_issue_4278(a):
+        return True
+    if known_issues.has_issue_4280(a):
+        return True
+    if known_issues.has_issue_4282(a):
+        return True
+    if known_issues.has_issue_4283(a):
+        return True
+    return False


### PR DESCRIPTION
Extends the no-raise property-test family (#4265) to a third operation, `ak.ravel`, and covers the two defects the new module's gates surfaced: a regular list with no variable-length dimension under a union crashes or silently reorders the interleaving broadcast (#4282, found by a local nightly-profile run of `test_flatten.py` on 2026-07-31 and deferred from #4281), and a record directly under an option node survives `ak.ravel`'s flattening un-split and fails the merge (#4283, found by the new module's first nightly-profile run).

Changes, in `tests/properties/operations/`:

- `test_ravel.py`: new module from the template (`test_flatten.py` is the closer twin). `ak.ravel` has no `axis`: the options are `highlevel`, `behavior`, and `attrs` only, so `st_kwargs` keeps just the related-options part. `_should_not_raise` returns `True` unconditionally — probing on the released install found no documented rejection reachable from an array input and no option that affects raising — and `_would_raise_from_known_issue` applies seven predicates with no option conditions: 4261, 4262, 4263, 4278, 4280, 4282, and 4283 (the negative-axis 4260 cannot apply, `ak.ravel` having no `axis`).
- `known_issues.py`: new predicate `has_issue_4282` — a regular list with no variable-length list below it, anywhere under a union. The union fast path's marker broadcast relies on replicate-per-row variable-length broadcasting; a branch with only regular dimensions takes NumPy's right-aligned rules instead, raising `IndexError` (innermost size 1), `ValueError` (innermost size differing from the row count), or silently reordering (innermost size equal to the row count). A regular list of variable-length lists stays `has_issue_4262`'s trigger; the two triggers partition the regular-under-union space.
- `known_issues.py`: new predicate `has_issue_4283` — a record directly under an option node. `ak.ravel`'s `drop_nones=False` keeps such an option whole, so the record reaches `mergemany` un-split and a leaf part beside it fails the merge. `ak.flatten(axis=None)` projects options away and is unaffected — the first predicate that applies to one of the two operations only, so `test_flatten.py` does not wire it.
- `test_flatten.py`: `has_issue_4282` joins the `axis=None` clause; the falsifying example stored from the 2026-07-31 nightly-profile run now replays as filtered.

Verification:

- 101 truth checks pass: `has_issue_4282`'s boundary on handmade layouts (the three size/row-count manifestations, regular-of-regular, the CI datetime shape, single-field record content, descent through record/option/list, the 4262 complement, no-union and plain-array negatives), `has_issue_4283`'s boundary (all option flavors, a list above the option, the tuple-of-unknown finding shape, over-match cases that merge, list-of-records and no-option negatives), and a behavior oracle asserting every raise of `ak.flatten(axis=None)` or `ak.ravel` on the probe set is matched by a predicate wired to that operation.
- 59 derivation probes for the module: each of the five prior issues' falsifying layouts raises through `ak.ravel`, the drop-nones difference on the probe set, and no `behavior` lookups during `ak.ravel`.
- `tests/properties/operations` passes at the default profile (26 tests) and at the nightly profile (10,000 examples per test), with both stored falsifying examples replaying as filtered; pre-commit is green.

Issues #4282 and #4283 stay open; each predicate is deleted in the pull request that fixes its issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
