### PR TITLE
perf: restore the nominal isinstance fast path for concrete nplike and backend classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ disable = [
     "import-outside-toplevel",
     "inconsistent-return-statements",
     "invalid-class-object",
+    "invalid-metaclass",
     "invalid-name",
     "invalid-unary-operand-type",
     "keyword-arg-before-vararg",

--- a/src/awkward/_backends/backend.py
+++ b/src/awkward/_backends/backend.py
@@ -10,7 +10,7 @@ from awkward._kernels import KernelError
 from awkward._nplikes.numpy import Numpy
 from awkward._nplikes.numpy_like import NumpyLike, NumpyMetadata
 from awkward._singleton import PublicSingleton
-from awkward._typing import Callable, TypeAlias, TypeVar
+from awkward._typing import Callable, NominalMeta, TypeAlias, TypeVar
 
 np = NumpyMetadata.instance()
 numpy = Numpy.instance()
@@ -21,7 +21,7 @@ KernelKeyType: TypeAlias = tuple[Any, ...]
 KernelType: TypeAlias = "Callable[..., KernelError | None]"
 
 
-class Backend(PublicSingleton, ABC):
+class Backend(PublicSingleton, ABC, metaclass=NominalMeta):
     name: str
 
     @property

--- a/src/awkward/_nplikes/array_like.py
+++ b/src/awkward/_nplikes/array_like.py
@@ -10,6 +10,7 @@ from awkward._typing import (
     Any,
     DType,
     EllipsisType,
+    NominalMeta,
     Protocol,
     Self,
     SupportsIndex,
@@ -140,7 +141,7 @@ class ArrayLike(Protocol):
     def __invert__(self) -> Self: ...
 
 
-class MaterializableArray(ArrayLike):
+class MaterializableArray(ArrayLike, metaclass=NominalMeta):
     @abstractmethod
     def materialize(self) -> ArrayLike: ...
 

--- a/src/awkward/_nplikes/array_module.py
+++ b/src/awkward/_nplikes/array_module.py
@@ -18,7 +18,16 @@ from awkward._nplikes.numpy_like import (
 from awkward._nplikes.placeholder import PlaceholderArray
 from awkward._nplikes.shape import ShapeItem, unknown_length
 from awkward._nplikes.virtual import VirtualNDArray
-from awkward._typing import TYPE_CHECKING, Any, DType, Final, Literal, TypeVar, cast
+from awkward._typing import (
+    TYPE_CHECKING,
+    Any,
+    DType,
+    Final,
+    Literal,
+    NominalMeta,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
@@ -56,7 +65,7 @@ def _nplike_unique_has_equal_nan(module: Any) -> bool:
 ArrayLikeT = TypeVar("ArrayLikeT", bound=ArrayLike)
 
 
-class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT]):
+class ArrayModuleNumpyLike(NumpyLike[ArrayLikeT], metaclass=NominalMeta):
     """
     Some methods maintain virtualness while others are required to materialize the array.
     The `maybe_materialize` function is used for that purpose.

--- a/src/awkward/_nplikes/typetracer.py
+++ b/src/awkward/_nplikes/typetracer.py
@@ -29,6 +29,7 @@ from awkward._typing import (
     EllipsisType,
     Final,
     Literal,
+    NominalMeta,
     Self,
     SupportsIndex,
     TypeGuard,
@@ -236,7 +237,7 @@ class TypeTracerReport:
         return list(out)
 
 
-class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike):
+class TypeTracerArray(NDArrayOperatorsMixin, ArrayLike, metaclass=NominalMeta):
     _dtype: numpy.dtype
     _shape: tuple[ShapeItem, ...]
 
@@ -602,7 +603,7 @@ def try_touch_shape(array: Any):
 
 
 @register_nplike
-class TypeTracer(NumpyLike[TypeTracerArray]):
+class TypeTracer(NumpyLike[TypeTracerArray], metaclass=NominalMeta):
     known_data: Final = False
     is_eager: Final = True
     supports_structured_dtypes: Final = True

--- a/src/awkward/_typing.py
+++ b/src/awkward/_typing.py
@@ -79,3 +79,18 @@ JSONSerializable: TypeAlias = (
 JSONMapping: TypeAlias = "dict[str, JSONSerializable]"
 
 DType: TypeAlias = numpy.dtype
+
+
+class NominalMeta(type(Protocol)):
+    """Metaclass restoring the interpreter's ``isinstance`` fast path.
+
+    Concrete classes that descend from a ``Protocol`` inherit
+    ``typing._ProtocolMeta``, whose Python-level ``__instancecheck__`` costs
+    roughly four times a plain class check even though, for a non-protocol
+    subclass, it only performs the ordinary nominal test. Classes using this
+    metaclass are checked nominally and cannot be given virtual subclasses
+    through ``abc``'s ``register()``.
+    """
+
+    __instancecheck__ = type.__instancecheck__
+    __subclasscheck__ = type.__subclasscheck__


### PR DESCRIPTION
`PublicSingleton` and `ArrayLike` inherit from `Protocol`, so everything descending from them (backends, nplikes, typetracer arrays) gets `typing._ProtocolMeta.__instancecheck__`. That one is written in python and costs about 4x a plain class check, even though for a non-protocol subclass it only does the ordinary nominal test. None of these classes is ever checked structurally, so they get a metaclass that puts `type.__instancecheck__` back.

One thing to note: they can no longer be given virtual subclasses through `abc`'s `register()`. Nothing in awkward, uproot, dask-awkward, coffea or vector does that.
