### PR TITLE
fix: reject non-function experimental targets

### DIFF
--- a/src/awkward/_experimental.py
+++ b/src/awkward/_experimental.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from collections.abc import Callable
 from functools import wraps
-from inspect import currentframe
+from inspect import currentframe, isfunction
 
 from awkward._typing import ParamSpec, TypeVar, overload
 from awkward.errors import ExperimentalWarning
@@ -48,7 +48,7 @@ def experimental(
     the marked API usable from the second call on.
 
     Args:
-        func (callable or None): The function to mark, in the
+        func (function or None): The function to mark, in the
             ``@experimental`` form; None, in the ``@experimental()`` form.
 
     Returns:
@@ -86,7 +86,12 @@ def experimental(
     if func is None:
         # @experimental() -- the parenthesized form
         return experimental
-    if not callable(func):
+    if not isfunction(func):
+        if callable(func) or isinstance(func, (classmethod, property, staticmethod)):
+            raise TypeError(
+                "@experimental must directly decorate a plain function; place it below "
+                f"descriptor decorators (got {func!r})"
+            )
         raise TypeError(
             "@experimental accepts no arguments; use @experimental or "
             f"@experimental() (got {func!r})"

--- a/tests/test_4319_experimental_guard.py
+++ b/tests/test_4319_experimental_guard.py
@@ -1,0 +1,23 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+import pytest
+
+from awkward._experimental import experimental
+
+
+@pytest.mark.parametrize("descriptor", [classmethod, property, staticmethod])
+def test_descriptor_placement_is_rejected(descriptor):
+    def method(arg):
+        return arg
+
+    with pytest.raises(TypeError, match="directly decorate a plain function"):
+        experimental(descriptor(method))
+
+
+def test_callable_non_function_is_rejected():
+    class Callable:
+        def __call__(self):
+            return None
+
+    with pytest.raises(TypeError, match="directly decorate a plain function"):
+        experimental(Callable())


### PR DESCRIPTION
Closes #4319.

Reject descriptors and other callable non-function objects passed to
`@experimental`, with an error that explains the required decorator order.

Tests:
- Added coverage for `classmethod`, `property`, `staticmethod`, and a callable object.
- Ran the related experimental-mark tests: 25 passed.
- Ran pre-commit on the changed files: passed.

AI assistance: I used Codex for substantial implementation and test assistance. I reviewed the change and ran the listed checks locally.