### PR TITLE
chore: support uv workspaces

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -442,7 +442,7 @@ jobs:
               export PATH="/root/.local/bin:$PATH" &&
               source .venv/bin/activate &&
               cd /awkward &&
-              uv pip install -v . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
+              uv pip install -v --no-sources . ${STEPS_FIND_WHEEL_OUTPUTS_PATHS} pytest-github-actions-annotate-failures
             '
           docker commit build_container the_container
           docker rm build_container

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,13 @@ Parts of `awkward-cpp` are generated; building `awkward-cpp` from the repository
 
 ```bash
 git clone --recursive https://github.com/scikit-hep/awkward.git  # rapidjson submodule
-python -m pip install -v ./awkward-cpp   # generates headers, kernel signatures, and kernel tests
+uv sync   # uv workspace: builds awkward-cpp (generating headers, kernel signatures, and kernel tests) and installs both packages editable
+```
+
+Any `uv run ...` command does the same setup on demand and rebuilds `awkward-cpp` when its C++ sources or the kernel spec change (see `cache-keys` in `awkward-cpp/pyproject.toml`). The `dev` dependency group holds the test dependencies. Without uv:
+
+```bash
+python -m pip install -v ./awkward-cpp
 python -m pip install -e .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,14 @@ Awkward Array is shipped as two packages: `awkward` and `awkward-cpp`. The `awkw
 
 Building `awkward-cpp` requires generated code and datafiles (kernel specification, header-only includes, kernel tests). These are generated automatically when `awkward-cpp` is built from the repository — CMake runs the generation scripts at configure time — so no separate preparation step is needed to build the packages.
 
+The repository is a [uv](https://docs.astral.sh/uv/) workspace. If you use uv, one command sets up everything: it compiles `awkward-cpp`, installs both packages as editable installations, and installs the test dependencies from the `dev` dependency group:
+
+```bash
+uv sync
+```
+
+Any `uv run` command (for example `uv run pytest tests`) performs the same setup on demand, and `awkward-cpp` is rebuilt when its C++ sources or the kernel specification change. The sections below describe the manual, `pip`-based procedure.
+
 <details>
 
 The generated files can also be created without building anything, using the `prepare` [nox](https://nox.thea.codes/) session:

--- a/README.md
+++ b/README.md
@@ -103,17 +103,23 @@ Because of the two packages (`awkward-cpp` may be updated in GitHub but not on P
 
 # Installation for developers
 
-Clone this repository _recursively_ to get the header-only C++ dependencies, then generate sources with [nox](https://nox.thea.codes/), compile and install `awkward-cpp`, and finally install `awkward` as an editable installation:
+Clone this repository _recursively_ to get the header-only C++ dependencies. The repository is a [uv](https://docs.astral.sh/uv/) workspace, so `uv sync` (or any `uv run` command) compiles `awkward-cpp` and installs both packages as editable installations:
 
 ```bash
 git clone --recursive https://github.com/scikit-hep/awkward.git
 cd awkward
 
+uv sync
+```
+
+Without uv, compile and install `awkward-cpp`, then install `awkward` as an editable installation:
+
+```bash
 python -m pip install -v ./awkward-cpp
 python -m pip install -e .
 ```
 
-Tests can be run in parallel with [pytest](https://docs.pytest.org/):
+Tests can be run in parallel with [pytest](https://docs.pytest.org/) (prefix with `uv run` if you use uv):
 
 ```bash
 python -m pytest -n auto tests

--- a/awkward-cpp/pyproject.toml
+++ b/awkward-cpp/pyproject.toml
@@ -86,6 +86,20 @@ cmake.version = ">=3.29"
 if.from-sdist = false
 build.requires = ["pyyaml", "numpy"]
 
+# Rebuild the editable workspace install when the C++ sources or the kernel
+# spec change, not only when pyproject.toml changes.
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "CMakeLists.txt" },
+    { file = "include/**/*.h" },
+    { file = "src/**/*.cpp" },
+    { file = "src/**/*.py" },
+    { file = "../header-only/**/*.h" },
+    { file = "../dev/*.py" },
+    { file = "../kernel-specification.yml" },
+    { file = "../kernel-test-data.json" },
+]
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
@@ -110,6 +124,9 @@ build-verbosity = 1
 [tool.cibuildwheel.environment]
 PIP_ONLY_BINARY = "cmake,numpy"
 UV_ONLY_BINARY = "cmake,numpy"
+# The test step installs the repository root with uv; do not replace the wheel
+# under test with the awkward-cpp workspace source.
+UV_NO_SOURCES = "1"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-win*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,25 @@ mccabe.max-complexity = 100
 "jax".msg = "Use `jax = ak._nplikes.Jax.instance()` instead"
 "cupy".msg = "Use `cupy = ak._nplikes.Cupy.instance()` instead"
 
+[dependency-groups]
+dev = [
+    "hypothesis-awkward",
+    "numba; sys_platform != 'win32'",
+    "numexpr",
+    "pandas; sys_platform != 'win32'",
+    "pyarrow; sys_platform != 'win32'",
+    "pytest>=6",
+    "pytest-cov",
+    "pytest-xdist",
+    "PyYAML",
+]
+
 [tool.uv]
 exclude-newer = "7 days"
 exclude-newer-package = { awkward_cpp = false }
+
+[tool.uv.workspace]
+members = ["awkward-cpp"]
+
+[tool.uv.sources]
+awkward_cpp = { workspace = true }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Makes the repository a uv workspace. `uv sync` (or any `uv run` command) from the repository root now builds `awkward-cpp`, installs `awkward` and `awkward-cpp` as editable installations, and installs the test dependencies from the new `dev` dependency group.

- `awkward-cpp/pyproject.toml` gets `[tool.uv] cache-keys` for the C++ sources, headers, `dev/` scripts, header-only files, and the kernel spec and test data at the repository root, so the editable install rebuilds when they change.
- `uv pip install .` at the root honors the workspace source. The s390x test step passes `--no-sources`, and the cibuildwheel environment sets `UV_NO_SOURCES=1`, so those steps keep testing the prebuilt wheel instead of a source build.
- README, CONTRIBUTING, and AGENTS.md document `uv sync` as the primary setup and keep the pip procedure as the fallback.

Verified locally from a clean checkout: `uv sync`, then `uv run pytest tests` and the generated kernel suites pass. Touching a kernel `.cpp` file or `kernel-specification.yml` triggers a rebuild on the next `uv sync`.
