### PR TITLE
fix: nested zero-field `RecordArray` length in virtual `from_buffers`

### DIFF
--- a/src/awkward/operations/ak_from_buffers.py
+++ b/src/awkward/operations/ak_from_buffers.py
@@ -711,7 +711,8 @@ def _reconstitute(
     elif isinstance(form, ak.forms.RecordForm):
 
         def _length_generator():
-            return length
+            (result,) = shape_generator()
+            return result
 
         contents = [
             _reconstitute(

--- a/tests/test_4288_virtual_zero_field_record_length.py
+++ b/tests/test_4288_virtual_zero_field_record_length.py
@@ -1,0 +1,141 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pytest
+
+import awkward as ak
+
+
+@pytest.mark.parametrize(
+    ("form", "length", "container", "expected"),
+    [
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64", ak.forms.RecordForm([], None), form_key="list"
+            ),
+            1,
+            {"list-offsets": lambda: np.array([0, 3], dtype=np.int64)},
+            [[(), (), ()]],
+            id="ListOffsetArray-tuple",
+        ),
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64", ak.forms.RecordForm([], []), form_key="list"
+            ),
+            1,
+            {"list-offsets": lambda: np.array([0, 3], dtype=np.int64)},
+            [[{}, {}, {}]],
+            id="ListOffsetArray-record",
+        ),
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64", ak.forms.RecordForm([], None), form_key="list"
+            ),
+            1,
+            {"list-offsets": lambda: np.array([0, 0], dtype=np.int64)},
+            [[]],
+            id="ListOffsetArray-empty-list",
+        ),
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64", ak.forms.RecordForm([], None), form_key="list"
+            ),
+            0,
+            {"list-offsets": lambda: np.array([0], dtype=np.int64)},
+            [],
+            id="ListOffsetArray-zero-length",
+        ),
+        pytest.param(
+            ak.forms.ListForm(
+                "i64", "i64", ak.forms.RecordForm([], None), form_key="list"
+            ),
+            1,
+            {
+                "list-starts": lambda: np.array([0], dtype=np.int64),
+                "list-stops": lambda: np.array([2], dtype=np.int64),
+            },
+            [[(), ()]],
+            id="ListArray",
+        ),
+        pytest.param(
+            ak.forms.IndexedForm(
+                "i64", ak.forms.RecordForm([], []), form_key="indexed"
+            ),
+            3,
+            {"indexed-index": lambda: np.array([2, 0, 1], dtype=np.int64)},
+            [{}, {}, {}],
+            id="IndexedArray",
+        ),
+        pytest.param(
+            ak.forms.ByteMaskedForm(
+                "i8",
+                ak.forms.ListOffsetForm(
+                    "i64", ak.forms.RecordForm([], None), form_key="list"
+                ),
+                valid_when=True,
+                form_key="mask",
+            ),
+            2,
+            {
+                "mask-mask": lambda: np.array([1, 0], dtype=np.int8),
+                "list-offsets": lambda: np.array([0, 2, 3], dtype=np.int64),
+            },
+            [[(), ()], None],
+            id="ByteMaskedArray-ListOffsetArray",
+        ),
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64",
+                ak.forms.ListOffsetForm(
+                    "i64", ak.forms.RecordForm([], None), form_key="inner"
+                ),
+                form_key="outer",
+            ),
+            1,
+            {
+                "outer-offsets": lambda: np.array([0, 2], dtype=np.int64),
+                "inner-offsets": lambda: np.array([0, 1, 3], dtype=np.int64),
+            },
+            [[[()], [(), ()]]],
+            id="nested-ListOffsetArray",
+        ),
+        pytest.param(
+            ak.forms.ListOffsetForm(
+                "i64",
+                ak.forms.RecordForm([ak.forms.RecordForm([], None)], ["a"]),
+                form_key="list",
+            ),
+            1,
+            {"list-offsets": lambda: np.array([0, 2], dtype=np.int64)},
+            [[{"a": ()}, {"a": ()}]],
+            id="zero-field-record-as-field",
+        ),
+        pytest.param(
+            ak.forms.RecordForm([], None),
+            4,
+            {},
+            [(), (), (), ()],
+            id="top-level",
+        ),
+        pytest.param(
+            ak.forms.RegularForm(ak.forms.RecordForm([], []), 3),
+            2,
+            {},
+            [[{}, {}, {}], [{}, {}, {}]],
+            id="RegularArray",
+        ),
+    ],
+)
+def test_from_buffers(
+    form: ak.forms.Form,
+    length: int,
+    container: dict[str, Callable[[], np.ndarray]],
+    expected: list[Any],
+) -> None:
+    virtual = ak.from_buffers(form, length, container)
+    assert len(virtual) == length
+    assert ak.materialize(virtual).tolist() == expected
+    assert virtual.tolist() == expected


### PR DESCRIPTION
Fixes #4288.

`ak.from_buffers` with virtual (callable) buffers reconstructs a zero-field `RecordArray` nested below a var-length list with no resolvable length: `ak.materialize`, `len()`, and `to_list()` all raise `TypeError: RecordArray if len(contents) == 0, a 'length' must be specified`, so the virtual array can never be materialized.

**Cause.** The `RecordForm` branch of `_reconstitute` (`src/awkward/operations/ak_from_buffers.py`) built the record's delayed-length callback as `return length`, returning the captured argument — which is `unknown_length` whenever an ancestor's element count lives in a virtual buffer — instead of consulting the parent-provided `shape_generator` closure, which can derive the count by materializing the parent's buffer. A record with at least one field recovers because its length falls back to the minimum of its contents' lengths, but a zero-field record has no contents. Introduced in #3889; the `RegularForm` branch of the same function already uses the correct pattern (`_zeros_length_generator`).

**Fix.** The callback now consults `shape_generator`, matching the `RegularForm` branch. The closure contract is uniform across all `_reconstitute` branches — every parent kind supplies a closure returning a 1-tuple of the child's element count — so list, indexed, masked, union, and regular parents are all covered. Records with fields keep their behavior: their existing fallback resolves through the same closure chain, so the same parent buffer is materialized either way.

**Tests.** `tests/test_4288_virtual_zero_field_record_length.py` feeds `ak.from_buffers` hard-coded forms, lengths, and callable buffers and asserts literal expected values: both flavors (`()` and `{}`), empty and non-empty, under `ListOffsetArray`, `ListArray`, `IndexedArray`, `ByteMaskedArray`, nested lists, a zero-field record as a record field, plus previously-working guards (top-level record, `RegularArray` parent). Without the fix, 9 of the 11 cases fail; the 2 guards pass.

**Verification.** The full test suite passes. The property tests run with hypothesis-awkward 0.20.0 — which starts generating zero-field records — drop from 14 failing tests to the 2 caused by the separate issue #4291 (`ak.ravel` / `ak.flatten(axis=None)`), so #4289's CI should show only those two failures once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
