### PR TITLE
fix: empty result for `ak.ravel`/`ak.flatten(axis=None)` with nothing to merge

### DIFF
--- a/src/awkward/operations/ak_flatten.py
+++ b/src/awkward/operations/ak_flatten.py
@@ -212,7 +212,11 @@ def _impl(array, axis, highlevel, behavior, attrs):
             isinstance(x, ak.contents.Content) for x in out
         )
 
-        out = ak._do.mergemany(out)
+        if len(out) == 0:
+            # A zero-field record or a union that no values reach
+            out = ak.contents.EmptyArray(backend=layout.backend)
+        else:
+            out = ak._do.mergemany(out)
 
     elif axis == 0 or maybe_posaxis(layout, axis, 1) == 0:
 

--- a/src/awkward/operations/ak_ravel.py
+++ b/src/awkward/operations/ak_ravel.py
@@ -76,7 +76,11 @@ def _impl(array, highlevel, behavior, attrs):
         isinstance(x, ak.contents.Content) for x in out
     )
 
-    result = ak._do.mergemany(out)
+    if len(out) == 0:
+        # A zero-field record or a union that no values reach
+        result = ak.contents.EmptyArray(backend=layout.backend)
+    else:
+        result = ak._do.mergemany(out)
 
     wrapped_out = ctx.wrap(result, highlevel=highlevel)
 

--- a/tests/properties/operations/known_issues.py
+++ b/tests/properties/operations/known_issues.py
@@ -165,23 +165,6 @@ def has_issue_4262(a: ak.Array) -> bool:
     return False
 
 
-def has_issue_4263(a: ak.Array) -> bool:
-    """Return `True` if a union that no values reach is in the array.
-
-    `ak.flatten(axis=None)` and `ak.ravel` collect the values of
-    every branch and merge them with `ak._do.mergemany`; a union that
-    no values reach — judged on reachable values, so an option mask
-    or an empty list above the union counts — contributes no parts,
-    and the merge fails its `assert len(contents) != 0` instead of
-    returning an empty result. Which branch types the collection
-    keeps depends on the current implementation's internals, so every
-    such union matches here, although one with only plain numeric
-    branches happens to work. Reported:
-    https://github.com/scikit-hep/awkward/issues/4263
-    """
-    return _reaches_empty_union(a.layout)
-
-
 def has_issue_4264(a: ak.Array) -> bool:
     """Return `True` if an option type sits under an untrimmed regular list.
 
@@ -558,28 +541,3 @@ def _overflowing_unit_span(form: ak.forms.Form) -> bool:
         for units in spans.values()
         if units
     )
-
-
-def _reaches_empty_union(layout: ak.contents.Content) -> bool:
-    """Return `True` if a union that no values reach is in the layout.
-
-    Descends through reachable values only: option and indexed nodes
-    are projected, union branches are projected one by one, and
-    record, regular, and list contents are trimmed to the range their
-    parent references.
-    """
-    if layout.is_union:
-        return layout.length == 0 or any(
-            _reaches_empty_union(layout.project(i)) for i in range(len(layout.contents))
-        )
-    if layout.is_record:
-        return any(_reaches_empty_union(c[: layout.length]) for c in layout.contents)
-    if layout.is_option or layout.is_indexed:
-        return _reaches_empty_union(layout.project())
-    # A RegularArray is also a list, so this branch must come first.
-    if layout.is_regular:
-        return _reaches_empty_union(layout.content[: layout.length * layout.size])
-    if layout.is_list:
-        lst = layout.to_ListOffsetArray64(False)
-        return _reaches_empty_union(lst.content[lst.offsets[0] : lst.offsets[-1]])
-    return False

--- a/tests/properties/operations/test_flatten.py
+++ b/tests/properties/operations/test_flatten.py
@@ -163,8 +163,6 @@ def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
                 return True
             if known_issues.has_issue_4262(a):
                 return True
-            if known_issues.has_issue_4263(a):
-                return True
             if known_issues.has_issue_4278(a):
                 return True
             if known_issues.has_issue_4280(a):

--- a/tests/properties/operations/test_ravel.py
+++ b/tests/properties/operations/test_ravel.py
@@ -125,8 +125,6 @@ def _would_raise_from_known_issue(a: ak.Array, kwargs: Kwargs) -> bool:
         return True
     if known_issues.has_issue_4262(a):
         return True
-    if known_issues.has_issue_4263(a):
-        return True
     if known_issues.has_issue_4278(a):
         return True
     if known_issues.has_issue_4280(a):

--- a/tests/test_4263_ravel_empty_union.py
+++ b/tests/test_4263_ravel_empty_union.py
@@ -1,0 +1,70 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+OPERATIONS = [
+    pytest.param(ak.ravel, id="ravel"),
+    pytest.param(lambda a: ak.flatten(a, axis=None), id="flatten-axis-None"),
+]
+
+
+def _union_of_float_and_zero_field_record(tags, index):
+    return ak.contents.UnionArray(
+        ak.index.Index8(np.array(tags, dtype=np.int8)),
+        ak.index.Index64(np.array(index, dtype=np.int64)),
+        [
+            ak.contents.NumpyArray(np.array([1.5, 2.5])),
+            ak.contents.RecordArray([], fields=[], length=2),
+        ],
+    )
+
+
+CASES = [
+    pytest.param(
+        ak.Array([1, "s"])[:0],
+        [],
+        "0 * unknown",
+        id="empty-union-with-string-branch",
+    ),
+    pytest.param(
+        ak.Array([1, {"a": 1, "b": 2}])[:0],
+        [],
+        "0 * unknown",
+        id="empty-union-with-record-branch",
+    ),
+    pytest.param(
+        ak.Array([[1, "s"], []])[1:],
+        [],
+        "0 * unknown",
+        id="union-below-list-reached-by-no-values",
+    ),
+    pytest.param(
+        ak.Array([1, [2, 3]])[:0],
+        [],
+        "0 * int64",
+        id="empty-union-with-numeric-branches",
+    ),
+    pytest.param(
+        ak.Array(_union_of_float_and_zero_field_record(tags=[1, 1], index=[0, 1])),
+        [],
+        "0 * unknown",
+        id="union-where-only-zero-field-records-are-reached",
+    ),
+    pytest.param(
+        ak.Array(_union_of_float_and_zero_field_record(tags=[0, 1], index=[0, 0])),
+        [1.5],
+        "1 * float64",
+        id="union-zero-field-record-beside-leaf",
+    ),
+]
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+@pytest.mark.parametrize(("array", "expected", "expected_type"), CASES)
+def test_union_flattens_to_expected(operation, array, expected, expected_type):
+    result = operation(array)
+    assert result.to_list() == expected
+    assert str(result.type) == expected_type

--- a/tests/test_4291_ravel_zero_field_records.py
+++ b/tests/test_4291_ravel_zero_field_records.py
@@ -1,0 +1,68 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+OPERATIONS = [
+    pytest.param(ak.ravel, id="ravel"),
+    pytest.param(lambda a: ak.flatten(a, axis=None), id="flatten-axis-None"),
+]
+
+LAYOUTS = [
+    pytest.param(ak.Array([{}, {}, {}]).layout, id="records"),
+    pytest.param(
+        ak.contents.RecordArray([], fields=None, length=3),
+        id="tuples",
+    ),
+    pytest.param(ak.Array([{}])[:0].layout, id="length-zero"),
+    pytest.param(
+        ak.contents.ListOffsetArray(
+            ak.index.Index64(np.array([0, 3], dtype=np.int64)),
+            ak.contents.RecordArray([], fields=[], length=3),
+        ),
+        id="var-list",
+    ),
+    pytest.param(
+        ak.contents.RegularArray(ak.contents.RecordArray([], fields=[], length=6), 2),
+        id="regular-list",
+    ),
+    pytest.param(ak.Array([{"a": {}, "b": {}}] * 3).layout, id="record-of-records"),
+]
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_zero_field_records_flatten_to_empty(operation, layout):
+    result = operation(ak.Array(layout))
+    assert result.to_list() == []
+    assert str(result.type) == "0 * unknown"
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_leaf_beside_zero_field_record_is_kept(operation):
+    array = ak.Array([{"x": 1.1, "y": {}}, {"x": 2.2, "y": {}}])
+    result = operation(array)
+    assert result.to_list() == [1.1, 2.2]
+    assert str(result.type) == "2 * float64"
+
+
+def test_ravel_keeps_option_above_zero_field_record():
+    result = ak.ravel(ak.Array([{}, None]))
+    assert result.to_list() == [{}, None]
+    assert str(result.type) == "2 * ?{}"
+
+
+def test_flatten_axis_none_drops_option_above_zero_field_record():
+    result = ak.flatten(ak.Array([{}, None]), axis=None)
+    assert result.to_list() == []
+    assert str(result.type) == "0 * unknown"
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_typetracer_backend_is_preserved(operation):
+    array = ak.Array(ak.Array([{}, {}]).layout.to_typetracer(forget_length=False))
+    result = operation(array)
+    assert result.layout.backend.name == "typetracer"
+    assert str(result.type) == "0 * unknown"


### PR DESCRIPTION
Fixes #4291. Fixes #4263.

`ak.ravel` and `ak.flatten(axis=None)` collect every branch's leaf arrays with `ak._do.remove_structure` and merge them with `ak._do.mergemany`, whose first statement is `assert len(contents) != 0`. Two states leave the collection empty and hit that bare `AssertionError`: an array of zero-field records, which contribute no parts (#4291), and a union that no values reach when some branch is a string or a multi-field record (#4263).

This PR adds the same guard at both call sites: when `remove_structure` returns no parts, the result is an empty array (`EmptyArray`, type `0 * unknown`) instead of the merge. `ak._do.reduce`, the other `remove_structure` consumer, already handles this state the same way (`elif len(parts) == 0: layout = ak.contents.EmptyArray()`). The `EmptyArray` is created on the input's backend, so typetracer and CUDA inputs keep their backend. The guard only activates in a state that previously always raised, so no currently-working input changes behavior.

Choices worth noting:

- The result type is `0 * unknown`, not a typed empty. A typed record result would be wrong anyway: these operations erase record structure, and a zero-field record beside an ordinary leaf already flattens to nothing (`{x: float64, y: {}}` returns the bare `x` values).
- One visible asymmetry remains for #4263: `ak.flatten(ak.Array([1, "s"])[:0], axis=None)` now returns `0 * unknown`, while the all-numeric analog `ak.flatten(ak.Array([1, [2, 3]])[:0], axis=None)` returns `0 * int64` via the union fast path from #4109.
- `ak.ravel(ak.Array([{}, None]))` still returns `[{}, None]` (type `2 * ?{}`): with `drop_nones=False` the option and the record under it survive as one part, the mechanism reported in #4283, which this PR does not change.

Following the known-issues contract in `tests/properties/operations/known_issues.py`, the `has_issue_4263` predicate, its `_reaches_empty_union` helper, and its two uses in the `ak.ravel` and `ak.flatten` property-test modules are deleted, so the previously skipped draws are tested again. No predicate existed for #4291.

Regression tests cover both issues: `tests/test_4291_ravel_zero_field_records.py` (record and tuple flavors, length 0, nested below var-length and regular lists, a record of zero-field records, the mixed-record case, the option cases, and typetracer backend preservation) and `tests/test_4263_ravel_empty_union.py` (empty unions with string, multi-field-record, and numeric branches, a union below a list that no values reach, and unions with a zero-field-record branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
