### PR TITLE
ci: pin numpy below 2.5 in the GPU test environment

### DIFF
--- a/.github/actions/setup-gpu-env/action.yml
+++ b/.github/actions/setup-gpu-env/action.yml
@@ -18,6 +18,9 @@ runs:
         environment-name: test-env
         init-shell: bash
         # TODO: run the tests with cudf again when it supports numba-cuda>=0.23.0
+        # TODO: drop the numpy pin when a numba-cuda release supports
+        # numpy 2.5 (NVIDIA/numba-cuda#907): numba-cuda 0.30.4 references
+        # the removed np.row_stack at import time
         create-args: >-
           python=3.13
           pandas>=0.24
@@ -26,6 +29,7 @@ runs:
           cuda-version=${{ inputs.cuda-version }}
           cxx-compiler
           numba-cuda
+          numpy<2.5
 
     - name: Generate build files
       shell: bash -l {0}

--- a/requirements-test-gpu.txt
+++ b/requirements-test-gpu.txt
@@ -10,6 +10,10 @@ fsspec>=2022.11.0
 hypothesis-awkward==0.19.1
 numba>=0.60
 numba-cuda>=0.25.0
+# numpy<2.5 until a numba-cuda release supports numpy 2.5
+# (NVIDIA/numba-cuda#907): numba-cuda 0.30.4 references the removed
+# np.row_stack at import time
+numpy<2.5
 pyarrow
 pytest>=6
 PyYAML


### PR DESCRIPTION
The `Run GPU Tests` jobs fail on every PR since about 2026-08-15 (currently #4294 and #4312). The GPU environment is solved fresh from conda-forge with numpy unconstrained, and the solver now picks numpy 2.5.2. numba-cuda 0.30.4 registers an overload for `np.row_stack` unconditionally for numpy >= 2.0, but numpy 2.5 removed `np.row_stack` (deprecated since 2.0), so importing `numba_cuda/numba/cuda/np/npyimpl.py` raises `AttributeError: module 'numpy' has no attribute 'row_stack'` and the `tests-cuda` suite fails.

This PR constrains numpy to below 2.5 in two places:

- `.github/actions/setup-gpu-env/action.yml`: added to the micromamba `create-args`, so the conda solver picks a consistent environment. This is the change that fixes CI.
- `requirements-test-gpu.txt`: the same constraint for manual pip installs, which hit the same failure because the numba-cuda wheel does not cap numpy either. In CI this line is a no-op: the pip step finds the constraint already satisfied by the conda-installed numpy.

The pin is temporary. numba-cuda tracks numpy 2.5 support in NVIDIA/numba-cuda#907, and the candidate fix (NVIDIA/numba-cuda#916, mirroring the guard that numba 0.67.0 already ships) is unmerged as of this PR; the latest numba-cuda release, v0.30.4, predates it. Both files carry a TODO comment naming this removal condition.

After this merges, a CI re-run on the affected PRs picks up the fix without a rebase, because the `pull_request` merge ref includes main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)