### PR TITLE
docs: render experimental API notices

### DIFF
--- a/docs/_autoapi_templates/python/function.rst
+++ b/docs/_autoapi_templates/python/function.rst
@@ -16,6 +16,13 @@
    :{{ property }}:
    {% endfor %}
 
+   {% if obj.obj["is_experimental"] %}
+
+   .. warning::
+
+      This API is experimental and may change or be removed in any release.
+   {% endif %}
+
    {% if obj.docstring %}
 
    {{ obj.docstring|process_docstring(obj)|indent(3) }}

--- a/docs/_autoapi_templates/python/method.rst
+++ b/docs/_autoapi_templates/python/method.rst
@@ -14,6 +14,13 @@
    :{{ property }}:
    {% endfor %}
 
+   {% if obj.obj["is_experimental"] %}
+
+   .. warning::
+
+      This API is experimental and may change or be removed in any release.
+   {% endif %}
+
    {% if obj.docstring %}
 
    {{ obj.docstring|process_docstring(obj)|indent(3) }}

--- a/docs/_autoapi_templates/python/property.rst
+++ b/docs/_autoapi_templates/python/property.rst
@@ -14,6 +14,13 @@
    :{{ property }}:
    {% endfor %}
 
+   {% if obj.obj["is_experimental"] %}
+
+   .. warning::
+
+      This API is experimental and may change or be removed in any release.
+   {% endif %}
+
    {% if obj.docstring %}
 
    {{ obj.docstring|process_docstring(obj)|indent(3) }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,11 +129,36 @@ def _ak_output_filename(self):
 
 
 from autoapi._objects import PythonObject, TopLevelPythonObject  # noqa: E402
+from autoapi._parser import Parser  # noqa: E402
 
 PythonObject.output_dir = _flat_output_dir
 PythonObject.output_filename = _ak_output_filename
 TopLevelPythonObject.output_dir = _flat_output_dir
 TopLevelPythonObject.output_filename = _ak_output_filename
+
+
+_parse_functiondef = Parser.parse_functiondef
+
+
+def _is_experimental_decorator(decorator):
+    """Return whether an astroid decorator node applies ``@experimental``."""
+    if decorator.as_string() == "experimental":
+        return True
+    return decorator.as_string() == "experimental()"
+
+
+def _parse_functiondef_with_experimental(self, node):
+    """Preserve the experimental marker for the AutoAPI templates."""
+    parsed = _parse_functiondef(self, node)
+    if node.decorators and any(
+        _is_experimental_decorator(decorator) for decorator in node.decorators.nodes
+    ):
+        for item in parsed:
+            item["is_experimental"] = True
+    return parsed
+
+
+Parser.parse_functiondef = _parse_functiondef_with_experimental
 
 autoapi_template_dir = "_autoapi_templates"
 


### PR DESCRIPTION
## Summary
- preserve the `@experimental` marker while AutoAPI parses source files
- render a stability warning for marked functions, methods, and properties

Fixes #4300.

## Validation
- exercised the patched parser with bare and parenthesized decorators, plus marked properties and methods
- rendered every affected template with marked and unmarked objects
- passed `pre-commit.ci - pr`

## AI assistance
This change was developed with substantial assistance from OpenAI Codex. I reviewed the AutoAPI parser contract, the repository's existing documentation configuration, and the resulting diff and focused validation output before submitting it.