### PR TITLE
docs: add llms.txt and Markdown page versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "autoapi.extension",
     "myst_nb",
+    "sphinx_llm.txt",
     # Preserve old links
     # "jupyterlite_sphinx",
     "IPython.sphinxext.ipython_console_highlighting",
@@ -243,6 +244,20 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "_templates", "_autoapi_templates", "Thumbs.db", "jupyter_execute", ".*"]
 
+# -- Options for LLM-friendly output -----------------------------------------
+
+# The default would be the awkward package metadata summary
+llms_txt_description = (
+    "Documentation of Awkward Array, a library for nested, variable-sized data"
+    " (arbitrary-length lists, records, mixed types, and missing data) using"
+    " NumPy-like idioms."
+)
+
+# Run the Markdown sub-build after the HTML build so that it can reuse the
+# doctrees; autoapi writes generated files into the source tree, so the two
+# builds must not run at the same time.
+llms_txt_build_parallel = False
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -311,6 +326,8 @@ html_js_files = ["js/awkward.js"]
 myst_enable_extensions = ["colon_fence", "deflist"]
 
 nb_execution_mode = "cache"
+# Share the cache with the Markdown sub-build, which has its own output directory
+nb_execution_cache_path = str(pathlib.Path(__file__).parent / "_build" / "jupyter_cache")
 nb_execution_raise_on_error = True
 # unpkg is currently _very_ slow
 nb_ipywidgets_js = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,11 @@
+---
+myst:
+  html_meta:
+    description: Awkward Array is a library for nested, variable-sized data,
+      including arbitrary-length lists, records, mixed types, and missing data,
+      using NumPy-like idioms.
+---
+
 # Awkward Array documentation
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,7 @@ myst-nb~=1.0
 myst-parser~=2.0
 sphinx-external-toc
 sphinx-autoapi
+sphinx-llm
 ipyleaflet
 
 numpy


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds LLM-friendly docs output with NVIDIA's `sphinx-llm` (`sphinx_llm.txt` extension). It runs the Markdown builder alongside the HTML build and merges the results, so the whole thing is one extension and one build:

- `llms.txt` — sitemap with a one-line description per page.
- `llms-full.txt` — all docs in one file.
- `<page>.html.md` next to each `<page>.html`.

Awkward-specific settings:

- `llms_txt_build_parallel = False`, so the Markdown sub-build runs after the HTML build instead of at the same time. autoapi writes generated RST into the source tree, so two concurrent builds would clobber each other; the sequential sub-build also reuses the primary doctrees.
- `nb_execution_cache_path` is now explicit. The sub-build has its own output directory, and the default cache location is inside the output directory, so without this it would execute every notebook again.
- `llms_txt_description` is set because the default is the package metadata summary.
- `docs/index.md` gets a `myst.html_meta` description, which `llms.txt` uses for the index page.

Note that autoapi generates about 2000 pages, so `llms-full.txt` will be large. `llms_txt_exclude` can remove the generated API reference if that becomes a problem.

Ported from https://github.com/scikit-hep/uhi/pull/252.