### PR TITLE
perf: delegate Attrs.__contains__ to the backing dict

### DIFF
--- a/src/awkward/_attrs.py
+++ b/src/awkward/_attrs.py
@@ -59,6 +59,9 @@ class Attrs(Mapping):
     def __len__(self):
         return len(self._data)
 
+    def __contains__(self, key):
+        return key in self._data
+
     def __repr__(self):
         return f"Attrs({self._data!r})"
 


### PR DESCRIPTION
`Attrs` inherits `__contains__` from the `Mapping` mixin, which implements it with a try/except around `__getitem__`. The named axis key is looked up on every `__getitem__` of a highlevel array.
