### PR TITLE
ci: deploy the documentation to the gh-pages branch

### DIFF
--- a/.github/actions/deploy-to-gh-pages/action.yml
+++ b/.github/actions/deploy-to-gh-pages/action.yml
@@ -1,0 +1,99 @@
+name: Deploy to gh-pages
+description: Publish a file or directory to a path on the `gh-pages` branch.
+
+inputs:
+  source:
+    description: File or directory to publish. Leave empty to delete the target.
+    required: false
+    default: ""
+  target:
+    description: Path on the `gh-pages` branch to publish to.
+    required: true
+  message:
+    description: Commit message.
+    required: true
+  token:
+    description: Token used to push to the `gh-pages` branch.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Publish to gh-pages
+      shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        TARGET: ${{ inputs.target }}
+        MESSAGE: ${{ inputs.message }}
+        GH_TOKEN: ${{ inputs.token }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # The target is deleted and rewritten, so refuse anything that could
+        # reach outside of it: an absolute or empty path, a `.` or `..`
+        # segment, or the directory holding the branch itself
+        case "/${TARGET}/" in
+          *//* | */../* | */./* | */.git/*)
+            echo "::error::Refusing to publish to \`${TARGET}\`"
+            exit 1
+            ;;
+        esac
+
+        # `FETCH_HEAD` is per-worktree, so resolve it here and pass the commit
+        # to the linked worktree that holds the branch.
+        fetch_tip() {
+          git fetch --quiet --depth=1 origin gh-pages
+          git rev-parse FETCH_HEAD
+        }
+
+        stage() {
+          rm -rf "${worktree:?}/${TARGET:?}"
+          if [ -n "${SOURCE:-}" ]; then
+            mkdir -p "$(dirname "${worktree}/${TARGET}")"
+            cp -r "${SOURCE}" "${worktree}/${TARGET}"
+          fi
+          # GitHub Pages builds the site with Jekyll, which drops the
+          # `_static`, `_images`, ... directories that Sphinx generates.
+          touch "${worktree}/.nojekyll"
+          # The worktree is a clean checkout, so this only ever stages the
+          # target (which may not exist, e.g. when deleting an absent preview)
+          git -C "${worktree}" add --all
+        }
+
+        worktree="$(mktemp -d)"
+        git worktree add --quiet --detach "${worktree}" "$(fetch_tip)"
+
+        # Several workflows publish to `gh-pages`, so a push can lose a race
+        # with a concurrent one. Re-apply the change on the new tip and retry.
+        for attempt in 1 2 3; do
+          if [ "${attempt}" -gt 1 ]; then
+            echo "Push rejected, retrying (attempt ${attempt})"
+            git -C "${worktree}" reset --hard --quiet "$(fetch_tip)"
+          fi
+
+          stage
+
+          if git -C "${worktree}" diff --cached --quiet; then
+            echo "Nothing to publish to ${TARGET}"
+            break
+          fi
+
+          git -C "${worktree}" \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit --quiet -m "${MESSAGE}"
+
+          if git -C "${worktree}" push \
+              "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}" \
+              HEAD:refs/heads/gh-pages; then
+            break
+          fi
+
+          if [ "${attempt}" -eq 3 ]; then
+            echo "::error::Failed to push ${TARGET} to the gh-pages branch"
+            exit 1
+          fi
+        done
+
+        git worktree remove --force "${worktree}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,7 @@ jobs:
   docs:
     uses: ./.github/workflows/reusable-docs.yml
     permissions:
-      id-token: write # Required by the reusable docs deploy job for AWS OIDC.
-      contents: read
-    secrets:
-      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      AWS_DEPLOY_ROLE: ${{ secrets.AWS_DEPLOY_ROLE }}
+      contents: write # Required by the reusable docs deploy job to push to `gh-pages`.
 
   pass:
     name: Check CI result

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,28 @@
+name: Docs Preview Cleanup
+on: # zizmor: ignore[dangerous-triggers] This privileged workflow runs from the base branch and only removes a preview directory.
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: docs-preview-cleanup-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  remove-branch-preview:
+    runs-on: ubuntu-24.04
+    name: Remove Branch Preview
+    permissions:
+      contents: write # Required to push the removal to the `gh-pages` branch.
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: Remove artifacts
+      uses: ./.github/actions/deploy-to-gh-pages
+      with:
+        target: doc/pr/${{ github.event.number }}
+        message: "Remove preview for PR #${{ github.event.number }}"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -18,21 +18,19 @@ jobs:
     name: Deploy Branch Preview
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     permissions:
-      id-token: write # Required to assume the AWS deployment role through OIDC.
-      contents: read
+      contents: write # Required to push the preview to the `gh-pages` branch.
+      actions: read # Required to download the artifacts of the CI run.
       pull-requests: write # Required to comment with the preview URL.
     env:
-      S3_BUCKET: "preview.awkward-array.org"
-      DEPLOY_URL: "http://preview.awkward-array.org.s3-website.us-east-1.amazonaws.com"
+      DEPLOY_URL: "https://awkward-array.org/doc/pr"
     environment:
       name: docs
-      url: "${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}"
+      url: "${{ env.DEPLOY_URL }}/${{ steps.pr_number.outputs.pr_number }}/"
     steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        aws-region: eu-west-2
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
     - name: Download rendered docs
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
@@ -75,15 +73,24 @@ jobs:
     - name: Read PR number
       id: pr_number
       run: |
-        echo "pr_number=$(cat "${RUNNER_TEMP}/artifacts/pr_number.txt")" >> "${GITHUB_OUTPUT}"
+        pr_number=$(cat "${RUNNER_TEMP}/artifacts/pr_number.txt")
+        # The number is written by an unprivileged workflow, and is used below
+        # as a path on the `gh-pages` branch
+        if ! [[ "${pr_number}" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::Invalid PR number"
+          exit 1
+        fi
+        echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
         rm "${RUNNER_TEMP}/artifacts/pr_number.txt"
         rm "${RUNNER_TEMP}/artifacts/docs.zip"
         rm "${RUNNER_TEMP}/artifacts/pr_number.zip"
     - name: Sync artifacts
-      run: |
-        aws s3 sync "${RUNNER_TEMP}/artifacts/" "s3://${S3_BUCKET}/PR${STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER}"
-      env:
-        STEPS_PR_NUMBER_OUTPUTS_PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
+      uses: ./.github/actions/deploy-to-gh-pages
+      with:
+        source: ${{ runner.temp }}/artifacts
+        target: doc/pr/${{ steps.pr_number.outputs.pr_number }}
+        message: "Deploy preview for PR #${{ steps.pr_number.outputs.pr_number }}"
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Try to find previous bot comment
       uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
@@ -97,5 +104,5 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
-        PREVIEW_URL: ${{ env.DEPLOY_URL }}/PR${{ steps.pr_number.outputs.pr_number }}
+        PREVIEW_URL: ${{ env.DEPLOY_URL }}/${{ steps.pr_number.outputs.pr_number }}/
       run: gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "The documentation preview is ready to be viewed at <${PREVIEW_URL}>"

--- a/.github/workflows/docs-squash.yml
+++ b/.github/workflows/docs-squash.yml
@@ -1,0 +1,81 @@
+name: Squash Docs History
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type `gh-pages` to confirm that its history will be discarded
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: 'docs-squash'
+  cancel-in-progress: false
+
+jobs:
+  squash:
+    runs-on: ubuntu-24.04
+    name: Squash gh-pages history
+    permissions:
+      contents: write # Required to force-push the squashed `gh-pages` branch.
+    environment:
+      name: docs
+    steps:
+      - name: Check confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ "${CONFIRM}" != "gh-pages" ]; then
+            echo "::error::Type \`gh-pages\` in the confirmation field to run this workflow"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Every documentation deployment commits a full copy of a rendered site,
+      # so the history of `gh-pages` grows without bound. Only its tip is ever
+      # served, so it can be replaced by a single commit holding the same tree.
+      - name: Squash gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The parents of the tip are recorded in the commit itself, so a
+          # shallow fetch is enough to tell whether there is anything to squash
+          git fetch --quiet --depth=1 origin gh-pages
+          tip="$(git rev-parse FETCH_HEAD)"
+
+          if ! git cat-file commit "${tip}" | grep --quiet "^parent "; then
+            echo "\`gh-pages\` is already a single commit" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          squashed="$(
+            git \
+              -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit-tree "${tip}^{tree}" -m "Squash the documentation site
+
+          Replaces the history of \`gh-pages\` up to ${tip} with a single
+          commit holding the same content, to keep the repository small."
+          )"
+
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}" \
+            "${squashed}:refs/heads/gh-pages"
+
+          {
+            echo "Squashed \`gh-pages\` into a single commit."
+            echo
+            echo "| | commit |"
+            echo "| --- | --- |"
+            echo "| before | \`${tip}\` |"
+            echo "| after | \`${squashed}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -20,25 +20,18 @@ jobs:
     runs-on: ubuntu-22.04
     name: Push version switcher
     permissions:
-      id-token: write # Required to assume the AWS deployment role through OIDC.
-      contents: read
-    env:
-      S3_BUCKET: "awkward-array.org"
-      CLOUDFRONT_ID: "EFM4QVENUIXHS"
+      contents: write # Required to push the version selector to the `gh-pages` branch.
     environment:
       name: docs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
       # Pushes to main trigger latest
       - name: Push version selector
-        run: |
-          aws s3 cp docs/switcher.json "s3://${S3_BUCKET}/doc/switcher.json"
-          aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" \
-            --paths "/doc/switcher.json"
+        uses: ./.github/actions/deploy-to-gh-pages
+        with:
+          source: docs/switcher.json
+          target: doc/switcher.json
+          message: "Deploy version selector"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,11 +1,6 @@
 name: Docs
 on:
   workflow_call:
-    secrets:
-      AWS_ACCOUNT_ID:
-        required: false
-      AWS_DEPLOY_ROLE:
-        required: false
 
   workflow_dispatch:
 
@@ -26,6 +21,8 @@ env:
 jobs:
   awkward-cpp-wasm:
     name: Build C++ WASM
+    permissions:
+      contents: read # This job builds code from the pull request.
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +52,8 @@ jobs:
   awkward-cpp-x86-64:
     runs-on: ubuntu-24.04
     name: Build C++ x86
+    permissions:
+      contents: read # This job builds code from the pull request.
     defaults:
       run:
         # Ensure conda env is activated
@@ -112,6 +111,8 @@ jobs:
   awkward:
     runs-on: ubuntu-24.04
     name: Build Python
+    permissions:
+      contents: read # This job builds code from the pull request.
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -134,6 +135,8 @@ jobs:
     needs: [awkward-cpp-x86-64, awkward]
     runs-on: ubuntu-24.04
     name: Execute cppyy notebook
+    permissions:
+      contents: read # This job builds code from the pull request.
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -182,6 +185,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [awkward-cpp-x86-64, awkward, execute-cppyy]
     name: Build Docs
+    permissions:
+      contents: read # This job builds code from the pull request.
     defaults:
       run:
         # Ensure conda env is activated
@@ -303,52 +308,64 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'release'
     name: Deploy
     permissions:
-      id-token: write # Required to assume the AWS deployment role through OIDC.
-      contents: read
+      contents: write # Required to push the rendered docs to the `gh-pages` branch.
     env:
-      S3_BUCKET: "awkward-array.org"
-      PRODUCTION_URL: "http://awkward-array.org"
-      CLOUDFRONT_ID: "EFM4QVENUIXHS"
+      PRODUCTION_URL: "https://awkward-array.org"
     environment:
       name: docs
-      url: ${{ env.PRODUCTION_URL }}${{ steps.sync-main.outputs.path || steps.sync-stable.outputs.path }}
+      url: ${{ env.PRODUCTION_URL }}${{ github.event_name == 'release' && '/doc/stable' || '/doc/main' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
       - name: Download rendered docs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs
           path: built-docs
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.11"
       # Pushes to main trigger latest
       - name: Sync `main`
         if: github.event_name == 'push'
-        id: sync-main
-        run: |
-          aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/main/"
-          aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" \
-            --paths "/doc/main*"
-          echo "path=/doc/main" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/deploy-to-gh-pages
+        with:
+          source: built-docs
+          target: doc/main
+          message: "Deploy `main` documentation"
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Releases trigger versions
-      - name: Sync `stable`
+      - name: Read version
         if: github.event_name == 'release'
-        id: sync-stable
+        id: version
         run: |
           # Take only leading version
           version=$(echo "${GITHUB_REF_NAME}" | sed -n -E "s/v?([0-9]+\.[0-9]+)\.[0-9]+/\1/p")
-          aws s3 cp docs/switcher.json "s3://${S3_BUCKET}/doc/"
-          aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/$version/"
-          aws s3 sync built-docs/ "s3://${S3_BUCKET}/doc/stable/"
-          aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" \
-            --paths "/doc/$version*" "/doc/stable*" "/doc/switcher.json"
-          echo "path=/doc/stable" >> $GITHUB_OUTPUT
+          # An empty version would publish the docs to `doc` itself
+          if [ -z "$version" ]; then
+            echo "::error::Could not read a version from ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - name: Sync version selector
+        if: github.event_name == 'release'
+        uses: ./.github/actions/deploy-to-gh-pages
+        with:
+          source: docs/switcher.json
+          target: doc/switcher.json
+          message: "Deploy version selector"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync version
+        if: github.event_name == 'release'
+        uses: ./.github/actions/deploy-to-gh-pages
+        with:
+          source: built-docs
+          target: doc/${{ steps.version.outputs.version }}
+          message: "Deploy documentation for ${{ steps.version.outputs.version }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync `stable`
+        if: github.event_name == 'release'
+        uses: ./.github/actions/deploy-to-gh-pages
+        with:
+          source: built-docs
+          target: doc/stable
+          message: "Deploy `stable` documentation"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The documentation site has moved off the S3 bucket and CloudFront distribution: `awkward-array.org` is now served by GitHub Pages from the `gh-pages` branch, which already holds a copy of the previous bucket contents. This replaces the deployment steps in CI accordingly.

### What changed

A new `deploy-to-gh-pages` composite action publishes a file or a directory to a path on `gh-pages`. It fetches the branch shallowly, adds it as a detached worktree, replaces the target path, and commits and pushes as `github-actions[bot]`. An empty `source` deletes the target instead, and because several workflows write to the branch, a rejected push is retried up to three times, re-applying the change on the new tip each time.

The `aws s3 sync`/`aws s3 cp` and `aws cloudfront create-invalidation` steps are replaced by that action. The layout of the site is unchanged:

| Trigger | Before | After |
| --- | --- | --- |
| push to `main` | `s3://awkward-array.org/doc/main/` | `doc/main` |
| release | `doc/$version/`, `doc/stable/`, `doc/switcher.json` | same paths |
| `docs/switcher.json` changed | `doc/switcher.json` | same path |
| pull request | `preview.awkward-array.org/PR<number>` | `doc/pr/<number>/` |

The only user-visible change is the preview URL, which is now `https://awkward-array.org/doc/pr/<number>/`.

Two workflows are added:

- **`docs-preview-cleanup.yml`** removes `doc/pr/<number>` when a pull request closes. Previews were never removed from the bucket, but every deployment now fetches this branch, and a published GitHub Pages site may be no larger than 1 GB.
- **`docs-squash.yml`** is dispatched manually and squashes `gh-pages` into a single commit holding the same tree, so that superseded copies of the docs can be dropped from its history. It requires typing `gh-pages` in a confirmation field, and no-ops if the branch is already a single commit.

Deploy jobs now request `contents: write` rather than `id-token: write`, and the `AWS_ACCOUNT_ID` and `AWS_DEPLOY_ROLE` secrets are no longer referenced anywhere and can be removed. Because a called workflow inherits the permissions of its caller, the jobs of `reusable-docs.yml` that build code from the pull request are pinned to `contents: read`, leaving `contents: write` to the deploy job alone, which only runs on `push` and `release`. The PR number read from the preview artifact is now validated, since it is used as a path on a branch of this repository rather than a key in a separate bucket.

### Notes for review

- `.nojekyll` has already been pushed to `gh-pages`. GitHub Pages builds that branch with Jekyll, which excludes the `_static` and `_images` directories that Sphinx generates. The composite action keeps the file in place on every deployment.
- Squashing makes the old objects unreachable, but GitHub reclaims the space on its own schedule, so the reported repository size will lag. It also invalidates local clones of `gh-pages`, which need a `git reset --hard origin/gh-pages`.

### Previews now share an origin with the site

Previews used to be served from the separate `preview.awkward-array.org` bucket, and are now served from `awkward-array.org/doc/pr/<number>/`. Their contents come from the artifact built by the pull request, so anyone able to run CI on a pull request can serve arbitrary HTML and JavaScript from the same origin as the documentation. That was equally true of the bucket, but the origin was a different one, so this is a deliberate trade-off rather than a side effect and is worth agreeing on before merging. Modifying `docs/` is enough to do it; modifying a workflow is not required.

What a pull request cannot reach is unchanged. The token of a pull request from a fork is read-only and receives no secrets, whatever `permissions` the pull request declares. `docs-preview.yml` and `docs-preview-cleanup.yml` run the copy of themselves on the default branch, and check out the default and base branch respectively, so the composite action they call is always the reviewed one. The target path is `doc/pr/<validated integer>` and the artifact is copied into it, so a preview cannot touch `doc/main`, `doc/stable`, the root of the site, or the repository.

The exposure is therefore a convincing page on a trusted domain rather than access to anything. Two settings bound it, neither of them part of this pull request:

- Fork pull requests are approved under the `first_time_contributors` policy, so a contributor who has already landed a pull request runs CI, and so publishes a preview, without approval. `all_external_contributors` would require a maintainer to approve each run.
- `default_workflow_permissions` for the repository is `write`. Every workflow here declares `permissions` explicitly, so nothing relies on it today, but a workflow added without one would get a write token by default.
