### PR TITLE
perf: cheapen NumpyArray construction

### DIFF
--- a/src/awkward/contents/numpyarray.py
+++ b/src/awkward/contents/numpyarray.py
@@ -50,7 +50,7 @@ from awkward.errors import AxisError
 from awkward.forms.form import Form, FormKeyPathT
 from awkward.forms.numpyform import NumpyForm
 from awkward.index import Index
-from awkward.types.numpytype import primitive_to_dtype
+from awkward.types.numpytype import dtype_to_primitive, primitive_to_dtype
 
 if TYPE_CHECKING:
     from awkward._slicing import SliceItem
@@ -119,12 +119,14 @@ class NumpyArray(NumpyMeta, Content):
         if backend is None:
             backend = backend_of_obj(data, default=NumpyBackend.instance())
 
-        self._data = backend.nplike.asarray(data)
+        nplike = backend.nplike
+        self._data = nplike.asarray(data)
 
-        if not isinstance(backend.nplike, Jax):
-            ak.types.numpytype.dtype_to_primitive(self._data.dtype)
+        if not isinstance(nplike, Jax):
+            dtype_to_primitive(self._data.dtype)
 
-        if len(ak._util.maybe_shape_of(self._data)) == 0:
+        # `ndim` rather than the shape: a virtual array's shape may be unknown
+        if self._data.ndim == 0:
             raise TypeError(
                 f"{type(self).__name__} 'data' must be an array, not a scalar: {data!r}"
             )

--- a/src/awkward/types/numpytype.py
+++ b/src/awkward/types/numpytype.py
@@ -46,7 +46,7 @@ def primitive_to_dtype(primitive):
 
 @lru_cache
 def dtype_to_primitive(dtype):
-    if dtype.kind.upper() == "M" and dtype == dtype.newbyteorder("="):
+    if dtype.kind in "mM" and dtype == dtype.newbyteorder("="):
         return str(dtype)
     else:
         out = _dtype_to_primitive_dict.get(dtype)


### PR DESCRIPTION
`NumpyArray.__init__` used `len(maybe_shape_of(data)) == 0` where `data.ndim == 0` does, and looked `dtype_to_primitive` up through three attributes on every construction.
