### PR TITLE
fix: remove obsolete Feather warning workaround

### DIFF
--- a/src/awkward/operations/ak_from_feather.py
+++ b/src/awkward/operations/ak_from_feather.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import awkward as ak
 from awkward._dispatch import high_level_function
 
@@ -77,19 +75,7 @@ def _impl(
 ):
     import pyarrow.feather
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r".*pyarrow\.feather\.(write_feather|read_table) is deprecated.*",
-            category=FutureWarning,
-        )
-
-        arrow_table = pyarrow.feather.read_table(
-            path,
-            columns,
-            use_threads,
-            memory_map,
-        )
+    arrow_table = pyarrow.feather.read_table(path, columns, memory_map, use_threads)
 
     return ak.operations.ak_from_arrow._impl(
         arrow_table,

--- a/src/awkward/operations/ak_to_feather.py
+++ b/src/awkward/operations/ak_to_feather.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 
 import awkward as ak
 from awkward._dispatch import high_level_function
@@ -164,17 +163,6 @@ def _impl(
             f"'destination' argument of 'ak.to_feather' must be a path-like, not {type(destination).__name__} ('array' argument is first; 'destination' second)"
         ) from None
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="pyarrow.feather.write_feather is deprecated.*",
-            category=FutureWarning,
-        )
-        pyarrow.feather.write_feather(
-            table,
-            destination,
-            compression,
-            compression_level,
-            chunksize,
-            feather_version,
-        )
+    pyarrow.feather.write_feather(
+        table, destination, compression, compression_level, chunksize, feather_version
+    )


### PR DESCRIPTION
> [!IMPORTANT]
> Please do not merge this PR until Apache Arrow 25.0.1 has been released and is available on [PyPI](https://pypi.org/project/pyarrow/#history). PyArrow 25.0.0 still emits the `FutureWarning` removed by https://github.com/apache/arrow/pull/50685.

## Summary

Follow-up to #4198 and https://github.com/apache/arrow/pull/50685.

Arrow no longer deprecates the Feather V2 APIs. PyArrow 25.0.1 warns only for legacy Feather V1 files, using `DeprecationWarning`. This removes Awkward’s temporary suppression of the former blanket
`FutureWarning`.

The change also corrects the positional argument order passed to `pyarrow.feather.read_table`. Its signature places `memory_map` before `use_threads`, but Awkward previously passed these arguments in the
opposite order.

This keeps Awkward on the `pyarrow.feather` API rather than migrating to IPC, since Feather V2 remains supported upstream.

Closes #4199.

## Validation

- Targeted Feather tests pass with PyArrow 17.0.0.
- Targeted Feather tests pass with the PyArrow 25.0.1 RC1 Feather implementation.
- All pre-commit hooks pass.

## AI assistance disclosure

This change was prepared with AI assistance and reviewed locally.