### PR TITLE
perf: cache backend and nplike lookups for unrecognised types

### DIFF
--- a/src/awkward/_backends/dispatch.py
+++ b/src/awkward/_backends/dispatch.py
@@ -21,13 +21,15 @@ BackendLookup: TypeAlias = "Callable[[T], Backend]"
 BackendLookupFactory: TypeAlias = "Callable[[type[T]], BackendLookup[T]]"
 
 
-_type_to_backend_lookup: dict[type, BackendLookup] = {}
+_type_to_backend_lookup: dict[type, "BackendLookup | None"] = {}
 _backend_lookup_factories: list[BackendLookupFactory] = []
 _name_to_backend_cls: dict[str, type[Backend]] = {}
 
 
 def register_backend_lookup_factory(factory: BackendLookupFactory):
     _backend_lookup_factories.append(factory)
+    # a new factory may recognise types previously cached as unrecognised
+    _type_to_backend_lookup.clear()
 
 
 def register_backend(primary_nplike_cls: type[NumpyLike]):
@@ -75,19 +77,20 @@ def backend_of_obj(obj, default: D | Sentinel = UNSET) -> Backend | D:
     cls = type(obj)
     try:
         lookup = _type_to_backend_lookup[cls]
-        return lookup(obj)
     except KeyError:
+        lookup = None
         for factory in _backend_lookup_factories:
-            maybe_lookup = factory(cls)
-            if maybe_lookup is not None:
+            lookup = factory(cls)
+            if lookup is not None:
                 break
+        _type_to_backend_lookup[cls] = lookup
+
+    if lookup is None:
+        if default is UNSET:
+            raise TypeError(f"cannot find backend for {cls.__name__}")
         else:
-            if default is UNSET:
-                raise TypeError(f"cannot find backend for {cls.__name__}")
-            else:
-                return cast(D, default)
-        _type_to_backend_lookup[cls] = maybe_lookup
-        return maybe_lookup(obj)
+            return cast(D, default)
+    return lookup(obj)
 
 
 def backend_of(

--- a/src/awkward/_nplikes/dispatch.py
+++ b/src/awkward/_nplikes/dispatch.py
@@ -10,7 +10,7 @@ from awkward._util import UNSET, Sentinel
 D = TypeVar("D")
 
 
-_type_to_nplike: dict[type, NumpyLike] = {}
+_type_to_nplike: dict[type, NumpyLike | None] = {}
 _nplike_classes: list[type[NumpyLike]] = []
 
 
@@ -19,6 +19,8 @@ N = TypeVar("N", bound="type[NumpyLike]")
 
 def register_nplike(cls: N) -> N:
     _nplike_classes.append(cls)
+    # a new nplike may recognise types previously cached as unrecognised
+    _type_to_nplike.clear()
     return cls
 
 
@@ -40,7 +42,7 @@ def nplike_of_obj(
 
     cls = type(obj)
     try:
-        return _type_to_nplike[cls]
+        nplike = _type_to_nplike[cls]
     except KeyError:
         # Try and find the nplike for this type
         # caching the result by type
@@ -50,14 +52,16 @@ def nplike_of_obj(
         # TODO: replace this whole function with a more generic lookup registration system
         if isinstance(obj, VirtualNDArray):
             return obj.nplike
+        nplike = None
         for nplike_cls in _nplike_classes:
             if nplike_cls.is_own_array_type(cls):
                 nplike = nplike_cls.instance()
                 break
-        else:
-            if default is UNSET:
-                raise TypeError(f"cannot find nplike for {cls.__name__}")
-            else:
-                return cast(D, default)
         _type_to_nplike[cls] = nplike
-        return nplike
+
+    if nplike is None:
+        if default is UNSET:
+            raise TypeError(f"cannot find nplike for {cls.__name__}")
+        else:
+            return cast(D, default)
+    return nplike


### PR DESCRIPTION
`backend_of_obj` and `nplike_of_obj` re-scanned every registered lookup factory on every call for types that are not arrays at all, for example the field name string passed to `SlicingErrorContext`. We cache the misses too and clear them when a new backend or nplike is registered.
