### PR TITLE
fix: repair the try-it REPL by pinning jQuery and updating jQuery Terminal

### DIFF
--- a/docs/_static/try-it.html
+++ b/docs/_static/try-it.html
@@ -97,7 +97,7 @@
       }
 
       async function main() {
-        let indexURL = "https://cdn.jsdelivr.net/pyodide/v0.26.3/full/";
+        let indexURL = "https://cdn.jsdelivr.net/pyodide/v314.0.4/full/";
         const urlParams = new URLSearchParams(window.location.search);
         const buildParam = urlParams.get("build");
         if (buildParam) {
@@ -296,7 +296,7 @@
               import micropip
               import asyncio
               loop = asyncio.get_event_loop()
-              loop.run_until_complete(micropip.install("awkward==2.6.4"))
+              loop.run_until_complete(micropip.install("awkward"))
             `,
             { globals: namespace },
           ).then(function() {

--- a/docs/_static/try-it.html
+++ b/docs/_static/try-it.html
@@ -3,11 +3,35 @@
   <head>
     <meta charset="UTF-8" />
     <script data-domain="awkward-array.org" defer="defer" src="https://views.scientific-python.org/js/plausible.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/jquery.terminal.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/unix_formatting.min.js"></script>
+    <!--
+      Keep these pinned to exact versions with matching integrity hashes: a
+      floating version silently pulls in whatever npm serves next, which is how
+      jQuery 4.0 (which dropped $.isFunction) broke this page. The hashes are
+      the sha384 of the files published in the npm tarballs; regenerate them
+      when bumping a version. unix_formatting is loaded unminified because
+      upstream ships no unix_formatting.min.js -- requesting one makes jsDelivr
+      generate it with Terser, and hashing generated output would break the
+      page whenever jsDelivr updates its minifier.
+    -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
+      integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.46.2/js/jquery.terminal.min.js"
+      integrity="sha384-sLazBX/OQO51RGgWRoCaVomfEqMurYaCRa8YLLtrLg8bwves0t7R/mJTtKFQEdiV"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.46.2/js/unix_formatting.js"
+      integrity="sha384-VPARveXmiYVYTIsW12NagfB4SkaxoUOrUIawckkeL7thEc6oKFceIYYIGszXOTGm"
+      crossorigin="anonymous"
+    ></script>
     <link
-      href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/css/jquery.terminal.min.css"
+      href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.46.2/css/jquery.terminal.min.css"
+      integrity="sha384-2qGn13i031N9CesSTCyHkYT4O2VMEbb64dKZd8WS5w8Fs6Yi8XiZo91SEQJRIA9t"
+      crossorigin="anonymous"
       rel="stylesheet"
     />
     <style>


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #4304.

### What broke

`docs/_static/try-it.html` loaded jQuery from an unversioned CDN URL (`cdn.jsdelivr.net/npm/jquery`), while jQuery Terminal was pinned to 2.35.2 from 2023. When jQuery 4.0.0 was released on 2026-01-18 it removed `$.isFunction`, which 2.35.2 still calls, so the page dies with `jQuery.isFunction is not a function` and the terminal never becomes interactive — it just sits at a `>>>` prompt that ignores input.

The REPL had been broken for roughly seven months before @jcubic reported it, since nothing loads this page in CI.

### The fix

* Pin jQuery to 3.7.1 (the version jQuery Terminal declares as its dependency).
* Update jQuery Terminal 2.35.2 → 2.46.2.
* Add Subresource Integrity hashes to all four resources. Every hash was computed from the file published in the npm tarball and verified byte-identical to what jsDelivr currently serves.
* Load `unix_formatting.js` rather than `unix_formatting.min.js`. Upstream has never shipped a minified build of that file — in 2.35.2 and every version since, the tarball contains only `unix_formatting.js` — so the old URL was being satisfied by jsDelivr's on-the-fly Terser. Its own banner says "Do NOT use SRI with dynamically generated files", because the output changes when jsDelivr updates its minifier, which would fail the hash and block the script. The unminified file is 56 kB instead of 28 kB, which is negligible next to the Pyodide payload.

Pinning exactly, rather than floating or pinning the major, is deliberate: npm versions are immutable, so an exact pin plus an integrity hash means a compromised maintainer account or a bad release cannot change what this page executes in a reader's browser. A floating URL is what caused this outage in the first place.

### Also updated: Pyodide and Awkward

The page ran Pyodide 0.26.3 (Python 3.12) and pinned `awkward==2.6.4`, so the REPL demonstrated a release from April 2024.

`awkward-cpp` 55 now publishes a `pyemscripten_2026_0` wasm wheel, matching the ABI of the current Pyodide release, so `micropip` can resolve the newest Awkward without help. This moves the page to Pyodide 314.0.4 and drops the version pin.

Worth a reviewer's attention: Pyodide's own lockfile bundles `awkward-cpp` 52, while `awkward` 2.12.0 requires `awkward-cpp==55`, so `micropip` has to prefer the PyPI wheel over the bundled one.

### Verification

Reproduced the original failure and confirmed the jQuery fix in headless Chromium against the real CDN: the terminal boots, `micropip` installs Awkward, the example array is defined, and entering `ak.sum(example.x)` returns `16.5`, with no console errors and no resource blocked by an integrity check.

### Follow-up, not included here

These CDN URLs are invisible to Dependabot, so version bumps are manual and the integrity hashes must be regenerated alongside them.

AI assistance was used for this change, including the investigation, the browser-based verification, and the drafting of this description.
