### PR TITLE
fix: pass pointers, not raw addresses, to numba's `cgutils.pointer_add`

### DIFF
--- a/src/awkward/_connect/numba/arrayview.py
+++ b/src/awkward/_connect/numba/arrayview.py
@@ -1074,11 +1074,14 @@ def lower_asarray(context, builder, sig, args):
     bitwidth = ak._connect.numba.layout.type_bitwidth(rettype.dtype)
     itemsize = context.get_constant(numba.intp, bitwidth // 8)
 
+    dataptrtype = context.get_value_type(numba.types.CPointer(rettype.dtype))
     data = numba.core.cgutils.pointer_add(
         builder,
-        arrayptr,
+        # `arrayptr` is a raw address held as intp; pointer_add byte-GEPs
+        # from its argument, so it needs a pointer.
+        builder.inttoptr(arrayptr, dataptrtype),
         builder.mul(viewproxy.start, itemsize),
-        context.get_value_type(numba.types.CPointer(rettype.dtype)),
+        dataptrtype,
     )
 
     shape = context.make_tuple(

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -455,9 +455,7 @@ class ContentType(numba.types.Type):
 
 
 def castint(context, builder, fromtype, totype, val):
-    import llvmlite.ir.types
-
-    if isinstance(fromtype, llvmlite.ir.types.IntType):
+    if isinstance(fromtype, llvmlite.ir.IntType):
         if fromtype.width == 8:
             fromtype = numba.int8
         elif fromtype.width == 16:

--- a/src/awkward/_connect/numba/layout.py
+++ b/src/awkward/_connect/numba/layout.py
@@ -3,6 +3,7 @@
 
 import json
 
+import llvmlite.ir
 import numba
 from numba.core import cgutils
 from numba.core.errors import NumbaTypeError, NumbaValueError
@@ -493,12 +494,17 @@ def posat(context, builder, pos, offset):
 
 
 def getat(context, builder, baseptr, offset, rettype=None):
-    ptrtype = None
     if rettype is not None:
         ptrtype = context.get_value_type(numba.types.CPointer(rettype))
         bitwidth = type_bitwidth(rettype)
     else:
+        ptrtype = context.get_value_type(numba.types.CPointer(numba.intp))
         bitwidth = numba.intp.bitwidth
+    if isinstance(baseptr.type, llvmlite.ir.IntType):
+        # Entries of `arrayptrs` are raw addresses held as intp, but
+        # cgutils.pointer_add byte-GEPs from its argument, so it needs a
+        # pointer: numba >=0.67 no longer accepts the integer.
+        baseptr = builder.inttoptr(baseptr, ptrtype)
     byteoffset = builder.mul(offset, context.get_constant(numba.intp, bitwidth // 8))
     out = builder.load(
         numba.core.cgutils.pointer_add(builder, baseptr, byteoffset, ptrtype)


### PR DESCRIPTION
fixes https://github.com/scikit-hep/awkward/issues/4252

:robot: _AI text below_ :robot:

`main` CI has been red since [run 31617153736](https://github.com/scikit-hep/awkward/actions/runs/31617153736): 84 failures across the numba suite in every `full` job, on both 3.10 and 3.14, all platforms.

The trigger is not a merged commit — it is the **numba 0.67.0 / llvmlite 0.49.0 release on 2026-08-11**. The last green run (`279c4617`, Aug 10) installed numba 0.66.0 / llvmlite 0.48.0; the first red one installed 0.67.0 / 0.49.0, with `numpy` and `awkward-cpp` unchanged. The CI runs for the two commits in between were cancelled, which is why the breakage first surfaced on an unrelated PR.

## Cause

`getat` (`_connect/numba/layout.py`) and `lower_asarray` (`_connect/numba/arrayview.py`) hand `numba.core.cgutils.pointer_add` an entry of `arrayptrs` — a raw address held as `intp`, not an LLVM pointer.

That worked by accident. Through numba 0.66, `pointer_add` opened with `builder.ptrtoint(ptr, intp_t)`, and llvmlite's cast ops fold to a no-op when the value already has the target type (`llvmlite/ir/builder.py`: `if val.type == typ: return val`), so an `intp` passed straight through and the trailing `inttoptr` yielded a valid pointer.

numba 0.67 rewrote `pointer_add` to byte-GEP from its argument so the result keeps the pointer's provenance:

```python
base = builder.bitcast(ptr, int8_t.as_pointer())
addr = builder.gep(base, [offset])
return builder.bitcast(addr, return_type or ptr.type)
```

`bitcast` has no such fold, so the integer reached LLVM as `bitcast i64 ... to i8*` and every jitted `__getitem__` failed to compile:

```
LLVM IR parsing error
<string>:69:20: error: invalid cast opcode for cast from 'i64' to 'ptr'
  %".53" = bitcast i64 %".23" to i8*
```

This is long-standing misuse on our side that the rewrite exposed, not a numba bug.

## Fix

Convert the address with `inttoptr` before calling `pointer_add`, at both sites. The `isinstance(baseptr.type, llvmlite.ir.IntType)` guard leaves the outer `getat` call path — which passes the genuine `CPointer(intp)` `arrayptrs` — untouched.

The no-`rettype` branch of `getat` now names its pointer type explicitly instead of passing `ptrtype=None`; otherwise `pointer_add`'s `return_type or ptr.type` fallback would infer `i8*` from the converted base and the following `load` would read a single byte instead of an `intp`.

## Verification

Two isolated venvs, identical source:

| | numba 0.67.0 / llvmlite 0.49.0 | numba 0.66.0 / llvmlite 0.48.0 |
|---|---|---|
| before | 84 failed, 123 passed | 207 passed |
| after | 207 passed | 207 passed |

The 84 failures reproduce the CI count exactly. Full `tests/` also passes (4716 passed, 178 skipped), as does `prek -a`.

No new test file: the regression is covered end-to-end by the existing numba suite, and the naming convention wants a number that did not exist before this PR. Happy to add `tests/test_XXXX_numba_pointer_add.py` if preferred.

The other red job in that run, `Run GPU Tests (13)`, is unrelated infrastructure — `setup-micromamba` got a 503.

---

AI-assisted: diagnosis, patch, and this description were produced with Claude Code (Opus 5), reviewed by @ariostas.
