### PR TITLE
perf: write private attributes directly in Array and Record constructors

### DIFF
--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -289,7 +289,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         attrs=None,
         named_axis=None,
     ):
-        self._cpp_type = None
+        # these names are private, so bypass `__setattr__`'s per-name checks
+        state = self.__dict__
+        state["_cpp_type"] = None
         if isinstance(data, ak.contents.Content):
             layout = data
 
@@ -353,9 +355,9 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
             # if NAMED_AXIS_KEY is already in attrs, it will be overwritten
             attrs[NAMED_AXIS_KEY] = _named_axis
 
-        self._layout = layout
-        self._behavior = behavior
-        self._attrs = None if attrs is None else Attrs(attrs)
+        state["_layout"] = layout
+        state["_behavior"] = behavior
+        state["_attrs"] = None if attrs is None else Attrs(attrs)
 
         docstr = layout.purelist_parameter("__doc__")
         if isinstance(docstr, str):
@@ -377,12 +379,13 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         return id(self)
 
     def _update_class(self, restore=None):
-        self._numbaview = None
+        state = self.__dict__
+        state["_numbaview"] = None
         # invalidate the cached cppyy type, generator, and lookup: they hold raw
         # pointers into the old buffers, which are stale after the layout changes
-        self._cpp_type = self._generator = self._lookup = None
+        state["_cpp_type"] = state["_generator"] = state["_lookup"] = None
         previous_class = self.__class__
-        self.__class__ = get_array_class(self._layout, self._behavior)
+        self.__class__ = get_array_class(state["_layout"], state["_behavior"])
         if hasattr(self, "__awkward_validation__"):
             try:
                 self.__awkward_validation__()
@@ -1336,7 +1339,7 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
         to add or modify a field.
         """
         if name.startswith("_") or hasattr(type(self), name):
-            super().__setattr__(name, value)
+            object.__setattr__(self, name, value)
         elif name in self._layout.fields:
             raise AttributeError(
                 "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"
@@ -1915,9 +1918,10 @@ class Record(NDArrayOperatorsMixin):
             # if NAMED_AXIS_KEY is already in attrs, it will be overwritten
             attrs[NAMED_AXIS_KEY] = _named_axis
 
-        self._layout = layout
-        self._behavior = behavior
-        self._attrs = None if attrs is None else Attrs(attrs)
+        state = self.__dict__
+        state["_layout"] = layout
+        state["_behavior"] = behavior
+        state["_attrs"] = None if attrs is None else Attrs(attrs)
 
         docstr = layout.purelist_parameter("__doc__")
         if isinstance(docstr, str):
@@ -1934,9 +1938,10 @@ class Record(NDArrayOperatorsMixin):
         ak.jax.register_behavior_class(cls)
 
     def _update_class(self, restore=None):
-        self._numbaview = None
+        state = self.__dict__
+        state["_numbaview"] = None
         previous_class = self.__class__
-        self.__class__ = get_record_class(self._layout, self._behavior)
+        self.__class__ = get_record_class(state["_layout"], state["_behavior"])
         if hasattr(self, "__awkward_validation__"):
             try:
                 self.__awkward_validation__()
@@ -2306,7 +2311,7 @@ class Record(NDArrayOperatorsMixin):
         to add or modify a field.
         """
         if name.startswith("_") or hasattr(type(self), name):
-            super().__setattr__(name, value)
+            object.__setattr__(self, name, value)
         elif name in self._layout.fields:
             raise AttributeError(
                 "fields cannot be set as attributes. use #__setitem__ or #ak.with_field"

--- a/src/awkward/highlevel.py
+++ b/src/awkward/highlevel.py
@@ -278,6 +278,8 @@ class Array(NDArrayOperatorsMixin, Iterable, Sized):
     numeric leaves of the data structure, maintaining structure in the output.
     """
 
+    _numbaview = None
+
     def __init__(
         self,
         data,
@@ -1848,6 +1850,8 @@ class Record(NDArrayOperatorsMixin):
 
     See also #ak.Array and #ak.behavior.
     """
+
+    _numbaview = None
 
     def __init__(
         self,


### PR DESCRIPTION
Constructing a highlevel array or record goes through `__setattr__` nine times, and each call checks `startswith("_")` and `hasattr(type(self), name)`. These are all private names so we write them into the instance dict instead.
