### PR TITLE
ci: set the Dependabot cooldown to zero for hypothesis-awkward

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,3 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "hypothesis-awkward"
-    cooldown:
-      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,17 @@ updates:
   # samples, so existing tests might fail. Pinning + dependabot ensures
   # those failures surface in a dedicated upgrade PR rather than
   # randomly in unrelated CI runs.
+  #
+  # The cooldown is set to zero, not omitted: with no cooldown option,
+  # version updates get dependabot's default cooldown of three days.
+  # A cooldown also applies to a manually triggered run, so it does not
+  # merely postpone the upgrade PR: while it lasts, dependabot opens no
+  # PR even on request, and the upgrade has to be made by hand instead.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
     allow:
       - dependency-name: "hypothesis-awkward"
+    cooldown:
+      default-days: 0 # zizmor: ignore[dependabot-cooldown]


### PR DESCRIPTION
Dependabot watches a single package in the pip ecosystem: `hypothesis-awkward`, pinned to an exact version in `requirements-test-full.txt`. A new release produces more varied test samples, so the dedicated upgrade PR is where any resulting test failures are supposed to surface. A cooldown holds that PR back, and it applies to a manually triggered run as well: a manual Dependabot run after the `hypothesis-awkward` 0.20.0 release opened no PR. While the cooldown lasts there is no way to make Dependabot open the upgrade PR at all, so the upgrade has to be made by hand instead.

This sets `cooldown.default-days` to `0` for the pip ecosystem. The value is set explicitly rather than the block removed: since [2026-07-14](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/), version updates carry a default cooldown of three days when no cooldown option is configured, so deleting the block would have changed the window from seven days to three rather than removing it. Setting the value to zero is the documented opt-out — [dependabot-core discussion #15368](https://github.com/dependabot/dependabot-core/discussions/15368): "Use the `cooldown` option in your `dependabot.yml` to set a different window, or set it to `0` to remove the cooldown entirely."

zizmor's `dependabot-cooldown` audit rejects any window shorter than seven days, so it is suppressed for this entry with an inline `# zizmor: ignore[dependabot-cooldown]`, in the same style as the existing zizmor suppressions in this repository.

The github-actions ecosystem keeps its seven-day cooldown; nothing outside the pip entry changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
