### PR TITLE
chore: bump hypothesis-awkward from 0.19.1 to 0.20.0

### DIFF
--- a/requirements-test-full.txt
+++ b/requirements-test-full.txt
@@ -1,5 +1,5 @@
 fsspec>=2022.11.0;sys_platform != "win32"
-hypothesis-awkward==0.19.1
+hypothesis-awkward==0.20.0
 jax[cpu]>=0.2.15;sys_platform != "win32"
 numba>=0.50.0;sys_platform != "win32"
 numexpr>=2.7

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -7,7 +7,7 @@
 # cupy-cuda12x>=14
 # cuda-cccl[cu12]>=1.0.2
 fsspec>=2022.11.0
-hypothesis-awkward==0.19.1
+hypothesis-awkward==0.20.0
 numba>=0.60
 numba-cuda>=0.25.0
 pyarrow


### PR DESCRIPTION
Manual bump; Dependabot's 7-day cooldown would otherwise propose this around 2026-08-14.

0.20.0 starts generating zero-field records — including as leaves, and with the record length drawn independently — and adds record-field count options, so the property tests will draw record layouts they have not seen before ([release notes](https://github.com/scikit-hep/hypothesis-awkward/releases/tag/v0.20.0)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
