### PR TITLE
feat: preserve attrs through Arrow serialization

### DIFF
--- a/src/awkward/_attrs.py
+++ b/src/awkward/_attrs.py
@@ -43,7 +43,7 @@ def without_transient_attrs(attrs: dict[str, Any]) -> JSONMapping:
     return {k: v for k, v in attrs.items() if not k.startswith("@")}
 
 
-def serializable_attrs_of(obj) -> JSONMapping | None:
+def serializable_attrs_of(obj) -> "JSONMapping | None":
     """
     The attrs of a high-level object that should be written out when it is
     serialized: transient attrs (those whose key starts with `"@"`) are dropped,

--- a/src/awkward/_attrs.py
+++ b/src/awkward/_attrs.py
@@ -43,6 +43,19 @@ def without_transient_attrs(attrs: dict[str, Any]) -> JSONMapping:
     return {k: v for k, v in attrs.items() if not k.startswith("@")}
 
 
+def serializable_attrs_of(obj) -> JSONMapping | None:
+    """
+    The attrs of a high-level object that should be written out when it is
+    serialized: transient attrs (those whose key starts with `"@"`) are dropped,
+    as they may hold arbitrary, non-serializable objects. Returns None if there
+    is nothing to write.
+    """
+    attrs = attrs_of_obj(obj)
+    if not attrs:
+        return None
+    return without_transient_attrs(dict(attrs)) or None
+
+
 class Attrs(Mapping):
     def __init__(self, data: Mapping[str, Any]):
         self._data = {_enforce_str_key(k): v for k, v in data.items()}

--- a/src/awkward/_connect/pyarrow/__init__.py
+++ b/src/awkward/_connect/pyarrow/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "AwkwardArrowArray",
     "AwkwardArrowType",
     "and_validbytes",
+    "attrs_from_schema_metadata",
     "convert_awkward_arrow_table_to_native",
     "convert_native_arrow_table_to_awkward",
     "convert_to_array",
@@ -21,6 +22,7 @@ __all__ = [
     "import_pyarrow_parquet",
     "popbuffers",
     "remove_optiontype",
+    "table_with_attrs",
     "to_awkwardarrow_storage_types",
     "to_awkwardarrow_type",
     "to_length",
@@ -70,8 +72,10 @@ if error_message is None:
         to_awkwardarrow_storage_types,
     )
     from .table_conv import (
+        attrs_from_schema_metadata,
         convert_awkward_arrow_table_to_native,
         convert_native_arrow_table_to_awkward,
+        table_with_attrs,
     )
 else:
     AwkwardArrowArray = None
@@ -84,6 +88,8 @@ else:
 
     convert_awkward_arrow_table_to_native = nothing_without_pyarrow
     convert_native_arrow_table_to_awkward = nothing_without_pyarrow
+    table_with_attrs = nothing_without_pyarrow
+    attrs_from_schema_metadata = nothing_without_pyarrow
     and_validbytes = nothing_without_pyarrow
     to_validbits = nothing_without_pyarrow
     to_length = nothing_without_pyarrow

--- a/src/awkward/_connect/pyarrow/extn_types.py
+++ b/src/awkward/_connect/pyarrow/extn_types.py
@@ -40,6 +40,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
         record_is_scalar,
         is_nonnullable_nulltype=False,
         option_type=False,
+        attrs=None,
     ):
         self._mask_type = mask_type
         self._node_type = node_type
@@ -49,6 +50,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
         self._record_is_scalar = record_is_scalar
         self._is_nonnullable_nulltype = is_nonnullable_nulltype
         self._option_type = option_type
+        self._attrs = attrs
         super().__init__(storage_type, "awkward")
 
     def __str__(self):
@@ -81,6 +83,22 @@ class AwkwardArrowType(pyarrow.ExtensionType):
     def record_is_scalar(self):
         return self._record_is_scalar
 
+    @property
+    def attrs(self):
+        """
+        The `attrs` of the high-level array this type was built from, or None.
+        Only the outermost type of an array carries them.
+        """
+        return self._attrs
+
+    def with_attrs(self, attrs):
+        """
+        Returns a copy of this type carrying `attrs` (a JSON-compatible mapping).
+        """
+        metadata = self._metadata_as_dict()
+        metadata["attrs"] = attrs
+        return type(self)._from_metadata_object(self.storage_type, metadata)
+
     def __arrow_ext_class__(self):
         return AwkwardArrowArray
 
@@ -88,7 +106,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
         return json.dumps(self._metadata_as_dict()).encode(errors="surrogatescape")
 
     def _metadata_as_dict(self):
-        return {
+        out = {
             "mask_type": self._mask_type,
             "node_type": self._node_type,
             "mask_parameters": self._mask_parameters,
@@ -98,6 +116,11 @@ class AwkwardArrowType(pyarrow.ExtensionType):
             "is_nonnullable_nulltype": self._is_nonnullable_nulltype,
             "option_type": self._option_type,
         }
+        # only the outermost type of an array can have attrs; leaving the key out
+        # entirely keeps the serialized metadata identical to older versions'
+        if self._attrs is not None:
+            out["attrs"] = self._attrs
+        return out
 
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type, serialized):
@@ -117,6 +140,7 @@ class AwkwardArrowType(pyarrow.ExtensionType):
             metadata["record_is_scalar"],
             is_nonnullable_nulltype=metadata.get("is_nonnullable_nulltype", False),
             option_type=metadata.get("option_type", False),
+            attrs=metadata.get("attrs"),
         )
 
     @property

--- a/src/awkward/_connect/pyarrow/table_conv.py
+++ b/src/awkward/_connect/pyarrow/table_conv.py
@@ -14,6 +14,32 @@ from .extn_types import (
 )
 
 AWKWARD_INFO_KEY = b"awkward_array_metadata"  # metadata field in Table schema
+AWKWARD_ATTRS_KEY = b"AWKWARD_ATTRS"  # array attrs in the Table schema metadata
+PANDAS_ATTRS_KEY = b"PANDAS_ATTRS"  # the same, for tables written by pandas
+
+
+def table_with_attrs(table: pyarrow.Table, attrs: dict) -> pyarrow.Table:
+    """
+    Returns `table` with `attrs` (which must be JSON-compatible) stored in its
+    schema metadata, alongside any metadata the table already has.
+    """
+    metadata = {} if table.schema.metadata is None else table.schema.metadata.copy()
+    metadata[AWKWARD_ATTRS_KEY] = json.dumps(attrs).encode(errors="surrogatescape")
+    return table.replace_schema_metadata(metadata)
+
+
+def attrs_from_schema_metadata(metadata: dict | None) -> dict:
+    """
+    Extracts the array attrs from a Table or RecordBatch schema's metadata,
+    accepting those written by pandas as well as by Awkward. Returns an empty
+    dict if there are none.
+    """
+    if not metadata:
+        return {}
+    for key in (PANDAS_ATTRS_KEY, AWKWARD_ATTRS_KEY):
+        if key in metadata:
+            return json.loads(metadata[key].decode(errors="surrogatescape"))
+    return {}
 
 
 def convert_awkward_arrow_table_to_native(aatable: pyarrow.Table) -> pyarrow.Table:

--- a/src/awkward/operations/ak_from_arrow.py
+++ b/src/awkward/operations/ak_from_arrow.py
@@ -25,6 +25,10 @@ def from_arrow(
     through Parquet, making Parquet a good way to save Awkward Arrays for later
     use.
 
+    Any attrs that #ak.to_arrow or #ak.to_arrow_table stored in the Arrow data
+    are restored (as are those written by pandas, in the `"PANDAS_ATTRS"`
+    schema metadata), unless overridden by the `attrs` argument.
+
     Because awkward uses numpy's dtype system, timestamp types do not have
     timezones. If encountering timestamp types with timezones in the input
     arrow data, they will be silently dropped.
@@ -43,7 +47,8 @@ def from_arrow(
         behavior (None or dict): Custom #ak.behavior for the output array, if
             high-level.
         attrs (None or dict): Custom attributes for the output array, if
-            high-level.
+            high-level. These take precedence over any attrs stored in the
+            Arrow data itself.
 
     Returns:
         An #ak.Array built from the given Apache Arrow array.
@@ -55,6 +60,11 @@ def _impl(array, generate_bitmasks, highlevel, behavior, attrs):
     import awkward._connect.pyarrow
 
     pyarrow = awkward._connect.pyarrow.pyarrow
+
+    stored_attrs = _stored_attrs(array)
+    if stored_attrs:
+        # an explicit 'attrs' argument wins over what was stored in the Arrow data
+        attrs = {**stored_attrs, **(attrs or {})}
 
     ctx = HighLevelContext(behavior=behavior, attrs=attrs).finalize()
 
@@ -85,3 +95,28 @@ def _impl(array, generate_bitmasks, highlevel, behavior, attrs):
     ak._do.recursively_apply(out, remove_revertable)
 
     return ctx.wrap(out, highlevel=highlevel)
+
+
+def _stored_attrs(array) -> dict:
+    """
+    The attrs that #ak.to_arrow or #ak.to_arrow_table wrote into `array`: a Table
+    or RecordBatch carries them in its schema metadata, whereas a bare Array or
+    ChunkedArray can only carry them in its (extension) type.
+    """
+    import awkward._connect.pyarrow
+
+    pyarrow = awkward._connect.pyarrow.pyarrow
+
+    if isinstance(array, (pyarrow.lib.Table, pyarrow.lib.RecordBatch)):
+        return awkward._connect.pyarrow.attrs_from_schema_metadata(
+            array.schema.metadata
+        )
+
+    elif isinstance(array, (pyarrow.lib.Array, pyarrow.lib.ChunkedArray)):
+        awkwardarrow_type, _ = awkward._connect.pyarrow.to_awkwardarrow_storage_types(
+            array.type
+        )
+        if awkwardarrow_type is not None and awkwardarrow_type.attrs is not None:
+            return awkwardarrow_type.attrs
+
+    return {}

--- a/src/awkward/operations/ak_from_parquet.py
+++ b/src/awkward/operations/ak_from_parquet.py
@@ -349,16 +349,9 @@ def _read_parquet_file(
 
     arrow_table = ak._connect.pyarrow.convert_native_arrow_table_to_awkward(arrow_table)
 
-    array_attrs = {}
-    if arrow_table.schema.metadata:
-        if b"PANDAS_ATTRS" in arrow_table.schema.metadata:
-            array_metadata = arrow_table.schema.metadata[b"PANDAS_ATTRS"]
-            array_attrs = json.loads(array_metadata)
-        elif b"AWKWARD_ATTRS" in arrow_table.schema.metadata:
-            array_metadata = arrow_table.schema.metadata[b"AWKWARD_ATTRS"]
-            array_attrs = json.loads(array_metadata)
-    else:
-        array_attrs = {}
+    array_attrs = ak._connect.pyarrow.attrs_from_schema_metadata(
+        arrow_table.schema.metadata
+    )
 
     result = ak.operations.ak_from_arrow._impl(
         arrow_table,

--- a/src/awkward/operations/ak_to_arrow.py
+++ b/src/awkward/operations/ak_to_arrow.py
@@ -2,6 +2,7 @@
 
 
 import awkward as ak
+from awkward._attrs import serializable_attrs_of
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -35,6 +36,11 @@ def to_arrow(
     even through Parquet, making Parquet a good way to save Awkward Arrays for later
     use. If any third-party tools don't recognize Arrow's extension arrays, set this
     option to False for plain Arrow arrays.
+
+    With `extensionarray=True`, the array's #ak.Array.attrs are stored in the Arrow
+    type as well, so that #ak.from_arrow can restore them; they must therefore be
+    JSON-compatible. Transient attrs (those whose keys start with `"@"`) are dropped,
+    as they are when pickling.
 
     See also #ak.from_arrow, #ak.to_arrow_table, #ak.to_parquet, #ak.from_arrow_schema.
 
@@ -96,6 +102,8 @@ def _impl(
     extensionarray,
     count_nulls,
 ):
+    from awkward._connect.pyarrow import AwkwardArrowType, pyarrow
+
     layout = ak.operations.to_layout(array, allow_record=True, primitive_policy="error")
     if isinstance(layout, ak.record.Record):
         layout = layout.array[layout.at : layout.at + 1]
@@ -103,7 +111,7 @@ def _impl(
     else:
         record_is_scalar = False
 
-    return layout.to_arrow(
+    out = layout.to_arrow(
         list_to32=list_to32,
         string_to32=string_to32,
         bytestring_to32=bytestring_to32,
@@ -113,3 +121,13 @@ def _impl(
         count_nulls=count_nulls,
         record_is_scalar=record_is_scalar,
     )
+
+    # A bare Arrow array has nowhere to put metadata other than its type, so the
+    # attrs can only be stored (in the outermost type) if this is an extension array
+    attrs = serializable_attrs_of(array)
+    if attrs is not None and isinstance(out.type, AwkwardArrowType):
+        out = pyarrow.ExtensionArray.from_storage(
+            out.type.with_attrs(attrs), out.storage
+        )
+
+    return out

--- a/src/awkward/operations/ak_to_arrow_table.py
+++ b/src/awkward/operations/ak_to_arrow_table.py
@@ -4,6 +4,7 @@
 import json
 
 import awkward as ak
+from awkward._attrs import serializable_attrs_of
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
 from awkward._typing import Any
@@ -37,6 +38,11 @@ def to_arrow_table(
     even through Parquet, making Parquet a good way to save Awkward Arrays for later
     use. If any third-party tools don't recognize Arrow's extension arrays, set this
     option to False for plain Arrow arrays.
+
+    The array's #ak.Array.attrs are stored in the table's schema metadata, so that
+    #ak.from_arrow can restore them; they must therefore be JSON-compatible.
+    Transient attrs (those whose keys start with `"@"`) are dropped, as they are
+    when pickling.
 
     See also #ak.from_arrow, #ak.to_arrow, #ak.to_parquet.
 
@@ -98,7 +104,11 @@ def _impl(
     extensionarray,
     count_nulls,
 ):
-    from awkward._connect.pyarrow import direct_Content_subclass, pyarrow
+    from awkward._connect.pyarrow import (
+        direct_Content_subclass,
+        pyarrow,
+        table_with_attrs,
+    )
 
     layout = ak.operations.to_layout(array, allow_record=True, primitive_policy="error")
     if isinstance(layout, ak.record.Record):
@@ -187,9 +197,15 @@ def _impl(
     )
     out = pyarrow.Table.from_batches([batch])
 
-    if schema_parameters is None:
-        return out
-    else:
-        return out.replace_schema_metadata(
+    if schema_parameters is not None:
+        out = out.replace_schema_metadata(
             {"ak:parameters": json.dumps(schema_parameters)}
         )
+
+    # unlike a bare Arrow array, a Table can hold the attrs in its schema metadata,
+    # which is where Parquet expects to find them too
+    attrs = serializable_attrs_of(array)
+    if attrs is not None:
+        out = table_with_attrs(out, attrs)
+
+    return out

--- a/src/awkward/operations/ak_to_parquet.py
+++ b/src/awkward/operations/ak_to_parquet.py
@@ -1,7 +1,6 @@
 # BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
 
 
-import json
 from collections.abc import Mapping, Sequence
 from os import fsdecode
 
@@ -9,8 +8,11 @@ import fsspec
 
 import awkward as ak
 import awkward._connect.pyarrow
-from awkward._attrs import without_transient_attrs
-from awkward._connect.pyarrow import convert_awkward_arrow_table_to_native
+from awkward._attrs import serializable_attrs_of
+from awkward._connect.pyarrow import (
+    convert_awkward_arrow_table_to_native,
+    table_with_attrs,
+)
 from awkward._dispatch import high_level_function
 from awkward._nplikes.numpy_like import NumpyMetadata
 
@@ -417,17 +419,9 @@ def _impl(
 
     # when writing row groups iteratively, the attrs are those of the first array
     attrs_from = first_array if write_iteratively else array
-    if hasattr(attrs_from, "attrs") and attrs_from.attrs:
-        serializable_attrs = without_transient_attrs(attrs_from.attrs.to_dict())
-
-        # Only modify table metadata if there are actual non-transient attrs
-        if serializable_attrs:
-            existing_metadata = table.schema.metadata or {}
-            merged_metadata = {
-                **existing_metadata,
-                b"AWKWARD_ATTRS": json.dumps(serializable_attrs).encode("utf-8"),
-            }
-            table = table.replace_schema_metadata(merged_metadata)
+    serializable_attrs = serializable_attrs_of(attrs_from)
+    if serializable_attrs is not None:
+        table = table_with_attrs(table, serializable_attrs)
 
     if parquet_extra_options is None:
         parquet_extra_options = {}

--- a/tests/test_3278_arrow_attrs.py
+++ b/tests/test_3278_arrow_attrs.py
@@ -1,0 +1,125 @@
+# BSD 3-Clause License; see https://github.com/scikit-hep/awkward/blob/main/LICENSE
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import awkward as ak
+
+pyarrow = pytest.importorskip("pyarrow")
+
+
+@pytest.fixture(
+    params=[
+        ak.Array(
+            [[1.1, 2.2], [], [3.3]], attrs={"one": 1, "two": [2, {"three": None}]}
+        ),
+        ak.Array(
+            [{"x": 1, "y": [1.1]}, {"x": 2, "y": []}], attrs={"one": 1, "two": "2"}
+        ),
+    ],
+    ids=["array", "record-array"],
+)
+def array(request):
+    return request.param
+
+
+def test_to_arrow_roundtrip(array):
+    assert ak.from_arrow(ak.to_arrow(array)).attrs == array.attrs
+    assert ak.from_arrow(ak.to_arrow_table(array)).attrs == array.attrs
+
+
+def test_to_arrow_roundtrip_preserves_data(array):
+    for through in ak.to_arrow, ak.to_arrow_table:
+        result = ak.from_arrow(through(array))
+        assert result.to_list() == array.to_list()
+        assert result.type == array.type
+
+
+def test_to_arrow_table_without_extensionarray(array):
+    # the schema metadata is available whether or not there are extension arrays
+    table = ak.to_arrow_table(array, extensionarray=False)
+    assert ak.from_arrow(table).attrs == array.attrs
+
+
+def test_to_arrow_without_extensionarray(array):
+    # a plain Arrow array has nowhere to keep them, just as it has nowhere to
+    # keep the array's type
+    assert ak.from_arrow(ak.to_arrow(array, extensionarray=False)).attrs == {}
+
+
+def test_no_attrs_leaves_metadata_alone(array):
+    without = ak.Array(array.layout)
+    assert ak.to_arrow(without).type == ak.to_arrow(without).type
+    assert ak.from_arrow(ak.to_arrow(without)).attrs == {}
+
+    schema = ak.to_arrow_table(without).schema
+    assert schema.metadata is None or b"AWKWARD_ATTRS" not in schema.metadata
+    assert ak.from_arrow(ak.to_arrow_table(without)).attrs == {}
+
+
+def test_transient_attrs_are_dropped(array):
+    class NotSerializable:
+        pass
+
+    array = ak.Array(
+        array.layout, attrs={**array.attrs, "@transient": NotSerializable()}
+    )
+
+    assert ak.from_arrow(ak.to_arrow(array)).attrs == {
+        k: v for k, v in array.attrs.items() if k != "@transient"
+    }
+    assert ak.from_arrow(ak.to_arrow_table(array)).attrs == {
+        k: v for k, v in array.attrs.items() if k != "@transient"
+    }
+
+
+def test_only_transient_attrs():
+    class NotSerializable:
+        pass
+
+    array = ak.Array([[1.1, 2.2], []], attrs={"@transient": NotSerializable()})
+
+    assert ak.from_arrow(ak.to_arrow(array)).attrs == {}
+    assert ak.from_arrow(ak.to_arrow_table(array)).attrs == {}
+
+
+def test_explicit_attrs_take_precedence(array):
+    result = ak.from_arrow(ak.to_arrow(array), attrs={"one": "overridden", "new": True})
+    assert result.attrs == {**array.attrs, "one": "overridden", "new": True}
+
+
+def test_from_arrow_lowlevel(array):
+    # nothing to attach the attrs to; this must not raise
+    assert isinstance(
+        ak.from_arrow(ak.to_arrow(array), highlevel=False), ak.contents.Content
+    )
+
+
+def test_chunked_array_and_record_batch(array):
+    chunked = pyarrow.chunked_array([ak.to_arrow(array), ak.to_arrow(array)])
+    assert ak.from_arrow(chunked).attrs == array.attrs
+
+    table = ak.to_arrow_table(array)
+    assert ak.from_arrow(table.to_batches()[0]).attrs == array.attrs
+
+
+def test_non_serializable_attrs_raise():
+    array = ak.Array([[1.1, 2.2], []], attrs={"not_json": object()})
+
+    with pytest.raises(TypeError):
+        ak.to_arrow(array)
+    with pytest.raises(TypeError):
+        ak.to_arrow_table(array)
+
+
+def test_arrow_table_attrs_are_readable_by_parquet(array, tmp_path):
+    # ak.to_arrow_table stores attrs where ak.from_parquet looks for them
+    pyarrow_parquet = pytest.importorskip("pyarrow.parquet")
+
+    filename = os.path.join(tmp_path, "attrs.parquet")
+    pyarrow_parquet.write_table(ak.to_arrow_table(array), filename)
+
+    assert ak.from_parquet(filename).attrs == array.attrs


### PR DESCRIPTION
Closes https://github.com/scikit-hep/awkward/issues/3278

Parquet already writes the attrs into the table's schema metadata, so `ak.to_arrow_table` does the same under the same key. A bare Arrow array has nowhere to put them other than its type, so `ak.to_arrow` stores them in the outermost `AwkwardArrowType`, which means it can only do it with `extensionarray=True`. Either way `ak.from_arrow` restores them, and an explicit `attrs` argument takes precedence. Transient attrs are dropped, as they are when pickling.

The second commit moves the parquet side onto the same two helpers instead of repeating the metadata key and the json handling in `ak_to_parquet` and `ak_from_parquet`.
