### PR TITLE
perf: fast-path int and numpy integers in is_integer

### DIFF
--- a/src/awkward/_regularize.py
+++ b/src/awkward/_regularize.py
@@ -24,7 +24,12 @@ def is_sized_iterable(obj) -> bool:
 
 
 def is_integer(x) -> bool:
-    return isinstance(x, numbers.Integral) and not isinstance(x, bool)
+    # `numbers.Integral` is an ABC, so check the common cases without it
+    return (
+        type(x) is int
+        or isinstance(x, np.integer)
+        or (isinstance(x, numbers.Integral) and not isinstance(x, bool))
+    )
 
 
 def is_array_like(x) -> bool:
@@ -32,6 +37,8 @@ def is_array_like(x) -> bool:
 
 
 def is_integer_like(x) -> bool:
+    if type(x) is int:
+        return True
     # Integral types
     if isinstance(x, numbers.Integral):
         return not isinstance(x, bool)


### PR DESCRIPTION
`numbers.Integral` is an ABC and numpy scalars are very common as indices, so check `int` and `np.integer` before falling back to it.
