### PR TITLE
docs: require the experimental mark when introducing new public APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,12 @@ and it makes it easier to figure out why a particular test was added. The easies
 
 The property-based tests in `tests/properties/` (using [Hypothesis](https://hypothesis.readthedocs.io/) and [hypothesis-awkward](https://github.com/scikit-hep/hypothesis-awkward)) do not follow this naming convention; their directory structure roughly mirrors the source layout (e.g., `tests/properties/operations/` corresponds to `src/awkward/operations/`).
 
+### Introducing new public APIs
+
+Every new public function, method, and property accessor must be marked with the `@experimental` decorator in `src/awkward/_experimental.py`, whose docstring states what the mark promises and how to apply it. When the mark is removed has not been decided yet.
+
+Marks for classes, modules, module-level constants, and keyword arguments are not implemented yet. The rule behind the mark is being decided in [discussion #4197](https://github.com/scikit-hep/awkward/discussions/4197).
+
 ### Building documentation locally
 
 Documentation is automatically built by each pull request. You usually won't need to build the documentation locally, but if you do, this section describes how.

--- a/docs/reference/toctree.txt
+++ b/docs/reference/toctree.txt
@@ -351,6 +351,11 @@
     generated/ak.jax.register_behavior_class
 
 .. toctree::
+    :caption: Warnings
+
+    generated/ak.errors.ExperimentalWarning
+
+.. toctree::
     :caption: High-level data types
 
     generated/ak.types.Type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ filterwarnings = [
     "ignore:module 'sre_.*' is deprecated:DeprecationWarning",
     "ignore:Jitify is performing a one-time only warm-up",
     "ignore:The JAX backend is deprecated:DeprecationWarning",
+    "ignore::awkward.errors.ExperimentalWarning",
 ]
 log_level = "INFO"
 testpaths = ["tests", "tests-cuda", "tests-cuda-kernels", "tests-cuda-kernels-explicit"]


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` section, "Introducing new public APIs", requiring the `@experimental` mark added in #4279 on every new public function, method, and property accessor, and pointing to the decorator's docstring for what the mark promises and how to apply it.

Two supporting changes:

- `docs/reference/toctree.txt` lists `ak.errors.ExperimentalWarning`. The reference pages are generated by sphinx-autoapi with `autoapi_add_toctree_entry = False`, so a page stays orphaned until it is listed here. A local docs build confirms the page is generated and rendered.
- `pyproject.toml` ignores `awkward.errors.ExperimentalWarning` in the test suite. `filterwarnings = ["error"]` turns the warning into a raised exception, and since the mark warns once per process, only the first test to call a marked API would fail — a failure that moves with collection order and worker distribution. Nothing in the tree carries the mark yet, so this entry is preventive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
